### PR TITLE
TVPaint white background on thumbnail

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -13,6 +13,9 @@ class ExtractSequence(pyblish.api.Extractor):
     hosts = ["tvpaint"]
     families = ["review", "renderPass", "renderLayer"]
 
+    # Modifiable with settings
+    thumbnail_bg = [255, 255, 255, 255]
+
     def process(self, instance):
         self.log.info(
             "* Processing instance \"{}\"".format(instance.data["label"])

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -56,6 +56,8 @@ class ExtractSequence(pyblish.api.Extractor):
         handle_start = instance.context.data["handleStart"]
         handle_end = instance.context.data["handleEnd"]
 
+        scene_bg_color = instance.context.data["sceneBgColor"]
+
         # --- Fallbacks ----------------------------------------------------
         # This is required if validations of ranges are ignored.
         # - all of this code won't change processing if range to render
@@ -123,7 +125,8 @@ class ExtractSequence(pyblish.api.Extractor):
 
         if instance.data["family"] == "review":
             output_filenames, thumbnail_fullpath = self.render_review(
-                filename_template, output_dir, mark_in, mark_out
+                filename_template, output_dir, mark_in, mark_out,
+                scene_bg_color
             )
         else:
             # Render output
@@ -244,7 +247,9 @@ class ExtractSequence(pyblish.api.Extractor):
             for path in repre_filepaths
         ]
 
-    def render_review(self, filename_template, output_dir, mark_in, mark_out):
+    def render_review(
+        self, filename_template, output_dir, mark_in, mark_out, scene_bg_color
+    ):
         """ Export images from TVPaint using `tv_savesequence` command.
 
         Args:
@@ -255,6 +260,8 @@ class ExtractSequence(pyblish.api.Extractor):
             output_dir (str): Directory where files will be stored.
             mark_in (int): Starting frame index from which export will begin.
             mark_out (int): On which frame index export will end.
+            scene_bg_color (list): Bg color set in scene. Result of george
+                script command `tv_background`.
 
         Retruns:
             tuple: With 2 items first is list of filenames second is path to

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -14,7 +14,7 @@ class ExtractSequence(pyblish.api.Extractor):
     families = ["review", "renderPass", "renderLayer"]
 
     # Modifiable with settings
-    thumbnail_bg = [255, 255, 255, 255]
+    review_bg = [255, 255, 255, 255]
 
     def process(self, instance):
         self.log.info(
@@ -299,20 +299,6 @@ class ExtractSequence(pyblish.api.Extractor):
             # Composite background only on rgba images
             # - just making sure
             source_img = Image.open(first_frame_filepath)
-            if source_img.mode.lower() == "rgba":
-                bg_color = self._get_thumbnail_bg_color()
-                self.log.debug("Adding thumbnail background color {}.".format(
-                    " ".join(bg_color)
-                ))
-                bg_image = Image.new("RGBA", source_img.size, bg_color)
-                thumbnail_obj = Image.alpha_composite(bg_image, source_img)
-                thumbnail_obj.convert("RGB").save(thumbnail_filepath)
-            else:
-                self.log.info((
-                    "Source for thumbnail has mode \"{}\" (Expected: RGBA)."
-                    " Can't use thubmanail background color."
-                ).format(source_img.mode))
-                source_img.save(thumbnail_filepath)
 
         return output_filenames, thumbnail_filepath
 
@@ -411,9 +397,9 @@ class ExtractSequence(pyblish.api.Extractor):
             # Composite background only on rgba images
             # - just making sure
             if source_img.mode.lower() == "rgba":
-                bg_color = self._get_thumbnail_bg_color()
+                bg_color = self._get_review_bg_color()
                 self.log.debug("Adding thumbnail background color {}.".format(
-                    " ".join(bg_color)
+                    " ".join([str(val) for val in bg_color])
                 ))
                 bg_image = Image.new("RGBA", source_img.size, bg_color)
                 thumbnail_obj = Image.alpha_composite(bg_image, source_img)
@@ -428,13 +414,13 @@ class ExtractSequence(pyblish.api.Extractor):
 
         return output_filenames, thumbnail_filepath
 
-    def _get_thumbnail_bg_color(self):
+    def _get_review_bg_color(self):
         red = green = blue = 255
-        if self.thumbnail_bg:
-            if len(self.thumbnail_bg) == 4:
-                red, green, blue, _ = self.thumbnail_bg
-            elif len(self.thumbnail_bg) == 3:
-                red, green, blue = self.thumbnail_bg
+        if self.review_bg:
+            if len(self.review_bg) == 4:
+                red, green, blue, _ = self.review_bg
+            elif len(self.review_bg) == 3:
+                red, green, blue = self.review_bg
         return (red, green, blue)
 
     def _render_layer(

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -293,10 +293,15 @@ class ExtractSequence(pyblish.api.Extractor):
 
         thumbnail_filepath = os.path.join(output_dir, "thumbnail.jpg")
         if first_frame_filepath and os.path.exists(first_frame_filepath):
+            # Composite background only on rgba images
+            # - just making sure
             source_img = Image.open(first_frame_filepath)
-            thumbnail_obj = Image.new("RGB", source_img.size, (255, 255, 255))
-            thumbnail_obj.paste(source_img)
-            thumbnail_obj.save(thumbnail_filepath)
+            if source_img.mode.lower() == "rgba":
+                bg_image = Image.new("RGBA", source_img.size, (255, 255, 255))
+                thumbnail_obj = Image.alpha_composite(bg_image, source_img)
+                thumbnail_obj.convert("RGB").save(thumbnail_filepath)
+            else:
+                source_img.save(thumbnail_filepath)
 
         return output_filenames, thumbnail_filepath
 
@@ -392,9 +397,14 @@ class ExtractSequence(pyblish.api.Extractor):
         if thumbnail_src_filepath and os.path.exists(thumbnail_src_filepath):
             source_img = Image.open(thumbnail_src_filepath)
             thumbnail_filepath = os.path.join(output_dir, "thumbnail.jpg")
-            thumbnail_obj = Image.new("RGB", source_img.size, (255, 255, 255))
-            thumbnail_obj.paste(source_img)
-            thumbnail_obj.save(thumbnail_filepath)
+            # Composite background only on rgba images
+            # - just making sure
+            if source_img.mode.lower() == "rgba":
+                bg_image = Image.new("RGBA", source_img.size, (255, 255, 255))
+                thumbnail_obj = Image.alpha_composite(bg_image, source_img)
+                thumbnail_obj.convert("RGB").save(thumbnail_filepath)
+            else:
+                source_img.save(thumbnail_filepath)
 
         return output_filenames, thumbnail_filepath
 

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -318,11 +318,13 @@ class ExtractSequence(pyblish.api.Extractor):
             if first_frame_filepath is None:
                 first_frame_filepath = filepath
 
-        thumbnail_filepath = os.path.join(output_dir, "thumbnail.jpg")
+        thumbnail_filepath = None
         if first_frame_filepath and os.path.exists(first_frame_filepath):
-            # Composite background only on rgba images
-            # - just making sure
+            thumbnail_filepath = os.path.join(output_dir, "thumbnail.jpg")
             source_img = Image.open(first_frame_filepath)
+            if source_img.mode.lower() != "rgb":
+                source_img = source_img.convert("RGB")
+            source_img.save(thumbnail_filepath)
 
         return output_filenames, thumbnail_filepath
 

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -300,10 +300,18 @@ class ExtractSequence(pyblish.api.Extractor):
             # - just making sure
             source_img = Image.open(first_frame_filepath)
             if source_img.mode.lower() == "rgba":
-                bg_image = Image.new("RGBA", source_img.size, (255, 255, 255))
+                bg_color = self._get_thumbnail_bg_color()
+                self.log.debug("Adding thumbnail background color {}.".format(
+                    " ".join(bg_color)
+                ))
+                bg_image = Image.new("RGBA", source_img.size, bg_color)
                 thumbnail_obj = Image.alpha_composite(bg_image, source_img)
                 thumbnail_obj.convert("RGB").save(thumbnail_filepath)
             else:
+                self.log.info((
+                    "Source for thumbnail has mode \"{}\" (Expected: RGBA)."
+                    " Can't use thubmanail background color."
+                ).format(source_img.mode))
                 source_img.save(thumbnail_filepath)
 
         return output_filenames, thumbnail_filepath
@@ -403,13 +411,31 @@ class ExtractSequence(pyblish.api.Extractor):
             # Composite background only on rgba images
             # - just making sure
             if source_img.mode.lower() == "rgba":
-                bg_image = Image.new("RGBA", source_img.size, (255, 255, 255))
+                bg_color = self._get_thumbnail_bg_color()
+                self.log.debug("Adding thumbnail background color {}.".format(
+                    " ".join(bg_color)
+                ))
+                bg_image = Image.new("RGBA", source_img.size, bg_color)
                 thumbnail_obj = Image.alpha_composite(bg_image, source_img)
                 thumbnail_obj.convert("RGB").save(thumbnail_filepath)
+
             else:
+                self.log.info((
+                    "Source for thumbnail has mode \"{}\" (Expected: RGBA)."
+                    " Can't use thubmanail background color."
+                ).format(source_img.mode))
                 source_img.save(thumbnail_filepath)
 
         return output_filenames, thumbnail_filepath
+
+    def _get_thumbnail_bg_color(self):
+        red = green = blue = 255
+        if self.thumbnail_bg:
+            if len(self.thumbnail_bg) == 4:
+                red, green, blue, _ = self.thumbnail_bg
+            elif len(self.thumbnail_bg) == 3:
+                red, green, blue = self.thumbnail_bg
+        return (red, green, blue)
 
     def _render_layer(
         self,

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import copy
 import tempfile
 
 import pyblish.api
@@ -273,7 +274,11 @@ class ExtractSequence(pyblish.api.Extractor):
             filename_template.format(frame=mark_in)
         )
 
+        bg_color = self._get_review_bg_color()
+
         george_script_lines = [
+            # Change bg color to color from settings
+            "tv_background \"color\" {} {} {}".format(*bg_color),
             "tv_SaveMode \"PNG\"",
             "export_path = \"{}\"".format(
                 first_frame_filepath.replace("\\", "/")
@@ -282,6 +287,18 @@ class ExtractSequence(pyblish.api.Extractor):
                 mark_in, mark_out
             )
         ]
+        if scene_bg_color:
+            # Change bg color back to previous scene bg color
+            _scene_bg_color = copy.deepcopy(scene_bg_color)
+            bg_type = _scene_bg_color.pop(0)
+            orig_color_command = [
+                "tv_background",
+                "\"{}\"".format(bg_type)
+            ]
+            orig_color_command.extend(_scene_bg_color)
+
+            george_script_lines.append(" ".join(orig_color_command))
+
         lib.execute_george_through_file("\n".join(george_script_lines))
 
         first_frame_filepath = None

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -1,7 +1,7 @@
 {
     "publish": {
         "ExtractSequence": {
-            "thumbnail_bg": [
+            "review_bg": [
                 255,
                 255,
                 255,

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -1,5 +1,13 @@
 {
     "publish": {
+        "ExtractSequence": {
+            "thumbnail_bg": [
+                255,
+                255,
+                255,
+                255
+            ]
+        },
         "ValidateProjectSettings": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -19,9 +19,13 @@
                     "is_group": true,
                     "children": [
                         {
+                            "type": "label",
+                            "label": "<b>Review BG color</b> is used for whole scene review and for thumbnails."
+                        },
+                        {
                             "type": "color",
-                            "key": "thumbnail_bg",
-                            "label": "Thumbnail BG color",
+                            "key": "review_bg",
+                            "label": "Review BG color",
                             "use_alpha": false
                         }
                     ]

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -12,6 +12,21 @@
             "label": "Publish plugins",
             "children": [
                 {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "ExtractSequence",
+                    "label": "ExtractSequence",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "color",
+                            "key": "thumbnail_bg",
+                            "label": "Thumbnail BG color",
+                            "use_alpha": false
+                        }
+                    ]
+                },
+                {
                     "type": "schema_template",
                     "name": "template_publish_plugin",
                     "template_data": [


### PR DESCRIPTION
## Issue
Background of thumbnail has not set default background color so transparency is filled with black which is in most of cases unwanted behavior.

## Changes
- add white background for thumbnail image
    - make sure bg compositing is happening only if alpha is available

closes https://github.com/pypeclub/client/issues/107