### PR TITLE
Standalone publisher last project

### DIFF
--- a/openpype/tools/standalonepublish/app.py
+++ b/openpype/tools/standalonepublish/app.py
@@ -34,6 +34,8 @@ class Window(QtWidgets.QDialog):
         self._db = AvalonMongoDB()
         self._db.install()
 
+        self._settings = QtCore.QSettings("pypeclub", "StandalonePublisher")
+
         self.pyblish_paths = pyblish_paths
 
         self.setWindowTitle("Standalone Publish")
@@ -44,7 +46,9 @@ class Window(QtWidgets.QDialog):
         self.valid_parent = False
 
         # assets widget
-        widget_assets = AssetWidget(dbcon=self._db, parent=self)
+        widget_assets = AssetWidget(
+            self._settings, dbcon=self._db, parent=self
+        )
 
         # family widget
         widget_family = FamilyWidget(dbcon=self._db, parent=self)

--- a/openpype/tools/standalonepublish/app.py
+++ b/openpype/tools/standalonepublish/app.py
@@ -34,7 +34,12 @@ class Window(QtWidgets.QDialog):
         self._db = AvalonMongoDB()
         self._db.install()
 
-        self._settings = QtCore.QSettings("pypeclub", "StandalonePublisher")
+        try:
+            settings = QtCore.QSettings("pypeclub", "StandalonePublisher")
+        except Exception:
+            settings = None
+
+        self._settings = settings
 
         self.pyblish_paths = pyblish_paths
 
@@ -46,9 +51,7 @@ class Window(QtWidgets.QDialog):
         self.valid_parent = False
 
         # assets widget
-        widget_assets = AssetWidget(
-            self._settings, dbcon=self._db, parent=self
-        )
+        widget_assets = AssetWidget(self._db, settings, self)
 
         # family widget
         widget_family = FamilyWidget(dbcon=self._db, parent=self)

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -127,11 +127,12 @@ class AssetWidget(QtWidgets.QWidget):
     current_changed = QtCore.Signal()    # on view current index change
     task_changed = QtCore.Signal()
 
-    def __init__(self, dbcon, parent=None):
+    def __init__(self, settings, dbcon, parent=None):
         super(AssetWidget, self).__init__(parent=parent)
         self.setContentsMargins(0, 0, 0, 0)
 
         self.dbcon = dbcon
+        self._settings = settings
 
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -255,6 +255,16 @@ class AssetWidget(QtWidgets.QWidget):
         project_name = self.combo_projects.currentText()
         if project_name in projects:
             self.dbcon.Session["AVALON_PROJECT"] = project_name
+            last_projects = [
+                value
+                for value in self._settings.value("projects", "").split("|")
+            ]
+            if project_name in last_projects:
+                last_projects.remove(project_name)
+            last_projects.insert(0, project_name)
+            while len(last_projects) > 5:
+                last_projects.pop(-1)
+            self._settings.setValue("projects", "|".join(last_projects))
 
         self.project_changed.emit(project_name)
 

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -239,14 +239,31 @@ class AssetWidget(QtWidgets.QWidget):
         return output
 
     def _set_projects(self):
-        projects = list()
+        project_names = list()
         for project in self.dbcon.projects():
-            projects.append(project['name'])
+            project_name = project.get("name")
+            if project_name:
+                project_names.append(project_name)
 
         self.combo_projects.clear()
-        if len(projects) > 0:
-            self.combo_projects.addItems(projects)
-            self.dbcon.Session["AVALON_PROJECT"] = projects[0]
+
+        if not project_names:
+            return
+
+        sorted_project_names = list(sorted(project_names))
+        self.combo_projects.addItems(list(sorted(sorted_project_names)))
+
+        last_projects = self._settings.value("projects", "")
+        last_project = sorted_project_names[0]
+        for project_name in last_projects.split("|"):
+            if project_name in sorted_project_names:
+                last_project = project_name
+                break
+
+        index = sorted_project_names.index(last_project)
+        self.combo_projects.setCurrentIndex(index)
+
+        self.dbcon.Session["AVALON_PROJECT"] = last_project
 
     def on_project_change(self):
         projects = list()

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -140,6 +140,10 @@ class AssetWidget(QtWidgets.QWidget):
 
         # Project
         self.combo_projects = QtWidgets.QComboBox()
+        # Change delegate so stylysheets are applied
+        project_delegate = QtWidgets.QStyledItemDelegate(self.combo_projects)
+        self.combo_projects.setItemDelegate(project_delegate)
+
         self._set_projects()
         self.combo_projects.currentTextChanged.connect(self.on_project_change)
         # Tree View
@@ -199,6 +203,7 @@ class AssetWidget(QtWidgets.QWidget):
 
         self.selection_changed.connect(self._refresh_tasks)
 
+        self.project_delegate = project_delegate
         self.task_view = task_view
         self.task_model = task_model
         self.refreshButton = refresh


### PR DESCRIPTION
## Description
- it is handy that standalone publisher would remember last selected project instead of using first available

## Changes
- standalone publisher remembers 5 last selected projects and tries to set them on initialization
    - last selection is stored using QSettings
- project names in combobox are sorted

## How to test
1. open standalone publisher
2. change project (and remember selected project)
3. close standalone publisher
4. open standalone publisher
5. check if project is set to project from step 2

closes: https://github.com/pypeclub/client/issues/49