### PR TITLE
Default subset template for TVPaint review and workfile families

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -235,7 +235,8 @@
                 },
                 {
                     "families": [
-                        "review"
+                        "review",
+                        "workfile"
                     ],
                     "hosts": [
                         "tvpaint"

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -232,6 +232,16 @@
                     ],
                     "tasks": [],
                     "template": "{family}{Task}_{Render_layer}_{Render_pass}"
+                },
+                {
+                    "families": [
+                        "review"
+                    ],
+                    "hosts": [
+                        "tvpaint"
+                    ],
+                    "tasks": [],
+                    "template": "{family}{Task}"
                 }
             ]
         },


### PR DESCRIPTION
## Description
By default settings tvpaint review and workfile families are using subset template `{family}{Variant}` but as both are created dynamically during collection `"variant"` is never available. We lack default subset template for this purposes.

## Changes
- set default subset template for review and workfile family in tvpaint with `{family}{Task}` template