### PR TITLE
Maya: Redshift - set proper start frame on proxy

### DIFF
--- a/pype/plugins/maya/publish/extract_redshift_proxy.py
+++ b/pype/plugins/maya/publish/extract_redshift_proxy.py
@@ -73,6 +73,10 @@ class ExtractRedshiftProxy(pype.api.Extractor):
             'files': repr_files,
             "stagingDir": staging_dir,
         }
+        
+        if anim_on:
+            representation['frameStart'] = instance.data["proxyFrameStart"]
+        
         instance.data["representations"].append(representation)
 
         self.log.info("Extracted instance '%s' to: %s"

--- a/pype/plugins/maya/publish/extract_redshift_proxy.py
+++ b/pype/plugins/maya/publish/extract_redshift_proxy.py
@@ -73,10 +73,10 @@ class ExtractRedshiftProxy(pype.api.Extractor):
             'files': repr_files,
             "stagingDir": staging_dir,
         }
-        
+
         if anim_on:
             representation['frameStart'] = instance.data["proxyFrameStart"]
-        
+
         instance.data["representations"].append(representation)
 
         self.log.info("Extracted instance '%s' to: %s"


### PR DESCRIPTION
This sets proper start frame on redshift proxy representation if animation is turned on.