### PR TITLE
Fix: staging and `--use-version` option

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -657,7 +657,7 @@ class BootstrapRepos:
             ]
 
         # remove duplicates
-        openpype_versions = list(set(openpype_versions))
+        openpype_versions = sorted(list(set(openpype_versions)))
 
         return openpype_versions
 

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -15,6 +15,9 @@ from .pype_commands import PypeCommands
               expose_value=False, help="use specified version")
 @click.option("--use-staging", is_flag=True,
               expose_value=False, help="use staging variants")
+@click.option("--list-versions", is_flag=True, expose_value=False,
+              help=("list all detected versions. Use With `--use-staging "
+                    "to list staging versions."))
 def main(ctx):
     """Pype is main command serving as entry point to pipeline system.
 

--- a/start.py
+++ b/start.py
@@ -621,10 +621,26 @@ def _bootstrap_from_code(use_version, use_staging):
         # get current version of OpenPype
         local_version = bootstrap.get_local_live_version()
 
-    if use_version and use_version != local_version:
-        version_to_use = None
-        openpype_versions = bootstrap.find_openpype(
-            include_zips=True, staging=use_staging)
+    version_to_use = None
+    openpype_versions = bootstrap.find_openpype(
+        include_zips=True, staging=use_staging)
+    if use_staging and not use_version:
+        try:
+            version_to_use = openpype_versions[-1]
+        except IndexError:
+            _print("!!! No staging versions are found.")
+            list_versions(openpype_versions, local_version)
+            sys.exit(1)
+        if version_to_use.path.is_file():
+            version_to_use.path = bootstrap.extract_openpype(
+                version_to_use)
+        bootstrap.add_paths_from_directory(version_to_use.path)
+        os.environ["OPENPYPE_VERSION"] = str(version_to_use)
+        version_path = version_to_use.path
+        os.environ["OPENPYPE_REPOS_ROOT"] = (version_path / "openpype").as_posix()  # noqa: E501
+        _openpype_root = version_to_use.path.as_posix()
+
+    elif use_version and use_version != local_version:
         v: OpenPypeVersion
         found = [v for v in openpype_versions if str(v) == use_version]
         if found:

--- a/start.py
+++ b/start.py
@@ -812,7 +812,7 @@ def boot():
     from openpype.version import __version__
 
     assert version_path, "Version path not defined."
-    info = get_info()
+    info = get_info(use_staging)
     info.insert(0, f">>> Using OpenPype from [ {version_path} ]")
 
     t_width = 20
@@ -839,7 +839,7 @@ def boot():
         sys.exit(1)
 
 
-def get_info() -> list:
+def get_info(use_staging=None) -> list:
     """Print additional information to console."""
     from openpype.lib.mongo import get_default_components
     from openpype.lib.log import PypeLogger
@@ -847,7 +847,7 @@ def get_info() -> list:
     components = get_default_components()
 
     inf = []
-    if not getattr(sys, 'frozen', False):
+    if use_staging:
         inf.append(("OpenPype variant", "staging"))
     else:
         inf.append(("OpenPype variant", "production"))

--- a/start.py
+++ b/start.py
@@ -135,18 +135,36 @@ if sys.__stdout__:
     def _print(message: str):
         if message.startswith("!!! "):
             print("{}{}".format(term.orangered2("!!! "), message[4:]))
+            return
         if message.startswith(">>> "):
             print("{}{}".format(term.aquamarine3(">>> "), message[4:]))
+            return
         if message.startswith("--- "):
             print("{}{}".format(term.darkolivegreen3("--- "), message[4:]))
-        if message.startswith("    "):
-            print("{}{}".format(term.darkseagreen3("    "), message[4:]))
+            return
         if message.startswith("*** "):
             print("{}{}".format(term.gold("*** "), message[4:]))
+            return
         if message.startswith("  - "):
             print("{}{}".format(term.wheat("  - "), message[4:]))
+            return
         if message.startswith("  . "):
             print("{}{}".format(term.tan("  . "), message[4:]))
+            return
+        if message.startswith("     - "):
+            print("{}{}".format(term.seagreen3("     - "), message[7:]))
+            return
+        if message.startswith("     ! "):
+            print("{}{}".format(term.goldenrod("     ! "), message[7:]))
+            return
+        if message.startswith("     * "):
+            print("{}{}".format(term.aquamarine1("     * "), message[7:]))
+            return
+        if message.startswith("    "):
+            print("{}{}".format(term.darkseagreen3("    "), message[4:]))
+            return
+
+        print(message)
 else:
     def _print(message: str):
         print(message)
@@ -173,6 +191,17 @@ from igniter.bootstrap_repos import OpenPypeVersion  # noqa: E402
 bootstrap = BootstrapRepos()
 silent_commands = ["run", "igniter", "standalonepublisher",
                    "extractenvironments"]
+
+
+def list_versions(openpype_versions: list, local_version=None) -> None:
+    """Print list of detected versions."""
+    _print("  - Detected versions:")
+    for v in sorted(openpype_versions):
+        _print(f"     - {v}: {v.path}")
+    if not openpype_versions:
+        _print("     ! none in repository detected")
+    if local_version:
+        _print(f"     * local version {local_version}")
 
 
 def set_openpype_global_environments() -> None:
@@ -303,6 +332,7 @@ def _process_arguments() -> tuple:
     # check for `--use-version=3.0.0` argument and `--use-staging`
     use_version = None
     use_staging = False
+    print_versions = False
     for arg in sys.argv:
         if arg == "--use-version":
             _print("!!! Please use option --use-version like:")
@@ -313,11 +343,18 @@ def _process_arguments() -> tuple:
             r"--use-version=(?P<version>\d+\.\d+\.\d+(?:\S*)?)", arg)
         if m and m.group('version'):
             use_version = m.group('version')
+            _print(">>> Requested version [ {} ]".format(use_version))
             sys.argv.remove(arg)
+            if "+staging" in use_version:
+                use_staging = True
             break
     if "--use-staging" in sys.argv:
         use_staging = True
         sys.argv.remove("--use-staging")
+
+    if "--list-versions" in sys.argv:
+        print_versions = True
+        sys.argv.remove("--list-versions")
 
     # handle igniter
     # this is helper to run igniter before anything else
@@ -334,7 +371,7 @@ def _process_arguments() -> tuple:
         sys.argv.pop(idx)
         sys.argv.insert(idx, "tray")
 
-    return use_version, use_staging
+    return use_version, use_staging, print_versions
 
 
 def _determine_mongodb() -> str:
@@ -487,7 +524,7 @@ def _find_frozen_openpype(use_version: str = None,
                     openpype_version = openpype_versions[-1]
                 except IndexError:
                     _print(("!!! Something is wrong and we didn't "
-                          "found it again."))
+                            "found it again."))
                     sys.exit(1)
             elif return_code != 2:
                 _print(f"  . finished ({return_code})")
@@ -519,13 +556,8 @@ def _find_frozen_openpype(use_version: str = None,
         if found:
             openpype_version = sorted(found)[-1]
         if not openpype_version:
-            _print(f"!!! requested version {use_version} was not found.")
-            if openpype_versions:
-                _print("  - found: ")
-                for v in sorted(openpype_versions):
-                    _print(f"     - {v}: {v.path}")
-
-            _print(f"     - local version {local_version}")
+            _print(f"!!! Requested version {use_version} was not found.")
+            list_versions(openpype_versions, local_version)
             sys.exit(1)
 
     # test if latest detected is installed (in user data dir)
@@ -560,7 +592,7 @@ def _find_frozen_openpype(use_version: str = None,
     return openpype_version.path
 
 
-def _bootstrap_from_code(use_version):
+def _bootstrap_from_code(use_version, use_staging):
     """Bootstrap live code (or the one coming with frozen OpenPype.
 
     Args:
@@ -583,7 +615,8 @@ def _bootstrap_from_code(use_version):
 
     if use_version and use_version != local_version:
         version_to_use = None
-        openpype_versions = bootstrap.find_openpype(include_zips=True)
+        openpype_versions = bootstrap.find_openpype(
+            include_zips=True, staging=use_staging)
         v: OpenPypeVersion
         found = [v for v in openpype_versions if str(v) == use_version]
         if found:
@@ -600,13 +633,8 @@ def _bootstrap_from_code(use_version):
             os.environ["OPENPYPE_REPOS_ROOT"] = (version_path / "openpype").as_posix()  # noqa: E501
             _openpype_root = version_to_use.path.as_posix()
         else:
-            _print(f"!!! requested version {use_version} was not found.")
-            if openpype_versions:
-                _print("  - found: ")
-                for v in sorted(openpype_versions):
-                    _print(f"     - {v}: {v.path}")
-
-            _print(f"     - local version {local_version}")
+            _print(f"!!! Requested version {use_version} was not found.")
+            list_versions(openpype_versions, local_version)
             sys.exit(1)
     else:
         os.environ["OPENPYPE_VERSION"] = local_version
@@ -675,7 +703,7 @@ def boot():
     # Process arguments
     # ------------------------------------------------------------------------
 
-    use_version, use_staging = _process_arguments()
+    use_version, use_staging, print_versions = _process_arguments()
 
     if os.getenv("OPENPYPE_VERSION"):
         use_staging = "staging" in os.getenv("OPENPYPE_VERSION")
@@ -704,6 +732,24 @@ def boot():
     if not os.getenv("OPENPYPE_PATH") and openpype_path:
         os.environ["OPENPYPE_PATH"] = openpype_path
 
+    if print_versions:
+        if not use_staging:
+            _print("--- This will list only non-staging versions detected.")
+            _print("    To see staging versions, use --use-staging argument.")
+        else:
+            _print("--- This will list only staging versions detected.")
+            _print("    To see other version, omit --use-staging argument.")
+        _openpype_root = OPENPYPE_ROOT
+        openpype_versions = bootstrap.find_openpype(include_zips=True,
+                                                    staging=use_staging)
+        if getattr(sys, 'frozen', False):
+            local_version = bootstrap.get_version(Path(_openpype_root))
+        else:
+            local_version = bootstrap.get_local_live_version()
+
+        list_versions(openpype_versions, local_version)
+        sys.exit(1)
+
     # ------------------------------------------------------------------------
     # Find OpenPype versions
     # ------------------------------------------------------------------------
@@ -718,7 +764,7 @@ def boot():
             _print(f"!!! {e}")
             sys.exit(1)
     else:
-        version_path = _bootstrap_from_code(use_version)
+        version_path = _bootstrap_from_code(use_version, use_staging)
 
     # set this to point either to `python` from venv in case of live code
     # or to `openpype` or `openpype_console` in case of frozen code

--- a/start.py
+++ b/start.py
@@ -339,20 +339,21 @@ def _process_arguments() -> tuple:
             _print("    --use-version=3.0.0")
             sys.exit(1)
 
-        m = re.search(
-            r"--use-version=(?P<version>\d+\.\d+\.\d+(?:\S*)?)", arg)
-        if m and m.group('version'):
-            use_version = m.group('version')
-            _print(">>> Requested version [ {} ]".format(use_version))
-            sys.argv.remove(arg)
-            if "+staging" in use_version:
-                use_staging = True
-            break
-        else:
-            _print("!!! Requested version isn't in correct format.")
-            _print(("    Use --list-versions to find out"
-                   " proper version string."))
-            sys.exit(1)
+        if arg.startswith("--use-version="):
+            m = re.search(
+                r"--use-version=(?P<version>\d+\.\d+\.\d+(?:\S*)?)", arg)
+            if m and m.group('version'):
+                use_version = m.group('version')
+                _print(">>> Requested version [ {} ]".format(use_version))
+                sys.argv.remove(arg)
+                if "+staging" in use_version:
+                    use_staging = True
+                break
+            else:
+                _print("!!! Requested version isn't in correct format.")
+                _print(("    Use --list-versions to find out"
+                       " proper version string."))
+                sys.exit(1)
 
     if "--use-staging" in sys.argv:
         use_staging = True

--- a/start.py
+++ b/start.py
@@ -537,7 +537,7 @@ def _find_frozen_openpype(use_version: str = None,
             _print("*** Still no luck finding OpenPype.")
             _print(("*** We'll try to use the one coming "
                    "with OpenPype installation."))
-        version_path = _bootstrap_from_code(use_version)
+        version_path = _bootstrap_from_code(use_version, use_staging)
         openpype_version = OpenPypeVersion(
             version=BootstrapRepos.get_version(version_path),
             path=version_path)

--- a/start.py
+++ b/start.py
@@ -348,6 +348,12 @@ def _process_arguments() -> tuple:
             if "+staging" in use_version:
                 use_staging = True
             break
+        else:
+            _print("!!! Requested version isn't in correct format.")
+            _print(("    Use --list-versions to find out"
+                   " proper version string."))
+            sys.exit(1)
+
     if "--use-staging" in sys.argv:
         use_staging = True
         sys.argv.remove("--use-staging")
@@ -607,7 +613,8 @@ def _bootstrap_from_code(use_version, use_staging):
     _openpype_root = OPENPYPE_ROOT
     if getattr(sys, 'frozen', False):
         local_version = bootstrap.get_version(Path(_openpype_root))
-        _print(f"  - running version: {local_version}")
+        switch_str = f" - will switch to {use_version}" if use_version else ""
+        _print(f"  - booting version: {local_version}{switch_str}")
         assert local_version
     else:
         # get current version of OpenPype
@@ -706,8 +713,13 @@ def boot():
     use_version, use_staging, print_versions = _process_arguments()
 
     if os.getenv("OPENPYPE_VERSION"):
-        use_staging = "staging" in os.getenv("OPENPYPE_VERSION")
-        use_version = os.getenv("OPENPYPE_VERSION")
+        if use_version:
+            _print(("*** environment variable OPENPYPE_VERSION"
+                    "is overridden by command line argument."))
+        else:
+            _print(">>> version set by environment variable")
+            use_staging = "staging" in os.getenv("OPENPYPE_VERSION")
+            use_version = os.getenv("OPENPYPE_VERSION")
 
     # ------------------------------------------------------------------------
     # Determine mongodb connection

--- a/tests/igniter/test_bootstrap_repos.py
+++ b/tests/igniter/test_bootstrap_repos.py
@@ -330,8 +330,8 @@ def test_find_openpype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
     assert result[-1].path == expected_path, ("not a latest version of "
                                               "OpenPype 3")
 
+    printer("testing finding OpenPype in OPENPYPE_PATH ...")
     monkeypatch.setenv("OPENPYPE_PATH", e_path.as_posix())
-
     result = fix_bootstrap.find_openpype(include_zips=True)
     # we should have results as file were created
     assert result is not None, "no OpenPype version found"
@@ -348,6 +348,8 @@ def test_find_openpype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
                                               "OpenPype 1")
 
     monkeypatch.delenv("OPENPYPE_PATH", raising=False)
+
+    printer("testing finding OpenPype in user data dir ...")
 
     # mock appdirs user_data_dir
     def mock_user_data_dir(*args, **kwargs):
@@ -373,18 +375,7 @@ def test_find_openpype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
     assert result[-1].path == expected_path, ("not a latest version of "
                                               "OpenPype 2")
 
-    result = fix_bootstrap.find_openpype(e_path, include_zips=True)
-    assert result is not None, "no OpenPype version found"
-    expected_path = Path(
-        e_path / "{}{}{}".format(
-            test_versions_1[5].prefix,
-            test_versions_1[5].version,
-            test_versions_1[5].suffix
-        )
-    )
-    assert result[-1].path == expected_path, ("not a latest version of "
-                                              "OpenPype 1")
-
+    printer("testing finding OpenPype zip/dir precedence ...")
     result = fix_bootstrap.find_openpype(dir_path, include_zips=True)
     assert result is not None, "no OpenPype versions found"
     expected_path = Path(

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -185,9 +185,9 @@ Write-Host "Building OpenPype ..."
 $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
 $out = & poetry run python setup.py build 2>&1
+Set-Content -Path "$($openpype_root)\build\build.log" -Value $out
 if ($LASTEXITCODE -ne 0)
 {
-    Set-Content -Path "$($openpype_root)\build\build.log" -Value $out
     Write-Host "!!! " -NoNewLine -ForegroundColor Red
     Write-Host "Build failed. Check the log: " -NoNewline
     Write-Host ".\build\build.log" -ForegroundColor Yellow

--- a/website/docs/admin_openpype_commands.md
+++ b/website/docs/admin_openpype_commands.md
@@ -21,6 +21,8 @@ openpype_console --use-version=3.0.0-foo+bar
 
 `--use-staging` - to use staging versions of OpenPype.
 
+`--list-versions [--use-staging]` - to list available versions.
+
 For more information [see here](admin_use#run-openpype).
 
 ## Commands

--- a/website/docs/admin_use.md
+++ b/website/docs/admin_use.md
@@ -46,6 +46,16 @@ openpype_console --use-version=3.0.1
 `--use-staging` - to specify you prefer staging version. In that case it will be used
 (if found) instead of production one.
 
+:::tip List available versions
+To list all available versions, use:
+
+```shell
+openpype_console --list-versions
+```
+
+You can add `--use-staging` to list staging versions.
+:::
+
 ### Details
 When you run OpenPype from executable, few check are made: 
 


### PR DESCRIPTION
## Bug fix:

This is fixing issue #1719 and is adding some additional clarifications.

1) if invalid version format is requested with `--use-version`, error is displayed and execution is stopped.
2) `--list-versions [--use-staging]` option was added - this will list all available (detected) versions on all places OpenPype is looking. Without `--use-staging` only production  versions are displayed.
3) if `--use-version` is used with *staging* variant, `--use-staging` is implied.

Close #1719