### PR TITLE
StandalonePublisher: adding  exception for adding `delete` tag to repre

### DIFF
--- a/pype/plugins/standalonepublisher/publish/collect_instance_resources.py
+++ b/pype/plugins/standalonepublisher/publish/collect_instance_resources.py
@@ -198,8 +198,13 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
                     "step": 1,
                     "fps": self.context.data.get("fps"),
                     "name": "review",
-                    "tags": ["review", "ftrackreview", "delete"],
+                    "tags": ["review", "ftrackreview"],
                 })
+
+            if (instance_data.get("doNotDeleteReview") is not None) \
+                    and repre_data.get("tags"):
+                repre_data["tags"].append("delete")
+
             instance_data["representations"].append(repre_data)
 
             # add to frames for frame range reset


### PR DESCRIPTION
Client requested jpeg sequence `plateOffline` not to be deleted - originally meant only to be converted to mp4 and then deleted. But they wish to load it to nuke instead of mp4. This way it is preserved and yes it is hotfix but enhancement at the same time.

Closes https://github.com/pypeclub/client/issues/82