### PR TITLE
Ftrack missing custom attribute message

### DIFF
--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -409,9 +409,11 @@ class SyncEntitiesFactory:
             items.append({
                 "type": "label",
                 "value": (
-                    "<p>- Check if user \"{}\" has permissions"
-                    " to access the Custom attribute</p>"
-                ).format(self._api_key)
+                    "<p>- Check if your User and API key has permissions"
+                    " to access the Custom attribute."
+                    "<br>Username:\"{}\""
+                    "<br>API key:\"{}\"</p>"
+                ).format(self._api_user, self._api_key)
             })
             items.append({
                 "type": "label",

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -402,9 +402,9 @@ class SyncEntitiesFactory:
             items = []
             items.append({
                 "type": "label",
-                "value": "# Can't access Custom attribute <{}>".format(
-                    CUST_ATTR_ID_KEY
-                )
+                "value": (
+                    "# Can't access Custom attribute: <b>\"{}\"</b>"
+                ).format(CUST_ATTR_ID_KEY)
             })
             items.append({
                 "type": "label",


### PR DESCRIPTION
## Issue
Missing `avalon_mongo_id` or lack of permissions to the custom attribute will cause that popup message will show up but won't show much usefull information as `<` and `>` will cause that custom attribute name is not visible in ftrack and username is not shown at all.

## Changes
- custom attribute name is not wrapped with `<` and `>` but `"`
- details will show both username and api key