### PR TITLE
Maya: Extract review hotfix

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -72,7 +72,7 @@ class ExtractPlayblast(openpype.api.Extractor):
 
         # Isolate view is requested by having objects in the set besides a
         # camera.
-        if preset.pop("isolate_view", False) or instance.data.get("isolate"):
+        if preset.pop("isolate_view", False) and instance.data.get("isolate"):
             preset["isolate"] = instance.data["setMembers"]
 
         # Show/Hide image planes on request.

--- a/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
@@ -75,7 +75,7 @@ class ExtractThumbnail(openpype.api.Extractor):
 
         # Isolate view is requested by having objects in the set besides a
         # camera.
-        if preset.pop("isolate_view", False) or instance.data.get("isolate"):
+        if preset.pop("isolate_view", False) and instance.data.get("isolate"):
             preset["isolate"] = instance.data["setMembers"]
 
         with maintained_time():


### PR DESCRIPTION
Extract playblast had wrong condition causing it to trigger *isolate* mode even when it was not requested, causing gray screen renders.

### To reproduce the bug:

- run Maya
- create simple scene + camera
- select camera -> Pype / Create / Review
- make sure "isolate" is not enabled on instance
- publish

It should produce completely gray render. After this fix, playblast render should be as expected.

### To test if it didn't affect isolate
- run Maya
- create simple scene + camera
- select camera -> Pype / Create / Review
- make sure "isolate" **is enabled on instance**
- add one of the objects to Review instance
- publish

This should output only object added to review.

🔙  **Pype 2 backport PR:** #1713 
|---|