### PR TITLE
Mac launch arguments fix

### DIFF
--- a/openpype/hooks/pre_mac_launch.py
+++ b/openpype/hooks/pre_mac_launch.py
@@ -31,4 +31,4 @@ class LaunchWithTerminal(PreLaunchHook):
         if len(self.launch_context.launch_args) > 1:
             self.launch_context.launch_args.insert(1, "--args")
         # Prepend open arguments
-        self.launch_context.launch_args.insert(0, ["open", "-a"])
+        self.launch_context.launch_args.insert(0, ["open", "-na"])

--- a/openpype/modules/standalonepublish_action.py
+++ b/openpype/modules/standalonepublish_action.py
@@ -37,7 +37,7 @@ class StandAlonePublishAction(PypeModule, ITrayAction):
         args = get_pype_execute_args("standalonepublisher")
         kwargs = {}
         if platform.system().lower() == "darwin":
-            new_args = ["open", "-a", args.pop(0), "--args"]
+            new_args = ["open", "-na", args.pop(0), "--args"]
             new_args.extend(args)
             args = new_args
 


### PR DESCRIPTION
## Issue
We're modifying launch arguments for MacOS to launch new process using `open` command. At the time we've added this ability it didn't work with `-n` argument (create new independent process) so was skipped. Now the reason is known that `open` arguments must be in single dash and in specific order.

## Changes
- add argument to launch subprocess as new process to launch in mac arguments