### PR TITLE
Faster settings actions

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -519,6 +519,9 @@ class DictMutableKeysEntity(EndpointEntity):
         self.had_project_override = value is not NOT_SET
 
     def _discard_changes(self, on_change_trigger):
+        if not self.can_discard_changes:
+            return
+
         self.set_override_state(self._override_state)
         on_change_trigger.append(self.on_change)
 
@@ -527,6 +530,9 @@ class DictMutableKeysEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_studio_default(self, on_change_trigger):
+        if not self.can_remove_from_studio_default:
+            return
+
         value = self._default_value
         if value is NOT_SET:
             value = self.value_on_not_set
@@ -555,10 +561,7 @@ class DictMutableKeysEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_project_override(self, on_change_trigger):
-        if self._override_state is not OverrideState.PROJECT:
-            return
-
-        if not self.has_project_override:
+        if not self.can_remove_from_project_override:
             return
 
         if self._has_studio_override:

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -251,6 +251,9 @@ class InputEntity(EndpointEntity):
         self._current_value = copy.deepcopy(value)
 
     def _discard_changes(self, on_change_trigger=None):
+        if not self.can_discard_changes:
+            return
+
         self._value_is_modified = False
         if self._override_state >= OverrideState.PROJECT:
             self._has_project_override = self.had_project_override
@@ -286,6 +289,9 @@ class InputEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_studio_default(self, on_change_trigger):
+        if not self.can_remove_from_studio_default:
+            return
+
         value = self._default_value
         if value is NOT_SET:
             value = self.value_on_not_set
@@ -301,10 +307,7 @@ class InputEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_project_override(self, on_change_trigger):
-        if self._override_state is not OverrideState.PROJECT:
-            return
-
-        if not self._has_project_override:
+        if not self.can_remove_from_project_override:
             return
 
         self._has_project_override = False

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -343,7 +343,7 @@ class ListEntity(EndpointEntity):
         return output
 
     def _discard_changes(self, on_change_trigger):
-        if self._override_state is OverrideState.NOT_DEFINED:
+        if not self.can_discard_changes:
             return
 
         not_set = object()
@@ -405,7 +405,7 @@ class ListEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_studio_default(self, on_change_trigger):
-        if self._override_state is not OverrideState.STUDIO:
+        if not self.can_remove_from_studio_default:
             return
 
         value = self._default_value
@@ -433,10 +433,7 @@ class ListEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_project_override(self, on_change_trigger):
-        if self._override_state is not OverrideState.PROJECT:
-            return
-
-        if not self.has_project_override:
+        if not self.can_remove_from_project_override:
             return
 
         if self._has_studio_override:


### PR DESCRIPTION
## Changes
- skip processing of settings actions if it does not make sence to execute it on item
    - e.g. item without changes will skip discard changes action
    - for this logic is used same approach like for logic of showing actions in UI (`can_discard_changes`, `can_remove_from_studio_default`, `can_remove_from_project_override`)
- this is based on right implementation of the validation methods so it would be great to test as much as possible
    - bigger hierarchy the better to test it