### PR TITLE
Application without executables

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -484,6 +484,27 @@ class ApplicationExecutable:
         return bool(self._realpath())
 
 
+class UndefinedApplicationExecutable(ApplicationExecutable):
+    """Some applications do not require executable path from settings.
+
+    In that case this class is used to "fake" existing executable.
+    """
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return self.__class__.__name__
+
+    def __repr__(self):
+        return "<{}>".format(self.__class__.__name__)
+
+    def as_args(self):
+        return []
+
+    def exists(self):
+        return True
+
+
 @six.add_metaclass(ABCMeta)
 class LaunchHook:
     """Abstract base class of launch hook."""

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -191,26 +191,32 @@ class Application:
         self.full_label = full_label
         self._environment = data.get("environment") or {}
 
+        arguments = data.get("arguments")
+        if isinstance(arguments, dict):
+            arguments = arguments.get(platform.system().lower())
+
+        if not arguments:
+            arguments = []
+        self.arguments = arguments
+
+        if "executables" not in data:
+            self.executables = [
+                UndefinedApplicationExecutable()
+            ]
+            return
+
         _executables = data["executables"]
+        if isinstance(_executables, dict):
+            _executables = _executables.get(platform.system().lower())
+
         if not _executables:
             _executables = []
-
-        elif isinstance(_executables, dict):
-            _executables = _executables.get(platform.system().lower()) or []
-
-        _arguments = data["arguments"]
-        if not _arguments:
-            _arguments = []
-
-        elif isinstance(_arguments, dict):
-            _arguments = _arguments.get(platform.system().lower()) or []
 
         executables = []
         for executable in _executables:
             executables.append(ApplicationExecutable(executable))
 
         self.executables = executables
-        self.arguments = _arguments
 
     def __repr__(self):
         return "<{}> - {}".format(self.__class__.__name__, self.full_name)

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -1101,16 +1101,6 @@
         "variants": {
             "4-26": {
                 "use_python_2": false,
-                "executables": {
-                    "windows": [],
-                    "darwin": [],
-                    "linux": []
-                },
-                "arguments": {
-                    "windows": [],
-                    "darwin": [],
-                    "linux": []
-                },
                 "environment": {}
             }
         }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
@@ -30,7 +30,11 @@
                 "children": [
                     {
                         "type": "schema_template",
-                        "name": "template_host_variant_items"
+                        "name": "template_host_variant_items",
+                        "skip_paths": [
+                            "executables",
+                            "arguments"
+                        ]
                     }
                 ]
             }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
@@ -33,6 +33,7 @@
                         "name": "template_host_variant_items",
                         "skip_paths": [
                             "executables",
+                            "separator",
                             "arguments"
                         ]
                     }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/template_host_variant_items.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/template_host_variant_items.json
@@ -14,6 +14,7 @@
         "placeholder": "Executable path"
     },
     {
+        "key": "separator",
         "type":"separator"
     },
     {

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -532,7 +532,11 @@ def apply_local_settings_on_system_settings(system_settings, local_settings):
 
         variants = system_settings["applications"][app_group_name]["variants"]
         for app_name, app_value in value.items():
-            if not app_value or app_name not in variants:
+            if (
+                not app_value
+                or app_name not in variants
+                or "executables" not in variants[app_name]
+            ):
                 continue
 
             executable = app_value.get("executable")

--- a/openpype/tools/settings/local_settings/apps_widget.py
+++ b/openpype/tools/settings/local_settings/apps_widget.py
@@ -121,6 +121,9 @@ class AppGroupWidget(QtWidgets.QWidget):
 
         widgets_by_variant_name = {}
         for variant_name, variant_entity in valid_variants.items():
+            if "executables" not in variant_entity:
+                continue
+
             variant_widget = AppVariantWidget(
                 group_label, variant_name, variant_entity, content_widget
             )

--- a/openpype/tools/settings/local_settings/apps_widget.py
+++ b/openpype/tools/settings/local_settings/apps_widget.py
@@ -196,8 +196,12 @@ class LocalApplicationsWidgets(QtWidgets.QWidget):
 
             # Create App group specific widget and store it by the key
             group_widget = AppGroupWidget(entity, self)
-            self.widgets_by_group_name[key] = group_widget
-            self.content_layout.addWidget(group_widget)
+            if group_widget.widgets_by_variant_name:
+                self.widgets_by_group_name[key] = group_widget
+                self.content_layout.addWidget(group_widget)
+            else:
+                group_widget.setVisible(False)
+                group_widget.deleteLater()
 
     def update_local_settings(self, value):
         if not value:


### PR DESCRIPTION
## Description
- some applications can't have set executables because it's executable is calculated on the fly (namely Unreal)

## Changes
- application without `"executables"` key in variant will always have successfull validation of global executables existence
- default launch arguments are in that case empty so they must be filled in hooks
- these applications are not visible in local settings and local settings should skip their overriding
- Prelaunch hook should raise `ApplicationNotFound` exception if won't find proper executable
- removed `"executables"` and `"arguments"` from Unreal application

closes: https://github.com/pypeclub/OpenPype/issues/1674