### PR TITLE
TVPaint frame range definition

### DIFF
--- a/openpype/hosts/tvpaint/api/lib.py
+++ b/openpype/hosts/tvpaint/api/lib.py
@@ -77,8 +77,9 @@ def set_context_settings(asset_doc=None):
         handle_start = handles
         handle_end = handles
 
-    frame_start -= int(handle_start)
-    frame_end += int(handle_end)
+    # Always start from 0 Mark In and set only Mark Out
+    mark_in = 0
+    mark_out = mark_in + (frame_end - frame_start) + handle_start + handle_end
 
-    execute_george("tv_markin {} set".format(frame_start - 1))
-    execute_george("tv_markout {} set".format(frame_end - 1))
+    execute_george("tv_markin {} set".format(mark_in))
+    execute_george("tv_markout {} set".format(mark_out))

--- a/openpype/hosts/tvpaint/plugins/publish/collect_instance_frames.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instance_frames.py
@@ -1,0 +1,37 @@
+import pyblish.api
+
+
+class CollectOutputFrameRange(pyblish.api.ContextPlugin):
+    """Collect frame start/end from context.
+
+    When instances are collected context does not contain `frameStart` and
+    `frameEnd` keys yet. They are collected in global plugin
+    `CollectAvalonEntities`.
+    """
+    label = "Collect output frame range"
+    order = pyblish.api.CollectorOrder
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        for instance in context:
+            frame_start = instance.data.get("frameStart")
+            frame_end = instance.data.get("frameEnd")
+            if frame_start is not None and frame_end is not None:
+                self.log.debug(
+                    "Instance {} already has set frames {}-{}".format(
+                        str(instance), frame_start, frame_end
+                    )
+                )
+                return
+
+            frame_start = context.data.get("frameStart")
+            frame_end = context.data.get("frameEnd")
+
+            instance.data["frameStart"] = frame_start
+            instance.data["frameEnd"] = frame_end
+
+            self.log.info(
+                "Set frames {}-{} on instance {} ".format(
+                    frame_start, frame_end, str(instance)
+                )
+            )

--- a/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
@@ -86,9 +86,6 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             instance.data["publish"] = any_visible
 
-            instance.data["frameStart"] = context.data["sceneMarkIn"] + 1
-            instance.data["frameEnd"] = context.data["sceneMarkOut"] + 1
-
             self.log.debug("Created instance: {}\n{}".format(
                 instance, json.dumps(instance.data, indent=4)
             ))

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -109,7 +109,9 @@ class ExtractSequence(pyblish.api.Extractor):
         output_dir = instance.data.get("stagingDir")
         if not output_dir:
             # Create temp folder if staging dir is not set
-            output_dir = tempfile.mkdtemp().replace("\\", "/")
+            output_dir = (
+                tempfile.mkdtemp(prefix="tvpaint_render_")
+            ).replace("\\", "/")
             instance.data["stagingDir"] = output_dir
 
         self.log.debug(

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 import tempfile
 
 import pyblish.api


### PR DESCRIPTION
## Changes
- TVPaint implementation does not care about Mark In/Out values but only range
    - Frame index of Mark In is not modified so artist can set it to different frame than `1` but duration of Mark In/Out must match to duration of asset (shot) `({frame end} - {frame start} + 1) + {handle start} + {handle end}`
- Layers that does not have any content in Mark range are skipped during extractor
- extractor extract range from Mark in/out but then rename file sequences to right names
    - e.g. if Mark In is `0` and frameStart is `1001` then output `"frame.0000.png"` is renamed to `"frame.1001.png"`
    - renaming is going backwards from Mark Out/Frame End to Mark In/Frame Start to avoid clashing of filenames

||Pype 2 PRs|
|---|---|
|pype|https://github.com/pypeclub/OpenPype/pull/1424|

EDITED 29.4.2022:
## New changes
- as validation of mark in/out is optional extractor can handle that
     - if mark in/out range match output range it should have no affect
- renaming of filenames happens in one method out of rendering methods