### PR TITLE
WIP #595 - initial commit of Patch system

### DIFF
--- a/pype/mongodb.py
+++ b/pype/mongodb.py
@@ -1,0 +1,381 @@
+import os
+import sys
+import time
+import functools
+import logging
+import pymongo
+import ctypes
+from uuid import uuid4
+
+from avalon import schema
+
+
+def extract_port_from_url(url):
+    if sys.version_info[0] == 2:
+        from urlparse import urlparse
+    else:
+        from urllib.parse import urlparse
+    parsed_url = urlparse(url)
+    if parsed_url.scheme is None:
+        _url = "mongodb://{}".format(url)
+        parsed_url = urlparse(_url)
+    return parsed_url.port
+
+
+def requires_install(func):
+    func_obj = getattr(func, "__self__", None)
+
+    @functools.wraps(func)
+    def decorated(*args, **kwargs):
+        if func_obj is not None:
+            _obj = func_obj
+        else:
+            _obj = args[0]
+        if not _obj.is_installed():
+            if _obj.auto_install:
+                _obj.install()
+            else:
+                raise IOError(
+                    "'{}.{}()' requires to run install() first".format(
+                        _obj.__class__.__name__, func.__name__
+                    )
+                )
+        return func(*args, **kwargs)
+    return decorated
+
+
+def auto_reconnect(func):
+    """Handling auto reconnect in 3 retry times"""
+    retry_times = 3
+    reconnect_msg = "Reconnecting..."
+    func_obj = getattr(func, "__self__", None)
+
+    @functools.wraps(func)
+    def decorated(*args, **kwargs):
+        if func_obj is not None:
+            _obj = func_obj
+        else:
+            _obj = args[0]
+
+        for retry in range(1, retry_times + 1):
+            try:
+                return func(*args, **kwargs)
+            except pymongo.errors.AutoReconnect:
+                if hasattr(_obj, "log"):
+                    _obj.log.warning(reconnect_msg)
+                else:
+                    print(reconnect_msg)
+
+                if retry >= retry_times:
+                    raise
+                time.sleep(0.1)
+    return decorated
+
+class PypeMongoConnection:
+    """
+        Connection to 'pype' database (not avalon). This database should be
+        used for logs, configuration, upgrade patches etc.
+        Code based on AvalonMongoConnection, but for separation of avalon-pype
+        code is reproduced and simplified here.
+    """
+    _mongo_client = None
+    _is_installed = False
+    _databases = {}
+    log = logging.getLogger("PypeMongoConnection")
+
+    @classmethod
+    def register_database(cls, dbcon):
+        """
+            Sets accessible database connection to _databases.
+            One connection could potentially handle multiple databases (
+            on same url).
+        Args:
+            dbcon:
+
+        Returns:
+
+        """
+        if dbcon.id in cls._databases:
+            return
+
+        cls._databases[dbcon.id] = {
+            "object": dbcon,
+            "installed": False
+        }
+
+    @classmethod
+    def database(cls):
+        """
+            Expects environment variable "PYPE_MONGO_DB_NAME" or 'pype' as
+            a default.
+        Returns:
+           (pymongo.database)
+        """
+        return cls._mongo_client[os.getenv("PYPE_MONGO_DB_NAME") or "pype"]
+
+    @classmethod
+    def mongo_client(cls):
+        """
+        Returns:
+            (pymongo.mongo_client)
+
+        """
+        return cls._mongo_client
+
+    @classmethod
+    def install(cls, dbcon):
+        """
+            Creates persistent connection to 'dbCon', registers it to
+            _databases to be accessible by its 'uuid'.
+        Args:
+            dbcon (PypeMongoDB): similar to pymongo.database, database object
+                used for operations like 'find', 'insert_one'.
+
+        Returns:
+
+        """
+        if not cls._is_installed or cls._mongo_client is None:
+            cls._mongo_client = cls.create_connection()
+            cls._is_installed = True
+
+        cls.register_database(dbcon)
+        cls._databases[dbcon.id]["installed"] = True
+
+        cls.check_db_existence()
+
+    @classmethod
+    def is_installed(cls, dbcon):
+        """"
+            Checks if connection to 'dbcon' database exists. (eg. there is
+            mongoDB client connected to server and has connection to database)
+
+            Returns:
+                (boolean): true if connected
+        """
+        info = cls._databases.get(dbcon.id)
+        if not info:
+            return False
+        return cls._databases[dbcon.id]["installed"]
+
+    @classmethod
+    def _uninstall(cls):
+        """
+            Closes client's connection to server.
+        """
+        try:
+            cls._mongo_client.close()
+        except AttributeError:
+            pass
+        cls._is_installed = False
+        cls._mongo_client = None
+
+    @classmethod
+    def uninstall(cls, dbcon, force=False):
+        """
+            Deregisters connection to 'dbcon', if no more 'alive' databases
+            present, it closes client connection.
+            If 'force' all connected databases are deregistered and client
+            closed.
+        Args:
+            dbcon (PypeMongoDB): enhance mongodb.database
+            force (boolean):
+
+        Returns:
+
+        """
+        if force:
+            for key in cls._databases:
+                cls._databases[key]["object"].uninstall()
+            cls._uninstall()
+            return
+
+        cls._databases[dbcon.id]["installed"] = False
+
+        cls.check_db_existence()
+
+        any_is_installed = False
+        for key in cls._databases:
+            if cls._databases[key]["installed"]:
+                any_is_installed = True
+                break
+
+        if not any_is_installed:
+            cls._uninstall()
+
+    @classmethod
+    def check_db_existence(cls):
+        """ Double check existence and 'livenes'' of registered databases.
+            All non-existen databases are deregistered.
+            Updates '_databases'.
+        """
+        items_to_pop = set()
+        for db_id, info in cls._databases.items():
+            obj = info["object"]
+            # TODO check if should check for 1 or more
+            cls.log.info(ctypes.c_long.from_address(id(obj)).value)
+            if ctypes.c_long.from_address(id(obj)).value == 1:
+                items_to_pop.add(db_id)
+
+        for db_id in items_to_pop:
+            cls._databases.pop(db_id, None)
+
+    @classmethod
+    def create_connection(cls):
+        """
+            Tries to create mongodb client connection to server host configured
+            by environment variable 'PYPE_MONGO'.
+        Returns:
+            (pymongo.MongoClient) connected client
+        Raises:
+            IOError - if even after 3 retries host is not accessible
+        """
+        timeout = int(os.environ["AVALON_TIMEOUT"])
+        mongo_url = os.environ["PYPE_MONGO"]
+        kwargs = {
+            "host": mongo_url,
+            "serverSelectionTimeoutMS": timeout
+        }
+
+        port = extract_port_from_url(mongo_url)
+        if port is not None:
+            kwargs["port"] = int(port)
+
+        mongo_client = pymongo.MongoClient(**kwargs)
+
+        for _retry in range(3):
+            try:
+                t1 = time.time()
+                mongo_client.server_info()
+
+            except Exception:
+                cls.log.warning("Retrying...")
+                time.sleep(1)
+                timeout *= 1.5
+
+            else:
+                break
+
+        else:
+            raise IOError((
+                "ERROR: Couldn't connect to {} in less than {:.3f}ms"
+            ).format(mongo_url, timeout))
+
+        cls.log.info("Connected to {}, delay {:.3f}s".format(
+            mongo_url, time.time() - t1
+        ))
+        return mongo_client
+
+
+class PypeMongoDB:
+    """ Enhanced wrapper around pymongo.database used for all operations
+        based on pymongo.database.
+        Has a functionality for auto_connect, parent mongo client is
+        accessible.
+    """
+    def __init__(self, collection, auto_install=True):
+        self._id = uuid4()
+        self._database = None
+        self.auto_install = auto_install
+        self._collection = collection
+
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def __getattr__(self, attr_name):
+        """
+            All not explicitly implemented operations on pymongo.database
+            are wrapped in 'auto_reconnect' decorator
+        Args:
+            attr_name (string): attribute from pymongo.database
+
+        Returns:
+            attribute or wrapped callable
+        """
+        print("attr_name:: {}".format(attr_name))
+        self.log.debug("attr_name:: {}".format(attr_name))
+        attr = None
+        if self.is_installed() and self.auto_install:
+            self.install()
+
+        if self.is_installed():
+            attr = getattr(
+                self._database[self._collection],
+                attr_name,
+                None
+            )
+
+        if attr is None:
+            # Reraise attribute error
+            return self.__getattribute__(attr_name)
+
+        # Decorate function
+        if callable(attr):
+            attr = auto_reconnect(attr)
+        return attr
+
+    @property
+    def client(self):
+        """
+        Returns:
+            pymongo.MongoClient
+        """
+        return PypeMongoConnection.mongo_client()
+
+    @property
+    def id(self):
+        """
+            Identifier of database
+        Returns:
+            (uuid4)
+        """
+        return self._id
+
+    @property
+    def database(self):
+        if not self.is_installed() and self.auto_install:
+            self.install()
+
+        if self.is_installed():
+            return self._database
+
+        raise IOError(
+            "'{}.database' requires to run install() first".format(
+                self.__class__.__name__
+            )
+        )
+
+    def is_installed(self):
+        return PypeMongoConnection.is_installed(self)
+
+    def install(self):
+        """Establish a persistent connection to the database"""
+        if self.is_installed():
+            return
+
+        PypeMongoConnection.install(self)
+
+        self._database = PypeMongoConnection.database()
+
+    def uninstall(self):
+        """Close any connection to the database"""
+        PypeMongoConnection.uninstall(self)
+        self._database = None
+
+    @auto_reconnect
+    def insert_one(self, item, *args, **kwargs):
+        assert isinstance(item, dict), "item must be of type <dict>"
+        schema.validate(item)
+        return self._database[self._collection].insert_one(
+            item, *args, **kwargs
+        )
+
+    @auto_reconnect
+    def insert_many(self, items, *args, **kwargs):
+        # check if all items are valid
+        assert isinstance(items, list), "`items` must be of type <list>"
+        for item in items:
+            assert isinstance(item, dict), "`item` must be of type <dict>"
+            schema.validate(item)
+
+        return self._database[self._collection].insert_many(
+            items, *args, **kwargs
+        )

--- a/pype/mongodb.py
+++ b/pype/mongodb.py
@@ -71,6 +71,7 @@ def auto_reconnect(func):
                 time.sleep(0.1)
     return decorated
 
+
 class PypeMongoConnection:
     """
         Connection to 'pype' database (not avalon). This database should be

--- a/pype/mongodb.py
+++ b/pype/mongodb.py
@@ -314,7 +314,7 @@ class PypeMongoDB:
         return attr
 
     @property
-    def client(self):
+    def mongo_client(self):
         """
         Returns:
             pymongo.MongoClient

--- a/pype/tools/upgrade/__init__.py
+++ b/pype/tools/upgrade/__init__.py
@@ -1,4 +1,5 @@
 from . import executor
 
-def tray_init(tray_widget, main_widget): #TODO shouldnt be on tray init
+
+def tray_init(tray_widget, main_widget):  # TODO shouldn't be on tray init
     return executor.UpgradeExecutor()

--- a/pype/tools/upgrade/__init__.py
+++ b/pype/tools/upgrade/__init__.py
@@ -1,0 +1,3 @@
+
+def tray_init(tray_widget, main_widget):
+    return UpgradeExecutor()

--- a/pype/tools/upgrade/__init__.py
+++ b/pype/tools/upgrade/__init__.py
@@ -1,3 +1,4 @@
+from . import executor
 
-def tray_init(tray_widget, main_widget):
-    return UpgradeExecutor()
+def tray_init(tray_widget, main_widget): #TODO shouldnt be on tray init
+    return executor.UpgradeExecutor()

--- a/pype/tools/upgrade/executor.py
+++ b/pype/tools/upgrade/executor.py
@@ -163,7 +163,7 @@ class UpgradeExecutor:
 
         """
         module_info = pyclbr.readmodule(patch_name, [self.DB_PATCHES_DIR])
-        for class_name, cls_object in module_info.items():
+        for _, cls_object in module_info.items():
             if 'AbstractPatch' in cls_object.super:
                 return True
 

--- a/pype/tools/upgrade/executor.py
+++ b/pype/tools/upgrade/executor.py
@@ -23,41 +23,108 @@ class UpgradeExecutor:
     DB_PATCHES_DIR = os.path.join(os.path.dirname(__file__), 'patches')
     SKIP_PATCHES = []
 
-    def __init__(self, patches_dir=None, skip_patches=None):
+    def __init__(self, patches_dir=None, skip_patches=None, projects=None):
+        """
+            Initialize upgrade run
+        Args:
+            patches_dir (string): absolute path to folder with patches
+            skip_patches (list): of strings of patch names (file name without
+                extension) that should be skipped
+            projects (list): of strings of project names (eg. collection names)
+        """
         if patches_dir:  # for testing
             self.DB_PATCHES_DIR = patches_dir
+
+        self.projects = []
+        if projects:
+            self.projects = list(projects)
 
         # list of patches to be skipped - for testing mostly
         self.SKIP_PATCHES = skip_patches or []
 
-        patches = self.get_patches(self.DB_PATCHES_DIR)
-        log.debug("patches::{}".format(patches))
-
         self.conn = PypeMongoDB("upgrade_patches")
-        log.debug("connection {}".format(self.conn))
 
         self.avalon_conn = AvalonMongoDB()
         self.avalon_conn.install()
 
-        implemented_patches = self.get_implemented_patches()
-        log.debug("implemented_patches::{}".format(len(implemented_patches)))
+        self.something_updated = False
+
+        self.execute()
+
+    def execute(self):
+        """ Main function """
+        patches = self.get_patches(self.DB_PATCHES_DIR)
 
         for patch_name in patches:
+            if patch_name in self.SKIP_PATCHES:
+                continue
 
-            if patch_name not in implemented_patches and \
-                    self._is_real_patch(patch_name):
-                if self.is_locked():
-                    raise ValueError("System should be upgraded, but already "
-                                     "locked! Remove lock from DB.")
+            if not self._is_real_patch(patch_name):
+                continue
 
-                patch = self.get_patch(patch_name)
+            self.lock()
+
+            patch = self.get_patch(patch_name)
+
+            log_record = self.get_implemented_patch_report(patch.name)
+
+            if not log_record:
                 mongo_id = self.report_to_db(patch.get_report_record_base())
-                result, error_message = patch.run()
-                self.update_report(mongo_id, error_message)
-                log.debug("result {}, error_message {}".format(result,
-                                                               error_message))
+            else:
+                mongo_id = log_record["_id"]
+
+            if patch.is_affected('global') and \
+                    not self.is_applied_on(log_record, 'global'):
+                result, error_message = patch.run_global()
+                self.something_updated = True
+                applied_on = {'global': datetime.now(timezone.utc)}
+                self.update_report(mongo_id, error_message,
+                                   applied_on=applied_on)
                 if not result:
-                    raise ValueError("Patch {} failed".format(patch_name))
+                    raise ValueError(error_message)
+                log.debug("Ran {} for global section".format(patch_name))
+
+            if patch.is_affected('project'):
+                if self.projects:  # manual run on selected project(s)
+                    for project_name in self.projects:
+                        self.process_project_patch(mongo_id, patch,
+                                                   project_name,
+                                                   log_record)
+                else:
+                    for project in self.avalon_conn.projects():
+                        project_name = project["name"]
+                        self.process_project_patch(mongo_id, patch,
+                                                   project_name,
+                                                   log_record)
+
+        if not self.something_updated:
+            raise ValueError("Nothing updated, no updatable areas found.")
+
+        self.unlock()
+
+    def process_project_patch(self, mongo_id, patch, project_name, log_record):
+        """
+            Checks if 'patch' could be run on 'project_name', runs it and
+            stores result in DB.
+        Args:
+            mongo_id (ObjectId): report document from MongoDB
+            patch (AbstractPatch):
+            project_name (string):
+            log_record (dict): log document from Mongo
+
+        Raises:
+            (ValueError)
+
+        """
+        if self.is_upgradable(patch, project_name, log_record):
+            result, error_message = patch.run_on_project(project_name)
+            self.something_updated = True
+            applied_on = {project_name: datetime.now(timezone.utc)}
+            self.update_report(mongo_id, error_message, applied_on=applied_on)
+            if not result:
+                raise ValueError(error_message)
+
+            log.debug("Ran {} for {} section".format(patch.name, project_name))
 
     def get_patch(self, patch_name):
         """
@@ -74,7 +141,6 @@ class UpgradeExecutor:
         module_info = pyclbr.readmodule(patch_name, [self.DB_PATCHES_DIR])
         patch = None
         for class_name, cls_object in module_info.items():
-            log.debug("cls_object.super:: {}".format(cls_object.super))
             if 'AbstractPatch' in cls_object.super:
                 sys.path.append(self.DB_PATCHES_DIR)
                 module = importlib.import_module(patch_name)
@@ -98,7 +164,6 @@ class UpgradeExecutor:
         """
         module_info = pyclbr.readmodule(patch_name, [self.DB_PATCHES_DIR])
         for class_name, cls_object in module_info.items():
-            log.debug("cls_object.super:: {}".format(cls_object.super))
             if 'AbstractPatch' in cls_object.super:
                 return True
 
@@ -125,9 +190,26 @@ class UpgradeExecutor:
         """
             Returns all documents about finished patches.
         Returns:
-            (list) of documents
+            (dictionary) {'patch_name': ['project_A', 'project_B']}
         """
-        return [self.conn.database.upgrade_patches.find()]
+        return [self.conn.database.upgrade_patches.find({}, {})]
+
+    def get_implemented_patch_report(self, patch_name):
+        """
+            Return active log document for 'patch_name'.
+            Active means that previous run of the patch didn't failed.
+            There is single report document for whole patch which gets updated
+            if patch:
+                is triggered multiple times for selected projects (testing)
+                contains multiple targets ('global', 'project'...)
+        Args:
+            patch_name (string):
+
+        Returns:
+            (dictionary) from Mongo | None if not found
+        """
+        filter = {'name': patch_name, "error_message": {"$exists": False}}
+        return self.conn.database.upgrade_patches.find_one(filter)
 
     def is_locked(self):
         """
@@ -171,12 +253,15 @@ class UpgradeExecutor:
         """
         return self.conn.database.upgrade_patches.insert(report)
 
-    def update_report(self, mongo_id, error_message='', options={}):
+    def update_report(self, mongo_id, error_message='', applied_on=None,
+                      options=None):
         """
             Updates log report in db for particular patch
         Args:
-            mongo_id (ObjectId):
+            mongo_id (ObjectId): report document in MongoDB
             error_message (string):
+            applied_on (dict): 'global': 'DDMMYYYY hh:mm:ss' when area was
+                updated
             options (dict): additional info about patch run (did it save to db)
 
         """
@@ -188,10 +273,97 @@ class UpgradeExecutor:
         if error_message:
             report["error_message"] = error_message
 
-        log.debug("options {}".format(options))
-        for key, value in options:
-            report[key] = value
+        if options:
+            for key, value in options.items():
+                report[key] = value
 
-        log.debug("report {}".format(report))
+        if applied_on:
+            rec_applied = report.get("applied_on", {})
+            for key, value in applied_on.items():
+                if key in rec_applied.keys():
+                    report["error_message"] += " Double application of {}".\
+                        format(key)
+                    break
+
+                rec_applied[key] = value
+            report["applied_on"] = rec_applied
 
         self.conn.database.upgrade_patches.update(filter, report, upsert=True)
+
+    def is_upgradable(self, patch, project_name, log_record):
+        """
+            Checks if 'patch' should be triggered on 'project_name'
+        Args:
+            patch (AbstractPatch):
+            project_name (string):
+            log_record (dictionary): logging document from Mongo
+
+        Returns:
+            (bool)
+        """
+        return not self.is_applied_on(log_record, project_name) \
+            and not self.is_project_frozen(project_name) \
+            and self.is_version_applicable(project_name, patch.version)
+
+    def is_applied_on(self, log_record, label):
+        """
+            Check if 'label' was already applied for this patch 'log_record'
+        Args:
+            log_record (dict): from Mongo
+            label (string): 'global'|'project_A'
+
+        Returns:
+            (bool)
+        """
+        ret = False
+        if log_record and log_record["applied_on"]:
+            ret = log_record["applied_on"].get(label, False)
+        return ret
+
+    def is_project_frozen(self, project_name):
+        """
+            Check if 'project_name' is frozen, eg. shouldn't be updated at all
+        Args:
+            project_name (string):
+
+        Returns:
+            (bool)
+        Raises:
+            ValueError if project wasn't found
+        """
+        return self._get_project(project_name).get("freeze", False)
+
+    def is_version_applicable(self, project_name, version):
+        """
+            Check if version of the patch is bigger than version of the project
+            Other case would mean that patch is for this particular project
+            obsolete. Project was created in newer version, with newer
+            structure.
+        Args:
+            project_name (string):
+            version (string): "2.13.0"
+
+        Returns:
+            (bool)
+
+        """
+        project_version = self._get_project(project_name).get("version",
+                                                              "0.0.0")
+        return version > project_version
+
+    def _get_project(self, project_name):
+        """
+            Return project object by its name
+
+        Args:
+            project_name(string):
+        Returns:
+            (dictionary) - project object
+        Raises:
+            ValueError if project wasn't found
+        """
+        for project in self.avalon_conn.projects():
+            if project["name"] == project_name:
+                return project
+
+        raise ValueError("Project {} not found!".format(project_name))

--- a/pype/tools/upgrade/executor.py
+++ b/pype/tools/upgrade/executor.py
@@ -1,0 +1,155 @@
+from pype.api import Logger
+import os
+import pyclbr
+from pype.mongodb import PypeMongoDB
+from datetime import datetime, timezone
+import importlib
+import sys
+# keep it here for correct initialization of patches #TODO refactor
+from pype.tools.upgrade.patches.abtract_patch import AbstractPatch
+
+log = Logger().get_logger("UpgradeExecutor")
+
+
+class UpgradeExecutor:
+    """
+        Should be run by trigger or at start of Pype to check if any not
+        implemented updates (database or APIs) exist.
+        Useful for more automatic upgrade process.
+    """
+    DB_PATCHES_DIR = os.path.join(os.path.dirname(__file__), 'patches')
+    SKIP_PATCHES = []
+
+    def __init__(self, patches_dir=None, skip_patches=None):
+        if patches_dir:  # for testing
+            self.DB_PATCHES_DIR = patches_dir
+
+        # list of patches to be skipped - for testing mostly
+        self.SKIP_PATCHES = skip_patches or []
+
+        patches = self.get_patches(self.DB_PATCHES_DIR)
+        log.debug("patches::{}".format(patches))
+
+        self.conn = PypeMongoDB("upgrade_patches")
+        log.debug("connection {}".format(self.conn))
+
+        implemented_patches = self.get_implemented_patches()
+        log.debug("implemented_patches::{}".format(len(implemented_patches)))
+
+        for patch_name in patches:
+            if patch_name not in implemented_patches:
+                if self.is_locked():
+                    raise ValueError("System should be upgraded, but already "
+                                     "locked! Remove lock from DB.")
+                result, error_message = self.run_patch(patch_name)
+                self.report_to_db(patch_name, error_message)
+                log.debug("result {}, error_message {}".format(result,
+                                                               error_message))
+                if not result:
+                    raise ValueError("Patch {} failed".format(patch_name))
+
+    def run_patch(self, patch_name):
+        """
+            Checks if 'patch_name' implements 'AbstractPatch', triggers its
+            'run' method and returns result tuple
+        Args:
+            patch_name (string): file name of patch (without extension)
+
+        Returns:
+            (boolean, string): true if all OK, (false, error_message) otherwise
+        """
+        log.debug('----{}----'.format(patch_name))
+        patch_url = os.path.join(self.DB_PATCHES_DIR, patch_name + ".py")
+
+        module_info = pyclbr.readmodule(patch_name, [self.DB_PATCHES_DIR])
+        result = False
+        error_message = ''
+        for class_name, cls_object in module_info.items():
+            if 'AbstractPatch' in cls_object.super:
+                sys.path.append(self.DB_PATCHES_DIR)
+                module = importlib.import_module(patch_name)
+                cls = getattr(module, class_name)
+                # initialize patch class
+                patch = cls(pype_connection=self.conn)
+                log.debug("Run {}".format(patch_name))
+                # run patch
+                result, error_message = patch.run(projects=['petr_test'])
+                sys.path.pop()
+
+        return result, error_message
+
+    def get_patches(self, dir_name):
+        """
+            Lists all files in 'dir_name' and returns list of names of
+            python files
+        Args:
+            dir_name:
+
+        Returns:
+            (list) names of python files (without extension)
+        """
+        patches = []
+        for file_name in os.listdir(dir_name):
+            if '.py' in file_name and '__' not in file_name:
+                patches.append(file_name.replace('.py', ''))
+
+        return sorted(patches)
+
+    def get_implemented_patches(self):
+        """
+            Returns all documents about finished patches.
+        Returns:
+            (list) of documents
+        """
+        return [self.conn.database.upgrade_patches.find()]
+
+    def is_locked(self):
+        """
+            Checks database for presence of lock record.
+        Returns:
+            (boolean): true if lock record
+        """
+        lock_record_count = self.conn.database.upgrade_patches. \
+            count_documents({"type": "lock"})
+
+        return lock_record_count > 0
+
+    def lock(self):
+        """
+            Creates lock record in DB. If already present, raises error.
+            Created_dt in UTC.
+        Raises:
+            (ValueError)
+        """
+        if self.is_locked():
+            raise ValueError("Already locked. Remove lock record manually.")
+        lock_record = {"type": "lock", "start_dt": datetime.now(timezone.utc)}
+
+        self.conn.database.upgrade_patches.insert_one(lock_record)
+
+    def unlock(self):
+        """
+            Removes lock record in DB if present
+        """
+        self.conn.database.upgrade_patches.remove({"type": "lock"})
+
+    def report_to_db(self, patch_name, error_message='', options={}):
+        """
+            Creates log report in db for particular patch
+        Args:
+            patch_name (string):
+            error_message (string):
+            options (dict): additional info about patch run (did it save to db)
+
+        """
+        report = {
+            "patch_name": patch_name,
+            "finished_dt": datetime.now(timezone.utc)
+        }
+        if error_message:
+            report["error_message"] = error_message
+
+        for key, value in options:
+            report[key] = value
+
+        self.conn.database.upgrade_patches.insert_one(report)

--- a/pype/tools/upgrade/patches/001_test_patch.py
+++ b/pype/tools/upgrade/patches/001_test_patch.py
@@ -5,27 +5,49 @@ log = Logger().get_logger("UpgradeExecutor")
 
 
 class TestPatch(AbstractPatch):
+    """
+        Example implementation of Patch.
+        It requires working connection (avalon_connections for changes in
+        avalon DB, pype_connection for pype DB and Settings)
+
+        It implements most available methods from AbstractPatch in basic way.
+        Real world Patch could reimplemented anything needed, set pass to
+        any unwanted abstract methods.
+    """
     # implemented this way to reuse properties from AbstractPatch
+    name = '001_test_patch'  # should follow name of file
     version = "1.0.0"
-    affects = ["avalon_db", "pype_db"]
-    description = {"avalon_db": "Test avalon db patch",
+    affects = ["global", "project", "pype_db"]
+    applied_on = {}
+    description = {"global": "Test global db patch",
+                   "project": "Test project based updates",
                    "pype_db": "Test pype patch",
                    }
     implemented_by_PR = "666"
 
     """ Test implementation of patch """
     def __init__(self, avalon_connection=None, pype_connection=None):
-        log.debug("init TestPatch")
+        log.debug("TestPatch.init")
 
         self.avalon_conn = avalon_connection
         self.pype_conn = pype_connection
 
+    def run_global(self):
+        log.debug("TestPatch.run_global")
+        result, error = super().run_global()
+
+        return result, error
+
+    def run_on_project(self, project_name):
+        log.debug("TestPatch.run_on_project")
+        result, error = super().run_on_project(project_name)
+
+        return result, error
+
     def update_avalon_global(self):
         log.debug("TestPatch.update_avalon_global")
         try:
-            for project_name in self.avalon_conn.projects():
-                log.debug("project_name:: {}".format(project_name['name']))
-                raise ValueError("temp")
+            log.debug("run something not project dependent")
         except Exception as exp:
             log.warning(
                 "Error has happened during update_avalon_project",
@@ -51,9 +73,9 @@ class TestPatch(AbstractPatch):
 
         return True, ''
 
-    def update_api(self, api):
-        log.debug("TestPatch.update_avalon_global")
-        return True
+    def update_api(self, api=None):
+        log.debug("TestPatch.update_api")
+        return True, ''
 
     def update_pype_db(self):
         log.debug("TestPatch.update_pype_db")
@@ -70,15 +92,9 @@ class TestPatch(AbstractPatch):
 
         return True, ''
 
-    def run(self, projects=[]):
-        log.debug("run TestPatch")
-        result, error = self.update_avalon_global()
-        if result:
-            for project_name in projects:
-                result, error = self.update_avalon_project(project_name)
-                if not result:
-                    break
-        if result:
-            result, error = self.update_pype_db()
+    # not used methods - take only skeleton functionality
+    def update_settings_global(self):
+        super().update_settings_global()
 
-        return result, error
+    def update_settings_project(self, project_name):
+        super().update_settings_project()

--- a/pype/tools/upgrade/patches/001_test_patch.py
+++ b/pype/tools/upgrade/patches/001_test_patch.py
@@ -1,0 +1,61 @@
+from pype.tools.upgrade.patches.abtract_patch import AbstractPatch
+from pype.api import Logger
+import traceback
+
+log = Logger().get_logger("UpgradeExecutor")
+
+
+class TestPatch(AbstractPatch):
+    """ Test implementation of patch """
+    def __init__(self, avalon_connection=None, pype_connection=None):
+        log.debug("init TestPatch")
+
+        self.avalon_db = avalon_connection
+        self.pype_db = pype_connection
+
+    def update_avalon_global(self):
+        log.debug("TestPatch.update_avalon_global")
+        return True
+
+    def update_avalon_project(self, project_name):
+        log.debug("TestPatch.update_avalon_project")
+        # new_object = {"name": "test_object"}
+        # try:
+        #     self.avalon_db.database.project_name.insert_one(new_object)
+        # except:
+        #     log.warning(
+        #         "Error has happened during update_pype_db",
+        #         exc_info=True
+        #     )
+        #     return False, traceback.format_exception_only
+
+        return True, ''
+
+    def update_api(self, api):
+        log.debug("TestPatch.update_avalon_global")
+        return True
+
+    def update_pype_db(self):
+        log.debug("TestPatch.update_pype_db")
+        new_object = {"name": "test_object"}
+
+        try:
+            self.pype_db.database.upgrade_patches.insert_one(new_object)
+        except:
+            log.warning(
+                "Error has happened during update_pype_db",
+                exc_info=True
+            )
+            return False, traceback.format_exception_only
+
+        return True, ''
+
+    def run(self, projects=[]):
+        log.debug("run TestPatch")
+        result, error = self.update_pype_db()
+        if result:
+            for project_name in projects:
+                self.update_avalon_project(project_name)
+
+        return result, error
+

--- a/pype/tools/upgrade/patches/001_test_patch.py
+++ b/pype/tools/upgrade/patches/001_test_patch.py
@@ -1,33 +1,53 @@
 from pype.tools.upgrade.patches.abtract_patch import AbstractPatch
 from pype.api import Logger
-import traceback
 
 log = Logger().get_logger("UpgradeExecutor")
 
 
 class TestPatch(AbstractPatch):
+    # implemented this way to reuse properties from AbstractPatch
+    version = "1.0.0"
+    affects = ["avalon_db", "pype_db"]
+    description = {"avalon_db": "Test avalon db patch",
+                   "pype_db": "Test pype patch",
+                   }
+    implemented_by_PR = "666"
+
     """ Test implementation of patch """
     def __init__(self, avalon_connection=None, pype_connection=None):
         log.debug("init TestPatch")
 
-        self.avalon_db = avalon_connection
-        self.pype_db = pype_connection
+        self.avalon_conn = avalon_connection
+        self.pype_conn = pype_connection
 
     def update_avalon_global(self):
         log.debug("TestPatch.update_avalon_global")
-        return True
+        try:
+            for project_name in self.avalon_conn.projects():
+                log.debug("project_name:: {}".format(project_name['name']))
+                raise ValueError("temp")
+        except Exception as exp:
+            log.warning(
+                "Error has happened during update_avalon_project",
+                exc_info=True
+            )
+            return False, str(exp)
+
+        return True, ''
 
     def update_avalon_project(self, project_name):
-        log.debug("TestPatch.update_avalon_project")
-        # new_object = {"name": "test_object"}
-        # try:
-        #     self.avalon_db.database.project_name.insert_one(new_object)
-        # except:
-        #     log.warning(
-        #         "Error has happened during update_pype_db",
-        #         exc_info=True
-        #     )
-        #     return False, traceback.format_exception_only
+        log.debug("TestPatch.update_avalon_project {}".format(project_name))
+        filter = {"name": "test_object"}
+        update_object = {"$set": {"name": "test_object_upd"}}
+        try:
+            self.avalon_conn.Session["AVALON_PROJECT"] = project_name
+            self.avalon_conn.update_one(filter, update_object)
+        except Exception as exp:
+            log.warning(
+                "Error has happened during update_avalon_project",
+                exc_info=True
+            )
+            return False, str(exp)
 
         return True, ''
 
@@ -40,22 +60,25 @@ class TestPatch(AbstractPatch):
         new_object = {"name": "test_object"}
 
         try:
-            self.pype_db.database.upgrade_patches.insert_one(new_object)
-        except:
+            self.pype_conn.database.upgrade_patches.insert_one(new_object)
+        except Exception as exp:
             log.warning(
                 "Error has happened during update_pype_db",
                 exc_info=True
             )
-            return False, traceback.format_exception_only
+            return False, str(exp)
 
         return True, ''
 
     def run(self, projects=[]):
         log.debug("run TestPatch")
-        result, error = self.update_pype_db()
+        result, error = self.update_avalon_global()
         if result:
             for project_name in projects:
-                self.update_avalon_project(project_name)
+                result, error = self.update_avalon_project(project_name)
+                if not result:
+                    break
+        if result:
+            result, error = self.update_pype_db()
 
         return result, error
-

--- a/pype/tools/upgrade/patches/abtract_patch.py
+++ b/pype/tools/upgrade/patches/abtract_patch.py
@@ -161,7 +161,7 @@ class AbstractPatch(metaclass=ABCMeta):
             (dictionary): pre-filled from properties
         """
         rec = {
-            "name":  self.name,
+            "name": self.name,
             "version": self.version,
             "affects": self.affects,
             "description": self.description,

--- a/pype/tools/upgrade/patches/abtract_patch.py
+++ b/pype/tools/upgrade/patches/abtract_patch.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 from pype.api import Logger
 log = Logger().get_logger("UpgradeExecutor")
 
+
 class AbstractPatch(metaclass=ABCMeta):
     """
         Abstract class which structure all patches should follow.
@@ -59,6 +60,20 @@ class AbstractPatch(metaclass=ABCMeta):
             (boolean, string): (false, error message) if error
         """
 
+    def get_report_record_base(self):
+        """
+            Skeleton for reporting to db.
+        Returns:
+            (dictionary): pre-filled from properties
+        """
+        rec = {}
+        rec["version"] = self.version
+        rec["affects"] = self.affects
+        rec["description"] = self.description
+        rec["implemented_by_PR"] = self.implemented_by_PR
+
+        return rec
+
     @abstractmethod
     def run(self, projects=[]):
         """
@@ -75,3 +90,50 @@ class AbstractPatch(metaclass=ABCMeta):
         #         if self.update_api():
         #             if self.update_pype_db():
         #                 pass
+
+    # properties - set in implementing class as a class variables, not inside
+    # of init (that would result in infinitive recursion error)
+    @property
+    def version(self):
+        """ Version of Pype this patch brings to """
+        return self.version
+
+    @version.setter
+    def version(self, val):
+        self.version = val
+
+    @property
+    def affects(self):
+        """ This patch changes 'avalon_db', 'pype_db'... """
+        return self.affects
+
+    @affects.setter
+    def affects(self, val):
+        self.affects = val
+
+    @property
+    def description(self):
+        """ What kind of changes per 'affects' keys """
+        return self.description
+
+    @description.setter
+    def description(self, val):
+        self.description = val
+
+    @property
+    def applied_on(self):
+        """ Applied 'global'(not project change)|'project_A'... """
+        return self.applied_on
+
+    @applied_on.setter
+    def applied_on(self, val):
+        self.applied_on = val
+
+    @property
+    def implemented_by_PR(self):
+        """ Pull request id that implements this patch """
+        return self.implemented_by_PR
+
+    @implemented_by_PR.setter
+    def implemented_by_PR(self, val):
+        self.implemented_by_PR = val

--- a/pype/tools/upgrade/patches/abtract_patch.py
+++ b/pype/tools/upgrade/patches/abtract_patch.py
@@ -171,6 +171,33 @@ class AbstractPatch(metaclass=ABCMeta):
 
         return rec
 
+    def update_avalon_project_version(self, project_name, session=None):
+        """
+            Auxiliary function that logs to project document that this
+            project was updated. For debugging purposes.
+            It stores:
+                ...
+                "version": THIS_PATCH.version
+                "patched_versions": [PREVIOUS_PATCH.version...]
+        Args:
+            project_name (string):
+            session (MongoClient.session):
+
+        """
+        self.avalon_conn.Session["AVALON_PROJECT"] = project_name
+        filter = {"type": "project"}
+        project = self.avalon_conn.find_one(filter)
+        previous_version = project.get("version", '1.0.0')
+        patched_versions = project.get("patched_versions", [])
+        patched_versions.append(previous_version)
+
+        update_object = {"$set": {"version": self.version,
+                                  "patched_versions": patched_versions}}
+
+        self.avalon_conn.update_one(filter, update_object,
+                                    session=session)
+
+
     # properties - set in implementing class as a class variables, not inside
     # of init (that would result in infinitive recursion error)
     @property

--- a/pype/tools/upgrade/patches/abtract_patch.py
+++ b/pype/tools/upgrade/patches/abtract_patch.py
@@ -1,0 +1,77 @@
+from abc import ABCMeta, abstractmethod
+from pype.api import Logger
+log = Logger().get_logger("UpgradeExecutor")
+
+class AbstractPatch(metaclass=ABCMeta):
+    """
+        Abstract class which structure all patches should follow.
+    """
+
+    @abstractmethod
+    def __init__(self, avalon_connection=None, pype_connection=None):
+        """
+            Inject connected collection object to run db operations on.
+        Args:
+            avalon_connection (AvalonMongoDB):
+            pype_connection (PypeMongoDB):
+        """
+
+    @abstractmethod
+    def update_avalon_global(self):
+        """
+            Prepare and run queries that should be run on all projects.
+
+        Returns:
+            (boolean, string): (false, error message) if error
+        """
+        pass
+
+    @abstractmethod
+    def update_avalon_project(self, project_name):
+        """
+            Prepare and run queries for specific 'project_name'
+        Args:
+            project_name (string):
+
+        Returns:
+            (boolean, string): (false, error message) if error
+        """
+        pass
+
+    @abstractmethod
+    def update_api(self, api):
+        """
+            Prepare and run updates on external API (ftrack for example)
+        Args:
+            api (string):TODO
+
+        Returns:
+            (boolean, string): (false, error message) if error
+        """
+
+    @abstractmethod
+    def update_pype_db(self):
+        """
+            Prepare and run updates on 'pype' database.
+            For special cases.
+
+        Returns:
+            (boolean, string): (false, error message) if error
+        """
+
+    @abstractmethod
+    def run(self, projects=[]):
+        """
+            Runs all implemented method in sequence. Next step is triggered
+            only if previous finished successfully.
+            Logs errors into DB.
+        Args:
+            projects (list): projects names for 'update_avalon_project'
+        Returns:
+            (boolean, string): true if all OK, (false, error_message) otherwise
+        """
+        # if self.update_avalon_global():
+        #     if self.update_avalon_project():
+        #         if self.update_api():
+        #             if self.update_pype_db():
+        #                 pass


### PR DESCRIPTION
Basic implementation of executor
Created abstract patch class
Implemented example patch class
Basic implementation of new class for connecting to 'Pype' DB.

Currently implemented:

- System goes through predefined folder and looks for all files implementing AbstractPatch interface.
- Checks if these patches were implemented in DB (by name).
- If not checks if upgrade is not locked (someone else triggered upgrade and not finished)
- Runs example patch (currently updates only 'pype' Db), logs result in DB and finishes.

Main missing points:

- triggering execution of upgrade
- transactions
- ~~AvalonMongoDB passing (handling of Session)~~

PR resolves #595 