### PR TITLE
Settings Hosts enum

### DIFF
--- a/openpype/settings/entities/__init__.py
+++ b/openpype/settings/entities/__init__.py
@@ -101,6 +101,7 @@ from .color_entity import ColorEntity
 from .enum_entity import (
     BaseEnumEntity,
     EnumEntity,
+    HostsEnumEntity,
     AppsEnumEntity,
     ToolsEnumEntity,
     TaskTypeEnumEntity,
@@ -153,6 +154,7 @@ __all__ = (
 
     "BaseEnumEntity",
     "EnumEntity",
+    "HostsEnumEntity",
     "AppsEnumEntity",
     "ToolsEnumEntity",
     "TaskTypeEnumEntity",

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -102,6 +102,21 @@ class EnumEntity(BaseEnumEntity):
 
 
 class HostsEnumEntity(BaseEnumEntity):
+    """Enumeration of host names.
+
+    Enum items are hardcoded in definition of the entity.
+
+    Hosts enum can have defined empty value as valid option which is
+    represented by empty string. Schema key to set this option is
+    `use_empty_value` (true/false). And to set label of empty value set
+    `empty_label` (string).
+
+    Enum can have single and multiselection.
+
+    NOTE:
+    Host name is not the same as application name. Host name defines
+    implementation instead of application name.
+    """
     schema_types = ["hosts-enum"]
 
     def _item_initalization(self):
@@ -113,6 +128,7 @@ class HostsEnumEntity(BaseEnumEntity):
             self.schema_data.get("empty_label") or "< without host >"
         )
 
+        # These are hardcoded there is not list of available host in OpenPype
         self.enum_items = [
             {"aftereffects": "aftereffects"},
             {"blender": "blender"},

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -153,7 +153,7 @@ class HostsEnumEntity(BaseEnumEntity):
         for key in host_names:
             label = custom_labels.get(key, key)
             valid_keys.add(key)
-            enum_items.append({key, label})
+            enum_items.append({key: label})
 
         self.enum_items = enum_items
         self.valid_keys = valid_keys

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -101,6 +101,58 @@ class EnumEntity(BaseEnumEntity):
         super(EnumEntity, self).schema_validations()
 
 
+class HostsEnumEntity(BaseEnumEntity):
+    schema_types = ["hosts-enum"]
+
+    def _item_initalization(self):
+        self.multiselection = self.schema_data.get("multiselection", True)
+        self.use_empty_value = self.schema_data.get(
+            "use_empty_value", not self.multiselection
+        )
+        self.empty_label = (
+            self.schema_data.get("empty_label") or "< without host >"
+        )
+
+        self.enum_items = [
+            {"aftereffects": "aftereffects"},
+            {"blender": "blender"},
+            {"celaction": "celaction"},
+            {"fusion": "fusion"},
+            {"harmony": "harmony"},
+            {"hiero": "hiero"},
+            {"houdini": "houdini"},
+            {"maya": "maya"},
+            {"nuke": "nuke"},
+            {"photoshop": "photoshop"},
+            {"resolve": "resolve"},
+            {"tvpaint": "tvpaint"},
+            {"unreal": "unreal"}
+        ]
+
+        if self.use_empty_value:
+            self.enum_items.insert(0, {"": self.empty_label})
+
+        valid_keys = set()
+        for item in self.enum_items or []:
+            valid_keys.add(tuple(item.keys())[0])
+
+        self.valid_keys = valid_keys
+
+        if self.multiselection:
+            self.valid_value_types = (list, )
+            self.value_on_not_set = []
+        else:
+            for key in valid_keys:
+                if self.value_on_not_set is NOT_SET:
+                    self.value_on_not_set = key
+                    break
+
+            self.valid_value_types = (STRING_TYPE, )
+
+        # GUI attribute
+        self.placeholder = self.schema_data.get("placeholder")
+
+
 class AppsEnumEntity(BaseEnumEntity):
     schema_types = ["apps-enum"]
 

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -124,34 +124,38 @@ class HostsEnumEntity(BaseEnumEntity):
         self.use_empty_value = self.schema_data.get(
             "use_empty_value", not self.multiselection
         )
-        self.empty_label = (
-            self.schema_data.get("empty_label") or "< without host >"
-        )
+        custom_labels = self.schema_data.get("custom_labels") or {}
+
+        host_names = [
+            "aftereffects",
+            "blender",
+            "celaction",
+            "fusion",
+            "harmony",
+            "hiero",
+            "houdini",
+            "maya",
+            "nuke",
+            "photoshop",
+            "resolve",
+            "tvpaint",
+            "unreal"
+        ]
+        if self.use_empty_value:
+            host_names.insert(0, "")
+            # Add default label for empty value if not available
+            if "" not in custom_labels:
+                custom_labels[""] = "< without host >"
 
         # These are hardcoded there is not list of available host in OpenPype
-        self.enum_items = [
-            {"aftereffects": "aftereffects"},
-            {"blender": "blender"},
-            {"celaction": "celaction"},
-            {"fusion": "fusion"},
-            {"harmony": "harmony"},
-            {"hiero": "hiero"},
-            {"houdini": "houdini"},
-            {"maya": "maya"},
-            {"nuke": "nuke"},
-            {"photoshop": "photoshop"},
-            {"resolve": "resolve"},
-            {"tvpaint": "tvpaint"},
-            {"unreal": "unreal"}
-        ]
-
-        if self.use_empty_value:
-            self.enum_items.insert(0, {"": self.empty_label})
-
+        enum_items = []
         valid_keys = set()
-        for item in self.enum_items or []:
-            valid_keys.add(tuple(item.keys())[0])
+        for key in host_names:
+            label = custom_labels.get(key, key)
+            valid_keys.add(key)
+            enum_items.append({key, label})
 
+        self.enum_items = enum_items
         self.valid_keys = valid_keys
 
         if self.multiselection:

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -276,7 +276,7 @@
 - enumeration of available hosts
 - multiselection can be allowed with setting key `"multiselection"` to `True` (Default: `False`)
 - it is possible to add empty value (represented with empty string) with setting `"use_empty_value"` to `True` (Default: `False`)
-- to modify label of empty value set `"empty_label"` key with your label (Default: `< without host >`)
+- it is possible to set `"custom_labels"` for host names where key `""` is empty value (Default: `{}`)
 ```
 {
     "key": "host",
@@ -284,7 +284,10 @@
     "type": "hosts-enum",
     "multiselection": false,
     "use_empty_value": true,
-    "empty_label": "N/A"
+    "custom_labels": {
+        "": "N/A",
+        "nuke": "Nuke"
+    }
 }
 ```
 

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -272,6 +272,22 @@
 }
 ```
 
+### hosts-enum
+- enumeration of available hosts
+- multiselection can be allowed with setting key `"multiselection"` to `True` (Default: `False`)
+- it is possible to add empty value (represented with empty string) with setting `"use_empty_value"` to `True` (Default: `False`)
+- to modify label of empty value set `"empty_label"` key with your label (Default: `< without host >`)
+```
+{
+    "key": "host",
+    "label": "Host name",
+    "type": "hosts-enum",
+    "multiselection": false,
+    "use_empty_value": true,
+    "empty_label": "N/A"
+}
+```
+
 ## Inputs for setting value using Pure inputs
 - these inputs also have required `"key"`
 - attribute `"label"` is required in few conditions

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
@@ -59,10 +59,10 @@
                                         "object_type": "text"
                                     },
                                     {
+                                        "type": "hosts-enum",
                                         "key": "hosts",
                                         "label": "Host names",
-                                        "type": "list",
-                                        "object_type": "text"
+                                        "multiselection": true
                                     },
                                     {
                                         "type": "separator"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -90,10 +90,10 @@
                                 "object_type": "text"
                             },
                             {
+                                "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "type": "list",
-                                "object_type": "text"
+                                "multiselection": true
                             },
                             {
                                 "type": "splitter"
@@ -358,10 +358,10 @@
                                 "object_type": "text"
                             },
                             {
+                                "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "type": "list",
-                                "object_type": "text"
+                                "multiselection": true
                             },
                             {
                                 "type": "splitter"
@@ -492,10 +492,10 @@
                                 "object_type": "text"
                             },
                             {
+                                "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "type": "list",
-                                "object_type": "text"
+                                "multiselection": true
                             },
                             {
                                 "key": "tasks",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -35,10 +35,10 @@
                                 "object_type": "text"
                             },
                             {
+                                "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "type": "list",
-                                "object_type": "text"
+                                "multiselection": true
                             },
                             {
                                 "key": "tasks",
@@ -75,10 +75,10 @@
                         "type": "dict",
                         "children": [
                             {
+                                "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "type": "list",
-                                "object_type": "text"
+                                "multiselection": true
                             },
                             {
                                 "key": "tasks",

--- a/openpype/settings/entities/schemas/system_schema/host_settings/template_host_unchangables.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/template_host_unchangables.json
@@ -14,25 +14,11 @@
         "roles": ["developer"]
     },
     {
-        "type": "enum",
+        "type": "hosts-enum",
         "key": "host_name",
         "label": "Host implementation",
-        "enum_items": [
-            { "": "< without host >" },
-            { "aftereffects": "aftereffects" },
-            { "blender": "blender" },
-            { "celaction": "celaction" },
-            { "fusion": "fusion" },
-            { "harmony": "harmony" },
-            { "hiero": "hiero" },
-            { "houdini": "houdini" },
-            { "maya": "maya" },
-            { "nuke": "nuke" },
-            { "photoshop": "photoshop" },
-            { "resolve": "resolve" },
-            { "tvpaint": "tvpaint" },
-            { "unreal": "unreal" }
-        ],
+        "multiselection": false,
+        "use_empty_value": true,
         "roles": ["developer"]
     }
 ]


### PR DESCRIPTION
## Description
We use host names in filtering a lot but we don't have enumeration of available hosts in settings.

## Changes
- added `hosts-enum` entity type which is enumerator with all possible host names
- has single selection and multiselection option
- it is possible to have empty value with custom label which is stored as empty string `""`
    - to have this set `use_empty_value` to true/false
- entity can have defined `custom_labels` as dictionary where key is host name and valid is label
- replaced list of strings in hosts usage with new enum item

![image](https://user-images.githubusercontent.com/43494761/122911987-2833d380-d358-11eb-8b33-cc32ea700f1a.png)
