### PR TITLE
Project folder structure overrides

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_create_project_structure.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_project_structure.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 
 from openpype.modules.ftrack.lib import BaseAction, statics_icon
 from openpype.api import Anatomy, get_project_settings
@@ -84,6 +85,9 @@ class CreateProjectFolders(BaseAction):
             }
 
         try:
+            if isinstance(project_folder_structure, str):
+                project_folder_structure = json.loads(project_folder_structure)
+
             # Get paths based on presets
             basic_paths = self.get_path_items(project_folder_structure)
             self.create_folders(basic_paths, project_entity)

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -271,28 +271,7 @@
             }
         }
     },
-    "project_folder_structure": {
-        "__project_root__": {
-            "prod": {},
-            "resources": {
-                "footage": {
-                    "plates": {},
-                    "offline": {}
-                },
-                "audio": {},
-                "art_dept": {}
-            },
-            "editorial": {},
-            "assets[ftrack.Library]": {
-                "characters[ftrack]": {},
-                "locations[ftrack]": {}
-            },
-            "shots[ftrack.Sequence]": {
-                "scripts": {},
-                "editorial[ftrack.Folder]": {}
-            }
-        }
-    },
+    "project_folder_structure": "{\"__project_root__\": {\"prod\": {}, \"resources\": {\"footage\": {\"plates\": {}, \"offline\": {}}, \"audio\": {}, \"art_dept\": {}}, \"editorial\": {}, \"assets[ftrack.Library]\": {\"characters[ftrack]\": {}, \"locations[ftrack]\": {}}, \"shots[ftrack.Sequence]\": {\"scripts\": {}, \"editorial[ftrack.Folder]\": {}}}}",
     "sync_server": {
         "enabled": true,
         "config": {

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -337,6 +337,11 @@ How output of the schema could look like on save:
 - schema also defines valid value type
     - by default it is dictionary
     - to be able use list it is required to define `is_list` to `true`
+- output can be stored as string
+    - this is to allow any keys in dictionary
+    - set key `store_as_string` to `true`
+    - code using that setting must expected that value is string and use json module to convert it to python types
+
 ```
 {
     "type": "raw-json",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_global.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_global.json
@@ -17,7 +17,8 @@
             "type": "raw-json",
             "label": "Project Folder Structure",
             "key": "project_folder_structure",
-            "use_label_wrap": true
+            "use_label_wrap": true,
+            "store_as_string": true
         },
         {
             "type": "schema",


### PR DESCRIPTION
## Issue
- it is not possible to have setting overrides on project settings because current schema of project structure allows to have dots in dicitonary keys which is not allowd in settings

## Changes
- RawJson entity can store value as string
    - this value is not auto converted to python objects on load so it must be manually converted back using json module
- project folder strucuture is stored as string
- action using project folder structure settings expects string

closes: https://github.com/pypeclub/OpenPype/issues/1793