### PR TITLE
Ftrack timer thread

### DIFF
--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -363,7 +363,9 @@ class FtrackModule(
         return self.tray_module.validate()
 
     def tray_exit(self):
-        return self.tray_module.stop_action_server()
+        if self.tray_module:
+            self.tray_module.stop_action_server()
+            self.tray_module.stop_timer_thread()
 
     def set_credentials_to_env(self, username, api_key):
         os.environ["FTRACK_API_USER"] = username or ""

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -368,6 +368,10 @@ class FtrackEventsThread(threading.Thread):
 
         self.timer_session.event_hub.wait()
 
+    def stop(self):
+        if self.timer_session is not None:
+            self.timer_session.close()
+
     def get_data_from_task(self, task_entity):
         data = {}
         data['task_name'] = task_entity['name']

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -5,7 +5,7 @@ import threading
 from Qt import QtCore, QtWidgets, QtGui
 
 import ftrack_api
-from ..ftrack_server.lib import check_ftrack_url
+from ..ftrack_server.lib import check_ftrack_url, EasyStopSession
 from ..ftrack_server import socket_thread
 from ..lib import credentials
 from ..ftrack_module import FTRACK_MODULE_DIR
@@ -348,7 +348,7 @@ class FtrackEventsThread(threading.Thread):
         self.module = module
 
     def run(self):
-        self.timer_session = ftrack_api.Session(auto_connect_event_hub=True)
+        self.timer_session = EasyStopSession(auto_connect_event_hub=True)
         self.timer_session.event_hub.subscribe(
             'topic=ftrack.update and source.user.username={}'.format(
                 self.username
@@ -370,6 +370,7 @@ class FtrackEventsThread(threading.Thread):
 
     def stop(self):
         if self.timer_session is not None:
+            self.timer_session.event_hub.stop()
             self.timer_session.close()
 
     def get_data_from_task(self, task_entity):


### PR DESCRIPTION
## Description
Ftrack timer thread is currenly `QThread` which is `terminated` when QApplication ends without proper connection closing which can cause issues on reopen.

## Changes
- Ftrack timer thread is not `QThread` but `threading.Thread`
- implemented `EasyStopEventHub` (and related `EasyStopSession`)
    - will stop process event queue immediately if `stop` is called so is not blocking thread to stop and join
- use `EasyStopSession` in Ftrack timer thread

### How to test
- run `openpype_console` or run OpenPype from code (to see console if process is still running)
- be logged in Ftrack module
- Tray process should fully stop at any moment when tray `Exit` is triggered