### PR TITLE
Fix - single file files are str only, cast it to list to count properly

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py
@@ -43,7 +43,10 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
             self.log.warning("Cannot check for extension {}".format(ext))
             return
 
-        frames = len(instance.data.get("representations", [None])[0]["files"])
+        files = instance.data.get("representations", [None])[0]["files"]
+        if isinstance(files, str):
+            files = [files]
+        frames = len(files)
 
         err_msg = "Frame duration from DB:'{}' ". format(int(duration)) +\
                   " doesn't match number of files:'{}'".format(frames) +\


### PR DESCRIPTION
Validate Frames didn't count single file properly. Old implementation expected [], string is provided for single frame.

How to test it:
----------------
- try to publish single image file
- see error mesage of Validate Frames