### PR TITLE
Tools names forwards compatibility

### DIFF
--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -115,7 +115,9 @@ def launch_application(project_name, asset_name, task_name, app_name):
     # collect all the 'environment' attributes from parents
     tools_attr = [prep_env["AVALON_APP"], prep_env["AVALON_APP_NAME"]]
     tools_env = asset_document["data"].get("tools_env") or []
-    tools_attr.extend(tools_env)
+    # Forwards compatibility with OpenPype 3
+    for tool in tools_env:
+        tools_attr.append(tool.replace("/", "_"))
 
     tools_env = acre.get_tools(tools_attr)
     env = acre.compute(tools_env)


### PR DESCRIPTION
## Issue
- tool names in application preparation do not expect slash in tool name from OpenPype3

## Changes
- replace slash on tool name with underscore