### PR TITLE
Collect ftrack family bugs

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -51,7 +51,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             families = instance.data.get("families")
             add_ftrack_family = profile["add_ftrack_family"]
 
-            additional_filters = profile.get("additional_filters")
+            additional_filters = profile.get("advanced_filtering")
             if additional_filters:
                 add_ftrack_family = self._get_add_ftrack_f_from_addit_filters(
                     additional_filters,

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -229,7 +229,6 @@
                         "standalonepublisher"
                     ],
                     "families": [
-                        "review",
                         "plate"
                     ],
                     "tasks": [],


### PR DESCRIPTION
## Issue
- `CollectFtrackFamily` is looking for `"additional_filters"` key in settings but there is only `"advanced_filtering"`
- `review` instance is never added to ftrack by default which is confusing for most of cases

## Changes
- `CollectFtrackFamily` is looking for `"advanced_filtering"`
- `review` instances have ftrack family added