### PR TITLE
Build: don't add Poetry to `PATH`

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -83,7 +83,8 @@ function Show-PSWarning() {
 function Install-Poetry() {
     Write-Host ">>> " -NoNewline -ForegroundColor Green
     Write-Host "Installing Poetry ... "
-    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
+    $env:POETRY_HOME="$openpype_root\.poetry"
+    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
 }
 
 $art = @"
@@ -115,11 +116,9 @@ $openpype_root = (Get-Item $script_dir).parent.FullName
 
 $env:_INSIDE_OPENPYPE_TOOL = "1"
 
-# make sure Poetry is in PATH
 if (-not (Test-Path 'env:POETRY_HOME')) {
     $env:POETRY_HOME = "$openpype_root\.poetry"
 }
-$env:PATH = "$($env:PATH);$($env:POETRY_HOME)\bin"
 
 Set-Location -Path $openpype_root
 
@@ -164,7 +163,7 @@ Write-Host " ]" -ForegroundColor white
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -184,7 +183,7 @@ Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Building OpenPype ..."
 $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
-$out = & poetry run python setup.py build 2>&1
+$out = &  "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
 Set-Content -Path "$($openpype_root)\build\build.log" -Value $out
 if ($LASTEXITCODE -ne 0)
 {
@@ -195,7 +194,7 @@ if ($LASTEXITCODE -ne 0)
 }
 
 Set-Content -Path "$($openpype_root)\build\build.log" -Value $out
-& poetry run python "$($openpype_root)\tools\build_dependencies.py"
+& "$($env:POETRY_HOME)\bin\poetry" run python "$($openpype_root)\tools\build_dependencies.py"
 
 Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "restoring current directory"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -140,21 +140,6 @@ realpath () {
   echo $(cd $(dirname "$1") || return; pwd)/$(basename "$1")
 }
 
-##############################################################################
-# Install Poetry when needed
-# Globals:
-#   PATH
-# Arguments:
-#   None
-# Returns:
-#   None
-###############################################################################
-install_poetry () {
-  echo -e "${BIGreen}>>>${RST} Installing Poetry ..."
-  command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-}
-
 # Main
 main () {
   echo -e "${BGreen}"
@@ -171,11 +156,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   echo -e "${BIYellow}---${RST} Cleaning build directory ..."
   rm -rf "$openpype_root/build" && mkdir "$openpype_root/build" > /dev/null
@@ -201,11 +184,11 @@ if [ "$disable_submodule_update" == 1 ]; then
   fi
   echo -e "${BIGreen}>>>${RST} Building ..."
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    poetry run python "$openpype_root/setup.py" build > "$openpype_root/build/build.log" || { echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return; }
+    "$POETRY_HOME/bin/poetry" run python "$openpype_root/setup.py" build > "$openpype_root/build/build.log" || { echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return; }
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    poetry run python "$openpype_root/setup.py" bdist_mac > "$openpype_root/build/build.log" || { echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return; }
+    "$POETRY_HOME/bin/poetry" run python "$openpype_root/setup.py" bdist_mac > "$openpype_root/build/build.log" || { echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return; }
   fi
-  poetry run python "$openpype_root/tools/build_dependencies.py"
+  "$POETRY_HOME/bin/poetry" run python "$openpype_root/tools/build_dependencies.py"
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # fix code signing issue

--- a/tools/build_win_installer.ps1
+++ b/tools/build_win_installer.ps1
@@ -64,14 +64,6 @@ function Show-PSWarning() {
     }
 }
 
-function Install-Poetry() {
-    Write-Host ">>> " -NoNewline -ForegroundColor Green
-    Write-Host "Installing Poetry ... "
-    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
-    # add it to PATH
-    $env:PATH = "$($env:PATH);$($env:USERPROFILE)\.poetry\bin"
-}
-
 $art = @"
 
              . .   ..     .    ..

--- a/tools/create_env.ps1
+++ b/tools/create_env.ps1
@@ -49,9 +49,7 @@ function Install-Poetry() {
     Write-Host ">>> " -NoNewline -ForegroundColor Green
     Write-Host "Installing Poetry ... "
     $env:POETRY_HOME="$openpype_root\.poetry"
-    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
-    # add it to PATH
-    $env:PATH = "$($env:PATH);$openpype_root\.poetry\bin"
+    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
 }
 
 
@@ -94,11 +92,10 @@ $current_dir = Get-Location
 $script_dir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $openpype_root = (Get-Item $script_dir).parent.FullName
 
-# make sure Poetry is in PATH
 if (-not (Test-Path 'env:POETRY_HOME')) {
     $env:POETRY_HOME = "$openpype_root\.poetry"
 }
-$env:PATH = "$($env:PATH);$($env:POETRY_HOME)\bin"
+
 
 Set-Location -Path $openpype_root
 
@@ -145,7 +142,7 @@ Test-Python
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Install-Poetry
     Write-Host "INSTALLED" -ForegroundColor Cyan
@@ -160,7 +157,7 @@ if (-not (Test-Path -PathType Leaf -Path "$($openpype_root)\poetry.lock")) {
     Write-Host ">>> " -NoNewline -ForegroundColor green
     Write-Host "Installing virtual environment from lock."
 }
-& poetry install --no-root $poetry_verbosity
+& "$env:POETRY_HOME\bin\poetry" install --no-root $poetry_verbosity --ansi
 if ($LASTEXITCODE -ne 0) {
     Write-Host "!!! " -ForegroundColor yellow -NoNewline
     Write-Host "Poetry command failed."

--- a/tools/create_env.sh
+++ b/tools/create_env.sh
@@ -109,8 +109,7 @@ install_poetry () {
   echo -e "${BIGreen}>>>${RST} Installing Poetry ..."
   export POETRY_HOME="$openpype_root/.poetry"
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-  export PATH="$PATH:$POETRY_HOME/bin"
+  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
 }
 
 ##############################################################################
@@ -154,11 +153,10 @@ main () {
 
   # Directories
   openpype_root=$(realpath $(dirname $(dirname "${BASH_SOURCE[0]}")))
-  # make sure Poetry is in PATH
+
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
 
   pushd "$openpype_root" > /dev/null || return > /dev/null
@@ -177,7 +175,7 @@ main () {
     echo -e "${BIGreen}>>>${RST} Installing dependencies ..."
   fi
 
-  poetry install --no-root $poetry_verbosity || { echo -e "${BIRed}!!!${RST} Poetry environment installation failed"; return; }
+  "$POETRY_HOME/bin/poetry" install --no-root $poetry_verbosity || { echo -e "${BIRed}!!!${RST} Poetry environment installation failed"; return; }
 
   echo -e "${BIGreen}>>>${RST} Cleaning cache files ..."
   clean_pyc
@@ -186,10 +184,10 @@ main () {
   # cx_freeze will crash on missing __pychache__ on these but
   # reinstalling them solves the problem.
   echo -e "${BIGreen}>>>${RST} Fixing pycache bug ..."
-  poetry run python -m pip install --force-reinstall pip
-  poetry run pip install --force-reinstall setuptools
-  poetry run pip install --force-reinstall wheel
-  poetry run python -m pip install --force-reinstall pip
+  "$POETRY_HOME/bin/poetry" run python -m pip install --force-reinstall pip
+  "$POETRY_HOME/bin/poetry" run pip install --force-reinstall setuptools
+  "$POETRY_HOME/bin/poetry" run pip install --force-reinstall wheel
+  "$POETRY_HOME/bin/poetry" run python -m pip install --force-reinstall pip
 }
 
 main -3

--- a/tools/create_zip.ps1
+++ b/tools/create_zip.ps1
@@ -45,11 +45,9 @@ $openpype_root = (Get-Item $script_dir).parent.FullName
 
 $env:_INSIDE_OPENPYPE_TOOL = "1"
 
-# make sure Poetry is in PATH
 if (-not (Test-Path 'env:POETRY_HOME')) {
     $env:POETRY_HOME = "$openpype_root\.poetry"
 }
-$env:PATH = "$($env:PATH);$($env:POETRY_HOME)\bin"
 
 Set-Location -Path $openpype_root
 
@@ -87,7 +85,7 @@ if (-not $openpype_version) {
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -107,5 +105,5 @@ Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Generating zip from current sources ..."
 $env:PYTHONPATH="$($openpype_root);$($env:PYTHONPATH)"
 $env:OPENPYPE_ROOT="$($openpype_root)"
-& poetry run python "$($openpype_root)\tools\create_zip.py" $ARGS
+& "$($env:POETRY_HOME)\bin\poetry" run python "$($openpype_root)\tools\create_zip.py" $ARGS
 Set-Location -Path $current_dir

--- a/tools/create_zip.sh
+++ b/tools/create_zip.sh
@@ -114,11 +114,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   pushd "$openpype_root" > /dev/null || return > /dev/null
 
@@ -134,7 +132,7 @@ main () {
   echo -e "${BIGreen}>>>${RST} Generating zip from current sources ..."
   PYTHONPATH="$openpype_root:$PYTHONPATH"
   OPENPYPE_ROOT="$openpype_root"
-  poetry run python3 "$openpype_root/tools/create_zip.py" "$@"
+  "$POETRY_HOME/bin/poetry" run python3 "$openpype_root/tools/create_zip.py" "$@"
 }
 
 main "$@"

--- a/tools/fetch_thirdparty_libs.ps1
+++ b/tools/fetch_thirdparty_libs.ps1
@@ -17,18 +17,15 @@ $openpype_root = (Get-Item $script_dir).parent.FullName
 
 $env:_INSIDE_OPENPYPE_TOOL = "1"
 
-# make sure Poetry is in PATH
 if (-not (Test-Path 'env:POETRY_HOME')) {
     $env:POETRY_HOME = "$openpype_root\.poetry"
 }
-$env:PATH = "$($env:PATH);$($env:POETRY_HOME)\bin"
 
 Set-Location -Path $openpype_root
 
-
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -37,5 +34,5 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
     Write-Host "OK" -ForegroundColor Green
 }
 
-& poetry run python "$($openpype_root)\tools\fetch_thirdparty_libs.py"
+& "$($env:POETRY_HOME)\bin\poetry" run python "$($openpype_root)\tools\fetch_thirdparty_libs.py"
 Set-Location -Path $current_dir

--- a/tools/fetch_thirdparty_libs.sh
+++ b/tools/fetch_thirdparty_libs.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Run Pype Tray
-
-
 art () {
   cat <<-EOF
 
@@ -82,11 +79,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   echo -e "${BIGreen}>>>${RST} Reading Poetry ... \c"
   if [ -f "$POETRY_HOME/bin/poetry" ]; then
@@ -100,7 +95,7 @@ main () {
   pushd "$openpype_root" > /dev/null || return > /dev/null
 
   echo -e "${BIGreen}>>>${RST} Running Pype tool ..."
-  poetry run python "$openpype_root/tools/fetch_thirdparty_libs.py"
+  "$POETRY_HOME/bin/poetry" run python "$openpype_root/tools/fetch_thirdparty_libs.py"
 }
 
 main

--- a/tools/make_docs.ps1
+++ b/tools/make_docs.ps1
@@ -19,11 +19,9 @@ $openpype_root = (Get-Item $script_dir).parent.FullName
 
 $env:_INSIDE_OPENPYPE_TOOL = "1"
 
-# make sure Poetry is in PATH
 if (-not (Test-Path 'env:POETRY_HOME')) {
     $env:POETRY_HOME = "$openpype_root\.poetry"
 }
-$env:PATH = "$($env:PATH);$($env:POETRY_HOME)\bin"
 
 Set-Location -Path $openpype_root
 
@@ -50,7 +48,7 @@ Write-Host $art -ForegroundColor DarkGreen
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -63,10 +61,10 @@ Write-Host "This will not overwrite existing source rst files, only scan and add
 Set-Location -Path $openpype_root
 Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Running apidoc ..."
-& poetry run sphinx-apidoc -M -e -d 10  --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$($openpype_root)\docs\source" igniter
-& poetry run sphinx-apidoc.exe -M -e -d 10 --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$($openpype_root)\docs\source" openpype vendor, openpype\vendor
+& "$env:POETRY_HOME\bin\poetry" run sphinx-apidoc -M -e -d 10  --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$($openpype_root)\docs\source" igniter
+& "$env:POETRY_HOME\bin\poetry" run sphinx-apidoc.exe -M -e -d 10 --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$($openpype_root)\docs\source" openpype vendor, openpype\vendor
 
 Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Building html ..."
-& poetry run python "$($openpype_root)\setup.py" build_sphinx
+& "$env:POETRY_HOME\bin\poetry" run python "$($openpype_root)\setup.py" build_sphinx
 Set-Location -Path $current_dir

--- a/tools/make_docs.sh
+++ b/tools/make_docs.sh
@@ -83,11 +83,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   echo -e "${BIGreen}>>>${RST} Reading Poetry ... \c"
   if [ -f "$POETRY_HOME/bin/poetry" ]; then
@@ -101,11 +99,11 @@ main () {
   pushd "$openpype_root" > /dev/null || return > /dev/null
 
   echo -e "${BIGreen}>>>${RST} Running apidoc ..."
-  poetry run sphinx-apidoc -M -e -d 10  --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$openpype_root/docs/source" igniter
-  poetry run sphinx-apidoc -M -e -d 10 --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$openpype_root/docs/source" openpype vendor, openpype\vendor
+  "$POETRY_HOME/bin/poetry" run sphinx-apidoc -M -e -d 10  --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$openpype_root/docs/source" igniter
+  "$POETRY_HOME/bin/poetry" run sphinx-apidoc -M -e -d 10 --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode -o "$openpype_root/docs/source" openpype vendor, openpype\vendor
 
   echo -e "${BIGreen}>>>${RST} Building html ..."
-  poetry run python3 "$openpype_root/setup.py" build_sphinx
+  "$POETRY_HOME/bin/poetry" run python3 "$openpype_root/setup.py" build_sphinx
 }
 
 main

--- a/tools/run_project_manager.ps1
+++ b/tools/run_project_manager.ps1
@@ -47,7 +47,7 @@ Set-Location -Path $openpype_root
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -56,5 +56,5 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
     Write-Host "OK" -ForegroundColor Green
 }
 
-& poetry run python "$($openpype_root)\start.py" projectmanager
+& "$env:POETRY_HOME\bin\poetry" run python "$($openpype_root)\start.py" projectmanager
 Set-Location -Path $current_dir

--- a/tools/run_projectmanager.sh
+++ b/tools/run_projectmanager.sh
@@ -79,11 +79,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   pushd "$openpype_root" > /dev/null || return > /dev/null
 
@@ -97,7 +95,7 @@ main () {
   fi
 
   echo -e "${BIGreen}>>>${RST} Generating zip from current sources ..."
-  poetry run python "$openpype_root/start.py" projectmanager
+  "$POETRY_HOME/bin/poetry" run python "$openpype_root/start.py" projectmanager
 }
 
 main

--- a/tools/run_settings.ps1
+++ b/tools/run_settings.ps1
@@ -27,7 +27,7 @@ Set-Location -Path $openpype_root
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -36,5 +36,5 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
     Write-Host "OK" -ForegroundColor Green
 }
 
-& poetry run python "$($openpype_root)\start.py" settings --dev
+& "$env:POETRY_HOME\bin\poetry" run python "$($openpype_root)\start.py" settings --dev
 Set-Location -Path $current_dir

--- a/tools/run_settings.sh
+++ b/tools/run_settings.sh
@@ -79,11 +79,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   pushd "$openpype_root" > /dev/null || return > /dev/null
 
@@ -97,7 +95,7 @@ main () {
   fi
 
   echo -e "${BIGreen}>>>${RST} Generating zip from current sources ..."
-  poetry run python3 "$openpype_root/start.py" settings --dev
+  "$POETRY_HOME/bin/poetry" run python3 "$openpype_root/start.py" settings --dev
 }
 
 main

--- a/tools/run_tests.ps1
+++ b/tools/run_tests.ps1
@@ -59,11 +59,9 @@ $openpype_root = (Get-Item $script_dir).parent.FullName
 
 $env:_INSIDE_OPENPYPE_TOOL = "1"
 
-# make sure Poetry is in PATH
 if (-not (Test-Path 'env:POETRY_HOME')) {
     $env:POETRY_HOME = "$openpype_root\.poetry"
 }
-$env:PATH = "$($env:PATH);$($env:POETRY_HOME)\bin"
 
 Set-Location -Path $openpype_root
 
@@ -83,7 +81,7 @@ Write-Host " ] ..." -ForegroundColor white
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -102,7 +100,7 @@ Write-Host ">>> " -NoNewline -ForegroundColor green
 Write-Host "Testing OpenPype ..."
 $original_pythonpath = $env:PYTHONPATH
 $env:PYTHONPATH="$($openpype_root);$($env:PYTHONPATH)"
-& poetry run pytest -x --capture=sys --print -W ignore::DeprecationWarning "$($openpype_root)/tests"
+& "$env:POETRY_HOME\bin\poetry" run pytest -x --capture=sys --print -W ignore::DeprecationWarning "$($openpype_root)/tests"
 $env:PYTHONPATH = $original_pythonpath
 
 Write-Host ">>> " -NoNewline -ForegroundColor green

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -98,11 +98,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-  # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   echo -e "${BIGreen}>>>${RST} Reading Poetry ... \c"
   if [ -f "$POETRY_HOME/bin/poetry" ]; then
@@ -118,7 +116,7 @@ main () {
   echo -e "${BIGreen}>>>${RST} Testing OpenPype ..."
   original_pythonpath=$PYTHONPATH
   export PYTHONPATH="$openpype_root:$PYTHONPATH"
-  poetry run pytest -x --capture=sys --print -W ignore::DeprecationWarning "$openpype_root/tests"
+  "$POETRY_HOME/bin/poetry" run pytest -x --capture=sys --print -W ignore::DeprecationWarning "$openpype_root/tests"
   PYTHONPATH=$original_pythonpath
 }
 

--- a/tools/run_tray.ps1
+++ b/tools/run_tray.ps1
@@ -26,7 +26,7 @@ Set-Location -Path $openpype_root
 
 Write-Host ">>> " -NoNewline -ForegroundColor Green
 Write-Host "Reading Poetry ... " -NoNewline
-if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
+if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
     Write-Host "NOT FOUND" -ForegroundColor Yellow
     Write-Host "*** " -NoNewline -ForegroundColor Yellow
     Write-Host "We need to install Poetry create virtual env first ..."
@@ -35,5 +35,5 @@ if (-not (Test-Path -PathType Container -Path "$openpype_root\.poetry\bin")) {
     Write-Host "OK" -ForegroundColor Green
 }
 
-& poetry run python "$($openpype_root)\start.py" tray --debug
+& "$($env:POETRY_HOME)\bin\poetry" run python "$($openpype_root)\start.py" tray --debug
 Set-Location -Path $current_dir

--- a/tools/run_tray.sh
+++ b/tools/run_tray.sh
@@ -56,11 +56,9 @@ main () {
 
   _inside_openpype_tool="1"
 
-   # make sure Poetry is in PATH
   if [[ -z $POETRY_HOME ]]; then
     export POETRY_HOME="$openpype_root/.poetry"
   fi
-  export PATH="$POETRY_HOME/bin:$PATH"
 
   echo -e "${BIGreen}>>>${RST} Reading Poetry ... \c"
   if [ -f "$POETRY_HOME/bin/poetry" ]; then
@@ -74,7 +72,7 @@ main () {
   pushd "$openpype_root" > /dev/null || return > /dev/null
 
   echo -e "${BIGreen}>>>${RST} Running OpenPype Tray with debug option ..."
-  poetry run python3 "$openpype_root/start.py" tray --debug
+  "$POETRY_HOME/bin/poetry" run python3 "$openpype_root/start.py" tray --debug
 }
 
 main


### PR DESCRIPTION
This PR is updating deprecated **Poetry** installer. Scripts will no longer add Poetry to `PATH`. They will check for `POETRY_HOME` and use Poetry from there (this allows to use system-wide Poetry installation). If `POETRY_HOME` is not set, it will be for the current session and will point to OpenPype local Poetry installation.

**To test:** remove poetry from `PATH`, make sure that if you run `poetry` command from terminal, you'll get `command not found` error. Then run all relevant scripts in **tools** folder.