### PR TITLE
Maya: Split model content validator

### DIFF
--- a/pype/plugins/maya/publish/validate_model_content.py
+++ b/pype/plugins/maya/publish/validate_model_content.py
@@ -57,16 +57,8 @@ class ValidateModelContent(pyblish.api.InstancePlugin):
             cls.log.error("No shapes in the model instance")
             return True
 
-        # Top group
         assemblies = cmds.ls(content_instance, assemblies=True, long=True)
-        if len(assemblies) != 1:
-            cls.log.error("Must have exactly one top group")
-            if len(assemblies) == 0:
-                cls.log.warning("No top group found. "
-                                "(Are there objects in the instance?"
-                                " Or is it parented in another group?)")
-            return assemblies or True
-
+ 
         def _is_visible(node):
             """Return whether node is visible"""
             return lib.is_visible(node,

--- a/pype/plugins/maya/publish/validate_model_content.py
+++ b/pype/plugins/maya/publish/validate_model_content.py
@@ -58,7 +58,7 @@ class ValidateModelContent(pyblish.api.InstancePlugin):
             return True
 
         assemblies = cmds.ls(content_instance, assemblies=True, long=True)
- 
+
         def _is_visible(node):
             """Return whether node is visible"""
             return lib.is_visible(node,

--- a/pype/plugins/maya/publish/validate_model_top_group.py
+++ b/pype/plugins/maya/publish/validate_model_top_group.py
@@ -1,0 +1,51 @@
+#-*- coding: utf-8 -*-
+"""Validate if model content has single top group.
+
+This was splitted from `validate_model_content` by client request.
+
+Todo:
+    It would be better handle it back in the single validator using Settings.
+    
+Deprecated since 2.18
+
+"""
+from maya import cmds
+
+import pyblish.api
+import pype.api
+import pype.hosts.maya.action
+from pype.hosts.maya import lib
+
+
+class ValidateModelTopGroup(pyblish.api.InstancePlugin):
+    """Validate if model has only one top group."""
+
+    order = pype.api.ValidateContentsOrder
+    hosts = ["maya"]
+    families = ["model"]
+    label = "Model Top Group"
+    actions = [pype.hosts.maya.action.SelectInvalidAction]
+
+    @classmethod
+    def get_invalid(cls, instance):
+        content_instance = instance.data.get("setMembers", None)
+        if not content_instance:
+            cls.log.error("Instance has no nodes!")
+            return True
+
+        # Top group
+        assemblies = cmds.ls(content_instance, assemblies=True, long=True)
+        if len(assemblies) != 1:
+            cls.log.error("Must have exactly one top group")
+            if len(assemblies) == 0:
+                cls.log.warning("No top group found. "
+                                "(Are there objects in the instance?"
+                                " Or is it parented in another group?)")
+            return assemblies or True
+
+    def process(self, instance):
+
+        invalid = self.get_invalid(instance)
+
+        if invalid:
+            raise RuntimeError("Model content is invalid. See log.")

--- a/pype/plugins/maya/publish/validate_model_top_group.py
+++ b/pype/plugins/maya/publish/validate_model_top_group.py
@@ -1,11 +1,11 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """Validate if model content has single top group.
 
 This was splitted from `validate_model_content` by client request.
 
 Todo:
     It would be better handle it back in the single validator using Settings.
-    
+
 Deprecated since 2.18
 
 """
@@ -14,7 +14,6 @@ from maya import cmds
 import pyblish.api
 import pype.api
 import pype.hosts.maya.action
-from pype.hosts.maya import lib
 
 
 class ValidateModelTopGroup(pyblish.api.InstancePlugin):


### PR DESCRIPTION
With client request do disable validation of top level group when publishing model, this splits it into two files. The one validating top level group then can be disabled with presets/project overrides.

For **OpenPype 3** this should be solved by different approach. Check should be marked by enum flags and its combination should be settable in Settings to control validator behavior in more precise way.