### PR TITLE
#683 - Validate frame range in Standalone Publisher

### DIFF
--- a/pype/plugins/standalonepublisher/publish/validate_frame_ranges.py
+++ b/pype/plugins/standalonepublisher/publish/validate_frame_ranges.py
@@ -1,0 +1,44 @@
+import pyblish.api
+import pype.api
+from pype import lib
+
+
+class ValidateFrameRange(pyblish.api.InstancePlugin):
+    """Validating frame range of rendered files against state in DB."""
+
+    label = "Validate Frame Range"
+    hosts = ["standalonepublisher"]
+    families = ["render"]
+    order = pype.api.ValidateContentsOrder
+
+    optional = True
+    # published data might be sequence (.mov, .mp4) in that counting files
+    # doesnt make sense
+    check_extensions = ["exr", "dpx", "jpg", "jpeg", "png", "tiff", "tga",
+                        "gif", "svg"]
+
+    def process(self, instance):
+        asset_data = lib.get_asset(instance.data["asset"])["data"]
+
+        frame_start = asset_data["frameStart"]
+        frame_end = asset_data["frameEnd"]
+        handle_start = asset_data["handleStart"]
+        handle_end = asset_data["handleEnd"]
+        duration = (frame_end - frame_start + 1) + handle_start + handle_end
+
+        repre = instance.data.get("representations", [None])
+        if not repre:
+            return
+
+        ext = repre[0]['ext'].replace(".", '')
+
+        if not ext or ext.lower() not in self.check_extensions:
+            self.log.warning("Cannot check for extension {}".format(ext))
+            return
+
+        frames = len(instance.data.get("representations", [None])[0]["files"])
+
+        err_msg = "Frame duration from DB:'{}' ". format(int(duration)) +\
+                  " doesn't match number of files:'{}'".format(frames) +\
+                  " Please change frame range for Asset or limit no. of files"
+        assert frames == duration, err_msg


### PR DESCRIPTION
Closes https://github.com/pypeclub/client/issues/89

Calculates duration from Asset from DB, compares with number of published files.

Skips movie-like extensions (configurable).

How to test it:
Run Standalone publisher with 'Render' family, try to publish sequence of files
![Screenshot 2021-06-10 135839](https://user-images.githubusercontent.com/4457962/121521151-00f21380-c9f4-11eb-82c1-96ee914413f5.png)
