### PR TITLE
Store as list dictionary check initial value with right type

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -434,8 +434,19 @@ class DictMutableKeysEntity(EndpointEntity):
         if using_values_from_state:
             if _settings_value is NOT_SET:
                 initial_value = NOT_SET
+
+            elif self.store_as_list:
+                new_initial_value = []
+                for key, value in _settings_value:
+                    if key in initial_value:
+                        new_initial_value.append(key, initial_value.pop(key))
+
+                for key, value in initial_value.items():
+                    new_initial_value.append(key, value)
+                initial_value = new_initial_value
         else:
             initial_value = _settings_value
+
         self.initial_value = initial_value
 
     def _convert_to_regex_valid_key(self, key):


### PR DESCRIPTION
## Issue
Added feature to store modifiable dictionary as list is always resolved as modified on load. That is because on load are data autoconverted to dictionary which is not same type as output type and is not resolved in any way.

## Changes
- initial value has same type as output type so settings does not recognize initial values as changed