### PR TITLE
MongoDB: backup all collection data

### DIFF
--- a/openpype/scripts/backup_mongo_data.py
+++ b/openpype/scripts/backup_mongo_data.py
@@ -25,6 +25,8 @@ def backup(mongo_uri, mongo_db_name, collections, export_dir):
     # create cmd
     if "|" in collections:
         _collections = [c for c in collections.split("|")]
+    elif isinstance(collections, list):
+        _collections = collections
     else:
         _collections = [collections]
 

--- a/openpype/scripts/backup_mongo_data.py
+++ b/openpype/scripts/backup_mongo_data.py
@@ -1,0 +1,57 @@
+import subprocess
+import os
+import click
+
+@click.command()
+@click.option("--mongo-uri", help="mongo db uri", default=None)
+@click.option("--mongo-db-name", help="mongo db name", default=None)
+@click.option(
+    "--collections",
+    help="collection string as ex: `project01|project02",
+    default=None)
+@click.option("--export-dir",
+              help="Folder where should be saved all json files",
+              default=None,
+              type=click.Path())
+def backup(mongo_uri, mongo_db_name, collections, export_dir):
+    # input argument > mongo db url > mongodb+srv://user:password@mongodb.net
+    # input argument > mongo db name > avalon
+    # input argument > collections "project01|project02" (| slice to list)
+    # input argument > export_dir
+    assert any((mongo_uri, mongo_db_name, collections,
+               export_dir)), "missing input arguments"
+
+    # mongodb://<user>:<password>@<server>:<port>/<database>?authsource=admin
+    # create cmd
+    if "|" in collections:
+        _collections = [c for c in collections.split("|")]
+    else:
+        _collections = [collections]
+
+    for collection in _collections:
+        cmd_data = {
+            "uri": mongo_uri,
+            "dbName": mongo_db_name,
+            "collection": collection,
+            "fpath": os.path.join(export_dir, "{}.json".format(collection))
+        }
+        cmd = (
+            "mongoexport --uri=\"{uri}/{dbName}?authsource=admin\" "
+            "--collection=\"{collection}\" "
+            "--out=\"{fpath}\"").format(**cmd_data)
+
+        print(cmd)
+
+        pout = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, universal_newlines=True)
+
+        output, errors = pout.communicate()
+
+        if errors:
+            print(errors)
+        else:
+            print(output)
+
+if __name__ == '__main__':
+    backup()

--- a/tools/backup_mongo_data.py
+++ b/tools/backup_mongo_data.py
@@ -2,8 +2,8 @@ import subprocess
 import os
 import click
 
+
 @click.command()
-@click.option("--mongo-uri", help="mongo db uri", default=None)
 @click.option("--mongo-db-name", help="mongo db name", default=None)
 @click.option(
     "--collections",
@@ -13,16 +13,19 @@ import click
               help="Folder where should be saved all json files",
               default=None,
               type=click.Path())
-def backup(mongo_uri, mongo_db_name, collections, export_dir):
-    # input argument > mongo db url > mongodb+srv://user:password@mongodb.net
-    # input argument > mongo db name > avalon
-    # input argument > collections "project01|project02" (| slice to list)
-    # input argument > export_dir
+def backup(mongo_db_name, collections, export_dir):
+    """Backup OpenPype mongo db data
+
+    Args:
+        mongo_db_name (str): name of openpype database
+        collections (str): names of collections separated by `|` (no spaces)
+        export_dir (str): path pointing to directory of export
+    """
+    mongo_uri = os.getenv("OPENPYPE_MONGO")
+
     assert any((mongo_uri, mongo_db_name, collections,
                export_dir)), "missing input arguments"
 
-    # mongodb://<user>:<password>@<server>:<port>/<database>?authsource=admin
-    # create cmd
     if "|" in collections:
         _collections = [c for c in collections.split("|")]
     elif isinstance(collections, list):
@@ -54,6 +57,7 @@ def backup(mongo_uri, mongo_db_name, collections, export_dir):
             print(errors)
         else:
             print(output)
+
 
 if __name__ == '__main__':
     backup()

--- a/tools/run_mongo_backup.ps1
+++ b/tools/run_mongo_backup.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+  Helper script to run bsackup mongodb.
+
+.DESCRIPTION
+  This script will detect mongodb, add it to the PATH and launch it on specified port and db location.
+
+.EXAMPLE
+
+PS> .\run_mongo.ps1
+
+#>
+
+$art = @"
+
+             . .   ..     .    ..
+        _oOOP3OPP3Op_. .
+     .PPpo~.   ..   ~2p.  ..  ....  .  .
+    .Ppo . .pPO3Op.. . O:. . . .
+   .3Pp . oP3'. 'P33. . 4 ..   .  .   . .. .  .  .
+  .~OP    3PO.  .Op3    : . ..  _____  _____  _____
+  .P3O  . oP3oP3O3P' . . .   . /    /./    /./    /
+   O3:.   O3p~ .       .:. . ./____/./____/ /____/
+   'P .   3p3.  oP3~. ..P:. .  . ..  .   . .. .  .  .
+  . ':  . Po'  .Opo'. .3O. .  o[ by Pype Club ]]]==- - - .  .
+    . '_ ..  .    . _OP3..  .  .https://openpype.io.. .
+         ~P3.OPPPO3OP~ . ..  .
+           .  ' '. .  .. . . . ..  .
+
+"@
+
+Write-Host $art -ForegroundColor DarkGreen
+
+function Exit-WithCode($exitcode) {
+   # Only exit this host process if it's a child of another PowerShell parent process...
+   $parentPID = (Get-CimInstance -ClassName Win32_Process -Filter "ProcessId=$PID" | Select-Object -Property ParentProcessId).ParentProcessId
+   $parentProcName = (Get-CimInstance -ClassName Win32_Process -Filter "ProcessId=$parentPID" | Select-Object -Property Name).Name
+   if ('powershell.exe' -eq $parentProcName) { $host.SetShouldExit($exitcode) }
+
+   exit $exitcode
+}
+
+
+function Find-Mongo {
+    $defaultPath = "C:\Program Files\MongoDB\Server"
+    Write-Host ">>> " -NoNewLine -ForegroundColor Green
+    Write-Host "Detecting MongoDB ... " -NoNewline
+    if (-not (Get-Command "mongod" -ErrorAction SilentlyContinue)) {
+        if(Test-Path "$($defaultPath)\*\bin\mongod.exe" -PathType Leaf) {
+        # we have mongo server installed on standard Windows location
+        # so we can inject it to the PATH. We'll use latest version available.
+        $mongoVersions = Get-ChildItem -Directory 'C:\Program Files\MongoDB\Server' | Sort-Object -Property {$_.Name -as [int]}
+        if(Test-Path "$($mongoVersions[-1])\bin\mongod.exe" -PathType Leaf) {
+            $env:PATH = "$($env:PATH);$($mongoVersions[-1])\bin\"
+            Write-Host "OK" -ForegroundColor Green
+            Write-Host "  - auto-added from [ " -NoNewline
+            Write-Host "$($mongoVersions[-1])\bin\mongod.exe" -NoNewLine -ForegroundColor Cyan
+            Write-Host " ]"
+            return "$($mongoVersions[-1])\bin\mongod.exe"
+        } else {
+            Write-Host "FAILED " -NoNewLine -ForegroundColor Red
+            Write-Host "MongoDB not detected" -ForegroundColor Yellow
+            Write-Host "Tried to find it on standard location " -NoNewline -ForegroundColor Gray
+            Write-Host " [ " -NoNewline -ForegroundColor Cyan
+            Write-Host "$($mongoVersions[-1])\bin\mongod.exe" -NoNewline -ForegroundColor White
+            Write-Host " ] " -NoNewLine -ForegroundColor Cyan
+            Write-Host "but failed." -ForegroundColor Gray
+            Exit-WithCode 1
+        }
+    } else {
+        Write-Host "FAILED " -NoNewLine -ForegroundColor Red
+        Write-Host "MongoDB not detected in PATH" -ForegroundColor Yellow
+        Exit-WithCode 1
+    }
+  } else {
+        Write-Host "OK" -ForegroundColor Green
+        return Get-Command "mongod" -ErrorAction SilentlyContinue
+  }
+  <#
+  .SYNOPSIS
+  Function to detect mongod in path.
+  .DESCRIPTION
+  This will test presence of mongod in PATH. If it's not there, it will try
+  to find it in default install location. It support different mongo versions
+  (using latest if found). When mongod is found, path to it is added to PATH
+  #>
+}
+
+$script_dir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+$openpype_root = (Get-Item $script_dir).parent.FullName
+
+# mongodb port
+$port = 2707
+
+# path to database
+$dbpath = (Get-Item $openpype_root).parent.FullName + "\mongo_db_data"
+
+$mongoPath = Find-Mongo
+Start-Process -FilePath $mongopath "--dbpath $($dbpath) --port $($port)" -PassThru


### PR DESCRIPTION
Script possible to run anytime for backing up all collections from defined database.

Required:
mongo tools on PATH


- [x] move script to ./tools
- [x] remove mongodb uri and connect it to environ var instead
- [ ] finalize `run_mongodb_backup.ps1`