### PR TITLE
OpenPype style in modules

### DIFF
--- a/openpype/modules/clockify/clockify_api.py
+++ b/openpype/modules/clockify/clockify_api.py
@@ -36,6 +36,7 @@ class ClockifyAPI:
 
         self._secure_registry = None
 
+    @property
     def secure_registry(self):
         if self._secure_registry is None:
             self._secure_registry = OpenPypeSecureRegistry("clockify")

--- a/openpype/modules/clockify/widgets.py
+++ b/openpype/modules/clockify/widgets.py
@@ -21,14 +21,6 @@ class MessageWidget(QtWidgets.QWidget):
             QtCore.Qt.WindowMinimizeButtonHint
         )
 
-        # Font
-        self.font = QtGui.QFont()
-        self.font.setFamily("DejaVu Sans Condensed")
-        self.font.setPointSize(9)
-        self.font.setBold(True)
-        self.font.setWeight(50)
-        self.font.setKerning(True)
-
         # Size setting
         self.resize(self.SIZE_W, self.SIZE_H)
         self.setMinimumSize(QtCore.QSize(self.SIZE_W, self.SIZE_H))
@@ -52,7 +44,6 @@ class MessageWidget(QtWidgets.QWidget):
         labels = []
         for message in messages:
             label = QtWidgets.QLabel(message)
-            label.setFont(self.font)
             label.setCursor(QtGui.QCursor(QtCore.Qt.ArrowCursor))
             label.setTextFormat(QtCore.Qt.RichText)
             label.setWordWrap(True)
@@ -102,20 +93,11 @@ class ClockifySettings(QtWidgets.QWidget):
         icon = QtGui.QIcon(resources.pype_icon_filepath())
         self.setWindowIcon(icon)
 
+        self.setWindowTitle("Clockify settings")
         self.setWindowFlags(
             QtCore.Qt.WindowCloseButtonHint |
             QtCore.Qt.WindowMinimizeButtonHint
         )
-
-        self._translate = QtCore.QCoreApplication.translate
-
-        # Font
-        self.font = QtGui.QFont()
-        self.font.setFamily("DejaVu Sans Condensed")
-        self.font.setPointSize(9)
-        self.font.setBold(True)
-        self.font.setWeight(50)
-        self.font.setKerning(True)
 
         # Size setting
         self.resize(self.SIZE_W, self.SIZE_H)
@@ -123,63 +105,52 @@ class ClockifySettings(QtWidgets.QWidget):
         self.setMaximumSize(QtCore.QSize(self.SIZE_W+100, self.SIZE_H+100))
         self.setStyleSheet(style.load_stylesheet())
 
-        self.setLayout(self._main())
-        self.setWindowTitle('Clockify settings')
+        self._ui_init()
 
-    def _main(self):
-        self.main = QtWidgets.QVBoxLayout()
-        self.main.setObjectName("main")
+    def _ui_init(self):
+        label_api_key = QtWidgets.QLabel("Clockify API key:")
 
-        self.form = QtWidgets.QFormLayout()
-        self.form.setContentsMargins(10, 15, 10, 5)
-        self.form.setObjectName("form")
+        input_api_key = QtWidgets.QLineEdit()
+        input_api_key.setFrame(True)
+        input_api_key.setPlaceholderText("e.g. XX1XxXX2x3x4xXxx")
 
-        self.label_api_key = QtWidgets.QLabel("Clockify API key:")
-        self.label_api_key.setFont(self.font)
-        self.label_api_key.setCursor(QtGui.QCursor(QtCore.Qt.ArrowCursor))
-        self.label_api_key.setTextFormat(QtCore.Qt.RichText)
-        self.label_api_key.setObjectName("label_api_key")
+        error_label = QtWidgets.QLabel("")
+        error_label.setTextFormat(QtCore.Qt.RichText)
+        error_label.setWordWrap(True)
+        error_label.hide()
 
-        self.input_api_key = QtWidgets.QLineEdit()
-        self.input_api_key.setEnabled(True)
-        self.input_api_key.setFrame(True)
-        self.input_api_key.setObjectName("input_api_key")
-        self.input_api_key.setPlaceholderText(
-            self._translate("main", "e.g. XX1XxXX2x3x4xXxx")
-        )
+        form_layout = QtWidgets.QFormLayout()
+        form_layout.setContentsMargins(10, 15, 10, 5)
+        form_layout.addRow(label_api_key, input_api_key)
+        form_layout.addRow(error_label)
 
-        self.error_label = QtWidgets.QLabel("")
-        self.error_label.setFont(self.font)
-        self.error_label.setTextFormat(QtCore.Qt.RichText)
-        self.error_label.setObjectName("error_label")
-        self.error_label.setWordWrap(True)
-        self.error_label.hide()
+        btn_ok = QtWidgets.QPushButton("Ok")
+        btn_ok.setToolTip('Sets Clockify API Key so can Start/Stop timer')
 
-        self.form.addRow(self.label_api_key, self.input_api_key)
-        self.form.addRow(self.error_label)
-
-        self.btn_group = QtWidgets.QHBoxLayout()
-        self.btn_group.addStretch(1)
-        self.btn_group.setObjectName("btn_group")
-
-        self.btn_ok = QtWidgets.QPushButton("Ok")
-        self.btn_ok.setToolTip('Sets Clockify API Key so can Start/Stop timer')
-        self.btn_ok.clicked.connect(self.click_ok)
-
-        self.btn_cancel = QtWidgets.QPushButton("Cancel")
+        btn_cancel = QtWidgets.QPushButton("Cancel")
         cancel_tooltip = 'Application won\'t start'
         if self.optional:
             cancel_tooltip = 'Close this window'
-        self.btn_cancel.setToolTip(cancel_tooltip)
-        self.btn_cancel.clicked.connect(self._close_widget)
+        btn_cancel.setToolTip(cancel_tooltip)
 
-        self.btn_group.addWidget(self.btn_ok)
-        self.btn_group.addWidget(self.btn_cancel)
+        btn_group = QtWidgets.QHBoxLayout()
+        btn_group.addStretch(1)
+        btn_group.addWidget(btn_ok)
+        btn_group.addWidget(btn_cancel)
 
-        self.main.addLayout(self.form)
-        self.main.addLayout(self.btn_group)
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.addLayout(form_layout)
+        main_layout.addLayout(btn_group)
 
-        return self.main
+        btn_ok.clicked.connect(self.click_ok)
+        btn_cancel.clicked.connect(self._close_widget)
+
+        self.label_api_key = label_api_key
+        self.input_api_key = input_api_key
+        self.error_label = error_label
+
+        self.btn_ok = btn_ok
+        self.btn_cancel = btn_cancel
 
     def setError(self, msg):
         self.error_label.setText(msg)

--- a/openpype/modules/clockify/widgets.py
+++ b/openpype/modules/clockify/widgets.py
@@ -182,6 +182,17 @@ class ClockifySettings(QtWidgets.QWidget):
                 "Entered invalid API key"
             )
 
+    def showEvent(self, event):
+        super(ClockifySettings, self).showEvent(event)
+
+        # Make btns same width
+        max_width = max(
+            self.btn_ok.sizeHint().width(),
+            self.btn_cancel.sizeHint().width()
+        )
+        self.btn_ok.setMinimumWidth(max_width)
+        self.btn_cancel.setMinimumWidth(max_width)
+
     def closeEvent(self, event):
         if self.optional is True:
             event.ignore()

--- a/openpype/modules/clockify/widgets.py
+++ b/openpype/modules/clockify/widgets.py
@@ -1,6 +1,5 @@
 from Qt import QtCore, QtGui, QtWidgets
-from avalon import style
-from openpype import resources
+from openpype import resources, style
 
 
 class MessageWidget(QtWidgets.QWidget):

--- a/openpype/modules/ftrack/tray/login_dialog.py
+++ b/openpype/modules/ftrack/tray/login_dialog.py
@@ -1,6 +1,6 @@
 import os
 import requests
-from avalon import style
+from openpype import style
 from openpype.modules.ftrack.lib import credentials
 from . import login_tools
 from openpype import resources

--- a/openpype/modules/ftrack/tray/login_dialog.py
+++ b/openpype/modules/ftrack/tray/login_dialog.py
@@ -46,8 +46,11 @@ class CredentialsDialog(QtWidgets.QDialog):
         self.user_label = QtWidgets.QLabel("Username:")
         self.api_label = QtWidgets.QLabel("API Key:")
 
-        self.ftsite_input = QtWidgets.QLineEdit()
-        self.ftsite_input.setReadOnly(True)
+        self.ftsite_input = QtWidgets.QLabel()
+        self.ftsite_input.setTextInteractionFlags(
+            QtCore.Qt.TextBrowserInteraction
+        )
+        # self.ftsite_input.setReadOnly(True)
         self.ftsite_input.setCursor(QtGui.QCursor(QtCore.Qt.IBeamCursor))
 
         self.user_input = QtWidgets.QLineEdit()

--- a/openpype/modules/muster/widget_login.py
+++ b/openpype/modules/muster/widget_login.py
@@ -1,13 +1,12 @@
 import os
 from Qt import QtCore, QtGui, QtWidgets
-from avalon import style
-from openpype import resources
+from openpype import resources, style
 
 
 class MusterLogin(QtWidgets.QWidget):
 
     SIZE_W = 300
-    SIZE_H = 130
+    SIZE_H = 150
 
     loginSignal = QtCore.Signal(object, object, object)
 

--- a/openpype/modules/muster/widget_login.py
+++ b/openpype/modules/muster/widget_login.py
@@ -122,7 +122,6 @@ class MusterLogin(QtWidgets.QWidget):
             super().keyPressEvent(key_event)
 
     def setError(self, msg):
-
         self.error_label.setText(msg)
         self.error_label.show()
 
@@ -147,6 +146,17 @@ class MusterLogin(QtWidgets.QWidget):
 
     def save_credentials(self, username, password):
         self.module.get_auth_token(username, password)
+
+    def showEvent(self, event):
+        super(MusterLogin, self).showEvent(event)
+
+        # Make btns same width
+        max_width = max(
+            self.btn_ok.sizeHint().width(),
+            self.btn_cancel.sizeHint().width()
+        )
+        self.btn_ok.setMinimumWidth(max_width)
+        self.btn_cancel.setMinimumWidth(max_width)
 
     def closeEvent(self, event):
         event.ignore()

--- a/openpype/modules/timers_manager/widget_user_idle.py
+++ b/openpype/modules/timers_manager/widget_user_idle.py
@@ -1,6 +1,5 @@
-from avalon import style
 from Qt import QtCore, QtGui, QtWidgets
-from openpype import resources
+from openpype import resources, style
 
 
 class WidgetUserIdle(QtWidgets.QWidget):


### PR DESCRIPTION
## Changes
- Ftrack module
    - login widget is using openpype style
    - ftrack url is label instead of input (as user can't change the url)
- Clockify module
    - credentials widget use openpype style
    - fixed bug in clockify api
    - simplified a little bit code of widgets
    - ok and cancel buttons have same width
- Muster module
    - credentials widget use openpype style
    - ok and cancel buttons have same width
- Timers manager module
    - message box (about stopping timers) is using openpype style