### PR TITLE
Maya: Extract review hotfix - 2.x backport

### DIFF
--- a/pype/plugins/maya/publish/extract_playblast.py
+++ b/pype/plugins/maya/publish/extract_playblast.py
@@ -81,7 +81,7 @@ class ExtractPlayblast(pype.api.Extractor):
 
         # Isolate view is requested by having objects in the set besides a
         # camera.
-        if preset.pop("isolate_view", False) or instance.data.get("isolate"):
+        if preset.pop("isolate_view", False) and instance.data.get("isolate"):
             preset["isolate"] = instance.data["setMembers"]
 
         # Show/Hide image planes on request.

--- a/pype/plugins/maya/publish/extract_thumbnail.py
+++ b/pype/plugins/maya/publish/extract_thumbnail.py
@@ -78,7 +78,7 @@ class ExtractThumbnail(pype.api.Extractor):
 
         # Isolate view is requested by having objects in the set besides a
         # camera.
-        if preset.pop("isolate_view", False) or instance.data.get("isolate"):
+        if preset.pop("isolate_view", False) and instance.data.get("isolate"):
             preset["isolate"] = instance.data["setMembers"]
 
         with maintained_time():


### PR DESCRIPTION
Extract playblast had wrong condition causing it to trigger *isolate* mode even when it was not requested, causing gray screen renders.

### To reproduce the bug:

- run Maya
- create simple scene + camera
- select camera -> Pype / Create / Review
- make sure "isolate" is not enabled on instance
- publish

It should produce completely gray render. After this fix, playblast render should be as expected.

### To test if it didn't affect isolate
- run Maya
- create simple scene + camera
- select camera -> Pype / Create / Review
- make sure "isolate" **is enabled on instance**
- add one of the objects to Review instance
- publish

This should output only object added to review.

🗻 **OpenPype 3 PR:** #1714
|---|