### PR TITLE
Fix groups check in Python 2

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -468,7 +468,7 @@ class BaseItemEntity(BaseEntity):
             return False
 
         # Skip if entity is under group
-        if self.group_item:
+        if self.group_item is not None:
             return False
 
         # Skip if is group and any children is already marked with studio
@@ -495,7 +495,7 @@ class BaseItemEntity(BaseEntity):
             return False
 
         # Do not show on items under group item
-        if self.group_item:
+        if self.group_item is not None:
             return False
 
         # Skip if already is marked to save project overrides
@@ -796,7 +796,8 @@ class ItemEntity(BaseItemEntity):
         # Group item reference
         if self.parent.is_group:
             self.group_item = self.parent
-        elif self.parent.group_item:
+
+        elif self.parent.group_item is not None:
             self.group_item = self.parent.group_item
 
         self.key = self.schema_data.get("key")

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -222,7 +222,7 @@ class DictMutableKeysEntity(EndpointEntity):
         if self.value_is_env_group:
             self.item_schema["env_group_key"] = ""
 
-        if not self.group_item:
+        if self.group_item is None:
             self.is_group = True
 
     def schema_validations(self):

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -32,7 +32,7 @@ class EndpointEntity(ItemEntity):
         super(EndpointEntity, self).__init__(*args, **kwargs)
 
         if (
-            not (self.group_item or self.is_group)
+            not (self.group_item is not None or self.is_group)
             and not (self.is_dynamic_item or self.is_in_dynamic_item)
         ):
             self.is_group = True

--- a/openpype/settings/entities/item_entities.py
+++ b/openpype/settings/entities/item_entities.py
@@ -49,7 +49,7 @@ class PathEntity(ItemEntity):
         return self.child_obj.items()
 
     def _item_initalization(self):
-        if not self.group_item and not self.is_group:
+        if self.group_item is None and not self.is_group:
             self.is_group = True
 
         self.multiplatform = self.schema_data.get("multiplatform", False)
@@ -199,7 +199,7 @@ class ListStrictEntity(ItemEntity):
 
         # GUI attribute
         self.is_horizontal = self.schema_data.get("horizontal", True)
-        if not self.group_item and not self.is_group:
+        if self.group_item is None and not self.is_group:
             self.is_group = True
 
     def schema_validations(self):

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -148,7 +148,7 @@ class ListEntity(EndpointEntity):
             item_schema = {"type": item_schema}
         self.item_schema = item_schema
 
-        if not self.group_item:
+        if self.group_item is None:
             self.is_group = True
 
         # Value that was set on set_override_state


### PR DESCRIPTION
## Issue
- `group_item` entity returns different boolean value in Python 2 and 3

## Changes
- check if `group_item` is `None` instead of expecting return right boolean from object itself