### PR TITLE
Toggle Ftrack upload in StandalonePublisher

### DIFF
--- a/pype/plugins/ftrack/publish/collect_ftrack_api.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_api.py
@@ -12,7 +12,7 @@ except Exception:
 class CollectFtrackApi(pyblish.api.ContextPlugin):
     """ Collects an ftrack session and the current task id. """
 
-    order = pyblish.api.CollectorOrder + 0.4999
+    order = pyblish.api.CollectorOrder + 0.4998
     label = "Collect Ftrack Api"
 
     def process(self, context):

--- a/pype/plugins/ftrack/publish/collect_ftrack_api.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_api.py
@@ -12,7 +12,7 @@ except Exception:
 class CollectFtrackApi(pyblish.api.ContextPlugin):
     """ Collects an ftrack session and the current task id. """
 
-    order = pyblish.api.CollectorOrder + 0.4998
+    order = pyblish.api.CollectorOrder + 0.4999
     label = "Collect Ftrack Api"
 
     def process(self, context):

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -28,8 +28,8 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
     def process(self, instance):
         if self.profiles:
             anatomy_data = instance.context.data["anatomyData"]
-            task_name = anatomy_data.get("task",
-                                         os.environ["AVALON_TASK"])
+            task_name = instance.data("task",
+                                      instance.context.data["task"])
             host_name = anatomy_data.get("app",
                                          os.environ["AVALON_APP"])
             family = instance.data["family"]

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -23,7 +23,12 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
     label = "Collect Ftrack Family"
     order = pyblish.api.CollectorOrder + 0.4999
 
-    profiles = None
+    profiles = {
+        "hosts": [],
+        "families": [],
+        "task_names": [],
+        "add_to_ftrack": True
+    }
 
     def process(self, instance):
         if self.profiles:

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -37,7 +37,6 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             self.log.warning("No profiles present for adding Ftrack family")
             return
 
-        anatomy_data = instance.context.data["anatomyData"]
         task_name = instance.data("task",
                                   instance.context.data["task"])
         host_name = os.environ["AVALON_APP"]
@@ -58,4 +57,5 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             else:
                 instance.data["families"] = ["ftrack"]
 
-        self.log.debug("instance.data:: {}".format(instance.data))
+        self.log.debug("Resulting families '{}' for '{}'".format(
+            instance.data["families"], instance.data["family"]))

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -40,8 +40,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
         anatomy_data = instance.context.data["anatomyData"]
         task_name = instance.data("task",
                                   instance.context.data["task"])
-        host_name = anatomy_data.get("app",
-                                     os.environ["AVALON_APP"])
+        host_name = os.environ["AVALON_APP"]
         family = instance.data["family"]
 
         filtering_criteria = {

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -23,6 +23,8 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
     label = "Collect Ftrack Family"
     order = pyblish.api.CollectorOrder + 0.4999
 
+    hosts = ["standalonepublisher"]
+
     profiles = {
         "hosts": ["standalonepublisher"],
         "families": [],

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -24,7 +24,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.4999
 
     profiles = {
-        "hosts": [],
+        "hosts": ["standalonepublisher"],
         "families": [],
         "task_names": [],
         "add_to_ftrack": True

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -1,0 +1,41 @@
+"""
+Requires:
+    none
+
+Provides:
+    instance     -> families ([])
+"""
+import re
+import pyblish.api
+
+
+class CollectFtrackFamily(pyblish.api.InstancePlugin):
+    """
+        Adds explicitly 'ftrack' to families to upload instance to FTrack.
+
+        Uses selection by combination of hosts/families/tasks names (regex)
+    """
+    label = "Collect FTrack Family"
+    order = pyblish.api.CollectorOrder + 0.4999
+
+    hosts = ["standalonepublisher"]
+    families = ["render", "image"]
+    tasks = ['.*']
+
+    def process(self, instance):
+        if self.tasks:
+            anatomy_data = instance.context.data["anatomyData"]
+            task_name = anatomy_data["task"].lower()
+
+            if (not any([re.search(pattern, task_name)
+                         for pattern in self.tasks])):
+                self.log.debug("Task not matching, skipping.")
+                return
+
+        families = instance.data.get("families")
+        if families:
+            instance.data["families"].append("ftrack")
+        else:
+            instance.data["families"] = ["ftrack"]
+
+        self.log.debug("instance.data:: {}".format(instance.data))

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -31,27 +31,30 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
     }
 
     def process(self, instance):
-        if self.profiles:
-            anatomy_data = instance.context.data["anatomyData"]
-            task_name = instance.data("task",
-                                      instance.context.data["task"])
-            host_name = anatomy_data.get("app",
-                                         os.environ["AVALON_APP"])
-            family = instance.data["family"]
+        if not self.profiles:
+            self.log.warning("No profiles present for adding Ftrack family")
+            return
 
-            filtering_criteria = {
-                "hosts": host_name,
-                "families": family,
-                "tasks": task_name
-            }
-            profile = filter_profiles(self.profiles, filtering_criteria)
+        anatomy_data = instance.context.data["anatomyData"]
+        task_name = instance.data("task",
+                                  instance.context.data["task"])
+        host_name = anatomy_data.get("app",
+                                     os.environ["AVALON_APP"])
+        family = instance.data["family"]
 
-            if profile and profile["add_ftrack_family"]:
-                self.log.debug("Adding ftrack family")
-                families = instance.data.get("families")
-                if families and "ftrack" not in families:
-                    instance.data["families"].append("ftrack")
-                else:
-                    instance.data["families"] = ["ftrack"]
+        filtering_criteria = {
+            "hosts": host_name,
+            "families": family,
+            "tasks": task_name
+        }
+        profile = filter_profiles(self.profiles, filtering_criteria)
+
+        if profile and profile["add_ftrack_family"]:
+            self.log.debug("Adding ftrack family")
+            families = instance.data.get("families")
+            if families and "ftrack" not in families:
+                instance.data["families"].append("ftrack")
+            else:
+                instance.data["families"] = ["ftrack"]
 
         self.log.debug("instance.data:: {}".format(instance.data))

--- a/pype/plugins/ftrack/publish/collect_ftrack_family.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_family.py
@@ -21,7 +21,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
         Triggered everywhere, checks instance against configured
     """
     label = "Collect Ftrack Family"
-    order = pyblish.api.CollectorOrder + 0.4999
+    order = pyblish.api.CollectorOrder + 0.4998
 
     hosts = ["standalonepublisher"]
 

--- a/pype/plugins/standalonepublisher/publish/collect_context.py
+++ b/pype/plugins/standalonepublisher/publish/collect_context.py
@@ -34,7 +34,7 @@ class CollectContextDataSAPublish(pyblish.api.ContextPlugin):
 
     # presets
     batch_extensions = ["edl", "xml", "psd"]
-    default_families = ["ftrack"]
+    default_families = []
 
     def process(self, context):
         # get json paths from os and load them


### PR DESCRIPTION
Closes https://github.com/pypeclub/client/issues/86

SP previously added 'ftrack' family to all instances implicitly. It wasn't possible to decide when to send or not send to FTrack.

This new collector allows configuration by hosts/family/task names (regex) combination.

By default 'render' and 'image' instances will be marked to send to FTrack for 'standalonepublisher' host.

Requires updating pype-config with
https://github.com/pypeclub/pype-config/pull/109