### PR TITLE
Projection workflow

### DIFF
--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -92,7 +92,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 "harmony.palette",
                 "editorial",
                 "background",
-                "camerarig"
+                "camerarig",
+                "projection"
                 ]
     exclude_families = ["clip"]
     db_representation_context_keys = [
@@ -206,8 +207,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             data=version_data
         )
 
-        self.log.debug("Creating version ...")
-
         new_repre_names_low = [_repre["name"].lower() for _repre in repres]
 
         existing_version = io.find_one({
@@ -217,8 +216,18 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         })
 
         if existing_version is None:
+            self.log.debug("Creating new version...")
+
+            # Prefil id if it exists on the instance.
+            if "versionId" in instance.data:
+                self.log.debug(
+                    "Prefilled id: {}".format(instance.data["versionId"])
+                )
+                version["_id"] = instance.data["versionId"]
+
             version_id = io.insert_one(version).inserted_id
         else:
+            self.log.debug("Updating existing version...")
             # Check if instance have set `append` mode which cause that
             # only replicated representations are set to archive
             append_repres = instance.data.get("append", False)

--- a/pype/plugins/maya/create/create_projection.py
+++ b/pype/plugins/maya/create/create_projection.py
@@ -1,0 +1,33 @@
+import avalon.maya
+
+from pype.hosts.maya import lib
+
+
+class CreateProjection(avalon.maya.Creator):
+    """Geometry with projected texture."""
+
+    name = "projection"
+    label = "Projection"
+    family = "projection"
+    icon = "video-camera"
+    defaults = ["Main"]
+
+    def __init__(self, *args, **kwargs):
+        super(CreateProjection, self).__init__(*args, **kwargs)
+
+        self.data["renderlayer"] = lib.get_current_renderlayer()
+        self.data.update(lib.collect_animation_data())
+
+        self.data["writeColorSets"] = False  # Vertex colors with the geometry.
+        self.data["renderableOnly"] = False  # Only renderable visible shapes
+        self.data["visibleOnly"] = False     # only nodes that are visible
+        self.data["includeParentHierarchy"] = False  # Include parent groups
+        self.data["worldSpace"] = True       # Default to exporting world-space
+
+        # Add options for custom attributes
+        self.data["attr"] = ""
+        self.data["attrPrefix"] = ""
+
+        # Bake to world space by default, when this is False it will also
+        # include the parent hierarchy in the baked results
+        self.data["bakeToWorldSpace"] = True

--- a/pype/plugins/maya/publish/collect_projection.py
+++ b/pype/plugins/maya/publish/collect_projection.py
@@ -1,0 +1,138 @@
+import os
+import json
+
+from bson.objectid import ObjectId
+
+import pymel.core as pc
+
+import pyblish.api
+from avalon import io
+
+
+class CollectProjection(pyblish.api.InstancePlugin):
+    """Collect The geometry, camera and texture for projection."""
+
+    # Offset to be after instance collection.
+    order = pyblish.api.CollectorOrder + 0.01
+    label = "Collect Projection"
+    hosts = ["maya"]
+    families = ["projection"]
+
+    def ensure_unique_id(self, id):
+        if io.find_one({"_id": id}) is None:
+            return id
+        else:
+            return self.ensure_unique_id(ObjectId())
+
+    def process(self, instance):
+        # Collect nodes data.
+        material_types = ["lambert", "surfaceShader"]
+        cameras = []
+        assignments = []
+        for node in instance[:]:
+            shape = pc.PyNode(node)
+            if shape.nodeType() != "mesh":
+                shape = pc.PyNode(node).getShape()
+            shading_engine = shape.connections(type="shadingEngine")[0]
+            material = shading_engine.connections(type=material_types)[0]
+
+            connections = material.connections(
+                type="projection", connections=True
+            )
+            for attribute, projection in connections:
+                cameras.append(projection.connections(type="camera")[0])
+                file_node = projection.connections(type="file")[0]
+                path = file_node.fileTextureName.get()
+                assignments.append(
+                    {
+                        "path": path,
+                        "material": material.name(),
+                        "shape": shape.name(),
+                        "attribute": attribute.name(includeNode=False)
+                    }
+                )
+
+        # Collect camera instances (Will be validated to a single camera).
+        camera_name = cameras[0].getTransform().name()
+        camera_instance = instance.context.create_instance(camera_name)
+        camera_instance.data.update(instance.data)
+        camera_instance.data["name"] = instance.data["name"] + "_camera"
+        camera_instance.data["subset"] += "Camera"
+        camera_instance.data["family"] = "camera"
+        camera_instance.data["families"] = []
+        camera_instance.data["setMembers"] = [camera_name]
+        camera_instance.data["versionId"] = self.ensure_unique_id(ObjectId())
+        camera_instance.data["objectName"] = instance.data["name"]
+
+        # Collect pointcache instance.
+        pointcache_instance = instance.context.create_instance(instance[0])
+        pointcache_instance[:] = instance[:]
+        pointcache_instance.data.update(instance.data)
+        pointcache_instance.data["name"] = (
+            instance.data["name"] + "_pointcache"
+        )
+        pointcache_instance.data["subset"] += "Pointcache"
+        pointcache_instance.data["family"] = "pointcache"
+        pointcache_instance.data["families"] = []
+        pointcache_instance.data["versionId"] = self.ensure_unique_id(
+            ObjectId()
+        )
+        pointcache_instance.data["objectName"] = instance.data["name"]
+
+        # Collect image instances.
+        version_ids = {}
+        paths = []
+        for data in assignments:
+            if data["path"] in paths:
+                continue
+
+            paths.append(data["path"])
+
+            image_instance = instance.context.create_instance(data["path"])
+            image_instance.data.update(instance.data)
+            name = "{}{}{}".format(
+                instance.data["name"],
+                data["material"].title(),
+                data["attribute"].title()
+            )
+            image_instance.data["name"] = name
+            image_instance.data["label"] = "{} ({})".format(
+                name, os.path.basename(data["path"])
+            )
+            image_instance.data["subsetGroup"] = (
+                instance.data["subset"] + "Image"
+            )
+            image_instance.data["subset"] = name
+            image_instance.data["family"] = "image"
+            image_instance.data["families"] = []
+
+            if data["path"] not in version_ids:
+                version_id = self.ensure_unique_id(ObjectId())
+                image_instance.data["versionId"] = version_id
+                version_ids[data["path"]] = str(version_id)
+
+            ext = os.path.splitext(data["path"])[1][1:]
+            image_instance.data["representations"] = [
+                {
+                    "name": ext,
+                    "ext": ext,
+                    "files": os.path.basename(data["path"]),
+                    "stagingDir": os.path.dirname(data["path"])
+                }
+            ]
+            self.log.info(image_instance.data["representations"])
+
+        for data in assignments:
+            data["versionId"] = version_ids[data["path"]]
+            del data["path"]
+
+        # Collect instance data.
+        instance.data["jsonData"] = {
+            "assignments": assignments,
+            "cameraVersionId": str(camera_instance.data["versionId"]),
+            "pointcacheVersionId": str(pointcache_instance.data["versionId"])
+        }
+        self.log.info(
+            json.dumps(instance.data["jsonData"], sort_keys=True, indent=4)
+        )
+        instance.data["cameras"] = list(set(cameras))

--- a/pype/plugins/maya/publish/extract_projection.py
+++ b/pype/plugins/maya/publish/extract_projection.py
@@ -1,0 +1,32 @@
+import json
+import os
+
+import pyblish.api
+
+import pype.api
+
+
+class ExtractProjection(pype.api.Extractor):
+    """Extract projection."""
+
+    label = "Extract Projection"
+    hosts = ["maya"]
+    families = ["projection"]
+    order = pyblish.api.ExtractorOrder
+
+    def process(self, instance):
+        staging_dir = self.staging_dir(instance)
+
+        json_fname = "{0}.json".format(instance.name)
+        json_path = os.path.join(staging_dir, json_fname)
+        with open(json_path, "w") as f:
+            json.dump(instance.data["jsonData"], f, sort_keys=True, indent=4)
+
+        instance.data["representations"] = [
+            {
+                "name": "json",
+                "ext": "json",
+                "files": json_fname,
+                "stagingDir": staging_dir
+            }
+        ]

--- a/pype/plugins/maya/publish/validate_frame_range.py
+++ b/pype/plugins/maya/publish/validate_frame_range.py
@@ -84,10 +84,16 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
         """
         Repair instance container to match asset data.
         """
+        # Try and find object by "objectName" else fallback on instance name.
+        # This is for instances that are spawned from other instances.
+        object_name = instance.data.get("objectName", "")
+        if not cmds.objExists(object_name):
+            object_name = instance.data["name"]
+
         cmds.setAttr(
-            "{}.frameStart".format(instance.data["name"]),
+            "{}.frameStart".format(object_name),
             instance.context.data.get("frameStartHandle"))
 
         cmds.setAttr(
-            "{}.frameEnd".format(instance.data["name"]),
+            "{}.frameEnd".format(object_name),
             instance.context.data.get("frameEndHandle"))

--- a/pype/plugins/maya/publish/validate_pointcache.py
+++ b/pype/plugins/maya/publish/validate_pointcache.py
@@ -26,7 +26,7 @@ class ValidatePointcache(pyblish.api.InstancePlugin):
                     names[node_name] = [node]
 
             instance.data["invalid"] = []
-            for name, nodes in names.items():
+            for _, nodes in names.items():
                 if len(nodes) != 1:
                     invalid.extend(nodes)
                     instance.data["invalid"].extend(nodes)

--- a/pype/plugins/maya/publish/validate_pointcache.py
+++ b/pype/plugins/maya/publish/validate_pointcache.py
@@ -1,0 +1,43 @@
+import pyblish.api
+
+import pype.api
+import pype.hosts.maya.action
+
+
+class ValidatePointcache(pyblish.api.InstancePlugin):
+    """Validate pointcache content."""
+
+    order = pype.api.ValidateContentsOrder
+    label = "Pointcache"
+    hosts = ["maya"]
+    families = ["pointcache"]
+    actions = [pype.hosts.maya.action.SelectInvalidAction]
+
+    @classmethod
+    def get_invalid(cls, instance, compute=False):
+        invalid = []
+        if compute:
+            names = {}
+            for node in instance:
+                node_name = node.split("|")[-1]
+                try:
+                    names[node_name].append(node)
+                except KeyError:
+                    names[node_name] = [node]
+
+            instance.data["invalid"] = []
+            for name, nodes in names.items():
+                if len(nodes) != 1:
+                    invalid.extend(nodes)
+                    instance.data["invalid"].extend(nodes)
+        else:
+            invalid.extend(instance.data["invalid"])
+
+        return invalid
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance, compute=True)
+        if invalid:
+            raise RuntimeError(
+                "Meshes found is duplicate names: {}".format(invalid)
+            )

--- a/pype/plugins/maya/publish/validate_projection.py
+++ b/pype/plugins/maya/publish/validate_projection.py
@@ -1,0 +1,20 @@
+import pyblish.api
+
+import pype.api
+
+
+class ValidateProjection(pyblish.api.InstancePlugin):
+    """Validate projection data content."""
+
+    order = pype.api.ValidateContentsOrder
+    label = "Projection"
+    hosts = ["maya"]
+    families = ["projection"]
+
+    def process(self, instance):
+        cameras = instance.data["cameras"]
+        msg = (
+            "Only one camera per projection subset is supported."
+            "\nCameras found: {}".format([x.name() for x in cameras])
+        )
+        assert len(cameras) == 1, msg

--- a/pype/plugins/nuke/load/load_camera_abc.py
+++ b/pype/plugins/nuke/load/load_camera_abc.py
@@ -128,7 +128,15 @@ class AlembicCameraLoader(api.Loader):
 
             # collect input output dependencies
             dependencies = camera_node.dependencies()
-            dependent = camera_node.dependent()
+
+            dependent_connections = []
+            for dependent in camera_node.dependent():
+                for index in range(0, dependent.inputs()):
+                    connected_node = dependent.input(index)
+                    if connected_node == camera_node:
+                        dependent_connections.append(
+                            {"input": index, "node": dependent}
+                        )
 
             camera_node["frame_rate"].setValue(float(fps))
             camera_node["file"].setValue(file)
@@ -147,11 +155,8 @@ class AlembicCameraLoader(api.Loader):
             for i, input in enumerate(dependencies):
                 camera_node.setInput(i, input)
             # link to original output nodes
-            for d in dependent:
-                index = next((i for i, dpcy in enumerate(
-                              d.dependencies())
-                              if camera_node is dpcy), 0)
-                d.setInput(index, camera_node)
+            for connection in dependent_connections:
+                connection["node"].setInput(connection["input"], camera_node)
 
         # color node by correct color by actual version
         self.node_version_color(version, camera_node)

--- a/pype/plugins/nuke/load/load_pointcache_abc.py
+++ b/pype/plugins/nuke/load/load_pointcache_abc.py
@@ -9,7 +9,7 @@ class AlembicPointcacheLoader(api.Loader):
     This will load alembic pointcache into script.
     """
 
-    families = ["pointcache"]
+    families = ["pointcache", "animation"]
     representations = ["abc"]
 
     label = "Load Alembic Pointcache"

--- a/pype/plugins/nuke/load/load_pointcache_abc.py
+++ b/pype/plugins/nuke/load/load_pointcache_abc.py
@@ -1,0 +1,210 @@
+from avalon import api, io
+from avalon.nuke import lib as anlib
+from avalon.nuke import containerise
+import nuke
+
+
+class AlembicPointcacheLoader(api.Loader):
+    """
+    This will load alembic pointcache into script.
+    """
+
+    families = ["pointcache"]
+    representations = ["abc"]
+
+    label = "Load Alembic Pointcache"
+    icon = "code-fork"
+    color = "orange"
+    node_color = "0x3469ffff"
+
+    def create_read_geo(self, object_name, file, fps):
+        node = nuke.createNode(
+            "ReadGeo2", "name {} file {}".format(object_name, file)
+        )
+        node.forceValidate()
+        node["frame_rate"].setValue(float(fps))
+
+        # Ensure all items are imported and selected.
+        scene_view = node['scene_view']
+        scene_view.setImportedItems(scene_view.getAllItems())
+        scene_view.setSelectedItems(scene_view.getAllItems())
+
+        return node
+
+    def load(self, context, name, namespace, data):
+        # get main variables
+        version = context['version']
+        version_data = version.get("data", {})
+        vname = version.get("name", None)
+        first = version_data.get("frameStart", None)
+        last = version_data.get("frameEnd", None)
+        fps = version_data.get("fps") or nuke.root()["fps"].getValue()
+        namespace = namespace or context['asset']['name']
+        # Adding "1" to the end will encourage Nuke to increment this number
+        # for multiple instances of the pointcache.
+        object_name = "{}_{}_1".format(name, namespace)
+
+        # prepare data for imprinting
+        # add additional metadata from the version to imprint to Avalon knob
+        add_keys = ["source", "author", "fps"]
+
+        data_imprint = {"frameStart": first,
+                        "frameEnd": last,
+                        "version": vname,
+                        "objectName": object_name}
+
+        for k in add_keys:
+            data_imprint.update({k: version_data[k]})
+
+        # getting file path
+        file = self.fname.replace("\\", "/")
+
+        with anlib.maintained_selection():
+            node = self.create_read_geo(object_name, file, fps)
+            node_name = node.name()
+
+            # workaround because nuke's bug is not adding
+            # animation keys properly
+            xpos = node.xpos()
+            ypos = node.ypos()
+            nuke.nodeCopy("%clipboard%")
+            nuke.delete(node)
+            nuke.nodePaste("%clipboard%")
+            node = nuke.toNode(node_name)
+            node.setXYpos(xpos, ypos)
+
+        # color node by correct color by actual version
+        self.node_version_color(version, node)
+
+        return containerise(
+            node=node,
+            name=name,
+            namespace=namespace,
+            context=context,
+            loader=self.__class__.__name__,
+            data=data_imprint
+        )
+
+    def update(self, container, representation):
+        """
+            Called by Scene Inventory when look should be updated to current
+            version.
+            If any reference edits cannot be applied, eg. shader renamed and
+            material not present, reference is unloaded and cleaned.
+            All failed edits are highlighted to the user via message box.
+
+        Args:
+            container: object that has look to be updated
+            representation: (dict): relationship data to get proper
+                                    representation from DB and persisted
+                                    data in .json
+        Returns:
+            None
+        """
+        # get main variables
+        version = io.find_one({
+            "type": "version",
+            "_id": representation["parent"]
+        })
+        version_data = version.get("data", {})
+        vname = version.get("name", None)
+        first = version_data.get("frameStart", None)
+        last = version_data.get("frameEnd", None)
+        fps = version_data.get("fps") or nuke.root()["fps"].getValue()
+        file = api.get_representation_path(representation).replace("\\", "/")
+        object_name = container['objectName']
+
+        old_node = nuke.toNode(object_name)
+        xpos = old_node.xpos()
+        ypos = old_node.ypos()
+        dependencies = old_node.dependencies()
+
+        dependent_connections = []
+        for dependent in old_node.dependent():
+            for index in range(0, dependent.inputs()):
+                connected_node = dependent.input(index)
+                if connected_node == old_node:
+                    dependent_connections.append(
+                        {"input": index, "node": dependent}
+                    )
+
+        nuke.delete(old_node)
+
+        # Need to re-create node cause that is only way to avoid the pop-up
+        # dialog for importing.
+        node = self.create_read_geo(object_name, file, fps)
+        node.setXYpos(xpos, ypos)
+
+        # link to original input nodes
+        for i, input in enumerate(dependencies):
+            node.setInput(i, input)
+
+        for connection in dependent_connections:
+            connection["node"].setInput(connection["input"], node)
+
+        # prepare data for imprinting
+        # add additional metadata from the version to imprint to Avalon knob
+        add_keys = ["source", "author", "fps"]
+
+        data_imprint = {
+            "representation": str(representation["_id"]),
+            "frameStart": first,
+            "frameEnd": last,
+            "version": vname,
+            "objectName": object_name
+        }
+
+        for k in add_keys:
+            data_imprint.update({k: version_data[k]})
+
+        node["frame_rate"].setValue(float(fps))
+
+        # color node by correct color by actual version
+        self.node_version_color(version, node)
+
+        # Containerise node because its been re-created.
+        version = io.find_one({"_id": representation["parent"]})
+        subset = io.find_one({"_id": version["parent"]})
+        asset = io.find_one({"_id": subset["parent"]})
+        project = io.find_one({"_id": asset["parent"]})
+        context = {
+            "project": project,
+            "asset": asset,
+            "subset": subset,
+            "version": version,
+            "representation": representation
+        }
+        containerise(
+            node=node,
+            name=container["name"],
+            namespace=container["namespace"],
+            context=context,
+            loader=self.__class__.__name__,
+            data=data_imprint
+        )
+
+    def node_version_color(self, version, node):
+        """ Coloring a node by correct color by actual version
+        """
+        # get all versions in list
+        versions = io.find({
+            "type": "version",
+            "parent": version["parent"]
+        }).distinct('name')
+
+        max_version = max(versions)
+
+        # change color of node
+        if version.get("name") not in [max_version]:
+            node["tile_color"].setValue(int("0xd88467ff", 16))
+        else:
+            node["tile_color"].setValue(int(self.node_color, 16))
+
+    def switch(self, container, representation):
+        self.update(container, representation)
+
+    def remove(self, container):
+        from avalon.nuke import viewer_update_and_undo_stop
+        node = nuke.toNode(container['objectName'])
+        with viewer_update_and_undo_stop():
+            nuke.delete(node)

--- a/pype/plugins/nuke/load/load_projection.py
+++ b/pype/plugins/nuke/load/load_projection.py
@@ -1,0 +1,399 @@
+import json
+
+from bson.objectid import ObjectId
+
+import nuke
+import nukescripts
+
+from avalon import api, io
+from avalon.nuke import containerise, update_container
+
+
+class ProjectionLoader(api.Loader):
+    """
+    This will load camera, pointcache and image to build a projection setup.
+    """
+
+    families = ["projection"]
+    representations = ["json"]
+
+    label = "Load Projection"
+    icon = "camera"
+    color = "orange"
+    node_color = "0x3469ffff"
+    node_padding = 200
+
+    def node_version_color(self, version, node):
+        """ Coloring a node by correct color by actual version
+        """
+        # get all versions in list
+        versions = io.find({
+            "type": "version",
+            "parent": version["parent"]
+        }).distinct('name')
+
+        max_version = max(versions)
+
+        # change color of node
+        if version.get("name") not in [max_version]:
+            node["tile_color"].setValue(int("0xd88467ff", 16))
+        else:
+            node["tile_color"].setValue(int(self.node_color, 16))
+
+    def setup_nodes(self, json_path, context, control_node=None):
+        json_data = None
+        with open(json_path, "r") as f:
+            json_data = json.loads(f.read())
+
+        # Collect loaders from registry
+        camera_loader = None
+        pointcache_loader = None
+        image_loader = None
+        for loader in api.last_discovered_plugins[api.Loader.__name__]:
+            if loader.__name__ == "AlembicCameraLoader":
+                camera_loader = loader
+            if loader.__name__ == "AlembicPointcacheLoader":
+                pointcache_loader = loader
+            if loader.__name__ == "LoadImage":
+                image_loader = loader
+
+        # Generate contexts for loaders.
+        version = io.find_one({"_id": ObjectId(json_data["cameraVersionId"])})
+        subset = io.find_one({"_id": version["parent"]})
+        representation = io.find_one(
+            {"type": "representation", "parent": version["_id"], "name": "abc"}
+        )
+        camera_context = {
+            "project": context["project"],
+            "asset": context["asset"],
+            "subset": subset,
+            "version": version,
+            "representation": representation
+        }
+
+        version = io.find_one(
+            {"_id": ObjectId(json_data["pointcacheVersionId"])}
+        )
+        subset = io.find_one({"_id": version["parent"]})
+        representation = io.find_one(
+            {
+                "type": "representation",
+                "parent": version["_id"],
+                "name": "abc"
+            }
+        )
+        pointcache_context = {
+            "project": context["project"],
+            "asset": context["asset"],
+            "subset": subset,
+            "version": version,
+            "representation": representation
+        }
+
+        # Process assignments data.
+        rgb_attributes = ["outColor", "color"]
+        alpha_attributes = ["outTransparency"]
+        materials_data = {}
+        for data in json_data["assignments"]:
+            material_data = {}
+            try:
+                material_data = materials_data[data["material"]]
+            except KeyError:
+                pass
+
+            if data["attribute"] in rgb_attributes:
+                material_data["rgb"] = data["versionId"]
+
+            if data["attribute"] in alpha_attributes:
+                material_data["alpha"] = data["versionId"]
+
+            try:
+                shapes = material_data["shapes"]
+            except KeyError:
+                shapes = []
+            if data["shape"] not in shapes:
+                shapes.append(data["shape"])
+            material_data["shapes"] = shapes
+
+            materials_data[data["material"]] = material_data
+
+        # Setup data pipes.
+        pointcache_nodes = []
+        projection_nodes = []
+        invert_alpha_nodes = []
+        last_node = None
+        for material, data in materials_data.items():
+            all_nodes = []
+
+            # Load rgb image.
+            version = io.find_one(
+                {"_id": ObjectId(data["rgb"])}
+            )
+            subset = io.find_one({"_id": version["parent"]})
+            representation = io.find_one(
+                {
+                    "type": "representation",
+                    "parent": version["_id"],
+                    "name": {"$in": image_loader.representations}
+                }
+            )
+            image_context = {
+                "project": context["project"],
+                "asset": context["asset"],
+                "subset": subset,
+                "version": version,
+                "representation": representation
+            }
+            image_node = image_loader(image_context).load(
+                image_context, subset["name"], None, {}
+            )
+            all_nodes.append(image_node)
+
+            # Load alpha image.
+            alpha_node = None
+            if "alpha" in data:
+                version = io.find_one(
+                    {"_id": ObjectId(data["alpha"])}
+                )
+                subset = io.find_one({"_id": version["parent"]})
+                representation = io.find_one(
+                    {
+                        "type": "representation",
+                        "parent": version["_id"],
+                        "name": {"$in": image_loader.representations}
+                    }
+                )
+                image_context = {
+                    "project": context["project"],
+                    "asset": context["asset"],
+                    "subset": subset,
+                    "version": version,
+                    "representation": representation
+                }
+                alpha_node = image_loader(image_context).load(
+                    image_context, subset["name"], None, {}
+                )
+                all_nodes.append(alpha_node)
+
+            # Load pointcache.
+            pointcache_node = pointcache_loader(pointcache_context).load(
+                pointcache_context, subset["name"], None, {}
+            )
+            scene_view = pointcache_node["scene_view"]
+            items = []
+            for item in scene_view.getAllItems():
+                for shape_name in data["shapes"]:
+                    if item.endswith(shape_name):
+                        items.append(item)
+            scene_view.setImportedItems(items)
+            scene_view.setSelectedItems(items)
+
+            pointcache_nodes.append(pointcache_node)
+            all_nodes.append(pointcache_node)
+
+            # Load camera.
+            camera_node = camera_loader(camera_context).load(
+                camera_context, subset["name"], None, {}
+            )
+            all_nodes.append(camera_node)
+
+            # Projection node.
+            projection_node = nuke.createNode("Project3D2")
+            projection_nodes.append(projection_node)
+            all_nodes.append(projection_node)
+
+            # Setup nodes.
+            if last_node:
+                image_node.setXYpos(
+                    last_node.xpos() + (2 * self.node_padding), 0
+                )
+            else:
+                image_node.setXYpos(0, 0)
+            last_node = image_node
+
+            if alpha_node:
+                shuffle_copy_node = nuke.createNode("ShuffleCopy")
+                shuffle_copy_node.setInput(0, image_node)
+                shuffle_copy_node.setInput(1, alpha_node)
+                shuffle_copy_node["alpha"].setValue("red")
+                shuffle_copy_node.setXYpos(
+                    last_node.xpos(), last_node.ypos() + self.node_padding
+                )
+
+                alpha_node.setXYpos(
+                    shuffle_copy_node.xpos() - self.node_padding,
+                    shuffle_copy_node.ypos()
+                )
+
+                invert_alpha_node = nuke.createNode("Invert")
+                invert_alpha_node.setInput(0, shuffle_copy_node)
+                invert_alpha_node["channels"].setValue("alpha")
+                invert_alpha_node.autoplace()
+                invert_alpha_nodes.append(invert_alpha_node)
+
+                premult_node = nuke.createNode("Premult")
+                premult_node.setInput(0, invert_alpha_node)
+                premult_node.autoplace()
+
+                last_node = premult_node
+                all_nodes.extend(
+                    [shuffle_copy_node, invert_alpha_node, premult_node]
+                )
+
+            projection_node.setInput(0, last_node)
+            projection_node.setInput(1, camera_node)
+            projection_node.setXYpos(
+                last_node.xpos(), last_node.ypos() + self.node_padding
+            )
+            last_node = projection_node
+
+            camera_node.setXYpos(
+                projection_node.xpos() - self.node_padding,
+                projection_node.ypos()
+            )
+
+            pointcache_node.setInput(0, last_node)
+            pointcache_node.autoplace()
+            last_node = pointcache_node
+
+            for node in nuke.allNodes():
+                if node in all_nodes:
+                    node["selected"].setValue(True)
+                else:
+                    node["selected"].setValue(False)
+            backdrop = nukescripts.autoBackdrop()
+            backdrop.setName(material)
+            backdrop["label"].setValue(material)
+
+        # Scene node.
+        scene_node = nuke.createNode("Scene")
+        for count, node in enumerate(pointcache_nodes):
+            scene_node.setInput(count, node)
+
+        scene_node.setXYpos(
+            pointcache_nodes[0].xpos(), pointcache_nodes[0].ypos() + 300
+        )
+
+        # Output node.
+        output_node = nuke.createNode("Output")
+        output_node.setInput(0, scene_node)
+
+        # Control node.
+        valid_knobs = ["crop", "project_on", "occlusion_mode"]
+        if not control_node:
+            control_node = nuke.createNode(
+                "Project3D2", "name control"
+            )
+
+            control_node.setXYpos(
+                scene_node.xpos() - 100, scene_node.ypos()
+            )
+            code = """
+this_node = nuke.thisNode()
+this_knob = nuke.thisKnob()
+valid_knobs = {}
+for node in nuke.allNodes(filter="Project3D2"):
+    if node == this_node:
+        continue
+
+    if this_knob.name() not in valid_knobs:
+        continue
+
+    node[this_knob.name()].setValue(this_knob.value())
+            """.format(valid_knobs)
+
+            control_node["knobChanged"].setValue(code)
+
+            knob = nuke.Boolean_Knob("invert_alpha", "Invert Alpha")
+            control_node.addKnob(knob)
+
+        for node in projection_nodes:
+            for knob_name in valid_knobs:
+                node[knob_name].setValue(control_node[knob_name].value())
+
+        for node in invert_alpha_nodes:
+            node["disable"].setExpression(
+                "!{}.invert_alpha".format(control_node.name())
+            )
+
+        return control_node
+
+    def load(self, context, name, namespace, data):
+        # Setup group.
+        # Adding "1" to the end will encourage Nuke to increment this number
+        # for multiple instances of the pointcache.
+        object_name = "{}_{}_1".format(name, context["asset"]["name"])
+        group_node = nuke.createNode("Group", "name {}".format(object_name))
+
+        self.node_version_color(context["version"], group_node)
+
+        # Execute inside group.
+        control_node = None
+        with group_node:
+            control_node = self.setup_nodes(self.fname, context)
+        assert control_node is not None, "Setting up nodes went wrong."
+
+        containerise(
+            node=group_node,
+            name=name,
+            namespace=context["asset"]["name"],
+            context=context,
+            loader=self.__class__.__name__,
+            data={"objectName": group_node.name()}
+        )
+
+        group_node.addKnob(nuke.Text_Knob(""))
+
+        knob_names = ["crop", "project_on", "occlusion_mode", "invert_alpha"]
+        for knob_name in knob_names:
+            knob = control_node[knob_name]
+            label = knob.label()
+            if not knob.label():
+                label = knob.name()
+            link_knob = nuke.Link_Knob(knob.name(), label)
+            link_knob.setLink("{}.{}".format(
+                control_node.name(), knob.name())
+            )
+            group_node.addKnob(link_knob)
+
+        return group_node
+
+    def update(self, container, representation):
+        version = io.find_one({"_id": representation["parent"]})
+        subset = io.find_one({"_id": version["parent"]})
+        asset = io.find_one({"_id": subset["parent"]})
+        project = io.find_one({"_id": asset["parent"]})
+        context = {
+            "representation": representation,
+            "version": version,
+            "subset": subset,
+            "asset": asset,
+            "project": project
+        }
+        json_path = api.get_representation_path(representation)
+
+        # Execute inside group.
+        group_node = nuke.toNode(container["objectName"])
+        with group_node:
+            control_node = None
+            for node in nuke.allNodes():
+                if node.name() == "control":
+                    control_node = node
+                    continue
+                nuke.delete(node)
+
+            self.setup_nodes(json_path, context, control_node=control_node)
+
+        update_container(
+            group_node, {"representation": str(representation["_id"])}
+        )
+        self.node_version_color(context["version"], group_node)
+
+    def switch(self, container, representation):
+        self.update(container, representation)
+
+    def remove(self, container):
+        from avalon.nuke import viewer_update_and_undo_stop
+        node = nuke.toNode(container["objectName"])
+        with viewer_update_and_undo_stop():
+            nuke.delete(node)


### PR DESCRIPTION
**Goal**

Publish and load projection data from Maya to Nuke.

**Implementation**

In Maya there is a new creator called "Projection", where you can add the geometry with the projected material. When publishing we collect the camera, pointcache and images required. These components of the projection are separate instances to re-use existing code for camera and pointcaches. The relationships are stored as a json file on the "projection" instance.
Only one camera is supported per projection. This is for tidiness.

In Nuke we built a projection setup for each material inside a group and expose some common attributes.

Improvements:
- [ ] validation for missing files

Other features/bugfixes included:
- Prefill version id on instances. This is to be able to predict the version id at the collection stage.
- Frame range validation can use an optional `objectName` to set the frame start and end.
- Nuke camera loader was not restoring dependent connection correctly.
- Nuke pointcache loader.
- Validate pointcaches for duplicate names.