### PR TITLE
PS - added loader from sequence

### DIFF
--- a/openpype/hosts/photoshop/plugins/lib.py
+++ b/openpype/hosts/photoshop/plugins/lib.py
@@ -1,0 +1,26 @@
+import re
+
+
+def get_unique_layer_name(layers, asset_name, subset_name):
+    """
+        Gets all layer names and if 'asset_name_subset_name' is present, it
+        increases suffix by 1 (eg. creates unique layer name - for Loader)
+    Args:
+        layers (list) of dict with layers info (name, id etc.)
+        asset_name (string):
+        subset_name (string):
+
+    Returns:
+        (string): name_00X (without version)
+    """
+    name = "{}_{}".format(asset_name, subset_name)
+    names = {}
+    for layer in layers:
+        layer_name = re.sub(r'_\d{3}$', '', layer.name)
+        if layer_name in names.keys():
+            names[layer_name] = names[layer_name] + 1
+        else:
+            names[layer_name] = 1
+    occurrences = names.get(name, 0)
+
+    return "{}_{:0>3d}".format(name, occurrences + 1)

--- a/openpype/hosts/photoshop/plugins/load/load_image_from_sequence.py
+++ b/openpype/hosts/photoshop/plugins/load/load_image_from_sequence.py
@@ -1,13 +1,15 @@
 import os
+
+from avalon import api
 from avalon import photoshop
 from avalon.vendor import qargparse
 
-from openpype.hosts.photoshop.plugins.load.load_image import ImageLoader
+from openpype.hosts.photoshop.plugins.lib import get_unique_layer_name
 
 stub = photoshop.stub()
 
 
-class ImageFromSequenceLoader(ImageLoader):
+class ImageFromSequenceLoader(api.Loader):
     """ Load specifing image from sequence
 
         Used only as quick load of reference file from a sequence.
@@ -36,8 +38,11 @@ class ImageFromSequenceLoader(ImageLoader):
             if not os.path.exists(self.fname):
                 return
 
-        layer_name = self._get_unique_layer_name(context["asset"]["name"],
-                                                 name)
+        stub = photoshop.stub()
+        layer_name = get_unique_layer_name(stub.get_layers(),
+                                           context["asset"]["name"],
+                                           name)
+
         with photoshop.maintained_selection():
             layer = stub.import_smart_object(self.fname, layer_name)
 
@@ -59,7 +64,7 @@ class ImageFromSequenceLoader(ImageLoader):
         """
         files = []
         for context in repre_contexts:
-            fname = ImageLoader.filepath_from_context(context)
+            fname = ImageFromSequenceLoader.filepath_from_context(context)
             _, file_extension = os.path.splitext(fname)
 
             for file_name in os.listdir(os.path.dirname(fname)):

--- a/openpype/hosts/photoshop/plugins/load/load_image_from_sequence.py
+++ b/openpype/hosts/photoshop/plugins/load/load_image_from_sequence.py
@@ -1,0 +1,90 @@
+import os
+from avalon import photoshop
+from avalon.vendor import qargparse
+
+from openpype.hosts.photoshop.plugins.load.load_image import ImageLoader
+
+stub = photoshop.stub()
+
+
+class ImageFromSequenceLoader(ImageLoader):
+    """ Load specifing image from sequence
+
+        Used only as quick load of reference file from a sequence.
+
+        Plain ImageLoader picks first frame from sequence.
+
+        Loads only existing files - currently not possible to limit loaders
+        to single select - multiselect. If user selects multiple repres, list
+        for all of them is provided, but selection is only single file.
+        This loader will be triggered multiple times, but selected name will
+        match only to proper path.
+
+        Loader doesnt do containerization as there is currently no data model
+        of 'frame of rendered files' (only rendered sequence), update would be
+        difficult.
+    """
+
+    families = ["render"]
+    representations = ["*"]
+    options = []
+
+    def load(self, context, name=None, namespace=None, data=None):
+        if data.get("frame"):
+            self.fname = os.path.join(os.path.dirname(self.fname),
+                                      data["frame"])
+            if not os.path.exists(self.fname):
+                return
+
+        layer_name = self._get_unique_layer_name(context["asset"]["name"],
+                                                 name)
+        with photoshop.maintained_selection():
+            layer = stub.import_smart_object(self.fname, layer_name)
+
+        self[:] = [layer]
+        namespace = namespace or layer_name
+
+        return namespace
+
+    @classmethod
+    def get_options(cls, repre_contexts):
+        """
+            Returns list of files for selected 'repre_contexts'.
+
+            It returns only files with same extension as in context as it is
+            expected that context points to sequence of frames.
+
+            Returns:
+                (list) of qargparse.Choice
+        """
+        files = []
+        for context in repre_contexts:
+            fname = ImageLoader.filepath_from_context(context)
+            _, file_extension = os.path.splitext(fname)
+
+            for file_name in os.listdir(os.path.dirname(fname)):
+                if not file_name.endswith(file_extension):
+                    continue
+                files.append(file_name)
+
+        # return selection only if there is something
+        if not files or len(files) <= 1:
+            return []
+
+        return [
+            qargparse.Choice(
+                "frame",
+                label="Select specific file",
+                items=files,
+                default=0,
+                help="Which frame should be loaded?"
+            )
+        ]
+
+    def update(self, container, representation):
+        """No update possible, not containerized."""
+        pass
+
+    def remove(self, container):
+        """No update possible, not containerized."""
+        pass

--- a/openpype/hosts/photoshop/plugins/load/load_image_from_sequence.py
+++ b/openpype/hosts/photoshop/plugins/load/load_image_from_sequence.py
@@ -2,8 +2,10 @@ import os
 
 from avalon import api
 from avalon import photoshop
+from avalon.pipeline import get_representation_path_from_context
 from avalon.vendor import qargparse
 
+from openpype.lib import Anatomy
 from openpype.hosts.photoshop.plugins.lib import get_unique_layer_name
 
 stub = photoshop.stub()
@@ -64,7 +66,7 @@ class ImageFromSequenceLoader(api.Loader):
         """
         files = []
         for context in repre_contexts:
-            fname = ImageFromSequenceLoader.filepath_from_context(context)
+            fname = get_representation_path_from_context(context)
             _, file_extension = os.path.splitext(fname)
 
             for file_name in os.listdir(os.path.dirname(fname)):
@@ -93,3 +95,4 @@ class ImageFromSequenceLoader(api.Loader):
     def remove(self, container):
         """No update possible, not containerized."""
         pass
+


### PR DESCRIPTION
Closes https://github.com/pypeclub/client/issues/46

Loader allows user to select specific frame from sequence of files.

This loader is a bit specific as it doesn't produce container in the scene. Currently there is no container with frame field to store.
Customer is fine with it for now, might be necessary to be added in the future, but currently not extra limiting.

Still uses qargparse approach, no special nice dialog (that would need much more rework).

**How to test it:**
- open Photoshop
- click on Launch
- locate 'render' subset with multiple frames
- open context menu with rmb
- click on small rectangle at the end of line with ImageFromSequenceLoader
- select specific file

- please try some other existing loaders, dont need to be from PS