### PR TITLE
Launcher project changes

### DIFF
--- a/openpype/tools/launcher/lib.py
+++ b/openpype/tools/launcher/lib.py
@@ -15,12 +15,30 @@ provides a bridge between the file-based project inventory and configuration.
 """
 
 import os
-from Qt import QtGui
+from Qt import QtGui, QtCore
 from avalon.vendor import qtawesome
 from openpype.api import resources
 
 ICON_CACHE = {}
 NOT_FOUND = type("NotFound", (object, ), {})
+
+
+class ProjectHandler(QtCore.QObject):
+    project_changed = QtCore.Signal(str)
+
+    def __init__(self, dbcon, model):
+        super(ProjectHandler, self).__init__()
+        self.current_project = dbcon.Session.get("AVALON_PROJECT")
+        self.model = model
+        self.dbcon = dbcon
+
+    def set_project(self, project_name):
+        self.current_project = project_name
+        self.dbcon.Session["AVALON_PROJECT"] = project_name
+        self.project_changed.emit(project_name)
+
+    def refresh_model(self):
+        self.model.refresh()
 
 
 def get_action_icon(action):

--- a/openpype/tools/launcher/window.py
+++ b/openpype/tools/launcher/window.py
@@ -227,10 +227,7 @@ class AssetsPanel(QtWidgets.QWidget):
         """Callback on asset selection changed
 
         This updates the task view.
-
         """
-
-        print("Asset changed..")
 
         asset_name = None
         asset_silo = None


### PR DESCRIPTION
## Issue
Project changes may not be propagated in right way. So project clicked on first launcher page may be propagated to project combobox on page 2 but is not propagated to assets widget which is confusing and may cause crash of OpenPype Tray.

This happens since https://github.com/pypeclub/OpenPype/pull/1725 .

## Changes
- implemented `ProjectHandler` which handles project changes and refreshing of projects
- all callbacks related to project changes does not care about anything else that value passed with project change signal
    - ProjectHandler object always make all necessary steps before callbacks are triggered
    - this simplified a lot of code as propagation of project change was sequence based and race coditions were not always right