### PR TITLE
Forward/Backward compatible apps and tools with OpenPype 3

### DIFF
--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -393,6 +393,13 @@ class CustomAttributes(BaseAction):
 
             loaded_data = toml.load(os.path.join(launchers_path, file))
 
+            new_app_name = app_name
+            name_parts = app_name.split("_")
+            if len(name_parts) > 1:
+                name_start = name_parts.pop(0)
+                name_end = "_".join(name_parts)
+                new_app_name = "/".join((name_start, name_end))
+
             ftrack_label = loaded_data.get("ftrack_label")
             if ftrack_label:
                 parts = app_name.split("_")
@@ -401,7 +408,7 @@ class CustomAttributes(BaseAction):
             else:
                 ftrack_label = loaded_data.get("label", app_name)
 
-            app_definitions.append({app_name: ftrack_label})
+            app_definitions.append({new_app_name: ftrack_label})
 
         if missing_app_names:
             self.log.warning(

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -443,8 +443,19 @@ class CustomAttributes(BaseAction):
         tool_usages = self.presets.get("global", {}).get("tools") or {}
         tools_data = []
         for tool_name, usage in tool_usages.items():
-            if usage:
-                tools_data.append({tool_name: tool_name})
+            if not usage or not tool_name:
+                continue
+            # Forward compatibility with Pype 3
+            # - tools have group and variant joined with slash `/`
+            parts = tool_name.split("_")
+            if len(parts) == 1:
+                # This will cause incompatible tool name
+                new_name = parts[0]
+            else:
+                tool_group = parts.pop(0)
+                remainder = "_".join(parts)
+                new_name = "/".join([tool_group, remainder])
+            tools_data.append({new_name: new_name})
 
         # Make sure there is at least one item
         if not tools_data:

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -192,23 +192,25 @@ def get_project_apps(in_app_list):
         "Unexpected error happend during preparation of application"
     )
     warnings = collections.defaultdict(list)
-    for app in in_app_list:
+    for app_name in in_app_list:
+        # Forwards ompatibility
+        toml_filename = app_name.replace("/", "_")
         try:
-            toml_path = avalon.lib.which_app(app)
+            toml_path = avalon.lib.which_app(toml_filename)
             if not toml_path:
-                log.warning(missing_toml_msg + ' "{}"'.format(app))
-                warnings[missing_toml_msg].append(app)
+                log.warning(missing_toml_msg + ' "{}"'.format(toml_filename))
+                warnings[missing_toml_msg].append(toml_filename)
                 continue
 
             apps.append({
-                "name": app,
+                "name": app_name,
                 "label": toml.load(toml_path)["label"]
             })
         except Exception:
-            warnings[error_msg].append(app)
+            warnings[error_msg].append(toml_filename)
             log.warning((
                 "Error has happened during preparing application \"{}\""
-            ).format(app), exc_info=True)
+            ).format(toml_filename), exc_info=True)
     return apps, warnings
 
 


### PR DESCRIPTION
## Changes
- modified Pype 2 to be able to handle custom attribute changes in Ftrack from OpenPype 3

## Notes
Some forward compatible changes are already available in current pype and avalon-core.
- https://github.com/pypeclub/avalon-core/pull/307
- few untracked PRs in pype...

Trigger of Create/Update attributes action may cause loose of data.