### PR TITLE
Handle duplicated task names in project manager

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1797,7 +1797,11 @@ class AssetItem(BaseItem):
             item.setData(False, DUPLICATED_ROLE)
 
     def _remove_task(self, item):
+        # This method is probably obsolete with changed logic and added
+        #   `on_task_remove_state_change` method.
         item_id = item.data(IDENTIFIER_ROLE)
+        if item_id not in self._task_name_by_item_id:
+            return
 
         name = self._task_name_by_item_id.pop(item_id)
         self._task_items_by_name[name].remove(item)

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1810,6 +1810,9 @@ class AssetItem(BaseItem):
                 _item.setData(False, DUPLICATED_ROLE)
 
     def _rename_task(self, item):
+        if item.data(REMOVED_ROLE):
+            return
+
         new_name = item.data(QtCore.Qt.EditRole, "name").lower()
         item_id = item.data(IDENTIFIER_ROLE)
         prev_name = self._task_name_by_item_id[item_id]

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -2004,7 +2004,10 @@ class TaskItem(BaseItem):
             return True
 
         if role == REMOVED_ROLE:
+            if value == self._removed:
+                return False
             self._removed = value
+            self.parent().on_task_remove_state_change(self)
             return True
 
         if (

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1843,6 +1843,32 @@ class AssetItem(BaseItem):
     def on_task_name_change(self, task_item):
         self._rename_task(task_item)
 
+    def on_task_remove_state_change(self, task_item):
+        is_removed = task_item.data(REMOVED_ROLE)
+        item_id = task_item.data(IDENTIFIER_ROLE)
+        if is_removed:
+            name = self._task_name_by_item_id.pop(item_id)
+            self._task_items_by_name[name].remove(task_item)
+
+        else:
+            name = task_item.data(QtCore.Qt.EditRole, "name").lower()
+            self._task_name_by_item_id[item_id] = name
+            self._task_items_by_name[name].append(task_item)
+
+        # Remove from previous name mapping
+        if not self._task_items_by_name[name]:
+            self._task_items_by_name.pop(name)
+
+        elif len(self._task_items_by_name[name]) == 1:
+            if name in self._duplicated_task_names:
+                self._duplicated_task_names.remove(name)
+            task_item.setData(False, DUPLICATED_ROLE)
+
+        else:
+            self._duplicated_task_names.add(name)
+            for _item in self._task_items_by_name[name]:
+                _item.setData(True, DUPLICATED_ROLE)
+
     def add_child(self, item, row=None):
         if item in self._children:
             return


### PR DESCRIPTION
## Issue
Duplicated tasks are not handled properly on delete task in worst cases it will crash project manager.

## Changes
- removed task tells to it's asset that was removed and should not care about it's name duplicity
- task name operations are ignored on asset item level if task is marked as removed