### PR TITLE
New project anatomy values

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -91,8 +91,9 @@ def create_project(
     #   and Anatomy
     try:
         project_settings_entity = ProjectSettings(project_name)
-        # Remove project overrides will set all anatomy values to defaults
-        # - anatomy will still be overriden
+        # Trigger remove project overrides
+        #   - will set all anatomy values to defaults
+        #   - project's anatomy will still be overriden
         project_anatomy = project_settings_entity["project_anatomy"]
         project_anatomy.remove_from_project_override()
         project_settings_entity.save()

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -91,11 +91,6 @@ def create_project(
     #   and Anatomy
     try:
         project_settings_entity = ProjectSettings(project_name)
-        # Trigger remove project overrides
-        #   - will set all anatomy values to defaults
-        #   - project's anatomy will still be overriden
-        project_anatomy = project_settings_entity["project_anatomy"]
-        project_anatomy.remove_from_project_override()
         project_settings_entity.save()
     except SaveWarningExc as exc:
         print(str(exc))

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -91,6 +91,10 @@ def create_project(
     #   and Anatomy
     try:
         project_settings_entity = ProjectSettings(project_name)
+        # Remove project overrides will set all anatomy values to defaults
+        # - anatomy will still be overriden
+        project_anatomy = project_settings_entity["project_anatomy"]
+        project_anatomy.remove_from_project_override()
         project_settings_entity.save()
     except SaveWarningExc as exc:
         print(str(exc))

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -590,16 +590,21 @@ class MongoSettingsHandler(SettingsHandler):
                 attributes[key] = value
 
         project_doc_config = project_doc.get("config") or {}
+
         app_names = set()
-        if "apps" in project_doc_config:
-            for app_item in project_doc_config.pop("apps"):
+        if not project_doc_config or "apps" not in project_doc_config:
+            set_applications = False
+        else:
+            set_applications = True
+            for app_item in project_doc_config["apps"]:
                 if not app_item:
                     continue
                 app_name = app_item.get("name")
                 if app_name:
                     app_names.add(app_name)
 
-        attributes["applications"] = list(app_names)
+        if set_applications:
+            attributes["applications"] = list(app_names)
 
         output = {"attributes": attributes}
         for key in self.anatomy_keys:


### PR DESCRIPTION
## Issue
New project won't have set applications and tools on creation.

## Changes (EDITED 4.6.2021)
~- remove project overrides from project settings on new project creation~
    ~- this is cheat fix but work~
- anatomy overrides wont return attributes with filled applications if `"apps"` key is not in project config