### PR TITLE
Maya: fix yeti settings path in extractor

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
@@ -133,10 +133,10 @@ class ExtractYetiRig(openpype.api.Extractor):
         image_search_path = resources_dir = instance.data["resourcesDir"]
 
         settings = instance.data.get("rigsettings", None)
-        if settings:
-            settings["imageSearchPath"] = image_search_path
-            with open(settings_path, "w") as fp:
-                json.dump(settings, fp, ensure_ascii=False)
+        assert settings, "Yeti rig settings were not collected."
+        settings["imageSearchPath"] = image_search_path
+        with open(settings_path, "w") as fp:
+            json.dump(settings, fp, ensure_ascii=False)
 
         # add textures to transfers
         if 'transfers' not in instance.data:

--- a/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
@@ -192,12 +192,12 @@ class ExtractYetiRig(openpype.api.Extractor):
                 'stagingDir': dirname
             }
         )
-        self.log.info("settings file: {}".format(settings))
+        self.log.info("settings file: {}".format(settings_path))
         instance.data["representations"].append(
             {
                 'name': 'rigsettings',
                 'ext': 'rigsettings',
-                'files': os.path.basename(settings),
+                'files': os.path.basename(settings_path),
                 'stagingDir': dirname
             }
         )


### PR DESCRIPTION
Invalid variable pointing to file was set in representation in Yeti rig extractor in Maya.