### PR TITLE
Standalone publisher Thumbnail export args

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import subprocess
 import pyblish.api
 import openpype.api
 import openpype.lib
@@ -77,30 +76,30 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
 
             ffmpeg_args = self.ffmpeg_args or {}
 
-            jpeg_items = []
-            jpeg_items.append("\"{}\"".format(ffmpeg_path))
-            # override file if already exists
-            jpeg_items.append("-y")
+            jpeg_items = [
+                "\"{}\"".format(ffmpeg_path),
+                # override file if already exists
+                "-y"
+            ]
+
             # add input filters from peresets
             jpeg_items.extend(ffmpeg_args.get("input") or [])
             # input file
-            jpeg_items.append("-i {}".format(full_input_path))
+            jpeg_items.append("-i \"{}\"".format(full_input_path))
             # extract only single file
-            jpeg_items.append("-vframes 1")
+            jpeg_items.append("-frames:v 1")
 
             jpeg_items.extend(ffmpeg_args.get("output") or [])
 
             # output file
-            jpeg_items.append(full_thumbnail_path)
+            jpeg_items.append("\"{}\"".format(full_thumbnail_path))
 
             subprocess_jpeg = " ".join(jpeg_items)
 
             # run subprocess
             self.log.debug("Executing: {}".format(subprocess_jpeg))
-            subprocess.Popen(
-                subprocess_jpeg,
-                stdout=subprocess.PIPE,
-                shell=True
+            openpype.api.run_subprocess(
+                subprocess_jpeg, shell=True, logger=self.log
             )
 
         # remove thumbnail key from origin repre

--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -88,6 +88,13 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
             jpeg_items.append("-i \"{}\"".format(full_input_path))
             # extract only single file
             jpeg_items.append("-frames:v 1")
+            # Add black background for transparent images
+            jpeg_items.append((
+                "-filter_complex"
+                " \"color=black,format=rgb24[c]"
+                ";[c][0]scale2ref[c][i]"
+                ";[c][i]overlay=format=auto:shortest=1,setsar=1\""
+            ))
 
             jpeg_items.extend(ffmpeg_args.get("output") or [])
 

--- a/openpype/settings/defaults/project_settings/standalonepublisher.json
+++ b/openpype/settings/defaults/project_settings/standalonepublisher.json
@@ -154,7 +154,7 @@
         "ExtractThumbnailSP": {
             "ffmpeg_args": {
                 "input": [
-                    "-gamma 2.2"
+                    "-apply_trc gamma22"
                 ],
                 "output": []
             }


### PR DESCRIPTION
## Issue
- ffmepg arguments in extraction of thumbnail from standalone publisher did not expect some bad cases

## Changes
- fixed ffmpeg arguments in standalone publisher extract thumbnail
    - path with spaces or backslashes can be used now (for ffmpeg executable, input and ouput path)
- changed default input argument from `- gamma 2.2` to `-apply_trc gamma22`

Closes: https://github.com/pypeclub/OpenPype/issues/1700