### PR TITLE
Store data from modifiable dict as list

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -347,6 +347,7 @@ class DictMutableKeysEntity(EndpointEntity):
 
         using_project_overrides = False
         using_studio_overrides = False
+        using_default_values = False
         if (
             state is OverrideState.PROJECT
             and self.had_project_override
@@ -364,11 +365,21 @@ class DictMutableKeysEntity(EndpointEntity):
             metadata = self._studio_override_metadata
 
         else:
+            using_default_values = True
             value = self._default_value
             metadata = self._default_metadata
 
         if value is NOT_SET:
+            using_default_values = False
             value = self.value_on_not_set
+
+        using_values_from_state = False
+        if state is OverrideState.PROJECT:
+            using_values_from_state = using_project_overrides
+        elif state is OverrideState.STUDIO:
+            using_values_from_state = using_studio_overrides
+        elif state is OverrideState.DEFAULTS:
+            using_values_from_state = using_default_values
 
         new_value = copy.deepcopy(value)
 

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -1,6 +1,6 @@
 import re
 import copy
-
+import collections
 from .lib import (
     NOT_SET,
     OverrideState
@@ -98,7 +98,7 @@ class DictMutableKeysEntity(EndpointEntity):
         # TODO Check for value type if is Settings entity?
         child_obj = self.children_by_key.get(key)
         if not child_obj:
-            if not KEY_REGEX.match(key):
+            if not self.store_as_list and not KEY_REGEX.match(key):
                 raise InvalidKeySymbols(self.path, key)
 
             child_obj = self.add_key(key)
@@ -112,7 +112,7 @@ class DictMutableKeysEntity(EndpointEntity):
         if new_key == old_key:
             return
 
-        if not KEY_REGEX.match(new_key):
+        if not self.store_as_list and not KEY_REGEX.match(new_key):
             raise InvalidKeySymbols(self.path, new_key)
 
         self.children_by_key[new_key] = self.children_by_key.pop(old_key)
@@ -129,7 +129,7 @@ class DictMutableKeysEntity(EndpointEntity):
         if key in self.children_by_key:
             self.pop(key)
 
-        if not KEY_REGEX.match(key):
+        if not self.store_as_list and not KEY_REGEX.match(key):
             raise InvalidKeySymbols(self.path, key)
 
         if self.value_is_env_group:
@@ -370,7 +370,7 @@ class DictMutableKeysEntity(EndpointEntity):
         children_label_by_id = {}
         metadata_labels = metadata.get(M_DYNAMIC_KEY_LABEL) or {}
         for _key, _value in new_value.items():
-            if not KEY_REGEX.match(_key):
+            if not self.store_as_list and not KEY_REGEX.match(_key):
                 # Replace invalid characters with underscore
                 # - this is safety to not break already existing settings
                 _key = re.sub(

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -398,11 +398,7 @@ class DictMutableKeysEntity(EndpointEntity):
             if not self.store_as_list and not KEY_REGEX.match(_key):
                 # Replace invalid characters with underscore
                 # - this is safety to not break already existing settings
-                _key = re.sub(
-                    r"[^{}]+".format(KEY_ALLOWED_SYMBOLS),
-                    "_",
-                    _key
-                )
+                new_key = self._convert_to_regex_valid_key(_key)
 
             child_entity = self._add_key(_key)
             child_entity.update_default_value(_value)
@@ -419,6 +415,13 @@ class DictMutableKeysEntity(EndpointEntity):
         self.children_label_by_id = children_label_by_id
 
         self.initial_value = self.settings_value()
+
+    def _convert_to_regex_valid_key(self, key):
+        return re.sub(
+            r"[^{}]+".format(KEY_ALLOWED_SYMBOLS),
+            "_",
+            key
+        )
 
     def children_key_by_id(self):
         return {

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -410,6 +410,12 @@ class DictMutableKeysEntity(EndpointEntity):
 
     @property
     def value(self):
+        if self.store_as_list:
+            output = []
+            for key, child_entity in self.children_by_key.items():
+                output.append(key, child_entity.value)
+            return output
+
         output = {}
         for key, child_entity in self.children_by_key.items():
             output[key] = child_entity.value
@@ -489,6 +495,13 @@ class DictMutableKeysEntity(EndpointEntity):
         return False
 
     def _settings_value(self):
+        if self.store_as_list:
+            output = []
+            for key, child_entity in self.children_by_key.items():
+                child_value = child_entity.settings_value()
+                output.append([key, child_value])
+            return output
+
         output = {}
         for key, child_entity in self.children_by_key.items():
             child_value = child_entity.settings_value()

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -1,6 +1,5 @@
 import re
 import copy
-import collections
 from .lib import (
     NOT_SET,
     OverrideState
@@ -96,7 +95,7 @@ class DictMutableKeysEntity(EndpointEntity):
 
     def _convert_to_valid_type(self, value):
         try:
-            return collections.OrderedDict(value)
+            return dict(value)
         except Exception:
             pass
         return super(DictMutableKeysEntity, self)._convert_to_valid_type(value)

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -94,6 +94,13 @@ class DictMutableKeysEntity(EndpointEntity):
         for key in prev_keys:
             self.pop(key)
 
+    def _convert_to_valid_type(self, value):
+        try:
+            return collections.OrderedDict(value)
+        except Exception:
+            pass
+        return super(DictMutableKeysEntity, self)._convert_to_valid_type(value)
+
     def set_key_value(self, key, value):
         # TODO Check for value type if is Settings entity?
         child_obj = self.children_by_key.get(key)

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -244,6 +244,10 @@ class DictMutableKeysEntity(EndpointEntity):
         if used_temp_label:
             self.label = None
 
+        if self.value_is_env_group and self.store_as_list:
+            reason = "Item can't store environments metadata to list output."
+            raise EntitySchemaError(self, reason)
+
         if not self.schema_data.get("object_type"):
             reason = (
                 "Modifiable dictionary must have specified `object_type`."

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -194,6 +194,7 @@ class DictMutableKeysEntity(EndpointEntity):
         self.children_by_key = {}
         self.children_label_by_id = {}
 
+        self.store_as_list = self.schema_data.get("store_as_list") or False
         self.value_is_env_group = (
             self.schema_data.get("value_is_env_group") or False
         )

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -131,11 +131,15 @@ class DictMutableKeysEntity(EndpointEntity):
             self._has_project_override = True
         self.on_change()
 
-    def _add_key(self, key):
+    def _add_key(self, key, _ingore_key_validation=False):
         if key in self.children_by_key:
             self.pop(key)
 
-        if not self.store_as_list and not KEY_REGEX.match(key):
+        if (
+            not _ingore_key_validation
+            and not self.store_as_list
+            and not KEY_REGEX.match(key)
+        ):
             raise InvalidKeySymbols(self.path, key)
 
         if self.value_is_env_group:

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -605,7 +605,8 @@ class DictMutableKeysEntity(EndpointEntity):
 
         # Create new children
         for _key, _value in new_value.items():
-            child_entity = self._add_key(_key)
+            new_key = self._convert_to_regex_valid_key(_key)
+            child_entity = self._add_key(new_key)
             child_entity.update_default_value(_value)
             label = metadata_labels.get(_key)
             if label:
@@ -650,7 +651,8 @@ class DictMutableKeysEntity(EndpointEntity):
 
         # Create new children
         for _key, _value in new_value.items():
-            child_entity = self._add_key(_key)
+            new_key = self._convert_to_regex_valid_key(_key)
+            child_entity = self._add_key(new_key)
             child_entity.update_default_value(_value)
             if self._has_studio_override:
                 child_entity.update_studio_value(_value)

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
@@ -23,7 +23,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_djv.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_djv.json
@@ -23,7 +23,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_houdini.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_houdini.json
@@ -23,7 +23,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_maya.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_maya.json
@@ -23,7 +23,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_shell.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_shell.json
@@ -19,7 +19,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
@@ -23,7 +23,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
@@ -23,7 +23,6 @@
             "type": "dict-modifiable",
             "key": "variants",
             "collapsible_key": true,
-            "dynamic_label": false,
             "use_label_wrap": false,
             "object_type": {
                 "type": "dict",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/template_nuke.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/template_nuke.json
@@ -24,7 +24,6 @@
                 "type": "dict-modifiable",
                 "key": "variants",
                 "collapsible_key": true,
-                "dynamic_label": false,
                 "use_label_wrap": false,
                 "object_type": {
                     "type": "dict",

--- a/openpype/tools/settings/settings/dict_mutable_widget.py
+++ b/openpype/tools/settings/settings/dict_mutable_widget.py
@@ -102,7 +102,8 @@ class ModifiableDictEmptyItem(QtWidgets.QWidget):
 
     def _on_key_change(self):
         key = self.key_input.text()
-        self.key_is_valid = KEY_REGEX.match(key)
+        if not self.store_as_list:
+            self.key_is_valid = KEY_REGEX.match(key)
 
         if self.ignore_input_changes:
             return
@@ -174,7 +175,7 @@ class ModifiableDictItem(QtWidgets.QWidget):
         self.ignore_input_changes = entity_widget.ignore_input_changes
 
         self.is_key_duplicated = False
-        self.key_is_valid = False
+        self.key_is_valid = store_as_list
         self.is_required = False
 
         self.origin_key = None
@@ -404,7 +405,8 @@ class ModifiableDictItem(QtWidgets.QWidget):
 
     def _on_key_change(self):
         key = self.key_value()
-        self.key_is_valid = KEY_REGEX.match(key)
+        if not self.store_as_list:
+            self.key_is_valid = KEY_REGEX.match(key)
 
         if self.ignore_input_changes:
             return

--- a/openpype/tools/settings/settings/dict_mutable_widget.py
+++ b/openpype/tools/settings/settings/dict_mutable_widget.py
@@ -32,14 +32,15 @@ def create_remove_btn(parent):
 
 
 class ModifiableDictEmptyItem(QtWidgets.QWidget):
-    def __init__(self, entity_widget, parent):
+    def __init__(self, entity_widget, store_as_list, parent):
         super(ModifiableDictEmptyItem, self).__init__(parent)
         self.entity_widget = entity_widget
         self.collapsible_key = entity_widget.entity.collapsible_key
         self.ignore_input_changes = entity_widget.ignore_input_changes
 
+        self.store_as_list = store_as_list
         self.is_duplicated = False
-        self.key_is_valid = False
+        self.key_is_valid = store_as_list
 
         if self.collapsible_key:
             self.create_collapsible_ui()
@@ -161,8 +162,10 @@ class ModifiableDictEmptyItem(QtWidgets.QWidget):
 
 
 class ModifiableDictItem(QtWidgets.QWidget):
-    def __init__(self, collapsible_key, entity, entity_widget):
+    def __init__(self, collapsible_key, store_as_list, entity, entity_widget):
         super(ModifiableDictItem, self).__init__(entity_widget.content_widget)
+
+        self.store_as_list = store_as_list
 
         self.collapsible_key = collapsible_key
         self.entity = entity
@@ -607,7 +610,7 @@ class DictMutableKeysWidget(BaseWidget):
         self.add_required_keys()
 
         self.empty_row = ModifiableDictEmptyItem(
-            self, self.content_widget
+            self, self.entity.store_as_list, self.content_widget
         )
         self.content_layout.addWidget(self.empty_row)
 
@@ -734,7 +737,8 @@ class DictMutableKeysWidget(BaseWidget):
 
     def add_widget_for_child(self, child_entity):
         input_field = ModifiableDictItem(
-            self.entity.collapsible_key, child_entity, self
+            self.entity.collapsible_key, self.entity.store_as_list,
+            child_entity, self
         )
         self.input_fields.append(input_field)
 


### PR DESCRIPTION
## Description
Sometimes it is required to store dictionary with invalid characters in key for mongo and only possible way how to do it is to store dictionary as list of 2 size lists.

This change does not add ability of ordered dictionary!!!

## Changes
- added ability to store, load content of modifiable dict as list of lists (set key `"store_as_list"` to true in schema)
    - if stored data are dictionary but output should be list entity won't tell that there is a change
- modifiable dict can't store metadata about labels and environments
    - this is maybe not properly handled (it is possible to set label but won't be stored)
- as loaded may contain both dict and list of list only way how to handle this change is in code
    - easiest is to always convert loaded data to dict `dict(data)`
        - `dict` type can convert dict to dict and list of lists to dict so it should not matter if `data` contain one or another
- skip key regex validation if output will be stored as list\
- modifiable-dict currently has autofix of keys on load, but that cause that items seems unmodified on load which was changed and not data are marked as modified

### Example schema
```
{
    "type": "dict-modifiable",
    "store_as_list": true,
    "object_type": {
        "type": "number",
        "minimum": 0,
        "maximum": 300
    },
    "is_group": true,
    "key": "templates_mapping",
    "label": "Templates mapping",
    "is_file": true
}
```
### Example output
```
{
    "muster": {
        ...
        "template_mapping": [
            ["file_layers", 7],
            ["mentalray", 2],
            ["mentalray_sf", 6],
            ["redshift", 55],
            ["renderman", 29],
            ["software", 1],
            ["software_sf", 5],
            ["turtle", 10],
            ["vector", 4],
            ["vray", 37],
            ["ffmpeg", 48]
        ]
    ...
}
```