### PR TITLE
Bc/fix/docs

### DIFF
--- a/website/docs/dev_build.md
+++ b/website/docs/dev_build.md
@@ -137,12 +137,12 @@ $ pyenv install -v 3.7.10
 $ cd /path/to/pype-3
 
 # set local python version
-$ pyenv local 3.7.9
+$ pyenv local 3.7.10
 ```
 :::note Install build requirements for **Ubuntu**
 
 ```shell
-sudo apt-get update; sudo apt-get install --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev git
+sudo apt-get update; sudo apt-get install --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev git patchelf
 ```
 
 In case you run in error about `xcb` when running Pype,

--- a/website/docs/module_ftrack.md
+++ b/website/docs/module_ftrack.md
@@ -34,7 +34,7 @@ To prepare Ftrack for working with OpenPype you'll need to run [OpenPype Admin -
 Ftrack Event Server is the key to automation of many tasks like _status change_, _thumbnail update_, _automatic synchronization to Avalon database_ and many more. Event server should run at all times to perform the required processing as it is not possible to catch some of them retrospectively with enough certainty.
 
 ### Running event server
-There are specific launch arguments for event server. With `openpype eventserver` you can launch event server but without prior preparation it will terminate immediately. The reason is that event server requires 3 pieces of information: _Ftrack server url_, _paths to events_ and _credentials (Username and API key)_. Ftrack server URL and Event path are set from OpenPype's environments by default, but the credentials must be done separatelly for security reasons.
+There are specific launch arguments for event server. With `openpype_console eventserver` you can launch event server but without prior preparation it will terminate immediately. The reason is that event server requires 3 pieces of information: _Ftrack server url_, _paths to events_ and _credentials (Username and API key)_. Ftrack server URL and Event path are set from OpenPype's environments by default, but the credentials must be done separatelly for security reasons.
 
 
 
@@ -56,7 +56,7 @@ There are specific launch arguments for event server. With `openpype eventserver
 -   `--ftrack-url "https://yourdomain.ftrackapp.com/"` : Ftrack server URL _(it is not needed to enter if you have set `FTRACK_SERVER` in OpenPype' environments)_
 -   `--ftrack-events-path "//Paths/To/Events/"` : Paths to events folder. May contain multiple paths separated by `;`. _(it is not needed to enter if you have set `FTRACK_EVENTS_PATH` in OpenPype' environments)_
 
-So if you want to use OpenPype's environments then you can launch event server for first time with these arguments `openpype.exe eventserver --ftrack-user "my.username" --ftrack-api-key "00000aaa-11bb-22cc-33dd-444444eeeee" --store-credentials`. Since that time, if everything was entered correctly, you can launch event server with `openpype.exe eventserver`.
+So if you want to use OpenPype's environments then you can launch event server for first time with these arguments `openpype_console.exe eventserver --ftrack-user "my.username" --ftrack-api-key "00000aaa-11bb-22cc-33dd-444444eeeee" --store-credentials`. Since that time, if everything was entered correctly, you can launch event server with `openpype_console.exe eventserver`.
 
 </TabItem>
 <TabItem value="env">
@@ -100,14 +100,17 @@ Event server should **not** run more than once! It may cause major issues.
 <TabItem value="linux">
 
 - create file:
-    `sudo vi /opt/OpenPype/run_event_server.sh`
+    `sudo vi /opt/openpype/run_event_server.sh`
 -   add content to the file:
 ```sh
-#!\usr\bin\env
+#!/usr/bin/env
 export OPENPYPE_DEBUG=3
 pushd /mnt/pipeline/prod/openpype-setup
-. openpype eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key>
+. openpype_console eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key>
 ```
+-   change file permission:
+    `sudo chmod 0755 /opt/openpype/run_event_server.sh`
+
 -   create service file:
     `sudo vi /etc/systemd/system/openpype-ftrack-event-server.service`
 -   add content to the service file
@@ -145,7 +148,7 @@ WantedBy=multi-user.target
 @echo off
 set OPENPYPE_DEBUG=3
 pushd \\path\to\file\
-call openpype.bat eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key> 
+call openpype_console.exe eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key> 
 ```
 -   download and install `nssm.cc`
 -   create Windows service according to nssm.cc manual

--- a/website/docs/module_ftrack.md
+++ b/website/docs/module_ftrack.md
@@ -148,7 +148,7 @@ WantedBy=multi-user.target
 @echo off
 set OPENPYPE_DEBUG=3
 pushd \\path\to\file\
-call openpype_console.exe eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key> 
+openpype_console.exe eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key> 
 ```
 -   download and install `nssm.cc`
 -   create Windows service according to nssm.cc manual


### PR DESCRIPTION
# Minor errors

## Build OpenPYPE from source
(https://openpype.io/docs/dev_build)

In:
*Platform specific steps* -> *Linux* -> *Common steps for all Distros*

### Python version
```
...
$ pyenv install -v 3.7.10

...

# set local python version
$ pyenv local 3.7.9
```

=> Error: "pyenv: version '3.7.9' not installed"
  (Installing 3.7.10, but using 3.7.9)


### **patchelf**
When executing "build.sh" on a clean Ubuntu 20.04 install:
```
ValueError: Cannot find required utility `patchelf` in PATH
```
=> Need to install 'patchelf'.
```
sudo apt-get install patchelf
```

## Ftrack Administration
(https://openpype.io/docs/module_ftrack)

- Event server
=> Use of old executable names
  - Linux: 'openpype' instead of 'openpype_console'
  - Windows: 'call openpype.bat' instead of 'openpype_console.exe'


### Create Event Service

#### Casing mismatch

*"create file: sudo vi /opt/OpenPype/run_event_server.sh"*
A few lines below, when adding content to '/etc/systemd/system/openpype-ftrack-event-server.service':
```
ExecStart=/opt/openpype/run_event_server.sh
```
=> 'openpype' instead of 'OpenPype'

#### Executable script
The created file */opt/openpype/run_event_server.sh*
needs to be set executable:
```
sudo chmod 0755 /opt/openpype/run_event_server.sh
```

#### Invalid shebang
The created file */opt/openpype/run_event_server.sh*
contains an invalid shebang:
```
#!\usr\bin\env
```
should be:
```
#!/usr/bin/env
```