### PR TITLE
AE, PS, TVpaint, Blender: Add option to define path to workfile template

### DIFF
--- a/openpype/hooks/pre_copy_template_workfile.py
+++ b/openpype/hooks/pre_copy_template_workfile.py
@@ -1,0 +1,83 @@
+import os
+import platform
+import shutil
+from openpype.lib import PreLaunchHook
+from openpype.settings import (
+    get_project_settings
+)
+
+
+class AddTemplateWorkfileToLaunchArgs(PreLaunchHook):
+    """Add last workfile path to launch arguments.
+
+    This is not possible to do for all applications the same way.
+    """
+
+    order = 0
+    app_groups = ["blender", "photoshop", "tvpaint", "afftereffects"]
+
+    def execute(self):
+        if not self.data.get("start_last_workfile"):
+            self.log.info("It is set to not start last workfile on start.")
+            return
+
+        last_workfile = self.data.get("last_workfile_path")
+        if not last_workfile:
+            self.log.warning("Last workfile was not collected.")
+            return
+
+        if not os.path.exists(last_workfile):
+            self.log.info("Current context does not have any workfile yet.")
+            from_template = self.workfile_path(last_workfile)
+            if not from_template:
+                return
+
+        # Add path to workfile to arguments
+        self.launch_context.launch_args.append(last_workfile)
+
+    def workfile_path(self, last_workfile):
+
+        project = self.data["project_name"]
+
+        project_settings = get_project_settings(project)
+
+        host_settings = project_settings[self.application.group.name]
+
+        create_first_version = (
+            host_settings
+            ["workfile_builder"]
+            ["create_first_version"]
+        )
+
+        if not create_first_version:
+            return False
+
+        template_path = (
+            host_settings
+            ["workfile_builder"]
+            ["template_path"]
+            [platform.system().lower()]
+        )
+
+        if template_path:
+            if not os.path.exists(template_path):
+                self.log.warning(
+                    "Couldn't find workfile template file in {}".format(
+                        template_path
+                    )
+                )
+                return False
+
+            self.log.info(
+                f"Creating workfile from template: \"{template_path}\""
+            )
+
+            # Copy template workfile to new destinantion
+            shutil.copy2(
+                os.path.normpath(template_path),
+                os.path.normpath(last_workfile)
+            )
+
+        self.log.info(f"Workfile to open: \"{last_workfile}\"")
+
+        return True

--- a/openpype/hosts/tvpaint/hooks/pre_launch_args.py
+++ b/openpype/hosts/tvpaint/hooks/pre_launch_args.py
@@ -34,20 +34,6 @@ class TvpaintPrelaunchHook(PreLaunchHook):
             "run", self.launch_script_path(), executable_path
         )
 
-        # Add workfile to launch arguments
-        workfile_path = self.workfile_path()
-        if workfile_path:
-            new_launch_args.append(workfile_path)
-
-        # How to create new command line
-        # if platform.system().lower() == "windows":
-        #     new_launch_args = [
-        #         "cmd.exe",
-        #         "/c",
-        #         "Call cmd.exe /k",
-        #         *new_launch_args
-        #     ]
-
         # Append as whole list as these areguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)
 
@@ -65,37 +51,3 @@ class TvpaintPrelaunchHook(PreLaunchHook):
             "launch_script.py"
         )
         return script_path
-
-    def workfile_path(self):
-        workfile_path = self.data["last_workfile_path"]
-
-        # copy workfile from template if doesnt exist any on path
-        if not os.path.exists(workfile_path):
-            # TODO add ability to set different template workfile path via
-            # settings
-            pype_dir = os.path.dirname(os.path.abspath(tvpaint.__file__))
-            template_path = os.path.join(
-                pype_dir, "resources", "template.tvpp"
-            )
-
-            if not os.path.exists(template_path):
-                self.log.warning(
-                    "Couldn't find workfile template file in {}".format(
-                        template_path
-                    )
-                )
-                return
-
-            self.log.info(
-                f"Creating workfile from template: \"{template_path}\""
-            )
-
-            # Copy template workfile to new destinantion
-            shutil.copy2(
-                os.path.normpath(template_path),
-                os.path.normpath(workfile_path)
-            )
-
-        self.log.info(f"Workfile to open: \"{workfile_path}\"")
-
-        return workfile_path

--- a/openpype/settings/defaults/project_settings/aftereffects.json
+++ b/openpype/settings/defaults/project_settings/aftereffects.json
@@ -4,8 +4,12 @@
             "enabled": true,
             "optional": true,
             "active": true,
-            "skip_resolution_check": [".*"],
-            "skip_timelines_check": [".*"]
+            "skip_resolution_check": [
+                ".*"
+            ],
+            "skip_timelines_check": [
+                ".*"
+            ]
         },
         "AfterEffectsSubmitDeadline": {
             "use_published": true,
@@ -13,6 +17,14 @@
             "primary_pool": "",
             "secondary_pool": "",
             "chunk_size": 1000000
+        }
+    },
+    "workfile_builder": {
+        "create_first_version": false,
+        "template_path": {
+            "windows": "",
+            "darwin": "",
+            "linux": ""
         }
     }
 }

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -1,0 +1,10 @@
+{
+    "workfile_builder": {
+        "create_first_version": false,
+        "template_path": {
+            "windows": "",
+            "darwin": "",
+            "linux": ""
+        }
+    }
+}

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -272,8 +272,7 @@
             "active_site": "studio",
             "remote_site": "studio"
         },
-        "sites": {
-        }
+        "sites": {}
     },
     "project_plugins": {
         "windows": [],

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -13,5 +13,13 @@
                 "jpg"
             ]
         }
+    },
+    "workfile_builder": {
+        "create_first_version": false,
+        "template_path": {
+            "windows": "",
+            "darwin": "",
+            "linux": ""
+        }
     }
 }

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -32,5 +32,13 @@
             }
         }
     },
+    "workfile_builder": {
+        "create_first_version": false,
+        "template_path": {
+            "windows": "",
+            "darwin": "",
+            "linux": ""
+        }
+    },
     "filters": {}
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_main.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_main.json
@@ -80,6 +80,10 @@
                 },
                 {
                     "type": "schema",
+                    "name": "schema_project_blender"
+                },
+                {
+                    "type": "schema",
                     "name": "schema_project_aftereffects"
                 },
                 {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_aftereffects.json
@@ -85,6 +85,10 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "schema_template",
+            "name": "template_workfile_builder_simple"
         }
     ]
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -1,0 +1,13 @@
+{
+    "type": "dict",
+    "collapsible": true,
+    "key": "blender",
+    "label": "Blender",
+    "is_file": true,
+    "children": [
+        {
+            "type": "schema_template",
+            "name": "template_workfile_builder_simple"
+        }
+    ]
+}

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -52,6 +52,10 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "schema_template",
+            "name": "template_workfile_builder_simple"
         }
     ]
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -113,6 +113,10 @@
             ]
         },
         {
+            "type": "schema_template",
+            "name": "template_workfile_builder_simple"
+        },
+        {
             "type": "schema",
             "name": "schema_publish_gui_filter"
         }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_workfile_builder_simple.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_workfile_builder_simple.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "dict",
+        "collapsible": true,
+        "key": "workfile_builder",
+        "label": "Workfile Builder",
+        "children": [
+            {
+                "type": "boolean",
+                "key": "create_first_version",
+                "label": "Create first workfile",
+                "default": false
+            },
+            {
+                "type": "path",
+                "key": "template_path",
+                "label": "First workfile template",
+                "multiplatform": true,
+                "multipath": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This is a suplemental PR to #1571, which deals with more advanced version currently only for nuke. 

This simply adds option to define a template file and have it used as a first working file on a project and host basis. 

logic is handled in a global pre-hook and might clash with the more complex behaviour of Nuke, but should get us started. 