### PR TITLE
TVPaint loader settings

### DIFF
--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -16,5 +16,33 @@
             "active": true
         }
     },
+    "load": {
+        "LoadImage": {
+            "defaults": {
+                "stretch": true,
+                "timestretch": true,
+                "preload": true
+            },
+            "families": [
+                "render",
+                "image",
+                "background",
+                "plate"
+            ]
+        },
+        "ImportImage": {
+            "defaults": {
+                "stretch": true,
+                "timestretch": true,
+                "preload": true
+            },
+            "families": [
+                "render",
+                "image",
+                "background",
+                "plate"
+            ]
+        }
+    },
     "filters": {}
 }

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -22,26 +22,14 @@
                 "stretch": true,
                 "timestretch": true,
                 "preload": true
-            },
-            "families": [
-                "render",
-                "image",
-                "background",
-                "plate"
-            ]
+            }
         },
         "ImportImage": {
             "defaults": {
                 "stretch": true,
                 "timestretch": true,
                 "preload": true
-            },
-            "families": [
-                "render",
-                "image",
-                "background",
-                "plate"
-            ]
+            }
         }
     },
     "filters": {}

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -48,6 +48,84 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "load",
+            "label": "Loader plugins",
+            "children": [
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "LoadImage",
+                    "label": "Load Image",
+                    "children": [
+                        {
+                            "key": "defaults",
+                            "type": "dict",
+                            "children": [
+                                {
+                                    "type": "boolean",
+                                    "key": "stretch",
+                                    "label": "Stretch"
+                                },
+                                {
+                                    "type": "boolean",
+                                    "key": "timestretch",
+                                    "label": "TimeStretch"
+                                },
+                                {
+                                    "type": "boolean",
+                                    "key": "preload",
+                                    "label": "Preload"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "list",
+                            "key": "families",
+                            "label": "Families",
+                            "object_type": "text"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "ImportImage",
+                    "label": "Import Image",
+                    "children": [
+                        {
+                            "key": "defaults",
+                            "type": "dict",
+                            "children": [
+                                {
+                                    "type": "boolean",
+                                    "key": "stretch",
+                                    "label": "Stretch"
+                                },
+                                {
+                                    "type": "boolean",
+                                    "key": "timestretch",
+                                    "label": "TimeStretch"
+                                },
+                                {
+                                    "type": "boolean",
+                                    "key": "preload",
+                                    "label": "Preload"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "list",
+                            "key": "families",
+                            "label": "Families",
+                            "object_type": "text"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "type": "schema",
             "name": "schema_publish_gui_filter"
         }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -79,12 +79,6 @@
                                     "label": "Preload"
                                 }
                             ]
-                        },
-                        {
-                            "type": "list",
-                            "key": "families",
-                            "label": "Families",
-                            "object_type": "text"
                         }
                     ]
                 },
@@ -114,12 +108,6 @@
                                     "label": "Preload"
                                 }
                             ]
-                        },
-                        {
-                            "type": "list",
-                            "key": "families",
-                            "label": "Families",
-                            "object_type": "text"
                         }
                     ]
                 }


### PR DESCRIPTION
## Description
TVPaint loaders don't have schemas for their settings.

## Changes
- added settings for `LoadImage` and `ImportImage` loaders both have same settings
    - both have ability to modify families because a client have modified them, but we should maybe go through them and look if we can keep families out of settings?

## Note
- maybe we could get rid of `ImpotImage` loader not sure if would anybody use it anymore?