### PR TITLE
Build: stop cleaning of pyc files in build directory

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -175,9 +175,9 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
 
 Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Cleaning cache files ... " -NoNewline
-Get-ChildItem $openpype_root -Filter "*.pyc" -Force -Recurse | Remove-Item -Force
-Get-ChildItem $openpype_root -Filter "*.pyo" -Force -Recurse | Remove-Item -Force
-Get-ChildItem $openpype_root -Filter "__pycache__" -Force -Recurse | Remove-Item -Force -Recurse
+Get-ChildItem $openpype_root -Filter "*.pyc" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force
+Get-ChildItem $openpype_root -Filter "*.pyo" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force
+Get-ChildItem $openpype_root -Filter "__pycache__" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force -Recurse
 Write-Host "OK" -ForegroundColor green
 
 Write-Host ">>> " -NoNewline -ForegroundColor green

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -122,7 +122,8 @@ clean_pyc () {
   local path
   path=$openpype_root
   echo -e "${BIGreen}>>>${RST} Cleaning pyc at [ ${BIWhite}$path${RST} ] ... \c"
-  find "$path" -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
+  find "$path" -path ./build -prune -o -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
+
   echo -e "${BIGreen}DONE${RST}"
 }
 

--- a/tools/create_env.ps1
+++ b/tools/create_env.ps1
@@ -81,7 +81,7 @@ print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))
       Write-Host "FAILED Version [ $p ] is old and unsupported" -ForegroundColor red
       Set-Location -Path $current_dir
       Exit-WithCode 1
-    } elseif (($matches[1] = 3) -or ($matches[2] -gt 7)) {
+    } elseif (($matches[1] -eq 3) -and ($matches[2] -gt 7)) {
         Write-Host "WARNING Version [ $p ] is unsupported, use at your own risk." -ForegroundColor yellow
         Write-Host "*** " -NoNewline -ForegroundColor yellow
         Write-Host "OpenPype supports only Python 3.7" -ForegroundColor white

--- a/tools/create_env.ps1
+++ b/tools/create_env.ps1
@@ -76,15 +76,19 @@ print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))
       Set-Location -Path $current_dir
       Exit-WithCode 1
     }
-    # We are supporting python 3.6 and up
-    if(($matches[1] -lt 3) -or ($matches[2] -lt 7)) {
+    # We are supporting python 3.7 only
+    if (($matches[1] -lt 3) -or ($matches[2] -lt 7)) {
       Write-Host "FAILED Version [ $p ] is old and unsupported" -ForegroundColor red
       Set-Location -Path $current_dir
       Exit-WithCode 1
+    } elseif (($matches[1] = 3) -or ($matches[2] -gt 7)) {
+        Write-Host "WARNING Version [ $p ] is unsupported, use at your own risk." -ForegroundColor yellow
+        Write-Host "*** " -NoNewline -ForegroundColor yellow
+        Write-Host "OpenPype supports only Python 3.7" -ForegroundColor white
+    } else {
+        Write-Host "OK [ $p ]" -ForegroundColor green
     }
-    Write-Host "OK [ $p ]" -ForegroundColor green
 }
-
 
 $current_dir = Get-Location
 $script_dir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent

--- a/tools/create_env.sh
+++ b/tools/create_env.sh
@@ -126,7 +126,7 @@ clean_pyc () {
   local path
   path=$openpype_root
   echo -e "${BIGreen}>>>${RST} Cleaning pyc at [ ${BIWhite}$path${RST} ] ... \c"
-  find "$path" -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
+  find "$path" -path ./build -prune -o -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
   echo -e "${BIGreen}DONE${RST}"
 }
 

--- a/tools/create_zip.ps1
+++ b/tools/create_zip.ps1
@@ -98,9 +98,9 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
 
 Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Cleaning cache files ... " -NoNewline
-Get-ChildItem $openpype_root -Filter "*.pyc" -Force -Recurse | Remove-Item -Force
-Get-ChildItem $openpype_root -Filter "*.pyo" -Force -Recurse | Remove-Item -Force
-Get-ChildItem $openpype_root -Filter "__pycache__" -Force -Recurse | Remove-Item -Force -Recurse
+Get-ChildItem $openpype_root -Filter "*.pyc" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force
+Get-ChildItem $openpype_root -Filter "*.pyo" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force
+Get-ChildItem $openpype_root -Filter "__pycache__" -Force -Recurse|  Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force -Recurse
 Write-Host "OK" -ForegroundColor green
 
 Write-Host ">>> " -NoNewline -ForegroundColor green

--- a/tools/create_zip.sh
+++ b/tools/create_zip.sh
@@ -90,23 +90,6 @@ detect_python () {
 }
 
 ##############################################################################
-# Clean pyc files in specified directory
-# Globals:
-#   None
-# Arguments:
-#   Optional path to clean
-# Returns:
-#   None
-###############################################################################
-clean_pyc () {
-  local path
-  path=$openpype_root
-  echo -e "${BIGreen}>>>${RST} Cleaning pyc at [ ${BIWhite}$path${RST} ] ... \c"
-  find "$path" -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
-  echo -e "${BIGreen}DONE${RST}"
-}
-
-##############################################################################
 # Return absolute path
 # Globals:
 #   None

--- a/tools/run_tests.ps1
+++ b/tools/run_tests.ps1
@@ -94,8 +94,8 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
 
 Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Cleaning cache files ... " -NoNewline
-Get-ChildItem $openpype_root -Filter "*.pyc" -Force -Recurse | Remove-Item -Force
-Get-ChildItem $openpype_root -Filter "__pycache__" -Force -Recurse | Remove-Item -Force -Recurse
+Get-ChildItem $openpype_root -Filter "*.pyc" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force
+Get-ChildItem $openpype_root -Filter "__pycache__" -Force -Recurse | Where-Object { $_.FullName -inotmatch 'build' } | Remove-Item -Force -Recurse
 Write-Host "OK" -ForegroundColor green
 
 Write-Host ">>> " -NoNewline -ForegroundColor green

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -70,7 +70,7 @@ clean_pyc () {
   local path
   path=$openpype_root
   echo -e "${BIGreen}>>>${RST} Cleaning pyc at [ ${BIWhite}$path${RST} ] ... \c"
-  find "$path" -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
+  find "$path" -path ./build -prune -o -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
   echo -e "${BIGreen}DONE${RST}"
 }
 


### PR DESCRIPTION
## Bugfix:

running `/tools/create_env.ps1` cleaned python cache files (pyc/pyo/__pycache__) in whole openpype directory, including **build** directory. When something was there, it deleted cache file from there too even from necessary python system files. This broke the build with error like "invalid fs encoding".

This fix is directly excluding `build` directory from cleanup.

It is also specifying on Windows that OpenPype requires Python 3.7. It is prohibiting to run it with older versions and write warning if running with newer.