### PR TITLE
'Delivery action' report fix +typos

### DIFF
--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -387,15 +387,10 @@ class Delivery(BaseAction):
 
         try:
             self.db_con.install()
-            result = self.real_launch(session, entities, event)
-            if result["success"]:
-                job["status"] = "done"
-            else:
-                job["status"] = "failed"
+            report = self.real_launch(session, entities, event)
 
         except Exception as exc:
-            job["status"] = "failed"
-            result = {
+            report = {
                 "success": False,
                 "title": "Delivery failed",
                 "items": [{
@@ -415,7 +410,23 @@ class Delivery(BaseAction):
             session.commit()
             self.db_con.uninstall()
 
-        return result
+        if report["success"]:
+            job["status"] = "done"
+
+        else:
+            job["status"] = "failed"
+
+            self.show_interface(
+                items=report["items"],
+                title=report["title"],
+                event=event
+            )
+            return {
+                "success": False,
+                "message": "Delivery finished with errors. Read report messages."
+            }
+
+        return report
 
     def real_launch(self, session, entities, event):
         self.log.info("Delivery action just started.")
@@ -672,7 +683,7 @@ class Delivery(BaseAction):
 
     def report(self, report_items):
         items = []
-        title = "Delivery report"
+
         for msg, _items in report_items.items():
             if not _items:
                 continue
@@ -703,9 +714,8 @@ class Delivery(BaseAction):
 
         return {
             "items": items,
-            "title": title,
-            "success": False,
-            "message": "Delivery Finished"
+            "title": "Delivery report",
+            "success": False
         }
 
 

--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -423,7 +423,7 @@ class Delivery(BaseAction):
             )
             return {
                 "success": False,
-                "message": "Delivery finished with errors. Read report messages."
+                "message": "Errors during delivery process. See report."
             }
 
         return report

--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -657,7 +657,9 @@ class Delivery(BaseAction):
 
     def copy_file(self, src_path, dst_path):
         if os.path.exists(dst_path):
-            self.log.warning("Delivery file '{}' already exists".format(dst_path))
+            self.log.warning(
+                "Delivery file '{}' already exists".format(dst_path)
+            )
             return
         try:
             filelink.create(

--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -388,8 +388,13 @@ class Delivery(BaseAction):
         try:
             self.db_con.install()
             report = self.real_launch(session, entities, event)
+            if report["success"]:
+                job["status"] = "done"
+            else:
+                job["status"] = "failed"
 
         except Exception as exc:
+            job["status"] = "failed"
             report = {
                 "success": False,
                 "title": "Delivery failed",
@@ -410,12 +415,7 @@ class Delivery(BaseAction):
             session.commit()
             self.db_con.uninstall()
 
-        if report["success"]:
-            job["status"] = "done"
-
-        else:
-            job["status"] = "failed"
-
+        if not report["success"]:
             self.show_interface(
                 items=report["items"],
                 title=report["title"],


### PR DESCRIPTION
Fixed errors:
- Delivery action 'launch':
  - Result from 'real_launch' was not caught (report_items)
  - Invalid return types were used in case of skipped or empty data
- 'real_launch':
  - When 'anatomy' path is not solved, only 1 error message is kept (second one replaces first one in case both errors occur)
- Small typo corrections