### PR TITLE
Local settings UI crash on missing defaults

### DIFF
--- a/openpype/modules/settings_action.py
+++ b/openpype/modules/settings_action.py
@@ -114,6 +114,7 @@ class LocalSettingsAction(PypeModule, ITrayAction):
 
         # Tray attributes
         self.settings_window = None
+        self._first_trigger = True
 
     def connect_with_modules(self, *_a, **_kw):
         return
@@ -153,6 +154,9 @@ class LocalSettingsAction(PypeModule, ITrayAction):
         self.settings_window.raise_()
         self.settings_window.activateWindow()
 
-        # Reset content if was not visible
-        if not was_visible:
+        # Do not reset if it's first trigger of action
+        if self._first_trigger:
+            self._first_trigger = False
+        elif not was_visible:
+            # Reset content if was not visible
             self.settings_window.reset()

--- a/openpype/tools/settings/local_settings/window.py
+++ b/openpype/tools/settings/local_settings/window.py
@@ -188,8 +188,12 @@ class LocalSettingsWindow(QtWidgets.QWidget):
         save_btn.clicked.connect(self._on_save_clicked)
         reset_btn.clicked.connect(self._on_reset_clicked)
 
-        self.settings_widget = None
-        self.scroll_widget = scroll_widget
+        # Do not create local settings widget in init phase as it's using
+        #   settings objects that must be OK to be able create this widget
+        #   - we want to show dialog if anything goes wrong
+        #   - without reseting nothing is shown
+        self._settings_widget = None
+        self._scroll_widget = scroll_widget
         self.reset_btn = reset_btn
         self.save_btn = save_btn
 
@@ -204,12 +208,15 @@ class LocalSettingsWindow(QtWidgets.QWidget):
 
         error_msg = None
         try:
-            if self.settings_widget is None:
-                self.settings_widget = LocalSettingsWidget(self.scroll_widget)
-                self.scroll_widget.setWidget(self.settings_widget)
+            # Create settings widget if is not created yet
+            if self._settings_widget is None:
+                self._settings_widget = LocalSettingsWidget(
+                    self._scroll_widget
+                )
+                self._scroll_widget.setWidget(self._settings_widget)
 
             value = get_local_settings()
-            self.settings_widget.update_local_settings(value)
+            self._settings_widget.update_local_settings(value)
 
         except Exception as exc:
             error_msg = str(exc)
@@ -218,8 +225,8 @@ class LocalSettingsWindow(QtWidgets.QWidget):
         # Enable/Disable save button if crashed or not
         self.save_btn.setEnabled(not crashed)
         # Show/Hide settings widget if crashed or not
-        if self.settings_widget:
-            self.settings_widget.setVisible(not crashed)
+        if self._settings_widget:
+            self._settings_widget.setVisible(not crashed)
 
         if not crashed:
             return
@@ -245,6 +252,6 @@ class LocalSettingsWindow(QtWidgets.QWidget):
         self.reset()
 
     def _on_save_clicked(self):
-        value = self.settings_widget.settings_value()
+        value = self._settings_widget.settings_value()
         save_local_settings(value)
         self.reset()

--- a/openpype/tools/settings/local_settings/window.py
+++ b/openpype/tools/settings/local_settings/window.py
@@ -168,9 +168,6 @@ class LocalSettingsWindow(QtWidgets.QWidget):
 
         scroll_widget = QtWidgets.QScrollArea(self)
         scroll_widget.setObjectName("GroupWidget")
-        settings_widget = LocalSettingsWidget(scroll_widget)
-
-        scroll_widget.setWidget(settings_widget)
         scroll_widget.setWidgetResizable(True)
 
         footer = QtWidgets.QWidget(self)
@@ -191,7 +188,8 @@ class LocalSettingsWindow(QtWidgets.QWidget):
         save_btn.clicked.connect(self._on_save_clicked)
         reset_btn.clicked.connect(self._on_reset_clicked)
 
-        self.settings_widget = settings_widget
+        self.settings_widget = None
+        self.scroll_widget = scroll_widget
         self.reset_btn = reset_btn
         self.save_btn = save_btn
 
@@ -206,6 +204,10 @@ class LocalSettingsWindow(QtWidgets.QWidget):
 
         error_msg = None
         try:
+            if self.settings_widget is None:
+                self.settings_widget = LocalSettingsWidget(self.scroll_widget)
+                self.scroll_widget.setWidget(self.settings_widget)
+
             value = get_local_settings()
             self.settings_widget.update_local_settings(value)
 

--- a/openpype/tools/settings/local_settings/window.py
+++ b/openpype/tools/settings/local_settings/window.py
@@ -203,8 +203,40 @@ class LocalSettingsWindow(QtWidgets.QWidget):
     def reset(self):
         if self._reset_on_show:
             self._reset_on_show = False
-        value = get_local_settings()
-        self.settings_widget.update_local_settings(value)
+
+        error_msg = None
+        try:
+            value = get_local_settings()
+            self.settings_widget.update_local_settings(value)
+
+        except Exception as exc:
+            error_msg = str(exc)
+
+        crashed = error_msg is not None
+        # Enable/Disable save button if crashed or not
+        self.save_btn.setEnabled(not crashed)
+        # Show/Hide settings widget if crashed or not
+        if self.settings_widget:
+            self.settings_widget.setVisible(not crashed)
+
+        if not crashed:
+            return
+
+        # Show message with error
+        title = "Something went wrong"
+        msg = (
+            "This is probably a bug. Loading of settings failed."
+            "\n\nError message:\n{}"
+        ).format(error_msg)
+
+        dialog = QtWidgets.QMessageBox(
+            QtWidgets.QMessageBox.Warning,
+            title,
+            msg,
+            QtWidgets.QMessageBox.Ok,
+            self
+        )
+        dialog.exec_()
 
     def _on_reset_clicked(self):
         self.reset()

--- a/openpype/tools/settings/local_settings/window.py
+++ b/openpype/tools/settings/local_settings/window.py
@@ -227,12 +227,13 @@ class LocalSettingsWindow(QtWidgets.QWidget):
         # Show message with error
         title = "Something went wrong"
         msg = (
-            "This is probably a bug. Loading of settings failed."
+            "Bug: Loading of settings failed."
+            " Please contact your project manager or OpenPype team."
             "\n\nError message:\n{}"
         ).format(error_msg)
 
         dialog = QtWidgets.QMessageBox(
-            QtWidgets.QMessageBox.Warning,
+            QtWidgets.QMessageBox.Critical,
             title,
             msg,
             QtWidgets.QMessageBox.Ok,


### PR DESCRIPTION
## Issue
Local settings UI crashes OpenPype tray if there are missing default values for studio settings. This issue will never happen to user(99.99%).

## Changes
- local settings ui won't load any settings until is called `reset`
- local settings ui catch errors happened on `reset` and show them in dialog
    - hide widgets and disable save button
    - reset button is kept there to be able reset local settings when defaults are set
- local settings action in tray won't trigger `reset` on first show as that is handled by local settings ui itself

## How to test
Easiest is to rename `~/openpype/settings/defaults/system_settings/tools.json` to different name. That should cause missing defaults error but tray should be possible to start.

Closes: https://github.com/pypeclub/OpenPype/issues/1712