### PR TITLE
Global settings save/load out of system settings

### DIFF
--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -228,6 +228,14 @@ class MongoSettingsHandler(SettingsHandler):
         return self._attribute_keys
 
     def _extract_global_settings(self, data):
+        """Extract global settings data from system settings overrides.
+
+        This is now limited to "general" key in system settings which must be
+        set as group in schemas.
+
+        Returns:
+            dict: Global settings extracted from system settings data.
+        """
         output = {}
         if "general" not in data:
             return output


### PR DESCRIPTION
## Issue
Global settings are saved to both system and global settings document but are loaded only from system settings document which may cause issues if we'll add versioned settings.
- only place where global settings are used from right mongo document is in Igniter so igniter may use different values than are returned from `get_system_settings` function

## Changes
- global settings data are removed from system settings on save
- global settings are applied on system settings on load
    - system settings document is faked if is not available at all