### PR TITLE
FFmpeg filters in quote marks

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -547,10 +547,12 @@ class ExtractReview(pyblish.api.InstancePlugin):
         all_args.append("\"{}\"".format(self.ffmpeg_path))
         all_args.extend(input_args)
         if video_filters:
-            all_args.append("-filter:v {}".format(",".join(video_filters)))
+            all_args.append("-filter:v")
+            all_args.append("\"{}\"".format(",".join(video_filters)))
 
         if audio_filters:
-            all_args.append("-filter:a {}".format(",".join(audio_filters)))
+            all_args.append("-filter:a")
+            all_args.append("\"{}\"".format(",".join(audio_filters)))
 
         all_args.extend(output_args)
 


### PR DESCRIPTION
## Issue
Bash may have issue with few symbols (e.g. `(` ) in arguments if are not in quotation marks (`"`).

## Changes
- add video and audio filters into quotation marks

||OpenPype 2 PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1588|