### PR TITLE
Project Manger: Default name column width

### DIFF
--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -92,19 +92,16 @@ class HierarchyView(QtWidgets.QTreeView):
             "stretch": QtWidgets.QHeaderView.ResizeToContents
         },
         "name": {
-            "stretch": QtWidgets.QHeaderView.Stretch
+            "stretch": QtWidgets.QHeaderView.Interactive,
+            "width": 260
         },
         "type": {
             "stretch": QtWidgets.QHeaderView.Interactive,
-            "width": 100
+            "width": 140
         },
         "tools_env": {
             "stretch": QtWidgets.QHeaderView.Interactive,
-            "width": 140
-        },
-        "pixelAspect": {
-            "stretch": QtWidgets.QHeaderView.Interactive,
-            "width": 80
+            "width": 200
         }
     }
     persistent_columns = {
@@ -180,13 +177,14 @@ class HierarchyView(QtWidgets.QTreeView):
 
     def header_init(self):
         header = self.header()
-        header.setStretchLastSection(False)
 
         default_behavior = self.columns_sizes["default"]
         widths_by_idx = {}
         for idx in range(header.count()):
             key = self._source_model.columns[idx]
             behavior = self.columns_sizes.get(key, default_behavior)
+            if behavior is None:
+                continue
             logical_index = header.logicalIndex(idx)
             stretch = behavior["stretch"]
             header.setSectionResizeMode(logical_index, stretch)


### PR DESCRIPTION
## Changes
- define `"name"` column width and use interactive stretch to be able resize it and avoid strange behavior
   - it's not perfect but better then current situation