### PR TITLE
Tray style

### DIFF
--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -481,6 +481,11 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
     background: none;
 }
 
+/* Globally used names */
+#Separator {
+    background: {color:bg-menu-separator};
+}
+
 #IconBtn {}
 
 /* Project Manager stylesheets */

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -295,7 +295,7 @@ class PypeInfoSubWidget(QtWidgets.QWidget):
 
     def _create_separator(self):
         separator_widget = QtWidgets.QWidget(self)
-        separator_widget.setStyleSheet("background: #222222;")
+        separator_widget.setObjectName("Separator")
         separator_widget.setMinimumHeight(2)
         separator_widget.setMaximumHeight(2)
         return separator_widget

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -144,16 +144,14 @@ class CollapsibleWidget(QtWidgets.QWidget):
         button_toggle.setChecked(False)
 
         label_widget = QtWidgets.QLabel(label, parent=top_part)
-        spacer_widget = QtWidgets.QWidget(top_part)
 
         top_part_layout = QtWidgets.QHBoxLayout(top_part)
         top_part_layout.setContentsMargins(0, 0, 0, 5)
         top_part_layout.addWidget(button_toggle)
         top_part_layout.addWidget(label_widget)
-        top_part_layout.addWidget(spacer_widget, 1)
+        top_part_layout.addStretch(1)
 
         label_widget.setAttribute(QtCore.Qt.WA_TranslucentBackground)
-        spacer_widget.setAttribute(QtCore.Qt.WA_TranslucentBackground)
         self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
 
         self.button_toggle = button_toggle

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -2,8 +2,9 @@ import os
 import json
 import collections
 
-from avalon import style
 from Qt import QtCore, QtGui, QtWidgets
+
+from openpype import style
 from openpype.api import resources
 from openpype.settings.lib import get_local_settings
 from openpype.lib.pype_info import (
@@ -116,7 +117,6 @@ class EnvironmentsView(QtWidgets.QTreeView):
             event.ignore()
             return
         return super(EnvironmentsView, self).wheelEvent(event)
-
 
 
 class ClickableWidget(QtWidgets.QWidget):

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -5,13 +5,19 @@ import atexit
 import subprocess
 
 import platform
-from avalon import style
+
 from Qt import QtCore, QtGui, QtWidgets
-from openpype.api import Logger, resources
+
+import openpype.version
+from openpype.api import (
+    Logger,
+    resources,
+    get_system_settings
+)
 from openpype.lib import get_pype_execute_args
 from openpype.modules import TrayModulesManager, ITrayService
-from openpype.settings.lib import get_system_settings
-import openpype.version
+from openpype import style
+
 from .pype_info_widget import PypeInfoWidget
 
 


### PR DESCRIPTION
## Changes
- use OpenPype style in tray widgets
   - tray menu
   - OpenPype info widget

![image](https://user-images.githubusercontent.com/43494761/120463808-91997580-c39c-11eb-90c9-f186ae538029.png)
