### PR TITLE
Nuke: fixing render creator for no selection format failing

### DIFF
--- a/openpype/hosts/nuke/plugins/create/create_write_prerender.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_prerender.py
@@ -128,5 +128,4 @@ class CreateWritePrerender(plugin.PypeCreator):
             w_node["first"].setValue(nuke.root()["first_frame"].value())
             w_node["last"].setValue(nuke.root()["last_frame"].value())
 
-
         return write_node

--- a/openpype/hosts/nuke/plugins/create/create_write_render.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_render.py
@@ -100,6 +100,13 @@ class CreateWriteRender(plugin.PypeCreator):
                                    "/{subset}.{frame}.{ext}")})
 
         # add crop node to cut off all outside of format bounding box
+        # get width and height
+        try:
+            width, height = (selected_node.width(), selected_node.height())
+        except AttributeError:
+            actual_format = nuke.root().knob('format').value()
+            width, height = (actual_format.width(), actual_format.height())
+
         _prenodes = [
             {
                 "name": "Crop01",
@@ -108,8 +115,8 @@ class CreateWriteRender(plugin.PypeCreator):
                     ("box", [
                         0.0,
                         0.0,
-                        selected_node.width(),
-                        selected_node.height()
+                        width,
+                        height
                     ])
                 ],
                 "dependent": None


### PR DESCRIPTION
# Description
When `use selection` was ticked off the creator was failing as we could not retrieve format width and height from selected nodes. 

# Solution
Getting width and height was added to tray and if fails it will get format from root actual format

# Testing notes
1. open nuke and in workfile create version (if you are in untitled script) 
2. open Creator and chose Create Render Write
3. tick off `use selected`
4. hit create and write node should be created without troubles. 
5. Look inside of the created node (ctrl+enter) and look into properties of Crop node
6. width and height should be the same as it is set on script's actual format (with mouse over node graph window hit `s` and look down to format)