### PR TITLE
Transparent branches in view on Mac

### DIFF
--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -344,30 +344,35 @@ QAbstractItemView::item:selected:hover {
     background: {color:bg-view-selection-hover};
 }
 
+/* Row colors (alternate colors) are from left - right */
+QAbstractItemView:branch {
+    background: transparent;
+}
+
 QAbstractItemView::branch:open:has-children:!has-siblings,
 QAbstractItemView::branch:open:has-children:has-siblings {
     border-image: none;
     image: url(:/openpype/images/branch_open.png);
-    background: {color:bg-view};
+    background: transparent;
 }
 QAbstractItemView::branch:open:has-children:!has-siblings:hover,
 QAbstractItemView::branch:open:has-children:has-siblings:hover {
     border-image: none;
     image: url(:/openpype/images//branch_open_on.png);
-    /* background: {color:bg-view-hover}; */
+    background: transparent;
 }
 
 QAbstractItemView::branch:has-children:!has-siblings:closed,
 QAbstractItemView::branch:closed:has-children:has-siblings {
     border-image: none;
     image: url(:/openpype/images//branch_closed.png);
-    background: {color:bg-view};
+    background: transparent;
 }
 QAbstractItemView::branch:has-children:!has-siblings:closed:hover,
 QAbstractItemView::branch:closed:has-children:has-siblings:hover {
     border-image: none;
     image: url(:/openpype/images//branch_closed_on.png);
-    /* background: {color:bg-view-hover}; */
+    background: transparent;
 }
 
 /* Progress bar */

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -313,6 +313,8 @@ QAbstractItemView {
     border-radius: 0.2em;
     background: {color:bg-view};
     alternate-background-color: {color:bg-view-alternate};
+    /* Mac shows selection color on branches. */
+    selection-background-color: transparent;
 }
 
 QAbstractItemView:disabled{
@@ -346,11 +348,6 @@ QAbstractItemView::item:selected:hover {
 
 /* Row colors (alternate colors) are from left - right */
 QAbstractItemView:branch {
-    background: transparent;
-}
-
-/* Mac shows slection color on branches. */
-QAbstractItemView:branch:selected {
     background: transparent;
 }
 

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -349,6 +349,11 @@ QAbstractItemView:branch {
     background: transparent;
 }
 
+/* Mac shows slection color on branches. */
+QAbstractItemView:branch:selected {
+    background: transparent;
+}
+
 QAbstractItemView::branch:open:has-children:!has-siblings,
 QAbstractItemView::branch:open:has-children:has-siblings {
     border-image: none;


### PR DESCRIPTION
## Issue
- mac shows selection color (different than openpype's) on branches too

## Changes
- selection color is set to transparent
- also set transparent background for branches (alternate color is expanded to full width of view)