### PR TITLE
Workfile tool widths

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -944,10 +944,8 @@ class Window(QtWidgets.QMainWindow):
         split_widget.addWidget(tasks_widget)
         split_widget.addWidget(files_widget)
         split_widget.addWidget(side_panel)
-        split_widget.setStretchFactor(0, 1)
-        split_widget.setStretchFactor(1, 1)
-        split_widget.setStretchFactor(2, 3)
-        split_widget.setStretchFactor(3, 1)
+        split_widget.setSizes([255, 160, 455, 175])
+
         body_layout.addWidget(split_widget)
 
         # Add top margin for tasks to align it visually with files as
@@ -976,7 +974,7 @@ class Window(QtWidgets.QMainWindow):
         # Force focus on the open button by default, required for Houdini.
         files_widget.btn_open.setFocus()
 
-        self.resize(1000, 600)
+        self.resize(1200, 600)
 
     def keyPressEvent(self, event):
         """Custom keyPressEvent.


### PR DESCRIPTION
## Changes
- widths of Workfile tools widgets have better sizes to display it's content
    - workfile tool window is wider now

### Screenshot before
![image](https://user-images.githubusercontent.com/43494761/123401937-886c8480-d5a7-11eb-9e4d-ed379cb1df04.png)

### Screenshot now
![image](https://user-images.githubusercontent.com/43494761/123401867-7b4f9580-d5a7-11eb-9798-0e20ca9a2fda.png)

closes: https://github.com/pypeclub/OpenPype/issues/1633