### PR TITLE
TVPaint frame range definition

### DIFF
--- a/pype/hosts/tvpaint/lib.py
+++ b/pype/hosts/tvpaint/lib.py
@@ -48,24 +48,19 @@ def set_context_settings(asset):
     frame_start = asset["data"].get("frameStart")
     frame_end = asset["data"].get("frameEnd")
 
-    if frame_start and frame_end:
-        handles = asset["data"].get("handles") or 0
-        handle_start = asset["data"].get("handleStart")
-        if handle_start is None:
-            handle_start = handles
-
-        handle_end = asset["data"].get("handleEnd")
-        if handle_end is None:
-            handle_end = handles
-
-        frame_start -= int(handle_start)
-        frame_end += int(handle_end)
-
-        avalon.tvpaint.lib.execute_george(
-            "tv_markin {} set".format(frame_start - 1)
-        )
-        avalon.tvpaint.lib.execute_george(
-            "tv_markout {} set".format(frame_end - 1)
-        )
-    else:
+    if frame_start is None or frame_end is None:
         print("Frame range was not found!")
+        return
+
+    handles = asset["data"].get("handles") or 0
+    handle_start = asset["data"].get("handleStart")
+    handle_end = asset["data"].get("handleEnd")
+    if handle_start is None or handle_end is None:
+        handle_start = handle_end = handles
+
+    # Always start from 0 Mark In and set only Mark Out
+    mark_in = 0
+    mark_out = mark_in + (frame_end - frame_start) + handle_start + handle_end
+
+    avalon.tvpaint.lib.execute_george("tv_markin {} set".format(mark_in))
+    avalon.tvpaint.lib.execute_george("tv_markout {} set".format(mark_out))

--- a/pype/plugins/tvpaint/publish/collect_instance_frames.py
+++ b/pype/plugins/tvpaint/publish/collect_instance_frames.py
@@ -2,6 +2,12 @@ import pyblish.api
 
 
 class CollectOutputFrameRange(pyblish.api.ContextPlugin):
+    """Collect frame start/end from context.
+
+    When instances are collected context does not contain `frameStart` and
+    `frameEnd` keys yet. They are collected in global plugin
+    `CollectAvalonEntities`.
+    """
     label = "Collect output frame range"
     order = pyblish.api.CollectorOrder
     hosts = ["tvpaint"]

--- a/pype/plugins/tvpaint/publish/collect_instance_frames.py
+++ b/pype/plugins/tvpaint/publish/collect_instance_frames.py
@@ -1,0 +1,31 @@
+import pyblish.api
+
+
+class CollectOutputFrameRange(pyblish.api.ContextPlugin):
+    label = "Collect output frame range"
+    order = pyblish.api.CollectorOrder
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        for instance in context:
+            frame_start = instance.data.get("frameStart")
+            frame_end = instance.data.get("frameEnd")
+            if frame_start is not None and frame_end is not None:
+                self.log.debug(
+                    "Instance {} already has set frames {}-{}".format(
+                        str(instance), frame_start, frame_end
+                    )
+                )
+                return
+
+            frame_start = context.data.get("frameStart")
+            frame_end = context.data.get("frameEnd")
+
+            instance.data["frameStart"] = frame_start
+            instance.data["frameEnd"] = frame_end
+
+            self.log.info(
+                "Set frames {}-{} on instance {} ".format(
+                    frame_start, frame_end, str(instance)
+                )
+            )

--- a/pype/plugins/tvpaint/publish/collect_instances.py
+++ b/pype/plugins/tvpaint/publish/collect_instances.py
@@ -86,10 +86,6 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             instance.data["publish"] = any_visible
 
-            # Output frame range X not rendered output from TVPaint
-            instance.data["frameStart"] = context.data["frameStart"]
-            instance.data["frameEnd"] = context.data["frameEnd"]
-
             self.log.debug("Created instance: {}\n{}".format(
                 instance, json.dumps(instance.data, indent=4)
             ))

--- a/pype/plugins/tvpaint/publish/collect_instances.py
+++ b/pype/plugins/tvpaint/publish/collect_instances.py
@@ -86,8 +86,9 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             instance.data["publish"] = any_visible
 
-            instance.data["frameStart"] = context.data["sceneMarkIn"] + 1
-            instance.data["frameEnd"] = context.data["sceneMarkOut"] + 1
+            # Output frame range X not rendered output from TVPaint
+            instance.data["frameStart"] = context.data["sceneFrameStart"]
+            instance.data["frameEnd"] = context.data["sceneFrameEnd"]
 
             self.log.debug("Created instance: {}\n{}".format(
                 instance, json.dumps(instance.data, indent=4)

--- a/pype/plugins/tvpaint/publish/collect_instances.py
+++ b/pype/plugins/tvpaint/publish/collect_instances.py
@@ -87,8 +87,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
             instance.data["publish"] = any_visible
 
             # Output frame range X not rendered output from TVPaint
-            instance.data["frameStart"] = context.data["sceneFrameStart"]
-            instance.data["frameEnd"] = context.data["sceneFrameEnd"]
+            instance.data["frameStart"] = context.data["frameStart"]
+            instance.data["frameEnd"] = context.data["frameEnd"]
 
             self.log.debug("Created instance: {}\n{}".format(
                 instance, json.dumps(instance.data, indent=4)

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -77,6 +77,11 @@ class ExtractSequence(pyblish.api.Extractor):
                 filtered_layers
             )
 
+        # Sequence of one frame
+        if not repre_files:
+            self.log.warning("Extractor did not create any output.")
+            return
+
         # Fill tags and new families
         tags = []
         if family_lowered in ("review", "renderlayer"):

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -45,13 +45,10 @@ class ExtractSequence(pyblish.api.Extractor):
         )
 
         family_lowered = instance.data["family"].lower()
-        frame_start = instance.data["frameStart"]
-        frame_end = instance.data["frameEnd"]
-
         mark_in = instance.context.data["sceneMarkIn"]
         mark_out = instance.data["sceneMarkOut"]
 
-        filename_template = self._get_filename_template(frame_end)
+        filename_template = self._get_filename_template(mark_out)
         ext = os.path.splitext(filename_template)[1].replace(".", "")
 
         self.log.debug("Using file template \"{}\"".format(filename_template))
@@ -70,14 +67,12 @@ class ExtractSequence(pyblish.api.Extractor):
         if instance.data["family"] == "review":
             repre_files, thumbnail_fullpath = self.render_review(
                 filename_template, output_dir,
-                frame_start, frame_end,
                 mark_in, mark_out
             )
         else:
             # Render output
             repre_files, thumbnail_fullpath = self.render(
                 filename_template, output_dir,
-                frame_start, frame_end,
                 mark_in, mark_out,
                 filtered_layers
             )
@@ -141,8 +136,7 @@ class ExtractSequence(pyblish.api.Extractor):
         return "{{frame:0>{}}}".format(frame_padding) + ".png"
 
     def render_review(
-        self, filename_template, output_dir,
-        frame_start, frame_end, mark_in, mark_out
+        self, filename_template, output_dir, mark_in, mark_out
     ):
         """ Export images from TVPaint using `tv_savesequence` command.
 
@@ -162,7 +156,7 @@ class ExtractSequence(pyblish.api.Extractor):
         self.log.debug("Preparing data for rendering.")
         first_frame_filepath = os.path.join(
             output_dir,
-            filename_template.format(frame=frame_start)
+            filename_template.format(frame=mark_in)
         )
 
         george_script_lines = [
@@ -178,7 +172,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         output = []
         first_frame_filepath = None
-        for frame in range(frame_start, frame_end + 1):
+        for frame in range(mark_in, mark_out + 1):
             filename = filename_template.format(frame=frame)
             output.append(filename)
             if first_frame_filepath is None:
@@ -194,7 +188,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
     def render(
         self, filename_template, output_dir,
-        frame_start, frame_end, mark_in, mark_out, layers
+        mark_in, mark_out, layers
     ):
         """ Export images from TVPaint.
 

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -71,22 +71,19 @@ class ExtractSequence(pyblish.api.Extractor):
         )
 
         if instance.data["family"] == "review":
-            repre_files, thumbnail_fullpath = self.render_review(
-                filename_template, output_dir,
-                mark_in, mark_out,
-                frame_start, frame_end
+            output_filenames, thumbnail_fullpath = self.render_review(
+                filename_template, output_dir, mark_in, mark_out
             )
         else:
             # Render output
-            repre_files, thumbnail_fullpath = self.render(
+            output_filenames, thumbnail_fullpath = self.render(
                 filename_template, output_dir,
                 mark_in, mark_out,
-                frame_start, frame_end,
                 filtered_layers
             )
 
         # Sequence of one frame
-        if not repre_files:
+        if not output_filenames:
             self.log.warning("Extractor did not create any output.")
             return
 
@@ -152,10 +149,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         return "{{frame:0>{}}}".format(frame_padding) + ".png"
 
-    def render_review(
-        self, filename_template, output_dir, mark_in, mark_out,
-        frame_start, frame_end
-    ):
+    def render_review(self, filename_template, output_dir, mark_in, mark_out):
         """ Export images from TVPaint using `tv_savesequence` command.
 
         Args:
@@ -164,8 +158,8 @@ class ExtractSequence(pyblish.api.Extractor):
                 keyword argument `{frame}` or index argument (for same value).
                 Extension in template must match `save_mode`.
             output_dir (str): Directory where files will be stored.
-            first_frame (int): Starting frame from which export will begin.
-            last_frame (int): On which frame export will end.
+            mark_in (int): Starting frame index from which export will begin.
+            mark_out (int): On which frame index export will end.
 
         Retruns:
             tuple: With 2 items first is list of filenames second is path to
@@ -188,28 +182,22 @@ class ExtractSequence(pyblish.api.Extractor):
         ]
         lib.execute_george_through_file("\n".join(george_script_lines))
 
-        reversed_repre_filepaths = []
-        marks_range = range(mark_out, mark_in - 1, -1)
-        frames_range = range(frame_end, frame_start - 1, -1)
-        for mark, frame in zip(marks_range, frames_range):
-            new_filename = filename_template.format(frame=frame)
-            new_filepath = os.path.join(output_dir, new_filename)
-            reversed_repre_filepaths.append(new_filepath)
-
-            if mark != frame:
-                old_filename = filename_template.format(frame=mark)
-                old_filepath = os.path.join(output_dir, old_filename)
-                os.rename(old_filepath, new_filepath)
-
-        repre_filepaths = list(reversed(reversed_repre_filepaths))
-        repre_files = [
-            os.path.basename(path)
-            for path in repre_filepaths
-        ]
-
         first_frame_filepath = None
-        if repre_filepaths:
-            first_frame_filepath = repre_filepaths[0]
+        output_filenames = []
+        for frame in range(mark_in, mark_out + 1):
+            filename = filename_template.format(frame=frame)
+            output_filenames.append(filename)
+
+            filepath = os.path.join(output_dir, filename)
+            if not os.path.exists(filepath):
+                raise AssertionError(
+                    "Output was not rendered. File was not found {}".format(
+                        filepath
+                    )
+                )
+
+            if first_frame_filepath is None:
+                first_frame_filepath = filepath
 
         thumbnail_filepath = os.path.join(output_dir, "thumbnail.jpg")
         if first_frame_filepath and os.path.exists(first_frame_filepath):
@@ -217,12 +205,10 @@ class ExtractSequence(pyblish.api.Extractor):
             thumbnail_obj = Image.new("RGB", source_img.size, (255, 255, 255))
             thumbnail_obj.paste(source_img)
             thumbnail_obj.save(thumbnail_filepath)
-        return repre_files, thumbnail_filepath
 
-    def render(
-        self, filename_template, output_dir, mark_in, mark_out,
-        frame_start, frame_end, layers
-    ):
+        return output_filenames, thumbnail_filepath
+
+    def render(self, filename_template, output_dir, mark_in, mark_out, layers):
         """ Export images from TVPaint.
 
         Args:
@@ -231,8 +217,8 @@ class ExtractSequence(pyblish.api.Extractor):
                 keyword argument `{frame}` or index argument (for same value).
                 Extension in template must match `save_mode`.
             output_dir (str): Directory where files will be stored.
-            first_frame (int): Starting frame from which export will begin.
-            last_frame (int): On which frame export will end.
+            mark_in (int): Starting frame index from which export will begin.
+            mark_out (int): On which frame index export will end.
             layers (list): List of layers to be exported.
 
         Retruns:
@@ -292,7 +278,7 @@ class ExtractSequence(pyblish.api.Extractor):
             )
             return [], None
 
-        output_filepaths_by_frame = self._composite_files(
+        output_filepaths = self._composite_files(
             files_by_position,
             mark_in,
             mark_out,
@@ -301,27 +287,14 @@ class ExtractSequence(pyblish.api.Extractor):
         )
         self._cleanup_tmp_files(files_by_position)
 
-        reversed_repre_filepaths = []
-        marks_range = range(mark_out, mark_in - 1, -1)
-        frames_range = range(frame_end, frame_start - 1, -1)
-        for mark, frame in zip(marks_range, frames_range):
-            new_filename = filename_template.format(frame=frame)
-            new_filepath = os.path.join(output_dir, new_filename)
-            reversed_repre_filepaths.append(new_filepath)
-
-            if mark != frame:
-                old_filepath = output_filepaths_by_frame[mark]
-                os.rename(old_filepath, new_filepath)
-
-        repre_filepaths = list(reversed(reversed_repre_filepaths))
-        repre_files = [
-            os.path.basename(path)
-            for path in repre_filepaths
+        output_filenames = [
+            os.path.basename(filepath)
+            for filepath in output_filepaths
         ]
 
         thumbnail_src_filepath = None
-        if repre_filepaths:
-            thumbnail_src_filepath = repre_filepaths[0]
+        if output_filepaths:
+            thumbnail_src_filepath = output_filepaths[0]
 
         thumbnail_filepath = None
         if thumbnail_src_filepath and os.path.exists(thumbnail_src_filepath):
@@ -331,7 +304,7 @@ class ExtractSequence(pyblish.api.Extractor):
             thumbnail_obj.paste(source_img)
             thumbnail_obj.save(thumbnail_filepath)
 
-        return repre_files, thumbnail_filepath
+        return output_filenames, thumbnail_filepath
 
     def _render_layer(
         self,
@@ -611,14 +584,14 @@ class ExtractSequence(pyblish.api.Extractor):
             process_count -= 1
 
         processes = {}
-        output_filepaths_by_frame = {}
+        output_filepaths = []
         missing_frame_paths = []
         random_frame_path = None
         for frame_idx in sorted(images_by_frame.keys()):
             image_filepaths = images_by_frame[frame_idx]
             output_filename = filename_template.format(frame=frame_idx + 1)
             output_filepath = os.path.join(output_dir, output_filename)
-            output_filepaths_by_frame[frame_idx] = output_filepath
+            output_filepaths.append(output_filepath)
 
             # Store information about missing frame and skip
             if not image_filepaths:
@@ -684,7 +657,7 @@ class ExtractSequence(pyblish.api.Extractor):
                 transparent_filepath = filepath
             else:
                 self._copy_image(transparent_filepath, filepath)
-        return output_filepaths_by_frame
+        return output_filepaths
 
     def _cleanup_tmp_files(self, files_by_position):
         """Remove temporary files that were used for compositing."""

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -51,7 +51,10 @@ class ExtractSequence(pyblish.api.Extractor):
         frame_start = int(instance.data["frameStart"])
         frame_end = int(instance.data["frameEnd"])
 
-        filename_template = self._get_filename_template(mark_out)
+        filename_template = self._get_filename_template(
+            # Use the biggest number
+            max(mark_out, frame_end)
+        )
         ext = os.path.splitext(filename_template)[1].replace(".", "")
 
         self.log.debug("Using file template \"{}\"".format(filename_template))

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -51,6 +51,54 @@ class ExtractSequence(pyblish.api.Extractor):
         frame_start = int(instance.data["frameStart"])
         frame_end = int(instance.data["frameEnd"])
 
+        # Handles are not stored per instance but on Context
+        handle_start = instance.context.data["handleStart"]
+        handle_end = instance.context.data["handleEnd"]
+
+        # --- Fallbacks ----------------------------------------------------
+        # This is required if validations of ranges are ignored.
+        # - all of this code won't change processing if range to render
+        #   match to range of expected output
+
+        # Prepare output frames
+        output_frame_start = frame_start - handle_start
+        output_frame_end = frame_end + handle_end
+
+        # Change output frame start to 0 if handles cause it's negative number
+        if output_frame_start < 0:
+            self.log.warning((
+                "Frame start with handles has negative value."
+                " Changed to \"0\". Frames start: {}, Handle Start: {}"
+            ).format(frame_start, handle_start))
+            output_frame_start = 0
+
+        # Check Marks range and output range
+        output_range = output_frame_end - output_frame_start
+        marks_range = mark_out - mark_in
+
+        # Lower Mark Out if mark range is bigger than output
+        # - do not rendered not used frames
+        if output_range < marks_range:
+            new_mark_out = mark_out - (marks_range - output_range)
+            self.log.warning((
+                "Lowering render range to {} frames. Changed Mark Out {} -> {}"
+            ).format(marks_range + 1, mark_out, new_mark_out))
+            # Assign new mark out to variable
+            mark_out = new_mark_out
+
+        # Lower output frame end so representation has right `frameEnd` value
+        elif output_range > marks_range:
+            new_output_frame_end = (
+                output_frame_end - (output_range - marks_range)
+            )
+            self.log.warning((
+                "Lowering representation range to {} frames."
+                " Changed frame end {} -> {}"
+            ).format(output_range + 1, mark_out, new_mark_out))
+            output_frame_end = new_output_frame_end
+
+        # -------------------------------------------------------------------
+
         filename_template = self._get_filename_template(
             # Use the biggest number
             max(mark_out, frame_end)

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -251,7 +251,24 @@ class ExtractSequence(pyblish.api.Extractor):
                 mark_in,
                 mark_out
             )
-            files_by_position[position] = files_by_frames
+            if files_by_frames:
+                files_by_position[position] = files_by_frames
+            else:
+                self.log.warning((
+                    "Skipped layer \"{}\". Probably out of Mark In/Out range."
+                ).format(layer["name"]))
+
+        if not files_by_position:
+            layer_names = set(layer["name"] for layer in layers)
+            joined_names = ", ".join(
+                ["\"{}\"".format(name) for name in layer_names]
+            )
+            self.log.warning(
+                "Layers {} do not have content in range {} - {}".format(
+                    joined_names, mark_in, mark_out
+                )
+            )
+            return [], None
 
         output_filepaths = self._composite_files(
             files_by_position,

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -83,7 +83,8 @@ class ExtractSequence(pyblish.api.Extractor):
             tags.append("review")
 
         # Sequence of one frame
-        if len(repre_files) == 1:
+        single_file = len(repre_files) == 1
+        if single_file:
             repre_files = repre_files[0]
 
         new_repre = {
@@ -91,10 +92,15 @@ class ExtractSequence(pyblish.api.Extractor):
             "ext": ext,
             "files": repre_files,
             "stagingDir": output_dir,
-            "frameStart": frame_start,
-            "frameEnd": frame_end,
             "tags": tags
         }
+
+        if not single_file:
+            frame_start = instance.data["frameStart"]
+            frame_end = instance.data["frameEnd"]
+            new_repre["frameStart"] = frame_start
+            new_repre["frameEnd"] = frame_end
+
         self.log.debug("Creating new representation: {}".format(new_repre))
 
         instance.data["representations"].append(new_repre)

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -135,6 +135,12 @@ class ExtractSequence(pyblish.api.Extractor):
             self.log.warning("Extractor did not create any output.")
             return
 
+        repre_files = self._rename_output_files(
+            filename_template, output_dir,
+            mark_in, mark_out,
+            output_frame_start, output_frame_end
+        )
+
         # Fill tags and new families
         tags = []
         if family_lowered in ("review", "renderlayer"):
@@ -154,8 +160,8 @@ class ExtractSequence(pyblish.api.Extractor):
         }
 
         if not single_file:
-            new_repre["frameStart"] = frame_start
-            new_repre["frameEnd"] = frame_end
+            new_repre["frameStart"] = output_frame_start
+            new_repre["frameEnd"] = output_frame_end
 
         self.log.debug("Creating new representation: {}".format(new_repre))
 
@@ -196,6 +202,44 @@ class ExtractSequence(pyblish.api.Extractor):
             frame_padding = frame_end_str_len
 
         return "{{frame:0>{}}}".format(frame_padding) + ".png"
+
+    def _rename_output_files(
+        self, filename_template, output_dir,
+        mark_in, mark_out, output_frame_start, output_frame_end
+    ):
+        # Use differnet ranges based on Mark In and output Frame Start values
+        # - this is to make sure that filename renaming won't affect files that
+        #   are not renamed yet
+        mark_start_is_less = bool(mark_in < output_frame_start)
+        if mark_start_is_less:
+            marks_range = range(mark_out, mark_in - 1, -1)
+            frames_range = range(output_frame_end, output_frame_start - 1, -1)
+        else:
+            # This is less possible situation as frame start will be in most
+            #   cases higher than Mark In.
+            marks_range = range(mark_in, mark_out + 1)
+            frames_range = range(output_frame_start, output_frame_end + 1)
+
+        repre_filepaths = []
+        for mark, frame in zip(marks_range, frames_range):
+            new_filename = filename_template.format(frame=frame)
+            new_filepath = os.path.join(output_dir, new_filename)
+
+            repre_filepaths.append(new_filepath)
+
+            if mark != frame:
+                old_filename = filename_template.format(frame=frame)
+                old_filepath = os.path.join(output_dir, old_filename)
+                os.rename(old_filepath, new_filepath)
+
+        # Reverse repre files order if output
+        if mark_start_is_less:
+            repre_filepaths = list(reversed(repre_filepaths))
+
+        return [
+            os.path.basename(path)
+            for path in repre_filepaths
+        ]
 
     def render_review(self, filename_template, output_dir, mark_in, mark_out):
         """ Export images from TVPaint using `tv_savesequence` command.

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -228,7 +228,7 @@ class ExtractSequence(pyblish.api.Extractor):
             repre_filepaths.append(new_filepath)
 
             if mark != frame:
-                old_filename = filename_template.format(frame=frame)
+                old_filename = filename_template.format(frame=mark)
                 old_filepath = os.path.join(output_dir, old_filename)
                 os.rename(old_filepath, new_filepath)
 
@@ -681,7 +681,7 @@ class ExtractSequence(pyblish.api.Extractor):
         random_frame_path = None
         for frame_idx in sorted(images_by_frame.keys()):
             image_filepaths = images_by_frame[frame_idx]
-            output_filename = filename_template.format(frame=frame_idx + 1)
+            output_filename = filename_template.format(frame=frame_idx)
             output_filepath = os.path.join(output_dir, output_filename)
             output_filepaths.append(output_filepath)
 

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -231,7 +231,7 @@ class ExtractSequence(pyblish.api.Extractor):
         # Sort layer positions in reverse order
         sorted_positions = list(reversed(sorted(layers_by_position.keys())))
         if not sorted_positions:
-            return
+            return [], None
 
         self.log.debug("Collecting pre/post behavior of individual layers.")
         behavior_by_layer_id = lib.get_layers_pre_post_behavior(layer_ids)

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -309,6 +309,22 @@ class ExtractSequence(pyblish.api.Extractor):
         layer_id = layer["layer_id"]
         frame_start_index = layer["frame_start"]
         frame_end_index = layer["frame_end"]
+
+        pre_behavior = behavior["pre"]
+        post_behavior = behavior["post"]
+
+        # Check if layer is before mark in
+        if frame_end_index < mark_in_index:
+            # Skip layer if post behavior is "none"
+            if post_behavior == "none":
+                return {}
+
+        # Check if layer is after mark out
+        elif frame_start_index > mark_out_index:
+            # Skip layer if pre behavior is "none"
+            if pre_behavior == "none":
+                return {}
+
         exposure_frames = lib.get_exposure_frames(
             layer_id, frame_start_index, frame_end_index
         )
@@ -367,8 +383,6 @@ class ExtractSequence(pyblish.api.Extractor):
         self.log.debug("Filled frames {}".format(str(_debug_filled_frames)))
 
         # Fill frames by pre/post behavior of layer
-        pre_behavior = behavior["pre"]
-        post_behavior = behavior["post"]
         self.log.debug((
             "Completing image sequence of layer by pre/post behavior."
             " PRE: {} | POST: {}"

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -66,8 +66,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         if instance.data["family"] == "review":
             repre_files, thumbnail_fullpath = self.render_review(
-                filename_template, output_dir,
-                mark_in, mark_out
+                filename_template, output_dir, mark_in, mark_out
             )
         else:
             # Render output
@@ -198,8 +197,7 @@ class ExtractSequence(pyblish.api.Extractor):
         return output, thumbnail_filepath
 
     def render(
-        self, filename_template, output_dir,
-        mark_in, mark_out, layers
+        self, filename_template, output_dir, mark_in, mark_out, layers
     ):
         """ Export images from TVPaint.
 

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -164,8 +164,6 @@ class ExtractSequence(pyblish.api.Extractor):
             output_dir,
             filename_template.format(frame=frame_start)
         )
-        mark_in = frame_start - 1
-        mark_out = frame_end - 1
 
         george_script_lines = [
             "tv_SaveMode \"PNG\"",
@@ -233,9 +231,6 @@ class ExtractSequence(pyblish.api.Extractor):
         self.log.debug("Collecting pre/post behavior of individual layers.")
         behavior_by_layer_id = lib.get_layers_pre_post_behavior(layer_ids)
 
-        mark_in_index = frame_start - 1
-        mark_out_index = frame_end - 1
-
         tmp_filename_template = "pos_{pos}." + filename_template
 
         files_by_position = {}
@@ -248,15 +243,15 @@ class ExtractSequence(pyblish.api.Extractor):
                 tmp_filename_template,
                 output_dir,
                 behavior,
-                mark_in_index,
-                mark_out_index
+                mark_in,
+                mark_out
             )
             files_by_position[position] = files_by_frames
 
         output_filepaths = self._composite_files(
             files_by_position,
-            mark_in_index,
-            mark_out_index,
+            mark_in,
+            mark_out,
             filename_template,
             output_dir
         )

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -111,7 +111,9 @@ class ExtractSequence(pyblish.api.Extractor):
         output_dir = instance.data.get("stagingDir")
         if not output_dir:
             # Create temp folder if staging dir is not set
-            output_dir = tempfile.mkdtemp().replace("\\", "/")
+            output_dir = (
+                tempfile.mkdtemp(prefix="tvpaint_render_")
+            ).replace("\\", "/")
             instance.data["stagingDir"] = output_dir
 
         self.log.debug(

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -48,6 +48,9 @@ class ExtractSequence(pyblish.api.Extractor):
         frame_start = instance.data["frameStart"]
         frame_end = instance.data["frameEnd"]
 
+        mark_in = instance.context.data["sceneMarkIn"]
+        mark_out = instance.data["sceneMarkOut"]
+
         filename_template = self._get_filename_template(frame_end)
         ext = os.path.splitext(filename_template)[1].replace(".", "")
 
@@ -66,12 +69,16 @@ class ExtractSequence(pyblish.api.Extractor):
 
         if instance.data["family"] == "review":
             repre_files, thumbnail_fullpath = self.render_review(
-                filename_template, output_dir, frame_start, frame_end
+                filename_template, output_dir,
+                frame_start, frame_end,
+                mark_in, mark_out
             )
         else:
             # Render output
             repre_files, thumbnail_fullpath = self.render(
-                filename_template, output_dir, frame_start, frame_end,
+                filename_template, output_dir,
+                frame_start, frame_end,
+                mark_in, mark_out,
                 filtered_layers
             )
 
@@ -134,7 +141,8 @@ class ExtractSequence(pyblish.api.Extractor):
         return "{{frame:0>{}}}".format(frame_padding) + ".png"
 
     def render_review(
-        self, filename_template, output_dir, frame_start, frame_end
+        self, filename_template, output_dir,
+        frame_start, frame_end, mark_in, mark_out
     ):
         """ Export images from TVPaint using `tv_savesequence` command.
 
@@ -187,7 +195,8 @@ class ExtractSequence(pyblish.api.Extractor):
         return output, thumbnail_filepath
 
     def render(
-        self, filename_template, output_dir, frame_start, frame_end, layers
+        self, filename_template, output_dir,
+        frame_start, frame_end, mark_in, mark_out, layers
     ):
         """ Export images from TVPaint.
 

--- a/pype/plugins/tvpaint/publish/validate_marks.py
+++ b/pype/plugins/tvpaint/publish/validate_marks.py
@@ -23,7 +23,11 @@ class ValidateMarksRepair(pyblish.api.Action):
 
 
 class ValidateMarks(pyblish.api.ContextPlugin):
-    """Validate mark in and out are enabled."""
+    """Validate mark in and out are enabled and it's duration.
+
+    Mark In/Out does not have to match frameStart and frameEnd but duration is
+    important.
+    """
 
     label = "Validate Mark In/Out"
     order = pyblish.api.ValidatorOrder

--- a/pype/plugins/tvpaint/publish/validate_marks.py
+++ b/pype/plugins/tvpaint/publish/validate_marks.py
@@ -14,10 +14,9 @@ class ValidateMarksRepair(pyblish.api.Action):
     def process(self, context, plugin):
         expected_data = ValidateMarks.get_expected_data(context)
 
-        expected_data["markIn"] -= 1
-        expected_data["markOut"] -= 1
-
-        lib.execute_george("tv_markin {} set".format(expected_data["markIn"]))
+        lib.execute_george(
+            "tv_markin {} set".format(expected_data["markIn"])
+        )
         lib.execute_george(
             "tv_markout {} set".format(expected_data["markOut"])
         )
@@ -33,18 +32,32 @@ class ValidateMarks(pyblish.api.ContextPlugin):
 
     @staticmethod
     def get_expected_data(context):
+        scene_mark_in = context.data["sceneMarkIn"]
+
+        # Data collected in `CollectAvalonEntities`
+        frame_end = context.data["frameEnd"]
+        frame_start = context.data["frameStart"]
+        handle_start = context.data["handleStart"]
+        handle_end = context.data["handleEnd"]
+
+        # Calculate expeted Mark out (Mark In + duration - 1)
+        expected_mark_out = (
+            scene_mark_in
+            + (frame_end - frame_start)
+            + handle_start + handle_end
+        )
         return {
-            "markIn": int(context.data["frameStart"]),
+            "markIn": scene_mark_in,
             "markInState": True,
-            "markOut": int(context.data["frameEnd"]),
+            "markOut": expected_mark_out,
             "markOutState": True
         }
 
     def process(self, context):
         current_data = {
-            "markIn": context.data["sceneMarkIn"] + 1,
+            "markIn": context.data["sceneMarkIn"],
             "markInState": context.data["sceneMarkInState"],
-            "markOut": context.data["sceneMarkOut"] + 1,
+            "markOut": context.data["sceneMarkOut"],
             "markOutState": context.data["sceneMarkOutState"]
         }
         expected_data = self.get_expected_data(context)

--- a/pype/plugins/tvpaint/publish/validate_marks.py
+++ b/pype/plugins/tvpaint/publish/validate_marks.py
@@ -25,7 +25,7 @@ class ValidateMarksRepair(pyblish.api.Action):
 class ValidateMarks(pyblish.api.ContextPlugin):
     """Validate mark in and out are enabled."""
 
-    label = "Validate Marks"
+    label = "Validate Mark In/Out"
     order = pyblish.api.ValidatorOrder
     optional = True
     actions = [ValidateMarksRepair]


### PR DESCRIPTION
## Changes
- TVPaint implementation does not care about Mark In/Out values but only range
    - Frame index of Mark In is not modified so artist can set it to different frame than `1` but duration of Mark In/Out must match to duration of asset (shot) `({frame end} - {frame start} + 1) + {handle start} + {handle end}`
- Layers that does not have any content in Mark range are skipped during extractor
- extractor extract range from Mark in/out but then rename file sequences to right names
    - e.g. if Mark In is `0` and frameStart is `1001` then output `"frame.0000.png"` is renamed to `"frame.1001.png"`
    - renaming is going backwards from Mark Out/Frame End to Mark In/Frame Start to avoid clashing of filenames

||OpenPype 2 PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1425|