### PR TITLE
Codec determination in extract burnin

### DIFF
--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -108,11 +108,30 @@ def _prores_codec_args(ffprobe_data):
     return output
 
 
+def _h264_codec_args(ffprobe_data):
+    output = []
+
+    output.extend(["-codec:v", "h264"])
+
+    pix_fmt = ffprobe_data.get("pix_fmt")
+    if pix_fmt:
+        output.extend(["-pix_fmt", pix_fmt])
+
+    output.extend(["-intra"])
+    output.extend(["-g", "1"])
+
+    return output
+
+
 def get_codec_args(ffprobe_data):
     codec_name = ffprobe_data.get("codec_name")
-    # Handle prores
+    # Codec "prores"
     if codec_name == "prores":
         return _prores_codec_args(ffprobe_data)
+
+    # Codec "h264"
+    if codec_name == "h264":
+        return _h264_codec_args(ffprobe_data)
 
     output = []
     if codec_name:

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -145,6 +145,8 @@ def get_codec_args(ffprobe_data):
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 
+    output.extend(["-g", "1"])
+
     return output
 
 
@@ -637,14 +639,13 @@ def burnins_from_data(
     if codec_data:
         # Use codec definition from method arguments
         ffmpeg_args = codec_data
+        ffmpeg_args.append("-g 1")
 
     else:
         ffprobe_data = burnin._streams[0]
         ffmpeg_args.extend(get_codec_args(ffprobe_data))
 
     # Use group one (same as `-intra` argument, which is deprecated)
-    ffmpeg_args.append("-g 1")
-
     ffmpeg_args_str = " ".join(ffmpeg_args)
     burnin.render(
         output_path, args=ffmpeg_args_str, overwrite=overwrite, **data


### PR DESCRIPTION
## Issue
Determination of input codec in new FFmpeg does not work the same way as in previously used version of FFmpeg.

## Changes
- added few functions using codec specific keys from input data
    - these functions should be modified or added in future based on requirements of each codec
- these changes should handle current situation with decreased quality of outputs

## Notes
- don't have enough testing input sources to check all possibilities and validate output
    - there is a chance that I broke something which worked with previous code
- result will probably never be the same as adding video filters (drawing burnins) to output will aways cause some issues
- possible solution to keep source 1:1 is to add burnins as part of ExtractReview and force all host implementations to create review with it