### PR TITLE
Overscan color extract review

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1154,13 +1154,24 @@ class ExtractReview(pyblish.api.InstancePlugin):
             self.log.debug("height_scale: `{}`".format(height_scale))
             self.log.debug("height_half_pad: `{}`".format(height_half_pad))
 
+            # Overscal color
+            overscan_color_value = "black"
+            overscan_color = output_def.get("overscan_color")
+            if overscan_color:
+                bg_red, bg_green, bg_blue, _ = overscan_color
+                overscan_color_value = "#{0:0>2X}{1:0>2X}{2:0>2X}".format(
+                    bg_red, bg_green, bg_blue
+                )
+            self.log.debug("Overscan color: `{}`".format(overscan_color_value))
+
             filters.extend([
                 "scale={}x{}:flags=lanczos".format(
                     width_scale, height_scale
                 ),
-                "pad={}:{}:{}:{}:black".format(
+                "pad={}:{}:{}:{}:{}".format(
                     output_width, output_height,
-                    width_half_pad, height_half_pad
+                    width_half_pad, height_half_pad,
+                    overscan_color_value
                 ),
                 "setsar=1"
             ])

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -58,6 +58,12 @@
                             "overscan_crop": "",
                             "width": 0,
                             "height": 0,
+                            "overscan_color": [
+                                0,
+                                0,
+                                0,
+                                255
+                            ],
                             "bg_color": [
                                 0,
                                 0,

--- a/openpype/settings/entities/color_entity.py
+++ b/openpype/settings/entities/color_entity.py
@@ -12,6 +12,17 @@ class ColorEntity(InputEntity):
     def _item_initalization(self):
         self.valid_value_types = (list, )
         self.value_on_not_set = [0, 0, 0, 255]
+        self.use_alpha = self.schema_data.get("use_alpha", True)
+
+    def set_override_state(self, *args, **kwargs):
+        super(ColorEntity, self).set_override_state(*args, **kwargs)
+        value = self._current_value
+        if (
+            not self.use_alpha
+            and isinstance(value, list)
+            and len(value) == 4
+        ):
+            value[3] = 255
 
     def convert_to_valid_type(self, value):
         """Conversion to valid type.
@@ -51,4 +62,8 @@ class ColorEntity(InputEntity):
                 ).format(value)
                 raise BaseInvalidValueType(reason, self.path)
             new_value.append(item)
+
+        # Make sure
+        if not self.use_alpha:
+            new_value[3] = 255
         return new_value

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -204,6 +204,16 @@
                                         },
                                         {
                                             "type": "label",
+                                            "label": "Overscan color is used only when output aspect pixel ratio is not same as input ratio."
+                                        },
+                                        {
+                                            "type": "color",
+                                            "label": "Overscan color",
+                                            "key": "overscan_color",
+                                            "use_alpha": false
+                                        },
+                                        {
+                                            "type": "label",
                                             "label": "Background color is used only when input have transparency and Alpha is higher than 0."
                                         },
                                         {

--- a/openpype/tools/settings/settings/color_widget.py
+++ b/openpype/tools/settings/settings/color_widget.py
@@ -25,7 +25,9 @@ class ColorWidget(InputWidget):
             self._dialog.open()
             return
 
-        dialog = ColorDialog(self.input_field.color(), self)
+        dialog = ColorDialog(
+            self.input_field.color(), self.entity.use_alpha, self
+        )
         self._dialog = dialog
 
         dialog.open()
@@ -120,12 +122,12 @@ class ColorViewer(QtWidgets.QWidget):
 
 
 class ColorDialog(QtWidgets.QDialog):
-    def __init__(self, color=None, parent=None):
+    def __init__(self, color=None, use_alpha=True, parent=None):
         super(ColorDialog, self).__init__(parent)
 
         self.setWindowTitle("Color picker dialog")
 
-        picker_widget = ColorPickerWidget(color, self)
+        picker_widget = ColorPickerWidget(color, use_alpha, self)
 
         footer_widget = QtWidgets.QWidget(self)
 

--- a/openpype/widgets/color_widgets/color_view.py
+++ b/openpype/widgets/color_widgets/color_view.py
@@ -5,6 +5,8 @@ def draw_checkerboard_tile(piece_size=None, color_1=None, color_2=None):
     if piece_size is None:
         piece_size = 7
 
+    # Make sure piece size is not float
+    piece_size = int(piece_size)
     if color_1 is None:
         color_1 = QtGui.QColor(188, 188, 188)
 


### PR DESCRIPTION
## Description
- overscan color in extract review is now hardcoded to `black` (when input vs. output aspect ratio does not match)

## Changes
- color entity can have defined `use_alpha` attribute (true/false)
    - color widget won't show alpha inputs is `use_alpha` is false
- ExtractReview has `overscan_color` attribute which define padding color on aspect ratio change