### PR TITLE
Settings schema without prefill

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -885,7 +885,11 @@ class ItemEntity(BaseItemEntity):
 
     def create_schema_object(self, *args, **kwargs):
         """Reference method for creation of entities defined in RootEntity."""
-        return self.root_item.create_schema_object(*args, **kwargs)
+        return self.schema_hub.create_schema_object(*args, **kwargs)
+
+    @property
+    def schema_hub(self):
+        return self.root_item.schema_hub
 
     def get_entity_from_path(self, path):
         return self.root_item.get_entity_from_path(path)

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -1,4 +1,5 @@
 import copy
+import collections
 
 from .lib import (
     WRAPPER_TYPES,
@@ -138,7 +139,16 @@ class DictImmutableKeysEntity(ItemEntity):
                 method when handling gui wrappers.
         """
         added_children = []
-        for children_schema in schema_data["children"]:
+        children_deque = collections.deque()
+        for _children_schema in schema_data["children"]:
+            children_schemas = self.schema_hub.resolve_schema_data(
+                _children_schema
+            )
+            for children_schema in children_schemas:
+                children_deque.append(children_schema)
+
+        while children_deque:
+            children_schema = children_deque.popleft()
             if children_schema["type"] in WRAPPER_TYPES:
                 _children_schema = copy.deepcopy(children_schema)
                 wrapper_children = self._add_children(

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -472,3 +472,19 @@ class SchemasHub:
         self._gui_types = tuple(_gui_types)
 
         self._schema_subfolder = schema_subfolder
+
+    @property
+    def gui_types(self):
+        return self._gui_types
+
+    def get_schema(self, schema_name):
+        pass
+
+    def get_template(self, template_name):
+        pass
+
+    def resolve_schema_data(self, schema_data):
+        pass
+
+    def create_schema_object(self, schema_data, *args, **kwargs):
+        pass

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -271,6 +271,12 @@ class SchemasHub:
                 "Got unresolved schema data of type \"{}\"".format(schema_type)
             )
 
+        if schema_type in WRAPPER_TYPES:
+            raise ValueError((
+                "Function `create_schema_object` can't create entities"
+                " of any wrapper type. Got type: \"{}\""
+            ).format(schema_type))
+
         klass = self._loaded_types.get(schema_type)
         if not klass:
             raise KeyError("Unknown type \"{}\"".format(schema_type))

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -259,7 +259,7 @@ class SchemasHub:
         template_name = schema_data["name"]
         template_def = self.get_template(template_name)
 
-        filled_template = self._fill_schema_template(
+        filled_template = self._fill_template(
             schema_data, template_def
         )
         return filled_template
@@ -384,7 +384,7 @@ class SchemasHub:
         self._loaded_templates = loaded_templates
         self._loaded_schemas = loaded_schemas
 
-    def _fill_schema_template(self, child_data, template_def):
+    def _fill_template(self, child_data, template_def):
         template_name = child_data["name"]
 
         # Default value must be dictionary (NOT list)
@@ -400,7 +400,7 @@ class SchemasHub:
         output = []
         for single_template_data in template_data:
             try:
-                output.extend(self._fill_schema_template_data(
+                output.extend(self._fill_template_data(
                     template_def, single_template_data, skip_paths
                 ))
 
@@ -410,7 +410,7 @@ class SchemasHub:
                 )
         return output
 
-    def _fill_schema_template_data(
+    def _fill_template_data(
         self,
         template,
         template_data,
@@ -481,7 +481,7 @@ class SchemasHub:
                         if None in _skip_paths:
                             continue
 
-                output_item = self._fill_schema_template_data(
+                output_item = self._fill_template_data(
                     item,
                     template_data,
                     _skip_paths,
@@ -494,7 +494,7 @@ class SchemasHub:
         elif isinstance(template, dict):
             output = {}
             for key, value in template.items():
-                output[key] = self._fill_schema_template_data(
+                output[key] = self._fill_template_data(
                     value,
                     template_data,
                     skip_paths,

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -347,7 +347,22 @@ class SchemasHub:
         return copy.deepcopy(self._loaded_templates[template_name])
 
     def resolve_schema_data(self, schema_data):
-        pass
+        schema_type = schema_data["type"]
+        if schema_type not in ("schema", "template", "schema_template"):
+            return [schema_data]
+
+        if schema_type == "schema":
+            return self.resolve_schema_data(
+                self.get_schema(schema_data["name"])
+            )
+
+        template_name = schema_data["name"]
+        template_def = self.get_template(template_name)
+
+        filled_template = self._fill_schema_template(
+            schema_data, template_def
+        )
+        return filled_template
 
     def create_schema_object(self, schema_data, *args, **kwargs):
         schema_type = schema_data["type"]

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -350,7 +350,17 @@ class SchemasHub:
         pass
 
     def create_schema_object(self, schema_data, *args, **kwargs):
-        pass
+        schema_type = schema_data["type"]
+        if schema_type in ("schema", "template", "schema_template"):
+            raise ValueError(
+                "Got unresolved schema data of type \"{}\"".format(schema_type)
+            )
+
+        klass = self._loaded_types.get(schema_type)
+        if not klass:
+            raise KeyError("Unknown type \"{}\"".format(schema_type))
+
+        return klass(schema_data, *args, **kwargs)
 
     def _load_schemas(self):
         dirpath = os.path.join(

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -127,7 +127,16 @@ class SchemasHub:
         return self._gui_types
 
     def get_schema(self, schema_name):
-        """Get schema definition data by it's name."""
+        """Get schema definition data by it's name.
+
+        Returns:
+            dict: Copy of schema loaded from json files.
+
+        Raises:
+            KeyError: When schema name is stored in loaded templates or json
+                file was not possible to parse or when schema name was not
+                found.
+        """
         if schema_name not in self._loaded_schemas:
             if schema_name in self._loaded_templates:
                 raise KeyError((
@@ -148,7 +157,16 @@ class SchemasHub:
         return copy.deepcopy(self._loaded_schemas[schema_name])
 
     def get_template(self, template_name):
-        """Get template definition data by it's name."""
+        """Get template definition data by it's name.
+
+        Returns:
+            list: Copy of template items loaded from json files.
+
+        Raises:
+            KeyError: When template name is stored in loaded schemas or json
+                file was not possible to parse or when template name was not
+                found.
+        """
         if template_name not in self._loaded_templates:
             if template_name in self._loaded_schemas:
                 raise KeyError((
@@ -232,7 +250,16 @@ class SchemasHub:
         return klass(schema_data, *args, **kwargs)
 
     def _load_types(self):
-        """Prepare entity types for cretion of their objects."""
+        """Prepare entity types for cretion of their objects.
+
+        Currently all classes in `openpype.settings.entities` that inherited
+        from `BaseEntity` are stored as loaded types. GUI types are stored to
+        separated attribute to not mess up api access of entities.
+
+        TODOs:
+            Add more dynamic way how to add custom types from anywhere and
+            better handling of abstract classes. Skipping them is dangerous.
+        """
 
         from openpype.settings import entities
 
@@ -400,7 +427,25 @@ class SchemasHub:
         required_keys=None,
         missing_keys=None
     ):
-        """Fill template values with data from schema data."""
+        """Fill template values with data from schema data.
+
+        Template has more abilities than schemas. It is expected that template
+        will be used at multiple places (but may not). Schema represents
+        exactly one entity and it's children but template may represent more
+        entities.
+
+        Template can have "keys to fill" from their definition. Some key may be
+        required and some may be optional because template has their default
+        values defined.
+
+        Template also have ability to "skip paths" which means to skip entities
+        from it's content. A template can be used across multiple places with
+        different requirements.
+
+        Raises:
+            SchemaTemplateMissingKeys: When fill data do not contain all
+                required keys for template.
+        """
         first = False
         if required_keys is None:
             first = True

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import copy
+import inspect
 
 from .exceptions import (
     SchemaTemplateMissingKeys,

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -497,6 +497,7 @@ class SchemasHub:
                 .replace("{{", "__dbcb__")
                 .replace("}}", "__decb__")
             )
+            full_replacement = False
             for replacement_string in template_key_pattern.findall(template):
                 key = str(replacement_string[1:-1])
                 required_keys.add(key)
@@ -509,11 +510,19 @@ class SchemasHub:
                     # Replace the value with value from templates data
                     # - with this is possible to set value with different type
                     template = value
+                    full_replacement = True
                 else:
                     # Only replace the key in string
                     template = template.replace(replacement_string, value)
 
-            output = template.replace("__dbcb__", "{").replace("__decb__", "}")
+            if not full_replacement:
+                output = (
+                    template
+                    .replace("__dbcb__", "{")
+                    .replace("__decb__", "}")
+                )
+            else:
+                output = template
 
         else:
             output = template

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -307,10 +307,44 @@ class SchemasHub:
         return self._gui_types
 
     def get_schema(self, schema_name):
-        pass
+        if schema_name not in self._loaded_schemas:
+            if schema_name in self._loaded_templates:
+                raise KeyError((
+                    "Template \"{}\" is used as `schema`"
+                ).format(schema_name))
+
+            elif schema_name in self._crashed_on_load:
+                crashed_item = self._crashed_on_load[schema_name]
+                raise KeyError(
+                    "Unable to parse schema file \"{}\". {}".format(
+                        crashed_item["filpath"], crashed_item["message"]
+                    )
+                )
+
+            raise KeyError(
+                "Schema \"{}\" was not found".format(schema_name)
+            )
+        return copy.deepcopy(self._loaded_schemas[schema_name])
 
     def get_template(self, template_name):
-        pass
+        if template_name not in self._loaded_templates:
+            if template_name in self._loaded_schemas:
+                raise KeyError((
+                    "Schema \"{}\" is used as `template`"
+                ).format(template_name))
+
+            elif template_name in self._crashed_on_load:
+                crashed_item = self._crashed_on_load[template_name]
+                raise KeyError(
+                    "Unable to parse templace file \"{}\". {}".format(
+                        crashed_item["filpath"], crashed_item["message"]
+                    )
+                )
+
+            raise KeyError(
+                "Template \"{}\" was not found".format(template_name)
+            )
+        return copy.deepcopy(self._loaded_templates[template_name])
 
     def resolve_schema_data(self, schema_data):
         pass

--- a/openpype/settings/entities/root_entities.py
+++ b/openpype/settings/entities/root_entities.py
@@ -1,6 +1,7 @@
 import os
 import json
 import copy
+import collections
 
 from abc import abstractmethod
 
@@ -133,7 +134,17 @@ class RootEntity(BaseItemEntity):
 
     def _add_children(self, schema_data, first=True):
         added_children = []
-        for children_schema in schema_data["children"]:
+        children_deque = collections.deque()
+        for _children_schema in schema_data["children"]:
+            children_schemas = self.schema_hub.resolve_schema_data(
+                _children_schema
+            )
+            for children_schema in children_schemas:
+                children_deque.append(children_schema)
+
+        while children_deque:
+            children_schema = children_deque.popleft()
+
             if children_schema["type"] in WRAPPER_TYPES:
                 _children_schema = copy.deepcopy(children_schema)
                 wrapper_children = self._add_children(

--- a/openpype/settings/entities/root_entities.py
+++ b/openpype/settings/entities/root_entities.py
@@ -1,7 +1,6 @@
 import os
 import json
 import copy
-import inspect
 
 from abc import abstractmethod
 
@@ -10,8 +9,7 @@ from .lib import (
     NOT_SET,
     WRAPPER_TYPES,
     OverrideState,
-    get_studio_settings_schema,
-    get_project_settings_schema
+    SchemasHub
 )
 from .exceptions import (
     SchemaError,
@@ -53,7 +51,12 @@ class RootEntity(BaseItemEntity):
     """
     schema_types = ["root"]
 
-    def __init__(self, schema_data, reset):
+    def __init__(self, schema_hub, reset, main_schema_name=None):
+        self.schema_hub = schema_hub
+        if not main_schema_name:
+            main_schema_name = "schema_main"
+        schema_data = schema_hub.get_schema(main_schema_name)
+
         super(RootEntity, self).__init__(schema_data)
         self._require_restart_callbacks = []
         self._item_ids_require_restart = set()
@@ -143,11 +146,13 @@ class RootEntity(BaseItemEntity):
             child_obj = self.create_schema_object(children_schema, self)
             self.children.append(child_obj)
             added_children.append(child_obj)
-            if isinstance(child_obj, self._gui_types):
+            if isinstance(child_obj, self.schema_hub.gui_types):
                 continue
 
             if child_obj.key in self.non_gui_children:
-                raise KeyError("Duplicated key \"{}\"".format(child_obj.key))
+                raise KeyError(
+                    "Duplicated key \"{}\"".format(child_obj.key)
+                )
             self.non_gui_children[child_obj.key] = child_obj
 
         if not first:
@@ -159,9 +164,6 @@ class RootEntity(BaseItemEntity):
     def _item_initalization(self):
         # Store `self` to `root_item` for children entities
         self.root_item = self
-
-        self._loaded_types = None
-        self._gui_types = None
 
         # Children are stored by key as keys are immutable and are defined by
         # schema
@@ -201,54 +203,9 @@ class RootEntity(BaseItemEntity):
         Available entities are loaded on first run. Children entities can call
         this method.
         """
-        if self._loaded_types is None:
-            # Load available entities
-            from openpype.settings import entities
-
-            # Define known abstract classes
-            known_abstract_classes = (
-                entities.BaseEntity,
-                entities.BaseItemEntity,
-                entities.ItemEntity,
-                entities.EndpointEntity,
-                entities.InputEntity,
-                entities.BaseEnumEntity
-            )
-
-            self._loaded_types = {}
-            _gui_types = []
-            for attr in dir(entities):
-                item = getattr(entities, attr)
-                # Filter classes
-                if not inspect.isclass(item):
-                    continue
-
-                # Skip classes that do not inherit from BaseEntity
-                if not issubclass(item, entities.BaseEntity):
-                    continue
-
-                # Skip class that is abstract by design
-                if item in known_abstract_classes:
-                    continue
-
-                if inspect.isabstract(item):
-                    # Create an object to get crash and get traceback
-                    item()
-
-                # Backwards compatibility
-                # Single entity may have multiple schema types
-                for schema_type in item.schema_types:
-                    self._loaded_types[schema_type] = item
-
-                if item.gui_type:
-                    _gui_types.append(item)
-            self._gui_types = tuple(_gui_types)
-
-        klass = self._loaded_types.get(schema_data["type"])
-        if not klass:
-            raise KeyError("Unknown type \"{}\"".format(schema_data["type"]))
-
-        return klass(schema_data, *args, **kwargs)
+        return self.schema_hub.create_schema_object(
+            schema_data, *args, **kwargs
+        )
 
     def set_override_state(self, state):
         """Set override state and trigger it on children.
@@ -492,13 +449,13 @@ class SystemSettings(RootEntity):
             and debugging purposes.
     """
     def __init__(
-        self, set_studio_state=True, reset=True, schema_data=None
+        self, set_studio_state=True, reset=True, schema_hub=None
     ):
-        if schema_data is None:
+        if schema_hub is None:
             # Load system schemas
-            schema_data = get_studio_settings_schema()
+            schema_hub = SchemasHub("system_schema")
 
-        super(SystemSettings, self).__init__(schema_data, reset)
+        super(SystemSettings, self).__init__(schema_hub, reset)
 
         if set_studio_state:
             self.set_studio_state()
@@ -605,17 +562,17 @@ class ProjectSettings(RootEntity):
         project_name=None,
         change_state=True,
         reset=True,
-        schema_data=None
+        schema_hub=None
     ):
         self._project_name = project_name
 
         self._system_settings_entity = None
 
-        if schema_data is None:
+        if schema_hub is None:
             # Load system schemas
-            schema_data = get_project_settings_schema()
+            schema_hub = SchemasHub("projects_schema")
 
-        super(ProjectSettings, self).__init__(schema_data, reset)
+        super(ProjectSettings, self).__init__(schema_hub, reset)
 
         if change_state:
             if self.project_name is None:


### PR DESCRIPTION
## Changes
- loading of settings schema is handled using SchemaHub
- schemas are not resolved before are passed to root entity
    - schemas must be resolved in entities that can possibly have 'schema' or 'template' type as children
- json files that can't be parsed won't cause error if are not used
- this is required step as now filling of entity children had to be handled in single function which had to know all entities structure but with this change it is entity based so entity and it's schema data can have different definitions of children data (required for [this issue](https://github.com/pypeclub/OpenPype/issues/1749))

## How to test
It's tricky as everything should work almost the same way.