### PR TITLE
List append fix in mutable dict settings

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -439,10 +439,10 @@ class DictMutableKeysEntity(EndpointEntity):
                 new_initial_value = []
                 for key, value in _settings_value:
                     if key in initial_value:
-                        new_initial_value.append(key, initial_value.pop(key))
+                        new_initial_value.append([key, initial_value.pop(key)])
 
                 for key, value in initial_value.items():
-                    new_initial_value.append(key, value)
+                    new_initial_value.append([key, value])
                 initial_value = new_initial_value
         else:
             initial_value = _settings_value


### PR DESCRIPTION
## Issue
Dict mutable dict has bug in logic when loading data stored as list. It's appending `key: value` into list but not as list.

## Changes
- fix list appending, values are stored as 2 items in single list