### PR TITLE
Application executables with environment variables

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -460,6 +460,12 @@ class ApplicationExecutable:
             if os.path.exists(_executable):
                 executable = _executable
 
+        # Try to format executable with environments
+        try:
+            executable = executable.format(**os.environ)
+        except Exception:
+            pass
+
         self.executable_path = executable
 
     def __str__(self):


### PR DESCRIPTION
## Description
With this change it is possible to define executable path of application containing environments.
Environments must be avaialble in global environments of currently running process! It is not possible to set the environment e.g. in application group/variant environments.

## Changes
- try to format executable path with environments
   - failed formattings is ignored