### PR TITLE
Invitee email can be None which break the Ftrack commit.

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/action_clone_review_session.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_clone_review_session.py
@@ -16,6 +16,7 @@ def clone_review_session(session, entity):
 
     # Add all invitees.
     for invitee in entity["review_session_invitees"]:
+        # Make sure email is not None but string
         email = invitee["email"] or ""
         session.create(
             "ReviewSessionInvitee",

--- a/openpype/modules/ftrack/event_handlers_server/action_clone_review_session.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_clone_review_session.py
@@ -16,11 +16,12 @@ def clone_review_session(session, entity):
 
     # Add all invitees.
     for invitee in entity["review_session_invitees"]:
+        email = invitee["email"] or ""
         session.create(
             "ReviewSessionInvitee",
             {
                 "name": invitee["name"],
-                "email": invitee["email"],
+                "email": email,
                 "review_session": review_session
             }
         )


### PR DESCRIPTION
## Issue
Ftrack action `Clone Review Session` can crash if email on user entity is set to `None`.

## Changes
- make sure email is not None but string

||OpenPype 2 PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1785|