### PR TITLE
Extension and layer switching

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -241,7 +241,9 @@ class AExpectedFiles:
             "sceneName": scene_name,
             "layerName": layer_name,
             "renderer": self.renderer,
-            "defaultExt": cmds.getAttr("defaultRenderGlobals.imfPluginKey"),
+            "defaultExt": os.path.splitext(
+                cmds.renderSettings(firstImageName=True)[0]
+            )[1][1:],
             "filePrefix": file_prefix,
             "enabledAOVs": self.get_aovs(),
         }

--- a/pype/plugins/maya/publish/collect_render.py
+++ b/pype/plugins/maya/publish/collect_render.py
@@ -149,6 +149,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 self.log.warning(msg)
                 continue
 
+            self._rs.switchToLayer(maya_render_layers[expected_layer_name])
+
             # test if there are sets (subsets) to attach render to
             sets = cmds.sets(layer, query=True) or []
             attach_to = []
@@ -172,6 +174,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             renderer = cmds.getAttr(
                 "defaultRenderGlobals.currentRenderer"
             ).lower()
+
             # handle various renderman names
             if renderer.startswith("renderman"):
                 renderer = "renderman"


### PR DESCRIPTION
- getting expected files can sometimes fail (return nothing) on uninitiliazed attributes. Using alternative solution to get extension.
- switch layer to query attributes correctly.