### PR TITLE
Push hierarchical attributes care about task parent changes

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -55,10 +55,6 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             if entity_info.get("entityType") != "task":
                 continue
 
-            # Skip `Task` entity type
-            if entity_info["entity_type"].lower() == "task":
-                continue
-
             # Care only about changes of status
             changes = entity_info.get("changes")
             if not changes:
@@ -73,6 +69,14 @@ class PushFrameValuesToTaskEvent(BaseEvent):
 
             if project_id is None:
                 continue
+
+            # Skip `Task` entity type if parent didn't change
+            if entity_info["entity_type"].lower() == "task":
+                if (
+                    "parent_id" not in changes
+                    or changes["parent_id"]["new"] is None
+                ):
+                    continue
 
             if project_id not in entities_info_by_project_id:
                 entities_info_by_project_id[project_id] = []

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -151,6 +151,9 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             name_low = object_type["name"].lower()
             object_types_by_name[name_low] = object_type
 
+        # NOTE it would be nice to check if `interesting_data` do not contain
+        #   value changs of tasks that were created or moved
+        # - it is a complex way how to find out
         if interesting_data:
             self.process_attribute_changes(
                 session, object_types_by_name,

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -121,6 +121,9 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             ))
             return
 
+        interest_attributes = set(self.interest_attributes)
+        interest_entity_types = set(self.interest_entity_types)
+
         # Separate value changes and task parent changes
         _entities_info = []
         task_parent_changes = []

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -208,13 +208,13 @@ class PushFrameValuesToTaskEvent(BaseEvent):
                 self.join_query_keys(matching_parent_ids)
             )
         )
-        object_type_ids = set()
-        for entity in entities:
-            object_type_ids.add(entity["object_type_id"])
 
         # Prepare task object id
         task_object_id = object_types_by_name["task"]["id"]
+        object_type_ids = set()
         object_type_ids.add(task_object_id)
+        for entity in entities:
+            object_type_ids.add(entity["object_type_id"])
 
         attrs_by_obj_id, hier_attrs = self.attrs_configurations(
             session, object_type_ids, interest_attributes

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -121,11 +121,21 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             ))
             return
 
+        # Separate value changes and task parent changes
+        _entities_info = []
+        task_parent_changes = []
+        for entity_info in entities_info:
+            if entity_info["entity_type"].lower() == "task":
+                task_parent_changes.append(entity_info)
+            else:
+                _entities_info.append(entity_info)
+        entities_info = _entities_info
+
         # Filter entities info with changes
         interesting_data, changed_keys_by_object_id = self.filter_changes(
             session, event, entities_info, interest_attributes
         )
-        if not interesting_data:
+        if not interesting_data and not task_parent_changes:
             return
 
         # Prepare object types

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -131,6 +131,18 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             name_low = object_type["name"].lower()
             object_types_by_name[name_low] = object_type
 
+        if interesting_data:
+            self.process_attribute_changes(
+                session, object_types_by_name,
+                interesting_data, changed_keys_by_object_id,
+                interest_entity_types, interest_attributes
+            )
+
+    def process_attribute_changes(
+        self, session, object_types_by_name,
+        interesting_data, changed_keys_by_object_id,
+        interest_entity_types, interest_attributes
+    ):
         # Prepare task object id
         task_object_id = object_types_by_name["task"]["id"]
 
@@ -216,13 +228,13 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             task_entity_ids.add(task_id)
             parent_id_by_task_id[task_id] = task_entity["parent_id"]
 
-        self.finalize(
+        self.finalize_attribute_changes(
             session, interesting_data,
             changed_keys, attrs_by_obj_id, hier_attrs,
             task_entity_ids, parent_id_by_task_id
         )
 
-    def finalize(
+    def finalize_attribute_changes(
         self, session, interesting_data,
         changed_keys, attrs_by_obj_id, hier_attrs,
         task_entity_ids, parent_id_by_task_id

--- a/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_push_frame_values_to_task.py
@@ -124,8 +124,8 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             ))
             return
 
-        interest_attributes = set(self.interest_attributes)
-        interest_entity_types = set(self.interest_entity_types)
+        interest_attributes = set(interest_attributes)
+        interest_entity_types = set(interest_entity_types)
 
         # Separate value changes and task parent changes
         _entities_info = []

--- a/openpype/modules/ftrack/lib/__init__.py
+++ b/openpype/modules/ftrack/lib/__init__.py
@@ -13,7 +13,8 @@ from .custom_attributes import (
     default_custom_attributes_definition,
     app_definitions_from_app_manager,
     tool_definitions_from_app_manager,
-    get_openpype_attr
+    get_openpype_attr,
+    query_custom_attributes
 )
 
 from . import avalon_sync
@@ -37,6 +38,7 @@ __all__ = (
     "app_definitions_from_app_manager",
     "tool_definitions_from_app_manager",
     "get_openpype_attr",
+    "query_custom_attributes",
 
     "avalon_sync",
 

--- a/openpype/modules/ftrack/lib/custom_attributes.py
+++ b/openpype/modules/ftrack/lib/custom_attributes.py
@@ -81,3 +81,60 @@ def get_openpype_attr(session, split_hierarchical=True, query_keys=None):
         return custom_attributes, hier_custom_attributes
 
     return custom_attributes
+
+
+def join_query_keys(keys):
+    """Helper to join keys to query."""
+    return ",".join(["\"{}\"".format(key) for key in keys])
+
+
+def query_custom_attributes(session, conf_ids, entity_ids, table_name=None):
+    """Query custom attribute values from ftrack database.
+
+    Using ftrack call method result may differ based on used table name and
+    version of ftrack server.
+
+    Args:
+        session(ftrack_api.Session): Connected ftrack session.
+        conf_id(list, set, tuple): Configuration(attribute) ids which are
+            queried.
+        entity_ids(list, set, tuple): Entity ids for which are values queried.
+        table_name(str): Table nam from which values are queried. Not
+            recommended to change until you know what it means.
+    """
+    output = []
+    # Just skip
+    if not conf_ids or not entity_ids:
+        return output
+
+    if table_name is None:
+        table_name = "ContextCustomAttributeValue"
+
+    # Prepare values to query
+    attributes_joined = join_query_keys(conf_ids)
+    attributes_len = len(conf_ids)
+
+    # Query values in chunks
+    chunk_size = int(5000 / attributes_len)
+    # Make sure entity_ids is `list` for chunk selection
+    entity_ids = list(entity_ids)
+    for idx in range(0, len(entity_ids), chunk_size):
+        entity_ids_joined = join_query_keys(
+            entity_ids[idx:idx + chunk_size]
+        )
+
+        call_expr = [{
+            "action": "query",
+            "expression": (
+                "select value, entity_id from {}"
+                " where entity_id in ({}) and configuration_id in ({})"
+            ).format(table_name, entity_ids_joined, attributes_joined)
+        }]
+        if hasattr(session, "call"):
+            [result] = session.call(call_expr)
+        else:
+            [result] = session._call(call_expr)
+
+        for item in result["data"]:
+            output.append(item)
+    return output


### PR DESCRIPTION
## Issue
- task parent changes are not handled with event handling with hierarchical value pushing from parent to task on attribute value change
- it is confusing for users that value set on (e.g.) Shot is not propagated to value on created task which is annoyng especially if task attribute is used in expression

## Changes
- event handler also cares about change of task parent
- in that case is pushing of values more robust and a little bit slower as have to query hierarchical attribute values all the time

## How to test
1. Run event server with this branch
2. Make sure you have custom attribute available for `Shot` and `Task` and is hierarchical at the same time (`frameStart` or `frameEnd`)
3. Make sure settings for this event have proper values (`ProjectSettings/Ftrack/Server Actions/Events/Sync Hierarchical and Entity Attributes`)
    - event handler is enabled
    - entity type of interest contain `Shot` (used in example)
    - Attribute to sync contain `frameStart`
3. Create a `Shot` entity in ftrack
4. Change `frameStart` to 1001
5. The value should be propagated to the other one (hierarchical -> nonhierarchical or other way)
6. Create task under the `Shot` and check if value of `frameStart` will change to 1001 (on both hierarchical and non hierarchical attribute)

closes: https://github.com/pypeclub/OpenPype/issues/1748

||OpenPype 2 PRs|
|---|---|
|pype|https://github.com/pypeclub/OpenPype/pull/1765|