### PR TITLE
Undefined constant in subprocess module

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -26,7 +26,8 @@ from .terminal import Terminal
 from .execute import (
     get_pype_execute_args,
     execute,
-    run_subprocess
+    run_subprocess,
+    CREATE_NO_WINDOW
 )
 from .log import PypeLogger, timeit
 from .mongo import (

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -6,6 +6,9 @@ from .log import PypeLogger as Logger
 
 log = logging.getLogger(__name__)
 
+# MSDN process creation flag (Windows only)
+CREATE_NO_WINDOW = 0x08000000
+
 
 def execute(args,
             silent=False,

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -17,7 +17,8 @@ from openpype.lib import (
     get_pype_execute_args,
     should_decompress,
     get_decompress_dir,
-    decompress
+    decompress,
+    CREATE_NO_WINDOW
 )
 
 
@@ -253,9 +254,7 @@ class ExtractBurnin(openpype.api.Extractor):
                     "env": {}
                 }
                 if platform.system().lower() == "windows":
-                    process_kwargs["creationflags"] = (
-                        subprocess.CREATE_NO_WINDOW
-                    )
+                    process_kwargs["creationflags"] = CREATE_NO_WINDOW
 
                 openpype.api.run_subprocess(args, **process_kwargs)
                 # Remove the temporary json


### PR DESCRIPTION
## Issue
- some builds of python may not have constant `CREATE_NO_WINDOW` in `subprocess` module

## Changes
- defined custom constant as `subprocess` may not have defined CREATE_NO_WINDOW constant in all python builds