### PR TITLE
Project specific environments

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1159,6 +1159,9 @@ def prepare_host_environments(data, implementation_envs=True):
 def apply_project_environments_value(project_name, env, project_settings=None):
     """Apply project specific environments on passed environments.
 
+    The enviornments are applied on passed `env` argument value so it is not
+    required to apply changes back.
+
     Args:
         project_name (str): Name of project for which environemnts should be
             received.
@@ -1166,6 +1169,9 @@ def apply_project_environments_value(project_name, env, project_settings=None):
             will be applied.
         project_settings (dict): Project settings for passed project name.
             Optional if project settings are already prepared.
+
+    Returns:
+        dict: Passed env values with applied project environments.
 
     Raises:
         KeyError: If project settings do not contain keys for project specific
@@ -1177,10 +1183,9 @@ def apply_project_environments_value(project_name, env, project_settings=None):
         project_settings = get_project_settings(project_name)
 
     env_value = project_settings["global"]["project_environments"]
-    if not env_value:
-        return env
-    parsed = acre.parse(env_value)
-    return _merge_env(parsed, env)
+    if env_value:
+        env.update(_merge_env(acre.parse(env_value), env))
+    return env
 
 
 def prepare_context_environments(data):
@@ -1209,9 +1214,8 @@ def prepare_context_environments(data):
 
     # Load project specific environments
     project_name = project_doc["name"]
-    data["env"] = apply_project_environments_value(
-        project_name, data["env"]
-    )
+    # Apply project specific environments on current env value
+    apply_project_environments_value(project_name, data["env"])
 
     app = data["app"]
     workdir_data = get_workdir_data(


### PR DESCRIPTION
## Issue
Applying of project specific environments was broken as it didn't update environments but set it again which was unexpected for launching from launcher and ftrack.

Current state of project specific environments is that it will break all environments if it's not empty.

## Changes
- fix project specific environment variables to work as expected with updating the value instead of setting the value back

## How to test
- I did it with adding custom environment in application envirtonments (`"MY_TEST_ENV": "VALUE_1"`)
![image](https://user-images.githubusercontent.com/43494761/123413339-f4a0b580-d5b2-11eb-9b37-47b6bc012bf5.png)

- In project settings I've added `"MY_TEST_ENV": "{MY_TEST_ENV} - VALUE_2"`
![image](https://user-images.githubusercontent.com/43494761/123413308-ea7eb700-d5b2-11eb-9bbc-8defaeab94fa.png)

- On application launch checked if OpenPype loaded and if value of env `"MY_TEST_ENV"` is `"VALUE_1 - VALUE_2"`
![image](https://user-images.githubusercontent.com/43494761/123413447-1437de00-d5b3-11eb-8ef6-319548f5be18.png)
