### PR TITLE
MacOs Fix launch of standalone publisher

### DIFF
--- a/openpype/modules/standalonepublish_action.py
+++ b/openpype/modules/standalonepublish_action.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import platform
 import subprocess
 from openpype.lib import get_pype_execute_args
 from . import PypeModule, ITrayAction
@@ -35,4 +35,14 @@ class StandAlonePublishAction(PypeModule, ITrayAction):
 
     def run_standalone_publisher(self):
         args = get_pype_execute_args("standalonepublisher")
-        subprocess.Popen(args, creationflags=subprocess.DETACHED_PROCESS)
+        kwargs = {}
+        if platform.system().lower() == "darwin":
+            new_args = ["open", "-a", args.pop(0), "--args"]
+            new_args.extend(args)
+            args = new_args
+
+        detached_process = getattr(subprocess, "DETACHED_PROCESS", None)
+        if detached_process is not None:
+            kwargs["creationflags"] = detached_process
+
+        subprocess.Popen(args, **kwargs)


### PR DESCRIPTION
## Issue
- standalone publisher can't be launched in OpenPype on MacOs

## Changes
- standalone publisher is launched as new process and `DETACHED_PROCESS` is not used if not available