### PR TITLE
Standalone publisher thumbnail extractor fix

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -66,7 +66,6 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
         else:
             # Convert to jpeg if not yet
             full_input_path = os.path.join(thumbnail_repre["stagingDir"], file)
-            full_input_path = '"{}"'.format(full_input_path)
             self.log.info("input {}".format(full_input_path))
 
             full_thumbnail_path = tempfile.mkstemp(suffix=".jpg")[1]


### PR DESCRIPTION
## Issue
- full input path has double quotations once on top of iteration and second when passed to ffmpeg args which breaks the path if has spaces or other breaking characters

## Changes
- removed qutation adding on top of iteration as it's confusing

## How to test
- open standalone publisher
- add there video file with spaces in path
- check thumbnail and preview
- publish it as e.g. plate
- `Extract thumbnail SP` should not crash