### PR TITLE
Settings actions process fix

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -517,6 +517,54 @@ class BaseItemEntity(BaseEntity):
             return False
         return True
 
+    @property
+    def can_trigger_discard_changes(self):
+        """Defines if can trigger `discard_changes`.
+
+        Also can be used as validation before the method is called.
+        """
+        return self._can_discard_changes
+
+    @property
+    def can_trigger_add_to_studio_default(self):
+        """Defines if can trigger `add_to_studio_default`.
+
+        Also can be used as validation before the method is called.
+        """
+        if self.is_dynamic_item or self.is_in_dynamic_item:
+            return False
+        return self._can_add_to_studio_default
+
+    @property
+    def can_trigger_remove_from_studio_default(self):
+        """Defines if can trigger `remove_from_studio_default`.
+
+        Also can be used as validation before the method is called.
+        """
+        if self.is_dynamic_item or self.is_in_dynamic_item:
+            return False
+        return self._can_remove_from_studio_default
+
+    @property
+    def can_trigger_add_to_project_override(self):
+        """Defines if can trigger `add_to_project_override`.
+
+        Also can be used as validation before the method is called.
+        """
+        if self.is_dynamic_item or self.is_in_dynamic_item:
+            return False
+        return self._can_add_to_project_override
+
+    @property
+    def can_trigger_remove_from_project_override(self):
+        """Defines if can trigger `remove_from_project_override`.
+
+        Also can be used as validation before the method is called.
+        """
+        if self.is_dynamic_item or self.is_in_dynamic_item:
+            return False
+        return self._can_remove_from_project_override
+
     def discard_changes(self, on_change_trigger=None):
         """Discard changes on entity and it's children.
 
@@ -541,7 +589,7 @@ class BaseItemEntity(BaseEntity):
         """
         initialized = False
         if on_change_trigger is None:
-            if not self.can_discard_changes:
+            if not self.can_trigger_discard_changes:
                 return
 
             initialized = True
@@ -561,7 +609,7 @@ class BaseItemEntity(BaseEntity):
     def add_to_studio_default(self, on_change_trigger=None):
         initialized = False
         if on_change_trigger is None:
-            if not self.can_add_to_studio_default:
+            if not self.can_trigger_add_to_studio_default:
                 return
 
             initialized = True
@@ -598,7 +646,7 @@ class BaseItemEntity(BaseEntity):
         """
         initialized = False
         if on_change_trigger is None:
-            if not self.can_remove_from_studio_default:
+            if not self.can_trigger_remove_from_studio_default:
                 return
 
             initialized = True
@@ -622,7 +670,7 @@ class BaseItemEntity(BaseEntity):
     def add_to_project_override(self, on_change_trigger=None):
         initialized = False
         if on_change_trigger is None:
-            if not self.can_add_to_project_override:
+            if not self.can_trigger_add_to_project_override:
                 return
 
             initialized = True
@@ -662,7 +710,7 @@ class BaseItemEntity(BaseEntity):
 
         initialized = False
         if on_change_trigger is None:
-            if not self.can_remove_from_project_override:
+            if not self.can_trigger_remove_from_project_override:
                 return
             initialized = True
             on_change_trigger = []

--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -457,23 +457,14 @@ class BaseItemEntity(BaseEntity):
         pass
 
     @property
-    def can_discard_changes(self):
-        """Result defines if `discard_changes` will be processed.
-
-        Also can be used as validation before the method is called.
-        """
+    def _can_discard_changes(self):
+        """Defines if `discard_changes` will be processed."""
         return self.has_unsaved_changes
 
     @property
-    def can_add_to_studio_default(self):
-        """Result defines if `add_to_studio_default` will be processed.
-
-        Also can be used as validation before the method is called.
-        """
+    def _can_add_to_studio_default(self):
+        """Defines if `add_to_studio_default` will be processed."""
         if self._override_state is not OverrideState.STUDIO:
-            return False
-
-        if self.is_dynamic_item or self.is_in_dynamic_item:
             return False
 
         # Skip if entity is under group
@@ -487,15 +478,9 @@ class BaseItemEntity(BaseEntity):
         return True
 
     @property
-    def can_remove_from_studio_default(self):
-        """Result defines if `remove_from_studio_default` can be triggered.
-
-        This can be also used as validation before the method is called.
-        """
+    def _can_remove_from_studio_default(self):
+        """Defines if `remove_from_studio_default` can be processed."""
         if self._override_state is not OverrideState.STUDIO:
-            return False
-
-        if self.is_dynamic_item or self.is_in_dynamic_item:
             return False
 
         if not self.has_studio_override:
@@ -503,14 +488,8 @@ class BaseItemEntity(BaseEntity):
         return True
 
     @property
-    def can_add_to_project_override(self):
-        """Result defines if `add_to_project_override` can be triggered.
-
-        Also can be used as validation before the method is called.
-        """
-        if self.is_dynamic_item or self.is_in_dynamic_item:
-            return False
-
+    def _can_add_to_project_override(self):
+        """Defines if `add_to_project_override` can be processed."""
         # Show only when project overrides are set
         if self._override_state is not OverrideState.PROJECT:
             return False
@@ -525,14 +504,8 @@ class BaseItemEntity(BaseEntity):
         return True
 
     @property
-    def can_remove_from_project_override(self):
-        """Result defines if `remove_from_project_override` can be triggered.
-
-        This can be also used as validation before the method is called.
-        """
-        if self.is_dynamic_item or self.is_in_dynamic_item:
-            return False
-
+    def _can_remove_from_project_override(self):
+        """Defines if `remove_from_project_override` can be processed."""
         if self._override_state is not OverrideState.PROJECT:
             return False
 

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -522,7 +522,7 @@ class DictMutableKeysEntity(EndpointEntity):
         self.had_project_override = value is not NOT_SET
 
     def _discard_changes(self, on_change_trigger):
-        if not self.can_discard_changes:
+        if not self._can_discard_changes:
             return
 
         self.set_override_state(self._override_state)
@@ -533,7 +533,7 @@ class DictMutableKeysEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_studio_default(self, on_change_trigger):
-        if not self.can_remove_from_studio_default:
+        if not self._can_remove_from_studio_default:
             return
 
         value = self._default_value
@@ -574,7 +574,7 @@ class DictMutableKeysEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_project_override(self, on_change_trigger):
-        if not self.can_remove_from_project_override:
+        if not self._can_remove_from_project_override:
             return
 
         if self._has_studio_override:

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -251,7 +251,7 @@ class InputEntity(EndpointEntity):
         self._current_value = copy.deepcopy(value)
 
     def _discard_changes(self, on_change_trigger=None):
-        if not self.can_discard_changes:
+        if not self._can_discard_changes:
             return
 
         self._value_is_modified = False
@@ -289,7 +289,7 @@ class InputEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_studio_default(self, on_change_trigger):
-        if not self.can_remove_from_studio_default:
+        if not self._can_remove_from_studio_default:
             return
 
         value = self._default_value
@@ -307,7 +307,7 @@ class InputEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_project_override(self, on_change_trigger):
-        if not self.can_remove_from_project_override:
+        if not self._can_remove_from_project_override:
             return
 
         self._has_project_override = False

--- a/openpype/settings/entities/item_entities.py
+++ b/openpype/settings/entities/item_entities.py
@@ -453,4 +453,5 @@ class ListStrictEntity(ItemEntity):
 
     def reset_callbacks(self):
         super(ListStrictEntity, self).reset_callbacks()
-        self.child_obj.reset_callbacks()
+        for child_obj in self.children:
+            child_obj.reset_callbacks()

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -343,7 +343,7 @@ class ListEntity(EndpointEntity):
         return output
 
     def _discard_changes(self, on_change_trigger):
-        if not self.can_discard_changes:
+        if not self._can_discard_changes:
             return
 
         not_set = object()
@@ -405,7 +405,7 @@ class ListEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_studio_default(self, on_change_trigger):
-        if not self.can_remove_from_studio_default:
+        if not self._can_remove_from_studio_default:
             return
 
         value = self._default_value
@@ -433,7 +433,7 @@ class ListEntity(EndpointEntity):
         self.on_change()
 
     def _remove_from_project_override(self, on_change_trigger):
-        if not self.can_remove_from_project_override:
+        if not self._can_remove_from_project_override:
             return
 
         if self._has_studio_override:

--- a/openpype/tools/settings/settings/widgets/base.py
+++ b/openpype/tools/settings/settings/widgets/base.py
@@ -71,7 +71,7 @@ class BaseWidget(QtWidgets.QWidget):
     def _discard_changes_action(self, menu, actions_mapping):
         # TODO use better condition as unsaved changes may be caused due to
         #   changes in schema.
-        if not self.entity.can_discard_changes:
+        if not self.entity.can_trigger_discard_changes:
             return
 
         def discard_changes():
@@ -86,7 +86,7 @@ class BaseWidget(QtWidgets.QWidget):
     def _add_to_studio_default(self, menu, actions_mapping):
         """Set values as studio overrides."""
         # Skip if not in studio overrides
-        if not self.entity.can_add_to_studio_default:
+        if not self.entity.can_trigger_add_to_studio_default:
             return
 
         action = QtWidgets.QAction("Add to studio default")
@@ -94,7 +94,7 @@ class BaseWidget(QtWidgets.QWidget):
         menu.addAction(action)
 
     def _remove_from_studio_default_action(self, menu, actions_mapping):
-        if not self.entity.can_remove_from_studio_default:
+        if not self.entity.can_trigger_remove_from_studio_default:
             return
 
         def remove_from_studio_default():
@@ -106,7 +106,7 @@ class BaseWidget(QtWidgets.QWidget):
         menu.addAction(action)
 
     def _add_to_project_override_action(self, menu, actions_mapping):
-        if not self.entity.can_add_to_project_override:
+        if not self.entity.can_trigger_add_to_project_override:
             return
 
         action = QtWidgets.QAction("Add to project project override")
@@ -114,7 +114,7 @@ class BaseWidget(QtWidgets.QWidget):
         menu.addAction(action)
 
     def _remove_from_project_override_action(self, menu, actions_mapping):
-        if not self.entity.can_remove_from_project_override:
+        if not self.entity.can_trigger_remove_from_project_override:
             return
 
         def remove_from_project_override():


### PR DESCRIPTION
## Issue
- settings actions on entities may not be processed on dynamic items
    - currently known issues are with **strict list** item which does not process any of actions properly
    - settings actions are discard changes, add to studio/project overrides and remove from studio/project overrides
- issue started with https://github.com/pypeclub/OpenPype/pull/1446 where was added validation before action process but the validation also skip all dynamic items

## Changes
- action validations were split into 2 parts:
    1. action can be triggered on entity - kept to check if action process can start on entity (and can show action in gui on entity)
    2. action can be processed on entity - any parent triggered action and entity have to handle the changes