### PR TITLE
Settings list race condifiton and mutable dict list conversion

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -467,7 +467,7 @@ class DictMutableKeysEntity(EndpointEntity):
         if self.store_as_list:
             output = []
             for key, child_entity in self.children_by_key.items():
-                output.append(key, child_entity.value)
+                output.append([key, child_entity.value])
             return output
 
         output = {}

--- a/openpype/tools/settings/settings/list_item_widget.py
+++ b/openpype/tools/settings/settings/list_item_widget.py
@@ -100,7 +100,6 @@ class ListItem(QtWidgets.QWidget):
         self.input_field = self.create_ui_for_entity(
             self.category_widget, self.entity, self
         )
-        self.input_field.set_entity_value()
 
         spacer_widget = QtWidgets.QWidget(self)
         spacer_widget.setAttribute(QtCore.Qt.WA_TranslucentBackground)
@@ -336,6 +335,12 @@ class ListWidget(InputWidget):
 
             self.content_layout.insertWidget(row + 1, item_widget)
             self.input_fields.insert(row, item_widget)
+
+        # Change to entity value after item is added to `input_fields`
+        # - may cause recursion error as setting a value may cause input field
+        #   change which will trigger this validation if entity is already
+        #   added as widget here which won't because is not in input_fields
+        item_widget.input_field.set_entity_value()
 
         if previous_field:
             previous_field.order_changed()


### PR DESCRIPTION
## Issues
1. `add_row` may cause that settings ui will crash because of recursion error because it's children value change may trigger adding infinite children with same value
2. store as list in `DictMutableKeysDict` is still broken because of missing conversion to list in `value` property

## Changes
- trigger `set_entity_value` on ListWidget's `add_row` after new item is part of `input_fields`
- property `value` in `DictMutableKeysDict` is append list of key, value