### PR TITLE
Convert pyblish logs to string at the moment of logging

### DIFF
--- a/openpype/__init__.py
+++ b/openpype/__init__.py
@@ -67,6 +67,15 @@ def patched_discover(superclass):
 @import_wrapper
 def install():
     """Install Pype to Avalon."""
+    from pyblish.lib import MessageHandler
+
+    def modified_emit(obj, record):
+        """Method replacing `emit` in Pyblish's MessageHandler."""
+        record.msg = record.getMessage()
+        obj.records.append(record)
+
+    MessageHandler.emit = modified_emit
+
     log.info("Registering global plug-ins..")
     pyblish.register_plugin_path(PUBLISH_PATH)
     pyblish.register_discovery_filter(filter_pyblish_plugins)


### PR DESCRIPTION
## Issue
- objects passed to pyblish loggers are kept as objects until are shown in UI so in UI are not shown data representing state at the moment of logging but at the end of plugin processing

## Changes
- change pyblish `MessageHandler` emit method to convert messages to string at the moment of emmiting