### PR TITLE
Burnin custom font filepath

### DIFF
--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -172,19 +172,11 @@ class ExtractBurnin(openpype.api.Extractor):
                 elif "ftrackreview" in new_repre["tags"]:
                     new_repre["tags"].remove("ftrackreview")
 
-                burnin_values = copy.deepcopy(profile_burnins)
-
-                # Burnin values overrides
-                for key, value in burnin_def.items():
-                    key_low = key.lower()
-                    if key_low in self.positions:
-                        if value is not None:
-                            # Set or override value if is valid
-                            burnin_values[key_low] = value
-
-                        elif key_low in burnin_values:
-                            # Pop key if value is set to None (null in json)
-                            burnin_values.pop(key_low)
+                burnin_values = {}
+                for key in self.positions:
+                    value = burnin_def.get(key)
+                    if value:
+                        burnin_values[key] = value
 
                 # Remove "delete" tag from new representation
                 if "delete" in new_repre["tags"]:

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -111,7 +111,7 @@ class ExtractBurnin(openpype.api.Extractor):
             ).format(host_name, family, task_name, profile))
             return
 
-        profile_options = self._get_burnin_options()
+        burnin_options = self._get_burnin_options()
 
         # Prepare basic data for processing
         _burnin_data, _temp_data = self.prepare_basic_data(instance)
@@ -187,7 +187,8 @@ class ExtractBurnin(openpype.api.Extractor):
                     # able have multiple outputs in case of more burnin presets
                     # Join previous "outputName" with filename suffix
                     new_name = "_".join(
-                        [new_repre["outputName"], filename_suffix])
+                        [new_repre["outputName"], filename_suffix]
+                    )
                     new_repre["name"] = new_name
                     new_repre["outputName"] = new_name
 

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -458,23 +458,15 @@ class ExtractBurnin(openpype.api.Extractor):
             list: Containg all burnin definitions matching entered tags.
         """
         filtered_burnins = {}
-        repre_tags_low = [tag.lower() for tag in tags]
+        repre_tags_low = set(tag.lower() for tag in tags)
         for filename_suffix, burnin_def in burnin_defs.items():
             valid = True
-            output_filters = burnin_def.get("filter")
-            if output_filters:
+            tag_filters = burnin_def["filter"]["tags"]
+            if tag_filters:
                 # Check tag filters
-                tag_filters = output_filters.get("tags")
-                if tag_filters:
-                    tag_filters_low = [tag.lower() for tag in tag_filters]
-                    valid = False
-                    for tag in repre_tags_low:
-                        if tag in tag_filters_low:
-                            valid = True
-                            break
+                tag_filters_low = set(tag.lower() for tag in tag_filters)
 
-                    if not valid:
-                        continue
+                valid = bool(repre_tags_low & tag_filters_low)
 
             if valid:
                 filtered_burnins[filename_suffix] = burnin_def

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -60,7 +60,6 @@ class ExtractBurnin(openpype.api.Extractor):
     # Preset attributes
     profiles = None
     options = None
-    fields = None
 
     def process(self, instance):
         # ffmpeg doesn't support multipart exrs

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -49,12 +49,12 @@ class ExtractBurnin(openpype.api.Extractor):
     ]
     # Default options for burnins for cases that are not set in presets.
     default_options = {
-        "opacity": 1,
-        "x_offset": 5,
-        "y_offset": 5,
+        "font_size": 42,
+        "font_color": [255, 255, 255, 255],
+        "bg_color": [0, 0, 0, 127],
         "bg_padding": 5,
-        "bg_opacity": 0.5,
-        "font_size": 42
+        "x_offset": 5,
+        "y_offset": 5
     }
 
     # Preset attributes

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -3,18 +3,20 @@ import re
 import json
 import copy
 import tempfile
+import platform
+import shutil
+
 import clique
+import pyblish
 
 import openpype
 import openpype.api
-import pyblish
 from openpype.lib import (
     get_pype_execute_args,
     should_decompress,
     get_decompress_dir,
     decompress
 )
-import shutil
 
 
 class ExtractBurnin(openpype.api.Extractor):

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -173,14 +173,7 @@ class ExtractBurnin(openpype.api.Extractor):
                 elif "ftrackreview" in new_repre["tags"]:
                     new_repre["tags"].remove("ftrackreview")
 
-                burnin_options = copy.deepcopy(profile_options)
                 burnin_values = copy.deepcopy(profile_burnins)
-
-                # Options overrides
-                for key, value in (burnin_def.get("options") or {}).items():
-                    # Set or override value if is valid
-                    if value is not None:
-                        burnin_options[key] = value
 
                 # Burnin values overrides
                 for key, value in burnin_def.items():
@@ -235,7 +228,7 @@ class ExtractBurnin(openpype.api.Extractor):
                     "input": temp_data["full_input_path"],
                     "output": temp_data["full_output_path"],
                     "burnin_data": burnin_data,
-                    "options": burnin_options,
+                    "options": copy.deepcopy(burnin_options),
                     "values": burnin_values,
                     "full_input_path": temp_data["full_input_paths"][0],
                     "first_frame": temp_data["first_frame"]

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 
 import clique
+import six
 import pyblish
 
 import openpype
@@ -319,8 +320,7 @@ class ExtractBurnin(openpype.api.Extractor):
             sys_name = platform.system().lower()
             font_filepath = font_filepath.get(sys_name)
 
-        str_type = type("")
-        if font_filepath and isinstance(font_filepath, str_type):
+        if font_filepath and isinstance(font_filepath, six.string_types):
             font_filepath = font_filepath.format(**os.environ)
             if not os.path.exists(font_filepath):
                 font_filepath = None

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -315,19 +315,16 @@ class ExtractBurnin(openpype.api.Extractor):
         # Define font filepath
         # - font filepath may be defined in settings
         font_filepath = burnin_options.get("font_filepath")
-        self.log.info(str(font_filepath))
         if font_filepath and isinstance(font_filepath, dict):
             sys_name = platform.system().lower()
             font_filepath = font_filepath.get(sys_name)
 
-        self.log.info(str(font_filepath))
         str_type = type("")
         if font_filepath and isinstance(font_filepath, str_type):
             font_filepath = font_filepath.format(**os.environ)
             if not os.path.exists(font_filepath):
                 font_filepath = None
 
-        self.log.info(str(font_filepath))
         # Use OpenPype default font
         if not font_filepath:
             font_filepath = openpype.api.resources.get_liberation_font_path()

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -244,30 +244,25 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         timecode_text = options.get("timecode") or ""
         text_for_size += timecode_text
 
+        font_path = options.get("font")
+        if not font_path or not os.path.exists(font_path):
+            font_path = ffmpeg_burnins.FONT
+
+        options["font"] = font_path
+
         data.update(options)
-
-        os_system = platform.system().lower()
-        data_font = data.get("font")
-        if not data_font:
-            data_font = (
-                resources.get_liberation_font_path().replace("\\", "/")
-            )
-        elif isinstance(data_font, dict):
-            data_font = data_font[os_system]
-
-        if data_font:
-            data["font"] = data_font
-            options["font"] = data_font
-            if ffmpeg_burnins._is_windows():
-                data["font"] = (
-                    data_font
-                    .replace(os.sep, r'\\' + os.sep)
-                    .replace(':', r'\:')
-                )
-
         data.update(
             ffmpeg_burnins._drawtext(align, resolution, text_for_size, options)
         )
+
+        arg_font_path = font_path
+        if platform.system().lower() == "windows":
+            arg_font_path = (
+                arg_font_path
+                .replace(os.sep, r'\\' + os.sep)
+                .replace(':', r'\:')
+            )
+        data["font"] = arg_font_path
 
         self.filters['drawtext'].append(draw % data)
 

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -5,7 +5,6 @@ import subprocess
 import platform
 import json
 import opentimelineio_contrib.adapters.ffmpeg_burnins as ffmpeg_burnins
-from openpype.api import resources
 import openpype.lib
 
 

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -127,11 +127,8 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         if not streams:
             streams = _streams(source)
 
-        input_args = []
-        if first_frame:
-            input_args.append("-start_number {}".format(first_frame))
-
-        self.input_args = input_args
+        self.first_frame = first_frame
+        self.input_args = []
 
         super().__init__(source, streams)
 
@@ -291,6 +288,15 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         filters = ''
         if self.filter_string:
             filters = '-vf "{}"'.format(self.filter_string)
+
+        if self.first_frame is not None:
+            start_number_arg = "-start_number {}".format(self.first_frame)
+            self.input_args.append(start_number_arg)
+            if "start_number" not in args:
+                if not args:
+                    args = start_number_arg
+                else:
+                    args = " ".join((start_number_arg, args))
 
         input_args = ""
         if self.input_args:

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -87,7 +87,12 @@
                 ],
                 "x_offset": 5,
                 "y_offset": 5,
-                "bg_padding": 5
+                "bg_padding": 5,
+                "font_filepath": {
+                    "windows": "",
+                    "darwin": "",
+                    "linux": ""
+                }
             },
             "profiles": [
                 {

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -105,7 +105,11 @@
                             "TOP_RIGHT": "{anatomy[version]}",
                             "BOTTOM_LEFT": "{username}",
                             "BOTTOM_CENTERED": "{asset}",
-                            "BOTTOM_RIGHT": "{frame_start}-{current_frame}-{frame_end}"
+                            "BOTTOM_RIGHT": "{frame_start}-{current_frame}-{frame_end}",
+                            "filter": {
+                                "families": [],
+                                "tags": []
+                            }
                         }
                     }
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -385,6 +385,24 @@
                                             "key": "BOTTOM_RIGHT",
                                             "label": "BottomRight",
                                             "type": "text"
+                                        },
+                                        {
+                                            "key": "filter",
+                                            "label": "Additional filtering",
+                                            "type": "dict",
+                                            "highlight_content": true,
+                                            "children": [
+                                                {
+                                                    "key": "families",
+                                                    "label": "Families",
+                                                    "type": "list",
+                                                    "object_type": "text"
+                                                },
+                                                {
+                                                    "type": "schema",
+                                                    "name": "schema_representation_tags"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -101,30 +101,8 @@
                                             "type": "text"
                                         },
                                         {
-                                            "key": "tags",
-                                            "label": "Tags",
-                                            "type": "enum",
-                                            "multiselection": true,
-                                            "enum_items": [
-                                                {
-                                                    "burnin": "Add burnins"
-                                                },
-                                                {
-                                                    "ftrackreview": "Add to Ftrack"
-                                                },
-                                                {
-                                                    "delete": "Delete output"
-                                                },
-                                                {
-                                                    "slate-frame": "Add slate frame"
-                                                },
-                                                {
-                                                    "no-handles": "Skip handle frames"
-                                                },
-                                                {
-                                                    "sequence": "Output as image sequence"
-                                                }
-                                            ]
+                                            "type": "schema",
+                                            "name": "schema_representation_tags"
                                         },
                                         {
                                             "key": "ffmpeg_args",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -334,6 +334,13 @@
                             "type": "number",
                             "key": "bg_padding",
                             "label": "Padding aroung text"
+                        },
+                        {
+                            "type": "path",
+                            "key": "font_filepath",
+                            "label": "Font file path",
+                            "multipath": false,
+                            "multiplatform": true
                         }
                     ]
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_representation_tags.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_representation_tags.json
@@ -1,0 +1,26 @@
+{
+    "key": "tags",
+    "label": "Tags",
+    "type": "enum",
+    "multiselection": true,
+    "enum_items": [
+        {
+            "burnin": "Add burnins"
+        },
+        {
+            "ftrackreview": "Add to Ftrack"
+        },
+        {
+            "delete": "Delete output"
+        },
+        {
+            "slate-frame": "Add slate frame"
+        },
+        {
+            "no-handles": "Skip handle frames"
+        },
+        {
+            "sequence": "Output as image sequence"
+        }
+    ]
+}


### PR DESCRIPTION
## Changes
- added possibility to set path to font for extract burnin
    - path may contain environment variables `"{MY_PATH}/path/to/my/font.tff"`
- added to settings additional filtering of output definitions
    - additional filtering is defined by families and tags
- don't use `shell=True` for running subprocess which may cause issues on Mac and Linux workstations
    - for windows is added `CREATE_NO_WINDOW` flag which should avoid creating new terminal window
- font is not handled in burnin script but is prepared before got into the script
    - default font path should be set to `LiberationSans` font which is in OpenPype resources
    - default font is also used when can't access font set in settings
- start frame on processing of sequence in burnin script is also explicitly set to be start frame of an output

## Note
- add modifiable placeholders for text and path input (now shows placeholder `Executable path`)
- should raise an exception if can't find font from settings?