### PR TITLE
Otio unrelated error on import

### DIFF
--- a/openpype/lib/editorial.py
+++ b/openpype/lib/editorial.py
@@ -7,6 +7,8 @@ try:
     import opentimelineio as otio
     from opentimelineio import opentime as _ot
 except ImportError:
+    if not os.environ.get("AVALON_APP"):
+        raise
     otio = discover_host_vendor_module("opentimelineio")
     _ot = discover_host_vendor_module("opentimelineio.opentime")
 


### PR DESCRIPTION
## Issue
Opentimeline import inside openpype lib crashes in most of the time when is not build properly for openpype venv but the error raised during import in openpype process does not make sence as it's crashing because of missing env key `AVALON_APP` which can't be set in most of cases in openpype process (and wouldn't fix the error).

## Changes
- reraise exception if `AVALON_APP` is not set
    - solution is not perfect but much better then current state