### PR TITLE
Tray doubleclick

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -172,6 +172,10 @@ class ITrayModule:
         if self._tray_manager:
             self._tray_manager.show_tray_message(title, message, icon, msecs)
 
+    def add_doubleclick_callback(self, callback):
+        if hasattr(self.manager, "add_doubleclick_callback"):
+            self.manager.add_doubleclick_callback(self, callback)
+
 
 class ITrayAction(ITrayModule):
     """Implementation of Tray action.
@@ -183,6 +187,9 @@ class ITrayAction(ITrayModule):
     as it's not expected that action will use them. But it is possible if
     necessary.
     """
+
+    admin_action = False
+    _admin_submenu = None
 
     @property
     @abstractmethod
@@ -677,13 +684,35 @@ class TrayModulesManager(ModulesManager):
     )
 
     def __init__(self):
-        self.log = PypeLogger().get_logger(self.__class__.__name__)
+        self.log = PypeLogger.get_logger(self.__class__.__name__)
 
         self.modules = []
         self.modules_by_id = {}
         self.modules_by_name = {}
         self._report = {}
         self.tray_manager = None
+
+        self.doubleclick_callbacks = {}
+        self.doubleclick_callback = None
+
+    def add_doubleclick_callback(self, module, callback):
+        """Register doubleclick callbacks on tray icon.
+
+        Currently there is no way how to determine which is launched. Name of
+        callback can be defined with `doubleclick_callback` attribute.
+
+        Missing feature how to define default callback.
+        """
+        callback_name = "_".join([module.name, callback.__name__])
+        if callback_name not in self.doubleclick_callbacks:
+            self.doubleclick_callbacks[callback_name] = callback
+            if self.doubleclick_callback is None:
+                self.doubleclick_callback = callback_name
+            return
+
+        self.log.warning((
+            "Callback with name \"{}\" is already registered."
+        ).format(callback_name))
 
     def initialize(self, tray_manager, tray_menu):
         self.tray_manager = tray_manager

--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -15,6 +15,8 @@ class LauncherAction(PypeModule, ITrayAction):
     def tray_init(self):
         self.create_window()
 
+        self.add_doubleclick_callback(self.show_launcher)
+
     def tray_start(self):
         return
 

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -44,6 +44,18 @@ class TrayManager:
         self._main_thread_callbacks = collections.deque()
         self._execution_in_progress = None
 
+    @property
+    def doubleclick_callback(self):
+        """Doubleclick callback for Tray icon."""
+        callback_name = self.modules_manager.doubleclick_callback
+        return self.modules_manager.doubleclick_callbacks.get(callback_name)
+
+    def execute_doubleclick(self):
+        """Execute double click callback in main thread."""
+        callback = self.doubleclick_callback
+        if callback:
+            self.execute_in_main_thread(callback)
+
     def execute_in_main_thread(self, callback):
         self._main_thread_callbacks.append(callback)
 


### PR DESCRIPTION
## Changes
- modules can define doubleclick callbacks
   - not implemented way how to define which is used (not topic of this PR as Launcher is only registered callback)
- launcher register it's callback
- changed how click on icon works (to be able catch double click)
- this does not work on Mac as it's menu is displayed in a different way