### PR TITLE
Host name collecting fix

### DIFF
--- a/openpype/plugins/publish/collect_anatomy_context_data.py
+++ b/openpype/plugins/publish/collect_anatomy_context_data.py
@@ -71,6 +71,10 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
             app = app_manager.applications.get(app_name)
             if app:
                 context_data["app"] = app.host_name
+        # Use AVALON_APP as first if available it is the same as host name
+        # - only if is not defined use AVALON_APP_NAME (e.g. on Farm) and
+        #   set it back to AVALON_APP env variable
+        host_name = os.environ.get("AVALON_APP")
 
         datetime_data = context.data.get("datetimeData") or {}
         context_data.update(datetime_data)

--- a/openpype/plugins/publish/collect_anatomy_context_data.py
+++ b/openpype/plugins/publish/collect_anatomy_context_data.py
@@ -76,6 +76,7 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
                 app = app_manager.applications.get(app_name)
                 if app:
                     host_name = app.host_name
+                    os.environ["AVALON_APP"] = host_name
         context_data["app"] = host_name
 
         datetime_data = context.data.get("datetimeData") or {}

--- a/openpype/plugins/publish/collect_anatomy_context_data.py
+++ b/openpype/plugins/publish/collect_anatomy_context_data.py
@@ -65,16 +65,18 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
             "username": context.data["user"]
         }
 
-        app_manager = ApplicationManager()
-        app_name = os.environ.get("AVALON_APP_NAME")
-        if app_name:
-            app = app_manager.applications.get(app_name)
-            if app:
-                context_data["app"] = app.host_name
         # Use AVALON_APP as first if available it is the same as host name
         # - only if is not defined use AVALON_APP_NAME (e.g. on Farm) and
         #   set it back to AVALON_APP env variable
         host_name = os.environ.get("AVALON_APP")
+        if not host_name:
+            app_manager = ApplicationManager()
+            app_name = os.environ.get("AVALON_APP_NAME")
+            if app_name:
+                app = app_manager.applications.get(app_name)
+                if app:
+                    host_name = app.host_name
+        context_data["app"] = host_name
 
         datetime_data = context.data.get("datetimeData") or {}
         context_data.update(datetime_data)


### PR DESCRIPTION
## Issue
IntegrateNewAsset plugin is using `instance.data["anatomyData"]["app"]` but "app" is filled only if application is one of applications defined as host integration.

## Changes
- first tried value for `"app"` is taken from env variable `AVALON_APP` which is actually reserverd for host name
- if `AVALON_APP` is not defined then is tried to look for host name with `AVALON_APP_NAME` and `ApplicationManager`
    - when host name is found out it is set back to `AVALON_APP`
    - that is because `AVALON_APP` is used for filtering on some places