### PR TITLE
Use SubsetLoader and multiple contexts for delete_old_versions

### DIFF
--- a/pype/plugins/global/load/delete_old_versions.py
+++ b/pype/plugins/global/load/delete_old_versions.py
@@ -14,7 +14,10 @@ import avalon.pipeline
 from pype.api import Anatomy
 
 
-class DeleteOldVersions(api.Loader):
+class DeleteOldVersions(api.SubsetLoader):
+
+    is_multiple_contexts_compatible = True
+    sequence_splitter = "__sequence_splitter__"
 
     representations = ["*"]
     families = ["*"]
@@ -258,9 +261,11 @@ class DeleteOldVersions(api.Loader):
         )
 
         if not version_ids:
-            msg = "Skipping processing. Nothing to delete."
+            msg = "Skipping processing. Nothing to delete on {}/{}".format(
+                asset["name"], subset["name"]
+            )
             self.log.info(msg)
-            self.message(msg)
+            print(msg)
             return
 
         repres = list(self.dbcon.find({
@@ -396,25 +401,30 @@ class DeleteOldVersions(api.Loader):
             self.log.error(msg)
             self.message(msg)
 
-        msg = "Total size of files: " + self.sizeof_fmt(size)
-        self.log.info(msg)
-        self.message(msg)
+        return size
 
-    def load(self, context, name=None, namespace=None, options=None):
+    def load(self, contexts, name=None, namespace=None, options=None):
         try:
-            versions_to_keep = 2
-            remove_publish_folder = False
-            if options:
-                versions_to_keep = options.get(
-                    "versions_to_keep", versions_to_keep
-                )
-                remove_publish_folder = options.get(
-                    "remove_publish_folder", remove_publish_folder
-                )
+            size = 0
+            for count, context in enumerate(contexts):
+                versions_to_keep = 2
+                remove_publish_folder = False
+                if options:
+                    versions_to_keep = options.get(
+                        "versions_to_keep", versions_to_keep
+                    )
+                    remove_publish_folder = options.get(
+                        "remove_publish_folder", remove_publish_folder
+                    )
 
-            data = self.get_data(context, versions_to_keep)
+                data = self.get_data(context, versions_to_keep)
 
-            self.main(data, remove_publish_folder)
+                size += self.main(data, remove_publish_folder)
+                print("Progressing {}/{}".format(count + 1, len(contexts)))
+
+            msg = "Total size of files: " + self.sizeof_fmt(size)
+            self.log.info(msg)
+            self.message(msg)
 
         except Exception:
             self.log.error("Failed to delete versions.", exc_info=True)
@@ -436,6 +446,9 @@ class CalculateOldVersions(DeleteOldVersions):
     def main(self, data, remove_publish_folder):
         size = 0
 
+        if not data:
+            return size
+
         if remove_publish_folder:
             size = self.delete_whole_dir_paths(
                 data["dir_paths"].values(), delete=False
@@ -445,6 +458,4 @@ class CalculateOldVersions(DeleteOldVersions):
                 data["dir_paths"], data["file_paths_by_dir"], delete=False
             )
 
-        msg = "Total size of files: " + self.sizeof_fmt(size)
-        self.log.info(msg)
-        self.message(msg)
+        return size


### PR DESCRIPTION
- Only appears once in the right click menu.
- Size user feedback is only displayed once at the end of the operation.

I have a progress indicator printed atm, but would like to have a progress bar, but I'm shit at Qt stuff. Tried showing a progress bar but could not get it to show before the operation was completed.

Depends on https://github.com/pypeclub/avalon-core/pull/329