### PR TITLE
Blender can initialize differente user script paths

### DIFF
--- a/openpype/hosts/blender/api/__init__.py
+++ b/openpype/hosts/blender/api/__init__.py
@@ -4,6 +4,8 @@ import traceback
 
 import bpy
 
+from .lib import append_user_scripts
+
 from avalon import api as avalon
 from pyblish import api as pyblish
 
@@ -29,7 +31,7 @@ def install():
     pyblish.register_plugin_path(str(PUBLISH_PATH))
     avalon.register_plugin_path(avalon.Loader, str(LOAD_PATH))
     avalon.register_plugin_path(avalon.Creator, str(CREATE_PATH))
-
+    append_user_scripts()
     avalon.on("new", on_new)
     avalon.on("open", on_open)
 

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -78,8 +78,12 @@ def load_scripts(paths):
     addons_paths = []
     for base_path in paths:
         addons_path = os.path.join(base_path, "addons")
-        if os.path.exists(addons_path):
-            addons_paths.append(addons_path)
+        if not os.path.exists(addons_path):
+            continue
+        addons_paths.append(addons_path)
+        addons_module_path = os.path.join(addons_path, "modules")
+        if os.path.exists(addons_module_path):
+            bpy.utils._sys_path_ensure_prepend(addons_module_path)
 
     if addons_paths:
         # Fake addons

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -3,6 +3,7 @@ import traceback
 import importlib
 
 import bpy
+import addon_utils
 
 
 def load_scripts(paths):
@@ -73,6 +74,23 @@ def load_scripts(paths):
                     continue
                 for mod in bpy.utils.modules_from_path(path, loaded_modules):
                     test_register(mod)
+
+    addons_paths = []
+    for base_path in paths:
+        addons_path = os.path.join(base_path, "addons")
+        if os.path.exists(addons_path):
+            addons_paths.append(addons_path)
+
+    if addons_paths:
+        # Fake addons
+        origin_paths = addon_utils.paths
+
+        def new_paths():
+            paths = origin_paths() + addons_paths
+            return paths
+
+        addon_utils.paths = new_paths
+        addon_utils.modules_refresh()
 
     # load template (if set)
     if any(bpy.utils.app_template_paths()):

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -91,3 +91,15 @@ def load_scripts(paths):
                     "Warning, unregistered class: %s(%s)" %
                     (subcls.__name__, cls.__name__)
                 )
+
+
+def append_user_scripts():
+    user_scripts = os.environ.get("OPENPYPE_BLENDER_USER_SCRIPTS")
+    if not user_scripts:
+        return
+
+    try:
+        load_scripts(user_scripts.split(os.pathsep))
+    except Exception:
+        print("Couldn't load user scripts \"{}\"".format(user_scripts))
+        traceback.print_exc()

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -1,0 +1,93 @@
+import os
+import traceback
+import importlib
+
+import bpy
+
+
+def load_scripts(paths):
+    """Copy of `load_scripts` from Blender's implementation.
+
+    It is possible that whis function will be changed in future and usage will
+    be based on Blender version.
+    """
+    import bpy_types
+
+    loaded_modules = set()
+
+    previous_classes = [
+        cls
+        for cls in bpy.types.bpy_struct.__subclasses__()
+    ]
+
+    def register_module_call(mod):
+        register = getattr(mod, "register", None)
+        if register:
+            try:
+                register()
+            except:
+                traceback.print_exc()
+        else:
+            print("\nWarning! '%s' has no register function, "
+                  "this is now a requirement for registerable scripts" %
+                  mod.__file__)
+
+    def unregister_module_call(mod):
+        unregister = getattr(mod, "unregister", None)
+        if unregister:
+            try:
+                unregister()
+            except:
+                traceback.print_exc()
+
+    def test_reload(mod):
+        # reloading this causes internal errors
+        # because the classes from this module are stored internally
+        # possibly to refresh internal references too but for now, best not to.
+        if mod == bpy_types:
+            return mod
+
+        try:
+            return importlib.reload(mod)
+        except:
+            traceback.print_exc()
+
+    def test_register(mod):
+        if mod:
+            register_module_call(mod)
+            bpy.utils._global_loaded_modules.append(mod.__name__)
+
+    from bpy_restrict_state import RestrictBlend
+
+    with RestrictBlend():
+        for base_path in paths:
+            for path_subdir in bpy.utils._script_module_dirs:
+                path = os.path.join(base_path, path_subdir)
+                if not os.path.isdir(path):
+                    continue
+
+                bpy.utils._sys_path_ensure_prepend(path)
+
+                # Only add to 'sys.modules' unless this is 'startup'.
+                if path_subdir != "startup":
+                    continue
+                for mod in bpy.utils.modules_from_path(path, loaded_modules):
+                    test_register(mod)
+
+    # load template (if set)
+    if any(bpy.utils.app_template_paths()):
+        import bl_app_template_utils
+        bl_app_template_utils.reset(reload_scripts=False)
+        del bl_app_template_utils
+
+    for cls in bpy.types.bpy_struct.__subclasses__():
+        if cls in previous_classes:
+            continue
+        if not getattr(cls, "is_registered", False):
+            continue
+        for subcls in cls.__subclasses__():
+            if not subcls.is_registered:
+                print(
+                    "Warning, unregistered class: %s(%s)" %
+                    (subcls.__name__, cls.__name__)
+                )


### PR DESCRIPTION
## Issue
Blender can have set only one `BLENDER_USER_SCRIPTS` which is already occupied by OpenPype implementation.

## Changes
- blender install method also register plugins/scripts/addons from `OPENPYPE_BLENDER_USER_SCRIPTS`
- advantage is that it should be possible to register multiple paths

## Warning
- this implementation is using "copy" of inner blender python module function so it may change over time
- tested only on Windows with my custom plugin (didn't find other plugin that would use BLENDER_USER_PATH)
- implemented only OpenPype 3 variant

## Note
- `OPENPYPE_BLENDER_USER_SCRIPTS` was added with [PR](https://github.com/pypeclub/OpenPype/pull/1522)

Closes: https://github.com/pypeclub/OpenPype/issues/1050