### PR TITLE
Maya: Use of multiple deadline servers

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -928,6 +928,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             self.DEADLINE_REST_URL = os.environ.get(
                 "DEADLINE_REST_URL", "http://localhost:8082"
             )
+            if instance.data.get("deadlineUrl"):
+                self.DEADLINE_REST_URL = instance.data.get("deadlineUrl")
             assert self.DEADLINE_REST_URL, "Requires DEADLINE_REST_URL"
 
             self._submit_deadline_post_job(instance, render_job, instances)

--- a/pype/plugins/maya/create/create_render.py
+++ b/pype/plugins/maya/create/create_render.py
@@ -4,6 +4,9 @@ import os
 import json
 import appdirs
 import requests
+from collections import OrderedDict
+
+import six
 
 from maya import cmds
 import maya.app.renderSetup.model.renderSetup as renderSetup
@@ -79,6 +82,8 @@ class CreateRender(plugin.Creator):
         'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>'
     }
 
+    deadline_servers = {}
+
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super(CreateRender, self).__init__(*args, **kwargs)
@@ -93,10 +98,10 @@ class CreateRender(plugin.Creator):
         use_selection = self.options.get("useSelection")
         with lib.undo_chunk():
             self._create_render_settings()
-            instance = super(CreateRender, self).process()
+            self.instance = super(CreateRender, self).process()
             # create namespace with instance
             index = 1
-            namespace_name = "_{}".format(str(instance))
+            namespace_name = "_{}".format(str(self.instance))
             try:
                 cmds.namespace(rm=namespace_name)
             except RuntimeError:
@@ -104,12 +109,19 @@ class CreateRender(plugin.Creator):
                 pass
 
             while(cmds.namespace(exists=namespace_name)):
-                namespace_name = "_{}{}".format(str(instance), index)
+                namespace_name = "_{}{}".format(str(self.instance), index)
                 index += 1
 
             namespace = cmds.namespace(add=namespace_name)
 
-            cmds.setAttr("{}.machineList".format(instance), lock=True)
+            # add Deadline server selection list
+            cmds.scriptJob(
+                attributeChange=[
+                    "{}.deadlineServers".format(self.instance),
+                    self._deadline_webservice_changed
+                ])
+
+            cmds.setAttr("{}.machineList".format(self.instance), lock=True)
             self._rs = renderSetup.instance()
             layers = self._rs.getRenderLayers()
             if use_selection:
@@ -121,7 +133,7 @@ class CreateRender(plugin.Creator):
                     render_set = cmds.sets(
                         n="{}:{}".format(namespace, layer.name()))
                     sets.append(render_set)
-                cmds.sets(sets, forceElement=instance)
+                cmds.sets(sets, forceElement=self.instance)
 
             # if no render layers are present, create default one with
             # asterix selector
@@ -139,12 +151,63 @@ class CreateRender(plugin.Creator):
             cmds.setAttr(self._image_prefix_nodes[renderer],
                          self._image_prefixes[renderer],
                          type="string")
+        return self.instance
+
+    def _deadline_webservice_changed(self):
+        """Refresh Deadline served dependent options."""
+        # get selected server
+        webservice = self.deadline_servers[
+            self.server_aliases[
+                cmds.getAttr("{}.deadlineServers".format(self.instance))
+            ]
+        ]
+        pools = self._get_deadline_pools(webservice)
+        cmds.deleteAttr("{}.primaryPool".format(self.instance))
+        cmds.deleteAttr("{}.secondaryPool".format(self.instance))
+        cmds.addAttr(self.instance, longName="primaryPool",
+                     attributeType="enum",
+                     enumName=":".join(pools))
+        cmds.addAttr(self.instance, longName="secondaryPool",
+                     attributeType="enum",
+                     enumName=":".join(["-"] + pools))
+
+        # cmds.setAttr("{}.secondaryPool".format(self.instance), ["-"] + pools)
 
     def _create_render_settings(self):
         # get pools
         pools = []
+        deadline_url = os.getenv("DEADLINE_REST_URL")
+        if self.deadline_servers:
+            for key, server in self.deadline_servers.items():
+                if server == "DEADLINE_REST_URL":
+                    self.deadline_servers[key] = deadline_url
 
-        deadline_url = os.environ.get("DEADLINE_REST_URL", None)
+            self.server_aliases = self.deadline_servers.keys()
+            deadline_url = self.deadline_servers[self.server_aliases[0]]
+            print("deadline servers: {}".format(self.deadline_servers))
+            self.data["deadlineServers"] = self.server_aliases
+        else:
+            self.data["deadlineServers"] = [deadline_url]
+
+        self.data["suspendPublishJob"] = False
+        self.data["review"] = True
+        self.data["extendFrames"] = False
+        self.data["overrideExistingFrame"] = True
+        # self.data["useLegacyRenderLayers"] = True
+        self.data["priority"] = 50
+        self.data["framesPerTask"] = 1
+        self.data["whitelist"] = False
+        self.data["machineList"] = ""
+        self.data["useMayaBatch"] = False
+        self.data["tileRendering"] = False
+        self.data["tilesX"] = 2
+        self.data["tilesY"] = 2
+        self.data["convertToScanline"] = False
+        self.data["useReferencedAovs"] = False
+        # Disable for now as this feature is not working yet
+        # self.data["assScene"] = False
+
+        self.options = {"useSelection": False}  # Force no content
         muster_url = os.environ.get("MUSTER_REST_URL", None)
         if deadline_url and muster_url:
             self.log.error(
@@ -155,21 +218,11 @@ class CreateRender(plugin.Creator):
         if deadline_url is None:
             self.log.warning("Deadline REST API url not found.")
         else:
-            argument = "{}/api/pools?NamesOnly=true".format(deadline_url)
-            try:
-                response = self._requests_get(argument)
-            except requests.exceptions.ConnectionError as e:
-                msg = 'Cannot connect to deadline web service'
-                self.log.error(msg)
-                raise RuntimeError('{} - {}'.format(msg, e))
-            if not response.ok:
-                self.log.warning("No pools retrieved")
-            else:
-                pools = response.json()
-                self.data["primaryPool"] = pools
-                # We add a string "-" to allow the user to not
-                # set any secondary pools
-                self.data["secondaryPool"] = ["-"] + pools
+            pools = self._get_deadline_pools(deadline_url)
+            self.data["primaryPool"] = pools
+            # We add a string "-" to allow the user to not
+            # set any secondary pools
+            self.data["secondaryPool"] = ["-"] + pools
 
         if muster_url is None:
             self.log.warning("Muster REST API URL not found.")
@@ -193,26 +246,6 @@ class CreateRender(plugin.Creator):
                 pool_names.append(pool["name"])
 
             self.data["primaryPool"] = pool_names
-
-        self.data["suspendPublishJob"] = False
-        self.data["review"] = True
-        self.data["extendFrames"] = False
-        self.data["overrideExistingFrame"] = True
-        # self.data["useLegacyRenderLayers"] = True
-        self.data["priority"] = 50
-        self.data["framesPerTask"] = 1
-        self.data["whitelist"] = False
-        self.data["machineList"] = ""
-        self.data["useMayaBatch"] = False
-        self.data["tileRendering"] = False
-        self.data["tilesX"] = 2
-        self.data["tilesY"] = 2
-        self.data["convertToScanline"] = False
-        self.data["useReferencedAovs"] = False
-        # Disable for now as this feature is not working yet
-        # self.data["assScene"] = False
-
-        self.options = {"useSelection": False}  # Force no content
 
     def _load_credentials(self):
         """Load Muster credentials.
@@ -267,6 +300,33 @@ class CreateRender(plugin.Creator):
             raise Exception("Invalid response from Muster server")
 
         return pools
+
+    def _get_deadline_pools(self, webservice):
+        # type: (str) -> list
+        """Get pools from Deadline.
+
+        Args:
+            webservice (str): Server url.
+
+        Returns:
+            list: Pools.
+
+        Throws:
+            RuntimeError: If deadline webservice is unreachable.
+
+        """
+        argument = "{}/api/pools?NamesOnly=true".format(webservice)
+        try:
+            response = self._requests_get(argument)
+        except requests.exceptions.ConnectionError as exc:
+            msg = 'Cannot connect to deadline web service'
+            self.log.error(msg)
+            six.reraise(exc, RuntimeError('{} - {}'.format(msg, exc)))
+        if not response.ok:
+            self.log.warning("No pools retrieved")
+            return []
+
+        return response.json()
 
     def _show_login(self):
         # authentication token expired so we need to login to Muster

--- a/pype/plugins/maya/create/create_render.py
+++ b/pype/plugins/maya/create/create_render.py
@@ -4,7 +4,6 @@ import os
 import json
 import appdirs
 import requests
-from collections import OrderedDict
 
 import six
 

--- a/pype/plugins/maya/publish/collect_render.py
+++ b/pype/plugins/maya/publish/collect_render.py
@@ -96,6 +96,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     int(render_instance.data.get("deadlineServers"))
                 ]
             ]
+            if deadline_url == "DEADLINE_REST_URL":
+                deadline_url = os.getenv("DEADLINE_REST_URL", "")
         else:
             deadline_url = os.getenv("DEADLINE_REST_URL", "")
 

--- a/pype/plugins/maya/publish/collect_render.py
+++ b/pype/plugins/maya/publish/collect_render.py
@@ -19,6 +19,7 @@ Optional:
 
 Provides:
     instance    -> label
+    instance    -> deadline_server
     instance    -> subset
     instance    -> attachTo
     instance    -> setMembers
@@ -64,6 +65,14 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
     def process(self, context):
         """Entry point to collector."""
         render_instance = None
+
+        # load deadline servers from preset
+        deadline_servers = []
+        create_plugin_preset = context.data["presets"]["plugins"]["maya"].get("create")  # noqa: E501
+        if create_plugin_preset.get("CreateRender"):
+            deadline_servers = create_plugin_preset["CreateRender"].get(
+                "deadline_servers")
+
         for instance in context:
             if "rendering" in instance.data["families"]:
                 render_instance = instance
@@ -79,6 +88,16 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "layer collection."
             )
             return
+
+        if deadline_servers:
+
+            deadline_url = deadline_servers[
+                deadline_servers.keys()[
+                    int(render_instance.data.get("deadlineServers"))
+                ]
+            ]
+        else:
+            deadline_url = os.getenv("DEADLINE_REST_URL", "")
 
         render_globals = render_instance
         collected_render_layers = render_instance.data["setMembers"]
@@ -262,6 +281,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     "useReferencedAovs") or render_instance.data.get(
                         "vrayUseReferencedAovs") or False  # noqa: E501
             }
+            if deadline_url:
+                data["deadlineUrl"] = deadline_url
 
             if self.sync_workfile_version:
                 data["version"] = context.data["version"]

--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -273,6 +273,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         self.payload_skeleton = copy.deepcopy(payload_skeleton_template)
         self._deadline_url = os.environ.get(
             "DEADLINE_REST_URL", "http://localhost:8082")
+        if instance.data.get("deadlineUrl"):
+            self._deadline_url = instance.data.get("deadlineUrl")
         assert self._deadline_url, "Requires DEADLINE_REST_URL"
 
         context = instance.context

--- a/pype/plugins/maya/publish/validate_deadline_connection.py
+++ b/pype/plugins/maya/publish/validate_deadline_connection.py
@@ -19,6 +19,9 @@ class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
 
         if instance.data.get("deadlineUrl"):
             DEADLINE_REST_URL = instance.data.get("deadlineUrl")
+            self.log.info(
+                "We have deadline URL on instance {}".format(
+                    DEADLINE_REST_URL))
         else:
             try:
                 DEADLINE_REST_URL = os.environ["DEADLINE_REST_URL"]

--- a/pype/plugins/maya/publish/validate_deadline_connection.py
+++ b/pype/plugins/maya/publish/validate_deadline_connection.py
@@ -5,7 +5,7 @@ from pype.plugin import contextplugin_should_run
 import os
 
 
-class ValidateDeadlineConnection(pyblish.api.ContextPlugin):
+class ValidateDeadlineConnection(pyblish.api.InstancePlugin):
     """Validate Deadline Web Service is running"""
 
     label = "Validate Deadline Web Service"
@@ -15,17 +15,16 @@ class ValidateDeadlineConnection(pyblish.api.ContextPlugin):
     if not os.environ.get("DEADLINE_REST_URL"):
         active = False
 
-    def process(self, context):
+    def process(self, instance):
 
-        # Workaround bug pyblish-base#250
-        if not contextplugin_should_run(self, context):
-            return
-
-        try:
-            DEADLINE_REST_URL = os.environ["DEADLINE_REST_URL"]
-        except KeyError:
-            self.log.error("Deadline REST API url not found.")
-            raise ValueError("Deadline REST API url not found.")
+        if instance.data.get("deadlineUrl"):
+            DEADLINE_REST_URL = instance.data.get("deadlineUrl")
+        else:
+            try:
+                DEADLINE_REST_URL = os.environ["DEADLINE_REST_URL"]
+            except KeyError:
+                self.log.error("Deadline REST API url not found.")
+                raise ValueError("Deadline REST API url not found.")
 
         # Check response
         response = self._requests_get(DEADLINE_REST_URL)


### PR DESCRIPTION
## Feature

This feature allows to use multiple deadline webservice instance in Maya and allow user to choose from. When preset exists in `pype-config/presets/plugins/maya/create.json`:
```javascript
{
  "CreateRender": {
    "deadline_servers": {
      "default": "DEADLINE_REST_URL",
      "aws": "http://foo:2135"
    }
  }
}
```

Then when **render** instance is created in Maya, it will add *Deadline Servers* combo box to its attributes:

![image](https://user-images.githubusercontent.com/33513211/117335512-85a0bd80-ae9b-11eb-937e-96d9198634be.png)

It uses key as alias and values as its url. `DEADLINE_REST_URL` will be replaced by the one set with the same named environment variable. When user select different server, pools are queried from it.
Collector will then "bake" this value to `deadlineUrl` in published instance and rest of the plugins will use that.

**Note:** when this preset is not set, it will work as usual with `DEADLINE_REST_URL` env var set.

Closes pypeclub/client#60
🎫 **Freshdesk:** [#642](https://support.pype.club/helpdesk/tickets/642)