### PR TITLE
Failsafe for cross project containers.

### DIFF
--- a/pype/hosts/nuke/lib.py
+++ b/pype/hosts/nuke/lib.py
@@ -62,6 +62,14 @@ def check_inventory_versions():
                     "_id": io.ObjectId(avalon_knob_data["representation"])
                 })
 
+                # Failsafe for not finding the representation.
+                if not representation:
+                    log.warning(
+                        "Could not find the representation on "
+                        "node \"{}\"".format(node.name())
+                    )
+                    continue
+
                 # Get start frame from version data
                 version = io.find_one({
                     "type": "version",


### PR DESCRIPTION
If a container from another project is in the script, the `check_inventory_versions` method errors. This method is run when saving the script which prevents the user from saving the work.
Reduced the error to a log warning about which nodes are the issue.

Error:
```
Traceback (most recent call last):
  File "C:/Program Files/Nuke11.0v4/plugins\nuke\callbacks.py", line 92, in onScriptSave
    _doCallbacks(onScriptSaves)
  File "C:/Program Files/Nuke11.0v4/plugins\nuke\callbacks.py", line 46, in _doCallbacks
    f[0](*f[1],**f[2])
  File "C:\Users\tokejepsen\bumpybox_development\pype-setup\repos\pype\pype\hosts\nuke\lib.py", line 68, in check_inventory_versions
    "_id": representation["parent"]
TypeError: 'NoneType' object has no attribute '__getitem__'
```

||OpenPype 3 PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1806|