### PR TITLE
Add asset on task item

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -380,6 +380,9 @@ class HierarchyModel(QtCore.QAbstractItemModel):
         item_id = source_index.data(IDENTIFIER_ROLE)
         item = self.items_by_id[item_id]
 
+        if isinstance(item, TaskItem):
+            item = item.parent()
+
         if isinstance(item, (RootItem, ProjectItem)):
             name = "ep"
             new_row = None


### PR DESCRIPTION
## Issue
- click on `Add Asset` button in project manager with selected Task will cause crash on project manager

## Changes
- add asset on task item won't crash but create asset on it's parent