### PR TITLE
Reinstate Nuke asset dependency.

### DIFF
--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -151,7 +151,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
                 "BatchName": script_name,
 
                 # Asset dependency to wait for at least the scene file to sync.
-                # "AssetDependency0": script_path,
+                "AssetDependency0": script_path,
 
                 # Job name, as seen in Monitor
                 "Name": jobname,


### PR DESCRIPTION
This is meant as a reminder to reinstate an asset dependency on Nuke script file, in some way or another.