### PR TITLE
Settings UI copy/paste

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -871,6 +871,10 @@ class ItemEntity(BaseItemEntity):
         """Call save on root item."""
         self.root_item.save()
 
+    @property
+    def root_key(self):
+        return self.root_item.root_key
+
     def schema_validations(self):
         if not self.label and self.use_label_wrap:
             reason = (

--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -279,6 +279,11 @@ class BaseItemEntity(BaseEntity):
                 self, "Dynamic entity can't require restart."
             )
 
+    @abstractproperty
+    def root_key(self):
+        """Root is represented as this dictionary key."""
+        pass
+
     @abstractmethod
     def set_override_state(self, state):
         """Set override state and trigger it on children.

--- a/openpype/settings/entities/root_entities.py
+++ b/openpype/settings/entities/root_entities.py
@@ -491,6 +491,8 @@ class SystemSettings(RootEntity):
         schema_data (dict): Pass schema data to entity. This is for development
             and debugging purposes.
     """
+    root_key = SYSTEM_SETTINGS_KEY
+
     def __init__(
         self, set_studio_state=True, reset=True, schema_data=None
     ):
@@ -600,6 +602,8 @@ class ProjectSettings(RootEntity):
         schema_data (dict): Pass schema data to entity. This is for development
             and debugging purposes.
     """
+    root_key = PROJECT_SETTINGS_KEY
+
     def __init__(
         self,
         project_name=None,

--- a/openpype/settings/entities/root_entities.py
+++ b/openpype/settings/entities/root_entities.py
@@ -189,11 +189,10 @@ class RootEntity(BaseItemEntity):
             if not KEY_REGEX.match(key):
                 raise InvalidKeySymbols(self.path, key)
 
+    @abstractmethod
     def get_entity_from_path(self, path):
-        """Return system settings entity."""
-        raise NotImplementedError((
-            "Method `get_entity_from_path` not available for \"{}\""
-        ).format(self.__class__.__name__))
+        """Return entity matching passed path."""
+        pass
 
     def create_schema_object(self, schema_data, *args, **kwargs):
         """Create entity by entered schema data.
@@ -504,6 +503,18 @@ class SystemSettings(RootEntity):
 
         if set_studio_state:
             self.set_studio_state()
+
+    def get_entity_from_path(self, path):
+        """Return system settings entity."""
+        path_parts = path.split("/")
+        first_part = path_parts[0]
+        output = self
+        if first_part == self.root_key:
+            path_parts.pop(0)
+
+        for path_part in path_parts:
+            output = output[path_part]
+        return output
 
     def _reset_values(self):
         default_value = get_default_settings()[SYSTEM_SETTINGS_KEY]

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -221,6 +221,13 @@ class BaseWidget(QtWidgets.QWidget):
                 ))
                 dialog.exec_()
 
+        # Simple paste value method
+        def paste_value():
+            _set_entity_value(self.entity, value)
+
+        action = QtWidgets.QAction("Paste", menu)
+        output.append((action, paste_value))
+
         # Paste value to matchin entity
         def paste_value_to_path():
             _set_entity_value(matching_entity, value)
@@ -228,13 +235,6 @@ class BaseWidget(QtWidgets.QWidget):
         if matching_entity is not None:
             action = QtWidgets.QAction("Paste to same entity", menu)
             output.append((action, paste_value_to_path))
-
-        # Simple paste value method
-        def paste_value():
-            _set_entity_value(self.entity, value)
-
-        action = QtWidgets.QAction("Paste")
-        output.append((action, paste_value))
 
         return output
 

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -233,7 +233,7 @@ class BaseWidget(QtWidgets.QWidget):
             _set_entity_value(matching_entity, value)
 
         if matching_entity is not None:
-            action = QtWidgets.QAction("Paste to same entity", menu)
+            action = QtWidgets.QAction("Paste to same place", menu)
             output.append((action, paste_value_to_path))
 
         return output

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -180,8 +180,10 @@ class BaseWidget(QtWidgets.QWidget):
 
     def _paste_value_actions(self, menu):
         output = []
+        # Allow paste of value only if were copied from this UI
         mime_data = QtWidgets.QApplication.clipboard().mimeData()
         mime_value = mime_data.data("application/copy_settings_value")
+        # Skip if there is nothing to do
         if not mime_value:
             return output
 
@@ -206,18 +208,9 @@ class BaseWidget(QtWidgets.QWidget):
             except Exception:
                 pass
 
-        # Paste value to matchin entity
-        def paste_value_to_path():
-            matching_entity.set(value)
-
-        if matching_entity is not None:
-            action = QtWidgets.QAction("Paste to same entity", menu)
-            output.append((action, paste_value_to_path))
-
-        # Simple paste value method
-        def paste_value():
+        def _set_entity_value(_entity, _value):
             try:
-                self.entity.set(value)
+                _entity.set(_value)
             except Exception:
                 dialog = QtWidgets.QMessageBox(self)
                 dialog.setWindowTitle("Value does not match settings schema")
@@ -227,6 +220,18 @@ class BaseWidget(QtWidgets.QWidget):
                     " settings entity."
                 ))
                 dialog.exec_()
+
+        # Paste value to matchin entity
+        def paste_value_to_path():
+            _set_entity_value(matching_entity, value)
+
+        if matching_entity is not None:
+            action = QtWidgets.QAction("Paste to same entity", menu)
+            output.append((action, paste_value_to_path))
+
+        # Simple paste value method
+        def paste_value():
+            _set_entity_value(self.entity, value)
 
         action = QtWidgets.QAction("Paste")
         output.append((action, paste_value))

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -214,6 +214,7 @@ class BaseWidget(QtWidgets.QWidget):
             action = QtWidgets.QAction("Paste to same entity", menu)
             output.append((action, paste_value_to_path))
 
+        # Simple paste value method
         def paste_value():
             try:
                 self.entity.set(value)

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -199,12 +199,14 @@ class BaseWidget(QtWidgets.QWidget):
             try:
                 self.entity.set(value)
             except Exception:
-                # TODO show dialog
-                print("Failed")
-                import sys
-                import traceback
-
-                traceback.print_exception(*sys.exc_info())
+                dialog = QtWidgets.QMessageBox(self)
+                dialog.setWindowTitle("Value does not match settings schema")
+                dialog.setIcon(QtWidgets.QMessageBox.Warning)
+                dialog.setText((
+                    "Pasted value does not seem to match schema of destination"
+                    " settings entity."
+                ))
+                dialog.exec_()
 
         def paste_value_to_path():
             entity = self.entity.get_entity_from_path(path)

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -195,6 +195,26 @@ class BaseWidget(QtWidgets.QWidget):
         path = mime_data_value["path"]
         root_key = mime_data_value["root_key"]
 
+        # Try to find matching entity to be able paste values to same spot
+        # - entity can't by dynamic or in dynamic item
+        # - must be in same root entity as source copy
+        #       Can't copy system settings <-> project settings
+        matching_entity = None
+        if path and root_key == self.entity.root_key:
+            try:
+                matching_entity = self.entity.get_entity_from_path(path)
+            except Exception:
+                pass
+
+        # Paste value to matchin entity
+        def paste_value_to_path():
+            matching_entity.set(value)
+
+        if matching_entity is not None:
+            action = QtWidgets.QAction("Paste to same entity", menu)
+            actions_mapping[action] = paste_value_to_path
+            menu.addAction(action)
+
         def paste_value():
             try:
                 self.entity.set(value)
@@ -207,15 +227,6 @@ class BaseWidget(QtWidgets.QWidget):
                     " settings entity."
                 ))
                 dialog.exec_()
-
-        def paste_value_to_path():
-            entity = self.entity.get_entity_from_path(path)
-            entity.set(value)
-
-        if path and root_key == self.entity.root_key:
-            action = QtWidgets.QAction("Paste to same entity")
-            actions_mapping[action] = paste_value_to_path
-            menu.addAction(action)
 
         action = QtWidgets.QAction("Paste")
         actions_mapping[action] = paste_value


### PR DESCRIPTION
## Description
- adding possibility to copy and paste values in settings ui

## Changes
- added `Copy`, `Paste` and `Paste to same entity` action
    - `Copy` - copy the value of right clicked entity
    - `Paste` - tries to paste copied value to right clicked entity (shows dialog on crash)
    - `Paste to same place` - paste the value to same hierarchi entity (shows dialog on crash)
        - I don't like the label, any suggestion are welcomed
- all paste actions are available only for values copied using `Copy` action

## Note
Paste can be slow now connected to "on change" callbacks slowing down whole UI but that is not part of this PR.

## Screenshot
![image](https://user-images.githubusercontent.com/43494761/123431326-6d127100-d5c9-11eb-8a8d-aad45ac0e5d0.png)