### PR TITLE
Sync server Qt layout fix

### DIFF
--- a/openpype/modules/sync_server/tray/app.py
+++ b/openpype/modules/sync_server/tray/app.py
@@ -45,7 +45,6 @@ class SyncServerWindow(QtWidgets.QDialog):
         self.pause_btn = QtWidgets.QPushButton("Pause server")
 
         left_column_layout.addWidget(self.pause_btn)
-        left_column.setLayout(left_column_layout)
 
         repres = SyncRepresentationSummaryWidget(
             sync_server,
@@ -59,8 +58,6 @@ class SyncServerWindow(QtWidgets.QDialog):
         split.addWidget(repres)
         split.setSizes([180, 950, 200])
         container_layout.addWidget(split)
-
-        container.setLayout(container_layout)
 
         body_layout = QtWidgets.QHBoxLayout(body)
         body_layout.addWidget(container)
@@ -77,7 +74,6 @@ class SyncServerWindow(QtWidgets.QDialog):
         layout.addWidget(body)
         layout.addWidget(footer)
 
-        self.setLayout(body_layout)
         self.setWindowTitle("Sync Queue")
 
         self.projects.project_changed.connect(

--- a/openpype/modules/sync_server/tray/widgets.py
+++ b/openpype/modules/sync_server/tray/widgets.py
@@ -602,7 +602,6 @@ class SyncServerDetailWindow(QtWidgets.QDialog):
         layout.addWidget(body)
         layout.addWidget(footer)
 
-        self.setLayout(body_layout)
         self.setWindowTitle("Sync Representation Detail")
 
 


### PR DESCRIPTION
## Issue
- sync server gui is setting layout specifically to wrong widgets even if are already set to right widget

## Changes
- removed "setLayout" methods as layouts are already set to right parents