### PR TITLE
Nuke: workfile version synced to db version always 

### DIFF
--- a/pype/plugins/nuke/publish/collect_workfile.py
+++ b/pype/plugins/nuke/publish/collect_workfile.py
@@ -73,7 +73,8 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
             "publish": root.knob('publish').value(),
             "family": family,
             "families": [family],
-            "representations": list()
+            "representations": list(),
+            "version": instance.context.data["version"]
         })
 
         # adding basic script data


### PR DESCRIPTION
As the client was pointing recently, our deadline submissions are having a versions discrepancy.
 
- missing version on instance data so the version is synced with db always