### PR TITLE
Use instance frame start instead of timeline.

### DIFF
--- a/pype/plugins/maya/publish/extract_thumbnail.py
+++ b/pype/plugins/maya/publish/extract_thumbnail.py
@@ -26,10 +26,6 @@ class ExtractThumbnail(pype.api.Extractor):
     def process(self, instance):
         self.log.info("Extracting capture..")
 
-        start = cmds.currentTime(query=True)
-        end = cmds.currentTime(query=True)
-        self.log.info("start: {}, end: {}".format(start, end))
-
         camera = instance.data['review_camera']
 
         capture_preset = ""
@@ -47,8 +43,8 @@ class ExtractThumbnail(pype.api.Extractor):
         # preset['compression'] = "qt"
         preset['quality'] = 50
         preset['compression'] = "jpg"
-        preset['start_frame'] = start
-        preset['end_frame'] = end
+        preset['start_frame'] = instance.data["frameStart"]
+        preset['end_frame'] = instance.data["frameStart"]
         preset['camera_options'] = {
             "displayGateMask": False,
             "displayResolution": False,


### PR DESCRIPTION
In some cases (simulation) the timeline and instance frame start do not align.