### PR TITLE
Bugfix  PS subset and quick review

### DIFF
--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -9,6 +9,7 @@ class CreateImage(openpype.api.Creator):
     name = "imageDefault"
     label = "Image"
     family = "image"
+    defaults = ["Main"]
 
     def process(self):
         groups = []
@@ -82,8 +83,7 @@ class CreateImage(openpype.api.Creator):
                 replace(stub.LOADED_ICON, '')
 
             if useSelection:
-                clean_subset_name = self.data["subset"].replace("Default", '')
-                subset_name = clean_subset_name + group.name
+                subset_name = self.data["subset"] + group.name
             else:
                 # use value provided by user from Creator
                 subset_name = self.data["subset"]

--- a/openpype/hosts/photoshop/plugins/publish/extract_image.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_image.py
@@ -35,21 +35,16 @@ class ExtractImage(openpype.api.Extractor):
                     if layer.visible and layer.id not in extract_ids:
                         stub.set_visible(layer.id, False)
 
-                save_options = []
-                if "png" in self.formats:
-                    save_options.append('png')
-                if "jpg" in self.formats:
-                    save_options.append('jpg')
-
                 file_basename = os.path.splitext(
                     stub.get_active_document_name()
                 )[0]
-                for extension in save_options:
+                for extension in self.formats:
                     _filename = "{}.{}".format(file_basename, extension)
                     files[extension] = _filename
 
                     full_filename = os.path.join(staging_dir, _filename)
                     stub.saveAs(full_filename, extension, True)
+                    self.log.info(f"Extracted: {extension}")
 
         representations = []
         for extension, filename in files.items():

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -6,7 +6,12 @@ from avalon import photoshop
 
 
 class ExtractReview(openpype.api.Extractor):
-    """Produce a flattened image file from all instances."""
+    """
+        Produce a flattened image file from all 'image' instances.
+
+        If no 'image' instance is created, it produces flattened image from
+        all visible layers.
+    """
 
     label = "Extract Review"
     hosts = ["photoshop"]
@@ -30,14 +35,15 @@ class ExtractReview(openpype.api.Extractor):
         )
         output_image_path = os.path.join(staging_dir, output_image)
         with photoshop.maintained_visibility():
-            # Hide all other layers.
-            extract_ids = set([ll.id for ll in stub.
-                               get_layers_in_layers(layers)])
-            self.log.info("extract_ids {}".format(extract_ids))
-            for layer in stub.get_layers():
-                # limit unnecessary calls to client
-                if layer.visible and layer.id not in extract_ids:
-                    stub.set_visible(layer.id, False)
+            if layers:
+                # Hide all other layers.
+                extract_ids = set([ll.id for ll in stub.
+                                   get_layers_in_layers(layers)])
+                self.log.debug("extract_ids {}".format(extract_ids))
+                for layer in stub.get_layers():
+                    # limit unnecessary calls to client
+                    if layer.visible and layer.id not in extract_ids:
+                        stub.set_visible(layer.id, False)
 
             stub.saveAs(output_image_path, 'jpg', True)
 

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -1,0 +1,17 @@
+{
+    "create": {
+        "CreateImage": {
+            "defaults": [
+                "Main"
+            ]
+        }
+    },
+    "publish": {
+        "ExtractImage": {
+            "formats": [
+                "png",
+                "jpg"
+            ]
+        }
+    }
+}

--- a/openpype/settings/entities/schemas/projects_schema/schema_main.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_main.json
@@ -84,6 +84,10 @@
                 },
                 {
                     "type": "schema",
+                    "name": "schema_project_photoshop"
+                },
+                {
+                    "type": "schema",
                     "name": "schema_project_harmony"
                 },
                 {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -1,0 +1,57 @@
+{
+    "type": "dict",
+    "collapsible": true,
+    "key": "photoshop",
+    "label": "Photoshop",
+    "is_file": true,
+    "children": [
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "create",
+            "label": "Creator plugins",
+            "children": [
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "CreateImage",
+                    "label": "Create Image",
+                    "children": [
+                        {
+                            "type": "list",
+                            "key": "defaults",
+                            "label": "Default Subsets",
+                            "object_type": "text"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "publish",
+            "label": "Publish plugins",
+            "children": [
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "ExtractImage",
+                    "label": "Extract Image",
+                    "children": [
+                        {
+                            "type": "label",
+                            "label": "Currently only jpg and png are supported"
+                        },
+                        {
+                            "type": "list",
+                            "key": "formats",
+                            "label": "Extract Formats",
+                            "object_type": "text"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Closes: https://github.com/pypeclub/client/issues/72

PS was hardcoding 'image' into subset name ignoring possible different value expected for Subset configured in `Settings > Project > Global > Tools > Creator`

PS is creating quick review with all visible layers if no 'image' instances are created (`previously blank picture`)

![Screenshot 2021-05-19 112935](https://user-images.githubusercontent.com/4457962/118843614-82a9c200-b8ca-11eb-8783-9641358db69a.png)
