### PR TITLE
Maya: Render workflow fixes

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -243,7 +243,10 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                         "Cannot get value of {}.{}".format(
                             node, attribute_name))
                 else:
-                    if value != render_value:
+                    # compare values as strings to get around various
+                    # datatypes possible in Settings and Render
+                    # Settings
+                    if str(value) != str(render_value):
                         invalid = True
                         cls.log.error(
                             ("Invalid value {} set on {}.{}. "

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -105,7 +105,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
     families = ["render.farm", "prerender.farm",
                 "renderlayer", "imagesequence", "vrayscene"]
 
-    aov_filter = {"maya": [r".+(?:\.|_)([Bb]eauty)(?:\.|_).*"],
+    aov_filter = {"maya": [r".*(?:\.|_)?([Bb]eauty)(?:\.|_)?.*"],
                   "aftereffects": [r".*"],  # for everything from AE
                   "harmony": [r".*"],  # for everything from AE
                   "celaction": [r".*"]}


### PR DESCRIPTION
## Bugs:

- validation: in validate render settings comparison of values failed because different possible types, they are now compared as strings.
- wrong regex in submit_publish job was missing `beauty` aov name so it was not marked for preview.

🔙 **pype 2 backport:** #1609