### PR TITLE
Enhance review letterbox feature

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -50,8 +50,19 @@
                                 "enabled": false,
                                 "ratio": 0.0,
                                 "state": "letterbox",
-                                "thickness": "fill",
-                                "color": "black"
+                                "fill_color": [
+                                    0,
+                                    0,
+                                    0,
+                                    255
+                                ],
+                                "line_thickness": 0,
+                                "line_color": [
+                                    255,
+                                    0,
+                                    0,
+                                    255
+                                ]
                             }
                         }
                     }

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -45,7 +45,14 @@
                                 ]
                             },
                             "width": 0,
-                            "height": 0
+                            "height": 0,
+                            "letter_box": {
+                                "enabled": false,
+                                "ratio": 0.0,
+                                "state": "letterbox",
+                                "thickness": "fill",
+                                "color": "black"
+                            }
                         }
                     }
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -239,16 +239,31 @@
                                                     ]
                                                 },
                                                 {
-                                                    "key": "thickness",
-                                                    "label": "Thickness",
-                                                    "type": "text",
-                                                    "default": "fill"
+                                                    "type": "schema_template",
+                                                    "name": "template_rgba_color",
+                                                    "template_data": [
+                                                        {
+                                                            "label": "Fill Color",
+                                                            "name": "fill_color"
+                                                        }
+                                                    ]
                                                 },
                                                 {
-                                                    "key": "color",
-                                                    "label": "Color",
-                                                    "type": "text",
-                                                    "default": "#000000"
+                                                    "key": "line_thickness",
+                                                    "label": "Line Thickness",
+                                                    "type": "number",
+                                                    "minimum": 0,
+                                                    "maximum": 1000
+                                                },
+                                                {
+                                                    "type": "schema_template",
+                                                    "name": "template_rgba_color",
+                                                    "template_data": [
+                                                        {
+                                                            "label": "Line Color",
+                                                            "name": "line_color"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -218,7 +218,7 @@
                                                 },
                                                 {
                                                     "key": "ratio",
-                                                    "label": "Letter box ratio",
+                                                    "label": "Ratio",
                                                     "type": "number",
                                                     "decimal": 4,
                                                     "default": 0,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -203,6 +203,54 @@
                                             "default": 0,
                                             "minimum": 0,
                                             "maximum": 100000
+                                        },
+                                        {
+                                            "key": "letter_box",
+                                            "label": "Letter box",
+                                            "type": "dict",
+                                            "checkbox_key": "enabled",
+                                            "children": [
+                                                {
+                                                    "type": "boolean",
+                                                    "key": "enabled",
+                                                    "label": "Enabled",
+                                                    "default": false
+                                                },
+                                                {
+                                                    "key": "ratio",
+                                                    "label": "Letter box ratio",
+                                                    "type": "number",
+                                                    "decimal": 4,
+                                                    "default": 0,
+                                                    "minimum": 0,
+                                                    "maximum": 10000
+                                                },
+                                                {
+                                                    "key": "state",
+                                                    "label": "Type",
+                                                    "type": "enum",
+                                                    "enum_items": [
+                                                        {
+                                                            "letterbox": "Letterbox"
+                                                        },
+                                                        {
+                                                            "pillar": "Pillar"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "key": "thickness",
+                                                    "label": "Thickness",
+                                                    "type": "text",
+                                                    "default": "fill"
+                                                },
+                                                {
+                                                    "key": "color",
+                                                    "label": "Color",
+                                                    "type": "text",
+                                                    "default": "#000000"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_rgba_color.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_rgba_color.json
@@ -1,0 +1,33 @@
+[
+    {
+        "type": "list-strict",
+        "key": "{name}",
+        "label": "{label}",
+        "object_types": [
+            {
+                "label": "R",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 255
+            },
+            {
+                "label": "G",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 255
+            },
+            {
+                "label": "B",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 255
+            },
+            {
+                "label": "A",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 255
+            }
+        ]
+    }
+]


### PR DESCRIPTION
- backward compatible with single float for config.
- support for pillar boxes.
- expose thickness of boxes to config.
- expose color of boxes to config.

Config of `letterbox` on the presets can be changed to a dictionary;
```
{
    "state": "pillar",
    "ratio": 1.777777,
    "thickness": 3,
    "color": "black"
}
```

## Pype 3 modifications
- added settings of letterbox (letterbox was not in settings at all)
- letterbox has enabled key as in settings is not possible to "not set" it

||Pype 2 PRs|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1371|