### PR TITLE
Validate is file attribute in settings schema

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -846,6 +846,13 @@ class ItemEntity(BaseItemEntity):
             )
             raise EntitySchemaError(self, reason)
 
+        if self.is_file and self.file_item is not None:
+            reason = (
+                "Entity has set `is_file` to true but"
+                " it's parent is already marked as file item."
+            )
+            raise EntitySchemaError(self, reason)
+
         super(ItemEntity, self).schema_validations()
 
     def create_schema_object(self, *args, **kwargs):

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -10,7 +10,6 @@
             "collapsible": true,
             "key": "publish",
             "label": "Publish plugins",
-            "is_file": true,
             "children": [
                 {
                     "type": "dict",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -603,7 +603,6 @@
             "collapsible": true,
             "key": "publish",
             "label": "Publish plugins",
-            "is_file": true,
             "children": [
                 {
                     "type": "dict",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
@@ -11,7 +11,6 @@
             "key": "create",
             "label": "Creator plugins",
             "collapsible_key": true,
-            "is_file": true,
             "object_type": {
                 "type": "dict",
                 "children": [
@@ -56,7 +55,6 @@
             "collapsible": true,
             "key": "publish",
             "label": "Publish plugins",
-            "is_file": true,
             "children": [
                 {
                     "type": "dict",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json
@@ -4,7 +4,6 @@
     "label": "Site Sync (beta testing)",
     "collapsible": true,
     "checkbox_key": "enabled",
-    "is_file": true,
     "children": [
     {
         "type": "boolean",
@@ -44,7 +43,6 @@
         "key": "sites",
         "label": "Sites",
         "collapsible_key": false,
-        "is_file": true,
         "object_type":
         {
             "type": "dict",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -10,7 +10,6 @@
             "collapsible": true,
             "key": "publish",
             "label": "Publish plugins",
-            "is_file": true,
             "children": [
                 {
                     "type": "schema_template",

--- a/openpype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_modules.json
@@ -97,7 +97,6 @@
                     "key": "sites",
                     "label": "Sites",
                     "collapsible_key": false,
-                    "is_file": true,
                     "object_type":
                     {
                         "type": "dict",
@@ -156,8 +155,7 @@
                     },
                     "is_group": true,
                     "key": "templates_mapping",
-                    "label": "Templates mapping",
-                    "is_file": true
+                    "label": "Templates mapping"
                 }
             ]
         },


### PR DESCRIPTION
## Issue
Settings entities may be marked to store their content into file even if their parent entity is already marked to storing to file. This may cause issues in future.

## Changes
- removed invalid `is_file` attributes from schema
- added validation of the attribute - entity can't have set `is_file` attribute to True if any parent already has