### PR TITLE
Use poetry to build / publish OpenPype wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Temporary Items
 # CX_Freeze
 ###########
 /build
+/dist/
 
 /vendor/bin/*
 /.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,23 @@ documentation = "https://openpype.io/docs/artist_getting_started"
 repository = "https://github.com/pypeclub/openpype"
 readme = "README.md"
 keywords = ["Pipeline", "Avalon", "VFX", "animation", "automation", "tracking", "asset management"]
+packages = [
+    {include = "igniter"},
+    {include = "repos"},
+    {include = "tools"},
+    {include = "tests"},
+    {include = "docs"},
+    {include = "openpype"},
+    {include = "start.py"},
+    {include = "LICENSE"},
+    {include = "README.md"},
+    {include = "setup.py"},
+    {include = "pyproject.toml"},
+    {include = "poetry.lock"}
+]
+
+[tool.poetry.scripts]
+openpype = 'start:boot'
 
 [tool.poetry.dependencies]
 python = "3.7.*"
@@ -66,6 +83,7 @@ sphinx-qt-documentation = "*"
 recommonmark = "*"
 wheel = "*"
 enlighten = "*"  # cool terminal progress bars
+aenum = "^3.1.0"  # cross-python compatible Enum, used in representations
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/pypeclub/openpype/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ sphinx-qt-documentation = "*"
 recommonmark = "*"
 wheel = "*"
 enlighten = "*"  # cool terminal progress bars
-aenum = "^3.1.0"  # cross-python compatible Enum, used in representations
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/pypeclub/openpype/issues"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,9 @@ install_requires = [
 ]
 
 includes = []
-excludes = []
+excludes = [
+    "openpype"
+]
 bin_includes = []
 include_files = [
     "igniter",

--- a/tools/build_dependencies.py
+++ b/tools/build_dependencies.py
@@ -120,7 +120,7 @@ _print("Copying dependencies ...")
 total_files = count_folders(site_pkg)
 progress_bar = enlighten.Counter(
     total=total_files, desc="Processing Dependencies",
-    units="%", color="green")
+    units="%", color=(53, 178, 202))
 
 
 def _progress(_base, _names):
@@ -140,7 +140,8 @@ to_delete = []
 deps_items = list(deps_dir.iterdir())
 item_count = len(list(libs_dir.iterdir()))
 find_progress_bar = enlighten.Counter(
-    total=item_count, desc="Finding duplicates", units="%", color="yellow")
+    total=item_count, desc="Finding duplicates", units="%",
+    color=(56, 211, 159))
 
 for d in libs_dir.iterdir():
     if (deps_dir / d.name) in deps_items:
@@ -152,16 +153,23 @@ find_progress_bar.close()
 # add openpype and igniter in libs too
 to_delete.append(libs_dir / "openpype")
 to_delete.append(libs_dir / "igniter")
+to_delete.append(libs_dir / "openpype.pth")
+to_delete.append(deps_dir / "openpype.pth")
 
 # delete duplicates
 # _print(f"Deleting {len(to_delete)} duplicates ...")
 delete_progress_bar = enlighten.Counter(
-    total=len(to_delete), desc="Deleting duplicates", units="%", color="red")
+    total=len(to_delete), desc="Deleting duplicates", units="%",
+    color=(251, 192, 32))
 for d in to_delete:
     if d.is_dir():
         shutil.rmtree(d)
     else:
-        d.unlink()
+        try:
+            d.unlink()
+        except FileNotFoundError:
+            # skip non-existent silently
+            pass
     delete_progress_bar.update()
 
 delete_progress_bar.close()


### PR DESCRIPTION
## Feature:

This adds ability to use poetry to build / publish OpenPype wheels.

```shell
poetry build
```

will creates OpenPype wheel unde `/dist` directory

```shell
poetry publish
```

will then publish just built wheel to [pypi](https://pypi.org/). You can add `--username` and `--password` to specify credentials for **pypi**. `--dry-run` will simulate process without publishing anything. For use with **pypi** [API tokens](https://pypi.org/help/#apitoken) should be used instead:

```shell
poetry config pypi-token.pypi pypi-api-token
```
------

OpenPype can be run after `poetry install` with `poetry run openpype`. Installing wheel will create executable script in target python `openpype`.