### PR TITLE
Autoupdate launcher

### DIFF
--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -91,27 +91,14 @@ class ProjectBar(QtWidgets.QWidget):
         index = self.project_combobox.findText(project_name)
         if index < 0:
             # Try refresh combobox model
-            self.project_combobox.blockSignals(True)
-            self.model.refresh()
-            self.project_combobox.blockSignals(False)
-
+            self.refresh()
             index = self.project_combobox.findText(project_name)
 
         if index >= 0:
             self.project_combobox.setCurrentIndex(index)
 
     def refresh(self):
-        prev_project_name = self.get_current_project()
-
-        # Refresh without signals
-        self.project_combobox.blockSignals(True)
-
         self.model.refresh()
-        self.set_project(prev_project_name)
-
-        self.project_combobox.blockSignals(False)
-
-        self.project_changed.emit(self.project_combobox.currentIndex())
 
 
 class ActionBar(QtWidgets.QWidget):

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -58,9 +58,6 @@ class ProjectBar(QtWidgets.QWidget):
         self.project_combobox = project_combobox
         self.refresh_timer = refresh_timer
 
-        # Initialize
-        self.refresh()
-
         # Signals
         refresh_timer.timeout.connect(self._on_refresh_timeout)
         self.project_combobox.currentIndexChanged.connect(self.project_changed)

--- a/openpype/tools/launcher/window.py
+++ b/openpype/tools/launcher/window.py
@@ -108,7 +108,6 @@ class ProjectsPanel(QtWidgets.QWidget):
         flick.activateOn(view)
         model = ProjectModel(self.dbcon)
         model.hide_invisible = True
-        model.refresh()
         view.setModel(model)
 
         layout.addWidget(view)
@@ -434,7 +433,6 @@ class LauncherWindow(QtWidgets.QDialog):
     def on_back_clicked(self):
         self.dbcon.Session["AVALON_PROJECT"] = None
         self.set_page(0)
-        self.project_panel.model.refresh()    # Refresh projects
         self.discover_actions()
 
     def on_action_clicked(self, action):

--- a/openpype/tools/launcher/window.py
+++ b/openpype/tools/launcher/window.py
@@ -297,6 +297,8 @@ class AssetsPanel(QtWidgets.QWidget):
 
 class LauncherWindow(QtWidgets.QDialog):
     """Launcher interface"""
+    # Refresh actions each 10000msecs
+    actions_refresh_timeout = 10000
 
     def __init__(self, parent=None):
         super(LauncherWindow, self).__init__(parent)
@@ -365,6 +367,10 @@ class LauncherWindow(QtWidgets.QDialog):
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
 
+        actions_refresh_timer = QtCore.QTimer()
+        actions_refresh_timer.setInterval(self.actions_refresh_timeout)
+
+        self.actions_refresh_timer = actions_refresh_timer
         self.message_label = message_label
         self.project_panel = project_panel
         self.asset_panel = asset_panel
@@ -374,6 +380,7 @@ class LauncherWindow(QtWidgets.QDialog):
         self._page = 0
 
         # signals
+        actions_refresh_timer.timeout.connect(self._on_action_timer)
         actions_bar.action_clicked.connect(self.on_action_clicked)
         action_history.trigger_history.connect(self.on_history_action)
         project_panel.project_clicked.connect(self.on_project_clicked)
@@ -388,9 +395,11 @@ class LauncherWindow(QtWidgets.QDialog):
         self.resize(520, 740)
 
     def showEvent(self, event):
-        super().showEvent(event)
-        # TODO implement refresh/reset which will trigger updating
-        self.discover_actions()
+        if not self.actions_refresh_timer.isActive():
+            self.actions_refresh_timer.start()
+            self.discover_actions()
+
+        super(LauncherWindow, self).showEvent(event)
 
     def set_page(self, page):
         current = self.page_slider.currentIndex()
@@ -422,6 +431,15 @@ class LauncherWindow(QtWidgets.QDialog):
 
     def filter_actions(self):
         self.actions_bar.filter_actions()
+
+    def _on_action_timer(self):
+        if not self.isVisible():
+            # Stop timer if widget is not visible
+            self.actions_refresh_timer.stop()
+
+        elif self.isActiveWindow():
+            # Refresh projects if window is active
+            self.discover_actions()
 
     def on_project_clicked(self, project_name):
         self.dbcon.Session["AVALON_PROJECT"] = project_name


### PR DESCRIPTION
## Changes
- project names are refreshed each 10 seconds
    - refreshing of projects won't reset whole model but removes not found projects and adds new projects
- actions are refreshed each 10 seconds
- refreshing happens only if launcher is active window to avoid repetitive calls to mongo if window is not active

## How to test
### Projects update
- open launcher
- create project (through project manager of ftrack project sync)
- set launcher as active window
- wait 10 seconds if project will appear in launcher

### Actions update
- open launcher
- click of project -> asset -> task
- remove/add applications for the project in settings (or through ftrack)
- set launcher as active window
- wait 10 seconds if application will show up

Would be great to test if it works on linux and mac as I'm not sure how "active window" is handled on them.