### PR TITLE
Settings application use python 2 only where needed

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -179,7 +179,7 @@ class Application:
         if group.enabled:
             enabled = data.get("enabled", True)
         self.enabled = enabled
-        self.use_python_2 = data["use_python_2"]
+        self.use_python_2 = data.get("use_python_2", False)
 
         self.label = data.get("variant_label") or name
         self.full_name = "/".join((group.name, name))

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -888,7 +888,6 @@
             "20": {
                 "enabled": true,
                 "variant_label": "20",
-                "use_python_2": false,
                 "executables": {
                     "windows": [],
                     "darwin": [],
@@ -904,7 +903,6 @@
             "17": {
                 "enabled": true,
                 "variant_label": "17",
-                "use_python_2": false,
                 "executables": {
                     "windows": [],
                     "darwin": [

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -1021,7 +1021,6 @@
             "2020": {
                 "enabled": true,
                 "variant_label": "2020",
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         ""
@@ -1039,7 +1038,6 @@
             "2021": {
                 "enabled": true,
                 "variant_label": "2021",
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\Adobe\\Adobe After Effects 2021\\Support Files\\AfterFX.exe"

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -807,7 +807,6 @@
         "environment": {},
         "variants": {
             "2-83": {
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe"
@@ -829,7 +828,6 @@
                 "environment": {}
             },
             "2-90": {
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\Blender Foundation\\Blender 2.90\\blender.exe"
@@ -851,7 +849,6 @@
                 "environment": {}
             },
             "2-91": {
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\Blender Foundation\\Blender 2.91\\blender.exe"

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -927,7 +927,6 @@
         "environment": {},
         "variants": {
             "animation_11-64bits": {
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\TVPaint Developpement\\TVPaint Animation 11 (64bits)\\TVPaint Animation 11 (64bits).exe"
@@ -943,7 +942,6 @@
                 "environment": {}
             },
             "animation_11-32bits": {
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files (x86)\\TVPaint Developpement\\TVPaint Animation 11 (32bits)\\TVPaint Animation 11 (32bits).exe"

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -975,7 +975,6 @@
             "2020": {
                 "enabled": true,
                 "variant_label": "2020",
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\Adobe\\Adobe Photoshop 2020\\Photoshop.exe"
@@ -993,7 +992,6 @@
             "2021": {
                 "enabled": true,
                 "variant_label": "2021",
-                "use_python_2": false,
                 "executables": {
                     "windows": [
                         "C:\\Program Files\\Adobe\\Adobe Photoshop 2021\\Photoshop.exe"

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -145,7 +145,10 @@ def _fill_schema_template_data(
                 # Only replace the key in string
                 template = template.replace(replacement_string, value)
 
-        output = template.replace("__dbcb__", "{").replace("__decb__", "}")
+        if isinstance(template, STRING_TYPE):
+            output = template.replace("__dbcb__", "{").replace("__decb__", "}")
+        else:
+            output = template
 
     else:
         output = template

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -129,6 +129,7 @@ def _fill_schema_template_data(
     elif isinstance(template, STRING_TYPE):
         # TODO find much better way how to handle filling template data
         template = template.replace("{{", "__dbcb__").replace("}}", "__decb__")
+        full_replacement = False
         for replacement_string in template_key_pattern.findall(template):
             key = str(replacement_string[1:-1])
             required_keys.add(key)
@@ -141,11 +142,12 @@ def _fill_schema_template_data(
                 # Replace the value with value from templates data
                 # - with this is possible to set value with different type
                 template = value
+                full_replacement = True
             else:
                 # Only replace the key in string
                 template = template.replace(replacement_string, value)
 
-        if isinstance(template, STRING_TYPE):
+        if not full_replacement:
             output = template.replace("__dbcb__", "{").replace("__decb__", "}")
         else:
             output = template

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_aftereffects.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_aftereffects.json
@@ -29,11 +29,13 @@
                     "template_data": [
                         {
                             "app_variant_label": "2020",
-                            "app_variant": "2020"
+                            "app_variant": "2020",
+                            "variant_skip_paths": ["use_python_2"]
                         },
                         {
                             "app_variant_label": "2021",
-                            "app_variant": "2021"
+                            "app_variant": "2021",
+                            "variant_skip_paths": ["use_python_2"]
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
@@ -30,7 +30,8 @@
                 "children": [
                     {
                         "type": "schema_template",
-                        "name": "template_host_variant_items"
+                        "name": "template_host_variant_items",
+                        "skip_paths": ["use_python_2"]
                     }
                 ]
             }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_harmony.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_harmony.json
@@ -29,11 +29,13 @@
                     "template_data": [
                         {
                             "app_variant_label": "20",
-                            "app_variant": "20"
+                            "app_variant": "20",
+                            "variant_skip_paths": ["use_python_2"]
                         },
                         {
                             "app_variant_label": "17",
-                            "app_variant": "17"
+                            "app_variant": "17",
+                            "variant_skip_paths": ["use_python_2"]
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_photoshop.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_photoshop.json
@@ -29,11 +29,13 @@
                     "template_data": [
                         {
                             "app_variant_label": "2020",
-                            "app_variant": "2020"
+                            "app_variant": "2020",
+                            "variant_skip_paths": ["use_python_2"]
                         },
                         {
                             "app_variant_label": "2021",
-                            "app_variant": "2021"
+                            "app_variant": "2021",
+                            "variant_skip_paths": ["use_python_2"]
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
@@ -30,7 +30,8 @@
                 "children": [
                     {
                         "type": "schema_template",
-                        "name": "template_host_variant_items"
+                        "name": "template_host_variant_items",
+                        "skip_paths": ["use_python_2"]
                     }
                 ]
             }

--- a/openpype/settings/entities/schemas/system_schema/host_settings/template_host_variant.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/template_host_variant.json
@@ -1,5 +1,10 @@
 [
     {
+        "__default_values__": {
+            "variant_skip_paths": null
+        }
+    },
+    {
         "type": "dict",
         "key": "{app_variant}",
         "label": "{app_variant_label}",
@@ -19,7 +24,8 @@
             },
             {
                 "type": "schema_template",
-                "name": "template_host_variant_items"
+                "name": "template_host_variant_items",
+                "skip_paths": "{variant_skip_paths}"
             }
         ]
     }


### PR DESCRIPTION
## Description
Setting of `Use python 2` is now on all applications but on few of them it doesn't make sence at all because will always use Python 3.

## Changes
- key `use_python_2` is not required key in application variant and is set to `False` by default
- fixed replacing of curly brackets when replacing template value
- removed `use_python_2` from applications where will be always Python 3
    - Blender
    - Harmony
    - Photoshop
    - Aftereffect
    - TVPaint