### PR TITLE
FFprobe streams order

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -89,8 +89,13 @@ def ffprobe_streams(path_to_file, logger=None):
 
     popen_stdout, popen_stderr = popen.communicate()
     if popen_stdout:
-        logger.debug("ffprobe stdout: {}".format(popen_stdout))
+        logger.debug("FFprobe stdout:\n{}".format(
+            popen_stdout.decode("utf-8")
+        ))
 
     if popen_stderr:
-        logger.debug("ffprobe stderr: {}".format(popen_stderr))
+        logger.warning("FFprobe stderr:\n{}".format(
+            popen_stderr.decode("utf-8")
+        ))
+
     return json.loads(popen_stdout)["streams"]

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -323,16 +323,29 @@ class ExtractReviewSlate(openpype.api.Extractor):
             )
             return codec_args
 
-        codec_name = streams[0].get("codec_name")
+        # Try to find first stream that is not an audio
+        no_audio_stream = None
+        for stream in streams:
+            if stream.get("codec_type") != "audio":
+                no_audio_stream = stream
+                break
+
+        if no_audio_stream is None:
+            self.log.warning((
+                "Couldn't find stream that is not an audio from file \"{}\""
+            ).format(full_input_path))
+            return codec_args
+
+        codec_name = no_audio_stream.get("codec_name")
         if codec_name:
             codec_args.append("-codec:v {}".format(codec_name))
 
-        profile_name = streams[0].get("profile")
+        profile_name = no_audio_stream.get("profile")
         if profile_name:
             profile_name = profile_name.replace(" ", "_").lower()
             codec_args.append("-profile:v {}".format(profile_name))
 
-        pix_fmt = streams[0].get("pix_fmt")
+        pix_fmt = no_audio_stream.get("pix_fmt")
         if pix_fmt:
             codec_args.append("-pix_fmt {}".format(pix_fmt))
         return codec_args


### PR DESCRIPTION
## Issue
Streams read from input file using ffprobe are not always in order we're using it now. We always expect that first stream is video or image stream but in some cases there can be an audio at first place. That is currently breaking all ffprobe usages.

## Changes
- instead of blindly using first stream from ffprobe is used first most matching the expectations
    - check if stream has width and height
    - ignore audio codec type if we expect video or image
- modified ffprobe reading in `ExtractReview` and `ExtractReviewSlate`
- ffprobe stdout, stderr is decoded to utf-8 before logging