### PR TITLE
Ftrack subprocess handle of stdout/stderr

### DIFF
--- a/openpype/modules/ftrack/ftrack_server/socket_thread.py
+++ b/openpype/modules/ftrack/ftrack_server/socket_thread.py
@@ -66,7 +66,16 @@ class SocketThread(threading.Thread):
             *self.additional_args,
             str(self.port)
         )
-        self.subproc = subprocess.Popen(args, env=env, stdin=subprocess.PIPE)
+        kwargs = {
+            "env": env,
+            "stdin": subprocess.PIPE
+        }
+        if not sys.stdout:
+            # Redirect to devnull if stdout is None
+            kwargs["stdout"] = subprocess.DEVNULL
+            kwargs["stderr"] = subprocess.DEVNULL
+
+        self.subproc = subprocess.Popen(args, **kwargs)
 
         # Listen for incoming connections
         sock.listen(1)


### PR DESCRIPTION
## Issue
Ftrack user event server is running as subprocess which cause issues with logging because all python subprocess.Popen objects have stdout and stderr which are inherited from source process, but if `openpype_gui` executable is used then sys.stdout and sys.stderr are set to None so new created processes get strange PIPE objects that can't work with `PypeStreamHandler` properly and may crash at any time because `flush` of the stream cause OSError.

## Changes
- redirect stdout of ftrack process to devnull if sys.stdout is None to prevent issues described above

### Why is that important
Any processed action can crash during logging (most visible when launchin application).

### How to replicate issue
Hard to say. I launched Nuke 5-10 timer in row from ftrack. One of launches should crash if `openpype_gui` executable is used.

Closes: https://github.com/pypeclub/client/issues/92