### PR TITLE
Maya: Deadline custom settings - Pype 2 backport

### DIFF
--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -265,6 +265,9 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
     asset_dependencies = False
     limit_groups = []
     group = "none"
+    job_info = {}
+    plugin_info = {}
+
 
     def process(self, instance):
         """Plugin entry point."""
@@ -534,6 +537,11 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         instance.data["outputDir"] = os.path.dirname(output_filename_0)
 
         self.preflight_check(instance)
+
+        # override deadline job/plugin info with presets
+        # TODO: this should be adopted to deadline abstract job class.
+        payload["JobInfo"].update(self.job_info)
+        payload["PluginInfo"].update(self.plugin_info)
 
         # Prepare tiles data ------------------------------------------------
         if instance.data.get("tileRendering"):


### PR DESCRIPTION
This PR adds ability to customize Deadlines `Job_Info` and `Plugin_Info` from presets.

It will update existing data prior to submission, useful for adding / overriding

⏩ **OpenPype 3 version: #1797
|---|