### PR TITLE
Environments in app executable for MacOS

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -449,6 +449,12 @@ class ApplicationExecutable:
     """Representation of executable loaded from settings."""
 
     def __init__(self, executable):
+        # Try to format executable with environments
+        try:
+            executable = executable.format(**os.environ)
+        except Exception:
+            pass
+
         # On MacOS check if exists path to executable when ends with `.app`
         # - it is common that path will lead to "/Applications/Blender" but
         #   real path is "/Applications/Blender.app"
@@ -459,12 +465,6 @@ class ApplicationExecutable:
             _executable = executable + ".app"
             if os.path.exists(_executable):
                 executable = _executable
-
-        # Try to format executable with environments
-        try:
-            executable = executable.format(**os.environ)
-        except Exception:
-            pass
 
         self.executable_path = executable
 


### PR DESCRIPTION
## Issue
- filling of executable paths happens after mac os specific modification of path so they may not work as expected

## Changes
- move environment filling before mac specific check