### PR TITLE
Sync to avalon do not store hierarchy key

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -1101,9 +1101,6 @@ class SyncToAvalonEvent(BaseEvent):
         # Parents, Hierarchy
         ent_path_items = [ent["name"] for ent in ftrack_ent["link"]]
         parents = ent_path_items[1:len(ent_path_items)-1:]
-        hierarchy = ""
-        if len(parents) > 0:
-            hierarchy = os.path.sep.join(parents)
 
         # TODO logging
         self.log.debug(
@@ -1132,7 +1129,6 @@ class SyncToAvalonEvent(BaseEvent):
                 "ftrackId": ftrack_ent["id"],
                 "entityType": ftrack_ent.entity_type,
                 "parents": parents,
-                "hierarchy": hierarchy,
                 "tasks": {},
                 "visualParent": vis_par
             }
@@ -1975,14 +1971,9 @@ class SyncToAvalonEvent(BaseEvent):
             if cur_par == parents:
                 continue
 
-            hierarchy = ""
-            if len(parents) > 0:
-                hierarchy = os.path.sep.join(parents)
-
             if "data" not in self.updates[mongo_id]:
                 self.updates[mongo_id]["data"] = {}
             self.updates[mongo_id]["data"]["parents"] = parents
-            self.updates[mongo_id]["data"]["hierarchy"] = hierarchy
 
         # Skip custom attributes if didn't change
         if not hier_cust_attrs_ids:

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -1237,12 +1237,8 @@ class SyncEntitiesFactory:
 
             ent_path_items = [ent["name"] for ent in entity["link"]]
             parents = ent_path_items[1:len(ent_path_items) - 1:]
-            hierarchy = ""
-            if len(parents) > 0:
-                hierarchy = os.path.sep.join(parents)
 
             data["parents"] = parents
-            data["hierarchy"] = hierarchy
             data["tasks"] = self.entities_dict[id].pop("tasks", {})
             self.entities_dict[id]["final_entity"]["data"] = data
             self.entities_dict[id]["final_entity"]["type"] = "asset"
@@ -2169,8 +2165,6 @@ class SyncEntitiesFactory:
             hierarchy = "/".join(parents)
             self.entities_dict[ftrack_id][
                 "final_entity"]["data"]["parents"] = parents
-            self.entities_dict[ftrack_id][
-                "final_entity"]["data"]["hierarchy"] = hierarchy
 
             _parents.append(self.entities_dict[ftrack_id]["name"])
             for child_id in self.entities_dict[ftrack_id]["children"]:
@@ -2181,7 +2175,6 @@ class SyncEntitiesFactory:
                 if "data" not in self.updates[mongo_id]:
                     self.updates[mongo_id]["data"] = {}
                 self.updates[mongo_id]["data"]["parents"] = parents
-                self.updates[mongo_id]["data"]["hierarchy"] = hierarchy
 
     def prepare_project_changes(self):
         ftrack_ent_dict = self.entities_dict[self.ft_project_id]


### PR DESCRIPTION
## Description
- sync to avalon store `"hierarchy"` key in asset document which is not used in code (`"parents"` key is used instead)

## Changes
- sync to avalon action and event are not storing `"hierarchy"` key on asset document

Closes https://github.com/pypeclub/OpenPype/issues/432