### PR TITLE
Validation of dynamic items in settings

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -251,10 +251,18 @@ class DictMutableKeysEntity(EndpointEntity):
             )
             raise EntitySchemaError(self, reason)
 
-        key = "__tmp__"
-        tmp_child = self._add_key(key)
-        tmp_child.schema_validations()
-        self.children_by_key.pop(key)
+        # Validate object type schema
+        child_validated = False
+        for child_entity in self.children_by_key.values():
+            child_entity.schema_validations()
+            child_validated = True
+            break
+
+        if not child_validated:
+            key = "__tmp__"
+            tmp_child = self._add_key(key)
+            tmp_child.schema_validations()
+            self.children_by_key.pop(key)
 
     def get_child_path(self, child_obj):
         result_key = None

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -251,8 +251,10 @@ class DictMutableKeysEntity(EndpointEntity):
             )
             raise EntitySchemaError(self, reason)
 
-        for child_obj in self.children_by_key.values():
-            child_obj.schema_validations()
+        key = "__tmp__"
+        tmp_child = self._add_key(key)
+        tmp_child.schema_validations()
+        self.children_by_key.pop(key)
 
     def get_child_path(self, child_obj):
         result_key = None

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -167,8 +167,10 @@ class ListEntity(EndpointEntity):
             )
             raise EntitySchemaError(self, reason)
 
-        for child_obj in self.children:
-            child_obj.schema_validations()
+        idx = 0
+        tmp_child = self._add_new_item(idx)
+        tmp_child.schema_validations()
+        self.children.pop(idx)
 
     def get_child_path(self, child_obj):
         result_idx = None

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -167,10 +167,18 @@ class ListEntity(EndpointEntity):
             )
             raise EntitySchemaError(self, reason)
 
-        idx = 0
-        tmp_child = self._add_new_item(idx)
-        tmp_child.schema_validations()
-        self.children.pop(idx)
+        # Validate object type schema
+        child_validated = False
+        for child_entity in self.children:
+            child_entity.schema_validations()
+            child_validated = True
+            break
+
+        if not child_validated:
+            idx = 0
+            tmp_child = self._add_new_item(idx)
+            tmp_child.schema_validations()
+            self.children.pop(idx)
 
     def get_child_path(self, child_obj):
         result_idx = None

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -247,8 +247,7 @@
                                         "label": "Used in plugins",
                                         "object_type": {
                                             "type": "text",
-                                            "key": "pluginClass",
-                                            "label": "Plugin Class"
+                                            "key": "pluginClass"
                                         }
                                     },
                                     {
@@ -295,8 +294,7 @@
                                         "label": "Used in plugins",
                                         "object_type": {
                                             "type": "text",
-                                            "key": "pluginClass",
-                                            "label": "Plugin Class"
+                                            "key": "pluginClass"
                                         }
                                     },
                                     {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_publish_gui_filter.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_publish_gui_filter.json
@@ -4,7 +4,6 @@
     "key": "filters",
     "label": "Publish GUI Filters",
     "object_type": {
-        "type": "raw-json",
-        "label": "Plugins"
+        "type": "raw-json"
     }
 }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
@@ -28,7 +28,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_djv.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_djv.json
@@ -28,7 +28,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_houdini.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_houdini.json
@@ -28,7 +28,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_maya.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_maya.json
@@ -28,7 +28,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_shell.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_shell.json
@@ -24,7 +24,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
@@ -28,7 +28,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
@@ -28,7 +28,6 @@
             "object_type": {
                 "type": "dict",
                 "collapsible": true,
-                "checkbox_key": "enabled",
                 "children": [
                     {
                         "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/template_nuke.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/template_nuke.json
@@ -29,7 +29,6 @@
                 "object_type": {
                     "type": "dict",
                     "collapsible": true,
-                    "checkbox_key": "enabled",
                     "children": [
                         {
                             "type": "schema_template",


### PR DESCRIPTION
## Issue
- dynamic items does not have validated schemas (children of `list` or `dict-modifiable` items)

## Changes
- on schema validation of items with dynamic children is created one temporary item and schema is validated on it (item is removed afterwards)
- fixed invalid schema data

## How to replicate bug
This may cause multiple issues one of them is duplicated key in `dict` item under `dict-modifiable`.
1. go to system settings schemas and open `schema_tools.json`
2. duplicate `"environment"` child under `tool_groups` key
3. open Settings UI
- you will see invalid value (red color) but you should see warning dialog which says that schema was validated