### PR TITLE
Settings permissions

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -26,7 +26,7 @@ def main(ctx):
 
 @main.command()
 @click.option("-d", "--dev", is_flag=True, help="Settings in Dev mode")
-def settings(dev=False):
+def settings(dev):
     """Show Pype Settings UI."""
     PypeCommands().launch_settings_gui(dev)
 

--- a/openpype/modules/settings_action.py
+++ b/openpype/modules/settings_action.py
@@ -66,7 +66,8 @@ class SettingsAction(PypeModule, ITrayAction):
         if self.settings_window:
             return
         from openpype.tools.settings import MainWidget
-        self.settings_window = MainWidget(self.user_role)
+
+        self.settings_window = MainWidget(self.user_role, reset_on_show=False)
         self.settings_window.trigger_restart.connect(self._on_trigger_restart)
 
     def _on_trigger_restart(self):

--- a/openpype/modules/settings_action.py
+++ b/openpype/modules/settings_action.py
@@ -45,7 +45,7 @@ class SettingsAction(PypeModule, ITrayAction):
 
         # User role
         # TODO should be changeable
-        self.user_role = "developer"
+        self.user_role = "manager"
 
         # Tray attributes
         self.settings_window = None

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -27,7 +27,10 @@ class PypeCommands:
         from openpype.tools import settings
 
         # TODO change argument options to allow enum of user roles
-        user_role = "developer"
+        if dev:
+            user_role = "developer"
+        else:
+            user_role = "manager"
         settings.main(user_role)
 
     @staticmethod

--- a/openpype/tools/settings/__init__.py
+++ b/openpype/tools/settings/__init__.py
@@ -16,14 +16,14 @@ from .settings import (
 
 def main(user_role=None):
     if user_role is None:
-        user_role = "artist"
-    else:
-        user_role_low = user_role.lower()
-        allowed_roles = ("developer", "manager", "artist")
-        if user_role_low not in allowed_roles:
-            raise ValueError("Invalid user role \"{}\". Expected {}".format(
-                user_role, ", ".join(allowed_roles)
-            ))
+        user_role = "manager"
+
+    user_role_low = user_role.lower()
+    allowed_roles = ("developer", "manager")
+    if user_role_low not in allowed_roles:
+        raise ValueError("Invalid user role \"{}\". Expected {}".format(
+            user_role, ", ".join(allowed_roles)
+        ))
 
     app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon(style.app_icon_path()))

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -351,6 +351,7 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
         dialog = None
         try:
             self._create_root_entity()
+
             self.entity.add_require_restart_change_callback(
                 self._on_require_restart_change
             )
@@ -363,6 +364,16 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
                 input_field.set_entity_value()
 
             self.ignore_input_changes.set_ignore(False)
+
+        except DefaultsNotDefined:
+            dialog = QtWidgets.QMessageBox(self)
+            dialog.setWindowTitle("Missing default values")
+            dialog.setText((
+                "Default values are not set and you"
+                " don't have permissions to modify them."
+                " Please contact OpenPype team."
+            ))
+            dialog.setIcon(QtWidgets.QMessageBox.Critical)
 
         except SchemaError as exc:
             dialog = QtWidgets.QMessageBox(self)
@@ -494,12 +505,7 @@ class SystemWidget(SettingsCategoryWidget):
                 self.modify_defaults_checkbox.setEnabled(True)
         except DefaultsNotDefined:
             if not self.modify_defaults_checkbox:
-                msg_box = QtWidgets.QMessageBox(
-                    "BUG: Default values are not set and you"
-                    " don't have permissions to modify them."
-                )
-                msg_box.exec_()
-                return
+                raise
 
             self.entity.set_defaults_state()
             self.modify_defaults_checkbox.setChecked(True)
@@ -571,12 +577,7 @@ class ProjectWidget(SettingsCategoryWidget):
 
         except DefaultsNotDefined:
             if not self.modify_defaults_checkbox:
-                msg_box = QtWidgets.QMessageBox(
-                    "BUG: Default values are not set and you"
-                    " don't have permissions to modify them."
-                )
-                msg_box.exec_()
-                return
+                raise
 
             self.entity.set_defaults_state()
             self.modify_defaults_checkbox.setChecked(True)

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -19,11 +19,11 @@ class MainWidget(QtWidgets.QWidget):
     widget_width = 1000
     widget_height = 600
 
-    def __init__(self, user_role, parent=None):
+    def __init__(self, user_role, parent=None, reset_on_show=True):
         super(MainWidget, self).__init__(parent)
 
         self._user_passed = False
-        self._reset_on_show = True
+        self._reset_on_show = reset_on_show
 
         self._password_dialog = None
 
@@ -95,6 +95,7 @@ class MainWidget(QtWidgets.QWidget):
     def showEvent(self, event):
         super(MainWidget, self).showEvent(event)
         if self._reset_on_show:
+            self._reset_on_show = False
             self.reset()
 
     def _show_password_dialog(self):


### PR DESCRIPTION
## Changes
- settings UI in tray will always use `manager` role
- settings UI cli handle `--dev` argument properly
- missing defaults should not add widgets to window
- fixed double reset of settings ui in tray