### PR TITLE
Console Listener on Python 2 fix

### DIFF
--- a/openpype/modules/webserver/host_console_listener.py
+++ b/openpype/modules/webserver/host_console_listener.py
@@ -6,7 +6,6 @@ from concurrent.futures import CancelledError
 from Qt import QtWidgets
 
 from openpype.modules import ITrayService
-from openpype.tools.tray_app.app import ConsoleDialog
 
 log = logging.getLogger(__name__)
 
@@ -35,6 +34,8 @@ class HostListener:
         webserver.add_route('*', "/ws/host_listener", self.websocket_handler)
 
     def _host_is_connecting(self, host_name, label):
+        from openpype.tools.tray_app.app import ConsoleDialog
+
         """ Initialize dialog, adds to submenu. """
         services_submenu = self.module._services_submenu
         action = QtWidgets.QAction(label, services_submenu)

--- a/openpype/modules/webserver/webserver_module.py
+++ b/openpype/modules/webserver/webserver_module.py
@@ -7,8 +7,6 @@ import six
 from openpype import resources
 from .. import PypeModule, ITrayService
 
-from openpype.modules.webserver.host_console_listener import HostListener
-
 
 @six.add_metaclass(ABCMeta)
 class IWebServerRoutes:
@@ -59,7 +57,11 @@ class WebServerModule(PypeModule, ITrayService):
         )
 
     def _add_listeners(self):
-        self._host_listener = HostListener(self.server_manager, self)
+        from openpype.modules.webserver import host_console_listener
+
+        self._host_listener = host_console_listener.HostListener(
+            self.server_manager, self
+        )
 
     def start_server(self):
         if self.server_manager:


### PR DESCRIPTION
## Issue
`HostListener` in webserver module may break Python 2 hosts as have Python 3 specific imports in global scope.

## Changes
- move import of HostListener from global scope to method where is used