### PR TITLE
Maya Hardware support

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -76,6 +76,7 @@ RENDERER_NAMES = {
     "arnold": "Arnold",
     "renderman": "Renderman",
     "redshift": "Redshift",
+    "mayahardware2": "Maya Hardware"
 }
 
 # not sure about the renderman image prefix
@@ -85,6 +86,7 @@ IMAGE_PREFIXES = {
     "arnold": "defaultRenderGlobals.imageFilePrefix",
     "renderman": "rmanGlobals.imageFileFormat",
     "redshift": "defaultRenderGlobals.imageFilePrefix",
+    "mayahardware2": "defaultRenderGlobals.imageFilePrefix"
 }
 
 
@@ -135,6 +137,9 @@ class ExpectedFiles:
                 layer, self._render_instance))
         if renderer.lower() == "renderman":
             return self._get_files(ExpectedFilesRenderman(
+                layer, self._render_instance))
+        if renderer.lower() == "mayahardware2":
+            return self._get_files(ExpectedFilesMayaHardware(
                 layer, self._render_instance))
 
         raise UnsupportedRendererException(
@@ -906,6 +911,31 @@ class ExpectedFilesMentalray(AExpectedFiles):
         """
         super(ExpectedFilesMentalray, self).__init__(layer, render_instance)
         raise UnimplementedRendererException("Mentalray not implemented")
+
+    def get_aovs(self):
+        """Get all AOVs.
+
+        See Also:
+            :func:`AExpectedFiles.get_aovs()`
+
+        """
+        return []
+
+
+class ExpectedFilesMayaHardware(AExpectedFiles):
+    """Expected files for Maya Hardware renderer.
+
+    Attributes:
+        aiDriverExtension (dict): Arnold AOV driver extension mapping.
+            Is there a better way?
+        renderer (str): name of renderer.
+
+    """
+
+    def __init__(self, layer, render_instance):
+        """Constructor."""
+        super(ExpectedFilesMayaHardware, self).__init__(layer, render_instance)
+        self.renderer = "mayahardware2"
 
     def get_aovs(self):
         """Get all AOVs.

--- a/pype/plugins/maya/create/create_render.py
+++ b/pype/plugins/maya/create/create_render.py
@@ -70,7 +70,8 @@ class CreateRender(plugin.Creator):
         'vray': 'vraySettings.fileNamePrefix',
         'arnold': 'defaultRenderGlobals.imageFilePrefix',
         'renderman': 'defaultRenderGlobals.imageFilePrefix',
-        'redshift': 'defaultRenderGlobals.imageFilePrefix'
+        'redshift': 'defaultRenderGlobals.imageFilePrefix',
+        'mayahardware2': 'defaultRenderGlobals.imageFilePrefix'
     }
 
     _image_prefixes = {
@@ -78,7 +79,8 @@ class CreateRender(plugin.Creator):
         'vray': 'maya/<scene>/<Layer>/<Layer>',
         'arnold': 'maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>',
         'renderman': 'maya/<Scene>/<layer>/<layer>_<aov>',
-        'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>'
+        'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>',
+        'mayahardware2': 'maya/<Scene>/<RenderLayer>/<RenderLayer>'
     }
 
     deadline_servers = {}

--- a/pype/plugins/maya/publish/validate_render_single_camera.py
+++ b/pype/plugins/maya/publish/validate_render_single_camera.py
@@ -12,7 +12,8 @@ ImagePrefixes = {
     'vray': 'vraySettings.fileNamePrefix',
     'arnold': 'defaultRenderGlobals.imageFilePrefix',
     'renderman': 'defaultRenderGlobals.imageFilePrefix',
-    'redshift': 'defaultRenderGlobals.imageFilePrefix'
+    'redshift': 'defaultRenderGlobals.imageFilePrefix',
+    'mayahardware2': 'defaultRenderGlobals.imageFilePrefix'
 }
 
 

--- a/pype/plugins/maya/publish/validate_rendersettings.py
+++ b/pype/plugins/maya/publish/validate_rendersettings.py
@@ -49,7 +49,8 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
         'vray': 'vraySettings.fileNamePrefix',
         'arnold': 'defaultRenderGlobals.imageFilePrefix',
         'renderman': 'rmanGlobals.imageFileFormat',
-        'redshift': 'defaultRenderGlobals.imageFilePrefix'
+        'redshift': 'defaultRenderGlobals.imageFilePrefix',
+        'mayaHardware2': 'defaultRenderGlobals.imageFilePrefix'
     }
 
     ImagePrefixTokens = {
@@ -57,7 +58,8 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
         'arnold': 'maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>',
         'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>',
         'vray': 'maya/<Scene>/<Layer>/<Layer>',
-        'renderman': '<layer>_<aov>.<f4>.<ext>'
+        'renderman': '<layer>_<aov>.<f4>.<ext>',
+        'mayaHardware2': 'maya/<Scene>/<RenderLayer>/<RenderLayer>'
     }
 
     # WARNING: There is bug? in renderman, translating <scene> token
@@ -150,6 +152,14 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 invalid = True
                 cls.log.error("Wrong directory prefix [ {} ]".format(
                     dir_prefix))
+
+        elif renderer == "mayaHardware2":
+            if re.search(cls.R_AOV_TOKEN, prefix):
+                invalid = True
+                cls.log.error(
+                    "Do not use AOV token [ {} ] - Maya Hardware does not "
+                    "support AOVs.".format(prefix)
+                )
 
         else:
             multipart = cmds.getAttr("defaultArnoldDriver.mergeAOVs")


### PR DESCRIPTION
- adds Maya Hardware support to the rendering pipeline. Normally render farms might not support this but because we use the Maya Sequence rendering (https://github.com/tokejepsen/MayaSequence) we can use Maya Hardware to render playblasts on the farm.
- Ensures the renderer is queried on all render layers.