### PR TITLE
Validate containers settings

### DIFF
--- a/openpype/settings/defaults/project_settings/harmony.json
+++ b/openpype/settings/defaults/project_settings/harmony.json
@@ -5,6 +5,11 @@
                 ".*"
             ]
         },
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateSceneSettings": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/defaults/project_settings/houdini.json
+++ b/openpype/settings/defaults/project_settings/houdini.json
@@ -1,0 +1,9 @@
+{
+    "publish": {
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        }
+    }
+}

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -127,6 +127,11 @@
         "CollectMayaRender": {
             "sync_workfile_version": false
         },
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateShaderName": {
             "enabled": false,
             "regex": "(?P<asset>.*)_(.*)_SHD"

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -21,6 +21,11 @@
         "PreCollectNukeInstances": {
             "sync_workfile_version": true
         },
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateKnobs": {
             "enabled": false,
             "knobs": {

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -7,6 +7,11 @@
         }
     },
     "publish": {
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ExtractImage": {
             "formats": [
                 "png",

--- a/openpype/settings/entities/schemas/projects_schema/schema_main.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_main.json
@@ -84,6 +84,10 @@
                 },
                 {
                     "type": "schema",
+                    "name": "schema_project_houdini"
+                },
+                {
+                    "type": "schema",
                     "name": "schema_project_blender"
                 },
                 {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_harmony.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_harmony.json
@@ -26,6 +26,16 @@
                     ]
                 },
                 {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateContainers",
+                            "label": "ValidateContainers"
+                        }
+                    ]
+                },
+                {
                     "type": "dict",
                     "collapsible": true,
                     "key": "ValidateSceneSettings",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_houdini.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_houdini.json
@@ -1,0 +1,27 @@
+{
+    "type": "dict",
+    "collapsible": true,
+    "key": "houdini",
+    "label": "Houdini",
+    "is_file": true,
+    "children": [
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "publish",
+            "label": "Publish plugins",
+            "children": [
+                {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateContainers",
+                            "label": "ValidateContainers"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -34,6 +34,16 @@
             "label": "Publish plugins",
             "children": [
                 {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateContainers",
+                            "label": "ValidateContainers"
+                        }
+                    ]
+                },
+                {
                     "type": "dict",
                     "collapsible": true,
                     "key": "ExtractImage",
@@ -50,7 +60,7 @@
                             "object_type": "text"
                         }
                     ]
-                }
+                }                
             ]
         },
         {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -28,7 +28,16 @@
             "type": "label",
             "label": "Validators"
         },
-
+        {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
+                    "key": "ValidateContainers",
+                    "label": "ValidateContainers"
+                }
+            ]
+        },
         {
             "type": "dict",
             "collapsible": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -30,6 +30,16 @@
             "label": "Validators"
         },
         {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
+                    "key": "ValidateContainers",
+                    "label": "ValidateContainers"
+                }
+            ]
+        },
+        {
             "type": "dict",
             "collapsible": true,
             "checkbox_key": "enabled",


### PR DESCRIPTION
## Description
We lack settings for `ValidateContainers` validator which is global validator but for multiple hosts.

## Changes
- added `ValidateContainers` settings into all hosts (that can use the plugin) so it's possible to modify it's behavior per host
    - created houdini settings with only this plugin

Part of https://github.com/pypeclub/OpenPype/issues/1661 Issue (not closing).