### PR TITLE
PS - group all published instances

### DIFF
--- a/pype/plugins/photoshop/publish/collect_instances.py
+++ b/pype/plugins/photoshop/publish/collect_instances.py
@@ -1,5 +1,6 @@
 import pyblish.api
 
+import avalon.api
 from avalon import photoshop
 
 
@@ -19,6 +20,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
     families_mapping = {
         "image": []
     }
+    # True will add all instances to same group in Loader
+    group_by_task_name = False
 
     def process(self, context):
         stub = photoshop.stub()
@@ -49,6 +52,12 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 layer_data["family"]
             ]
             instance.data["publish"] = layer.visible
+
+            if self.group_by_task_name:
+                task = avalon.api.Session["AVALON_TASK"]
+                sanitized_task_name = task[0].upper() + task[1:]
+                instance.data["subsetGroup"] = sanitized_task_name
+
             instance_names.append(layer_data["subset"])
 
             # Produce diagnostic message for any graphical

--- a/pype/plugins/photoshop/publish/collect_instances.py
+++ b/pype/plugins/photoshop/publish/collect_instances.py
@@ -54,9 +54,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
             instance.data["publish"] = layer.visible
 
             if self.group_by_task_name:
-                task = avalon.api.Session["AVALON_TASK"]
-                sanitized_task_name = task[0].upper() + task[1:]
-                instance.data["subsetGroup"] = sanitized_task_name
+                task_name = avalon.api.Session["AVALON_TASK"]
+                instance.data["subsetGroup"] = task_name
 
             instance_names.append(layer_data["subset"])
 


### PR DESCRIPTION
Grouped instances will show up together in Loader.

Configurable by `pype-config/presets/plugins/photoshop/publish.json`:
```
{
    "CollectInstances": {
        "group_by_task_name": true
    }
}
```

Closes: https://github.com/pypeclub/client/issues/56