### PR TITLE
nuke: fixing wrong name of family folder when `used existing frames`

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_instances.py
@@ -81,18 +81,18 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
                     if target == "Use existing frames":
                         # Local rendering
                         self.log.info("flagged for no render")
-                        families.append(family)
+                        families.append(families_ak.lower())
                     elif target == "Local":
                         # Local rendering
                         self.log.info("flagged for local render")
                         families.append("{}.local".format(family))
+                        family = families_ak.lower()
                     elif target == "On farm":
                         # Farm rendering
                         self.log.info("flagged for farm render")
                         instance.data["transfer"] = False
                         families.append("{}.farm".format(family))
-
-                    family = families_ak.lower()
+                        family = families_ak.lower()
 
                 node.begin()
                 for i in nuke.allNodes():


### PR DESCRIPTION
# Description
This is recurring issue and had been fixed many times. At the moment this is fixing the issue again. 

# Testing notes
1. create nuke write render node on any input
2. render images without publishing `render local` button
![image](https://user-images.githubusercontent.com/40640033/124905900-cecdd480-dfe6-11eb-8231-ecba181ea2cc.png)

3. set render node into `use existing images` 
4. publish 
5. correct result is that new version is created into folder `.../publish/render/...` and not `.../publish/write/...` 