### PR TITLE
Ftrack sync status

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py
@@ -66,15 +66,7 @@ class VersionToTaskStatus(BaseEvent):
             ))
             return
 
-        _status_mapping = event_settings["mapping"]
-        if not _status_mapping:
-            self.log.debug(
-                "Project \"{}\" does not have set mapping for {}".format(
-                    project_name, self.__class__.__name__
-                )
-            )
-            return
-
+        _status_mapping = event_settings["mapping"] or {}
         status_mapping = {
             key.lower(): value
             for key, value in _status_mapping.items()


### PR DESCRIPTION
## Issue
Ftrack version to task status mapping won't map statuses if mapping is not defined in settings which is not right and should contiue using default way (which is exact status mapping).

## Changes
- don't skip processing if mapping is not set and use default mapping

Closes: https://github.com/pypeclub/OpenPype/issues/1670