### PR TITLE
Nuke: ftrack family plugin settings preset

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_instances.py
@@ -70,8 +70,9 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
             review = False
             if "review" in node.knobs():
                 review = node["review"].value()
+
+            if review:
                 families.append("review")
-                families.append("ftrack")
 
             # Add all nodes in group instances.
             if node.Class() == "Group":

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -51,7 +51,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             families = instance.data.get("families")
             add_ftrack_family = profile["add_ftrack_family"]
 
-            additional_filters = profile.get("additional_filters")
+            additional_filters = profile.get("advanced_filtering")
             if additional_filters:
                 add_ftrack_family = self._get_add_ftrack_f_from_addit_filters(
                     additional_filters,

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -279,6 +279,25 @@
                     "tasks": [],
                     "add_ftrack_family": true,
                     "advanced_filtering": []
+                },
+                {
+                    "hosts": [
+                        "nuke"
+                    ],
+                    "families": [
+                        "write",
+                        "render"
+                    ],
+                    "tasks": [],
+                    "add_ftrack_family": false,
+                    "advanced_filtering": [
+                        {
+                            "families": [
+                                "review"
+                            ],
+                            "add_ftrack_family": true
+                        }
+                    ]
                 }
             ]
         },

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -229,7 +229,6 @@
                         "standalonepublisher"
                     ],
                     "families": [
-                        "review",
                         "plate"
                     ],
                     "tasks": [],


### PR DESCRIPTION
# Description
We have changed the way we are attaching `ftrack` family to any instance based on presets in settings. Nuke were missing this transition.

# Testing notes
1. open settings and save (to write defaults to your db)
2. make sure project overrides are not changing those new settings > look to Project settings / ftrack / Collect Ftrack Family / at bottom is nuke host preset
3. publish some render node and toggle review off 
4. notice that `Integrate Ftrack API` plugin is not present (that is correct)
5. toggle review on on the render node and refresh
6. check integrators and `Integrate Ftrack API` should be back again

![image](https://user-images.githubusercontent.com/40640033/124908922-291c6480-dfea-11eb-877d-8427954afcd0.png)


# dependencies
this PR has already merged https://github.com/pypeclub/OpenPype/pull/1801