### PR TITLE
Settings: settings for plugins

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial.py
@@ -2,7 +2,7 @@
 Optional:
     presets     -> extensions (
         example of use:
-            [".mov", ".mp4"]
+            ["mov", "mp4"]
     )
     presets     -> source_dir (
         example of use:
@@ -11,6 +11,7 @@ Optional:
             "{root[work]}/{project[name]}/inputs"
             "./input"
             "../input"
+            ""
     )
 """
 
@@ -48,7 +49,7 @@ class CollectEditorial(pyblish.api.InstancePlugin):
     actions = []
 
     # presets
-    extensions = [".mov", ".mp4"]
+    extensions = ["mov", "mp4"]
     source_dir = None
 
     def process(self, instance):
@@ -72,7 +73,7 @@ class CollectEditorial(pyblish.api.InstancePlugin):
             video_path = None
             basename = os.path.splitext(os.path.basename(file_path))[0]
 
-            if self.source_dir:
+            if self.source_dir is not "":
                 source_dir = self.source_dir.replace("\\", "/")
                 if ("./" in source_dir) or ("../" in source_dir):
                     # get current working dir
@@ -98,7 +99,7 @@ class CollectEditorial(pyblish.api.InstancePlugin):
                     if os.path.splitext(f)[0] not in basename:
                         continue
                     # filter out by respected extensions
-                    if os.path.splitext(f)[1] not in self.extensions:
+                    if os.path.splitext(f)[1][1:] not in self.extensions:
                         continue
                     video_path = os.path.join(
                         staging_dir, f

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial.py
@@ -73,7 +73,7 @@ class CollectEditorial(pyblish.api.InstancePlugin):
             video_path = None
             basename = os.path.splitext(os.path.basename(file_path))[0]
 
-            if self.source_dir is not "":
+            if self.source_dir != "":
                 source_dir = self.source_dir.replace("\\", "/")
                 if ("./" in source_dir) or ("../" in source_dir):
                     # get current working dir

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
@@ -17,16 +17,12 @@ class CollectInstances(pyblish.api.InstancePlugin):
         "referenceMain": {
             "family": "review",
             "families": ["clip"],
-            "extensions": [".mp4"]
+            "extensions": ["mp4"]
         },
         "audioMain": {
             "family": "audio",
             "families": ["clip"],
-            "extensions": [".wav"],
-        },
-        "shotMain": {
-            "family": "shot",
-            "families": []
+            "extensions": ["wav"],
         }
     }
     timeline_frame_start = 900000  # starndard edl default (10:00:00:00)
@@ -178,7 +174,16 @@ class CollectInstances(pyblish.api.InstancePlugin):
                         data_key: instance.data.get(data_key)})
 
                 # adding subsets to context as instances
+                self.subsets.update({
+                    "shotMain": {
+                        "family": "shot",
+                        "families": []
+                    }
+                })
                 for subset, properities in self.subsets.items():
+                    if properities["version"] == 0:
+                        properities.pop("version")
+
                     # adding Review-able instance
                     subset_instance_data = instance_data.copy()
                     subset_instance_data.update(properities)

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_resources.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_resources.py
@@ -177,18 +177,22 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
         collection_head_name = None
         # loop trough collections and create representations
         for _collection in collections:
-            ext = _collection.tail
+            ext = _collection.tail[1:]
             collection_head_name = _collection.head
             frame_start = list(_collection.indexes)[0]
             frame_end = list(_collection.indexes)[-1]
             repre_data = {
                 "frameStart": frame_start,
                 "frameEnd": frame_end,
-                "name": ext[1:],
-                "ext": ext[1:],
+                "name": ext,
+                "ext": ext,
                 "files": [item for item in _collection],
                 "stagingDir": staging_dir
             }
+
+            if instance_data.get("keepSequence"):
+                repre_data_keep = deepcopy(repre_data)
+                instance_data["representations"].append(repre_data_keep)
 
             if "review" in instance_data["families"]:
                 repre_data.update({
@@ -208,20 +212,20 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
 
         # loop trough reminders and create representations
         for _reminding_file in remainder:
-            ext = os.path.splitext(_reminding_file)[-1]
+            ext = os.path.splitext(_reminding_file)[-1][1:]
             if ext not in instance_data["extensions"]:
                 continue
             if collection_head_name and (
-                (collection_head_name + ext[1:]) not in _reminding_file
-            ) and (ext in [".mp4", ".mov"]):
+                (collection_head_name + ext) not in _reminding_file
+            ) and (ext in ["mp4", "mov"]):
                 self.log.info(f"Skipping file: {_reminding_file}")
                 continue
             frame_start = 1
             frame_end = 1
 
             repre_data = {
-                "name": ext[1:],
-                "ext": ext[1:],
+                "name": ext,
+                "ext": ext,
                 "files": _reminding_file,
                 "stagingDir": staging_dir
             }

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
@@ -131,20 +131,21 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
             tasks_to_add = dict()
             project_tasks = io.find_one({"type": "project"})["config"]["tasks"]
             for task_name, task_data in self.shot_add_tasks.items():
-                try:
-                    if task_data["type"] in project_tasks.keys():
-                        tasks_to_add.update({task_name: task_data})
-                    else:
-                        raise KeyError(
-                            "Wrong FtrackTaskType `{}` for `{}` is not"
-                            " existing in `{}``".format(
-                                task_data["type"],
-                                task_name,
-                                list(project_tasks.keys())))
-                except KeyError as error:
+                _task_data = deepcopy(task_data)
+
+                # fixing enumerator from settings
+                _task_data["type"] = task_data["type"][0]
+
+                # check if task type in project task types
+                if _task_data["type"] in project_tasks.keys():
+                    tasks_to_add.update({task_name: _task_data})
+                else:
                     raise KeyError(
-                        "Wrong presets: `{0}`".format(error)
-                    )
+                        "Wrong FtrackTaskType `{}` for `{}` is not"
+                        " existing in `{}``".format(
+                            _task_data["type"],
+                            task_name,
+                            list(project_tasks.keys())))
 
             instance.data["tasks"] = tasks_to_add
         else:

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -172,6 +172,8 @@
             "deadline_group": "",
             "deadline_chunk_size": 1,
             "deadline_priority": 50,
+            "publishing_script": "",
+            "skip_integration_repre_list": [],
             "aov_filter": {
                 "maya": [
                     ".+(?:\\.|_)([Bb]eauty)(?:\\.|_).*"

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -184,6 +184,10 @@
                     ".*"
                 ]
             }
+        },
+        "CleanUp": {
+            "paterns": [],
+            "remove_temp_renders": false
         }
     },
     "tools": {

--- a/openpype/settings/defaults/project_settings/standalonepublisher.json
+++ b/openpype/settings/defaults/project_settings/standalonepublisher.json
@@ -165,6 +165,51 @@
                 ],
                 "output": []
             }
+        },
+        "CollectHierarchyInstance": {
+            "shot_rename_template": "{project[code]}_{_sequence_}_{_shot_}",
+            "shot_rename_search_patterns": {
+                "_sequence_": "(\\d{4})(?=_\\d{4})",
+                "_shot_": "(\\d{4})(?!_\\d{4})"
+            },
+            "shot_add_hierarchy": {
+                "parents_path": "{project}/{folder}/{sequence}",
+                "parents": {
+                    "project": "{project[name]}",
+                    "sequence": "{_sequence_}",
+                    "folder": "shots"
+                }
+            },
+            "shot_add_tasks": {}
+        },
+        "shot_add_tasks": {
+            "custom_start_frame": 0,
+            "timeline_frame_start": 900000,
+            "timeline_frame_offset": 0,
+            "subsets": {
+                "referenceMain": {
+                    "family": "review",
+                    "families": [
+                        "clip"
+                    ],
+                    "extensions": [
+                        "mp4"
+                    ],
+                    "version": 0,
+                    "keepSequence": false
+                },
+                "audioMain": {
+                    "family": "audio",
+                    "families": [
+                        "clip"
+                    ],
+                    "extensions": [
+                        "wav"
+                    ],
+                    "version": 0,
+                    "keepSequence": false
+                }
+            }
         }
     }
 }

--- a/openpype/settings/defaults/project_settings/standalonepublisher.json
+++ b/openpype/settings/defaults/project_settings/standalonepublisher.json
@@ -166,6 +166,13 @@
                 "output": []
             }
         },
+        "CollectEditorial": {
+            "source_dir": "",
+            "extensions": [
+                "mov",
+                "mp4"
+            ]
+        },
         "CollectHierarchyInstance": {
             "shot_rename_template": "{project[code]}_{_sequence_}_{_shot_}",
             "shot_rename_search_patterns": {

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -139,7 +139,8 @@ class HostsEnumEntity(BaseEnumEntity):
             "photoshop",
             "resolve",
             "tvpaint",
-            "unreal"
+            "unreal",
+            "standalonepublisher"
         ]
         if self.use_empty_value:
             host_names.insert(0, "")

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
@@ -130,6 +130,145 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "CollectHierarchyInstance",
+                    "label": "Collect Instance Hierarchy",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "shot_rename_template",
+                            "label": "Shot rename template"
+                        },
+                        {
+                            "key": "shot_rename_search_patterns",
+                            "label": "Shot renaming paterns search",
+                            "type": "dict-modifiable",
+                            "highlight_content": true,
+                            "object_type": {
+                                "type": "text"
+                            }
+                        },
+                        {
+                            "type": "dict",
+                            "key": "shot_add_hierarchy",
+                            "label": "Shot hierarchy",
+                            "children": [
+                                {
+                                    "type": "text",
+                                    "key": "parents_path",
+                                    "label": "Parents path template"
+                                },
+                                {
+                                    "key": "parents",
+                                    "label": "Parents",
+                                    "type": "dict-modifiable",
+                                    "highlight_content": true,
+                                    "object_type": {
+                                        "type": "text"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "key": "shot_add_tasks",
+                            "label": "Add tasks to shot",
+                            "type": "dict-modifiable",
+                            "highlight_content": true,
+                            "object_type": {
+                                "type": "dict",
+                                "children": [
+                                    {
+                                        "type": "task-types-enum",
+                                        "key": "type",
+                                        "label": "Task type"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "shot_add_tasks",
+                    "label": "Collect Clip Instances",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "number",
+                            "key": "custom_start_frame",
+                            "label": "Custom start frame",
+                            "default": 0,
+                            "minimum": 1,
+                            "maximum": 100000
+                        },
+                        {
+                            "type": "number",
+                            "key": "timeline_frame_start",
+                            "label": "Timeline start frame",
+                            "default": 900000,
+                            "minimum": 1,
+                            "maximum": 10000000
+                        },
+                        {
+                            "type": "number",
+                            "key": "timeline_frame_offset",
+                            "label": "Timeline frame offset",
+                            "default": 0,
+                            "minimum": -1000000,
+                            "maximum": 1000000
+                        },
+                        {
+                            "key": "subsets",
+                            "label": "Subsets",
+                            "type": "dict-modifiable",
+                            "highlight_content": true,
+                            "object_type": {
+                                "type": "dict",
+                                "children": [
+                                    {
+                                        "type": "text",
+                                        "key": "family",
+                                        "label": "Family"
+                                    },
+                                    {
+                                        "type": "list",
+                                        "key": "families",
+                                        "label": "Families",
+                                        "object_type": "text"
+                                    },
+                                    {
+                                        "type": "splitter"
+                                    },
+                                    {
+                                        "type": "list",
+                                        "key": "extensions",
+                                        "label": "Extensions",
+                                        "object_type": "text"
+                                    },
+                                    {
+                                        "key": "version",
+                                        "label": "Version lock",
+                                        "type": "number",
+                                        "default": 0,
+                                        "minimum": 0,
+                                        "maximum": 10
+                                    }
+                                    ,
+                                    {
+                                        "type": "boolean",
+                                        "key": "keepSequence",
+                                        "label": "Keep sequence if used for review",
+                                        "default": false
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
@@ -134,6 +134,26 @@
                 {
                     "type": "dict",
                     "collapsible": true,
+                    "key": "CollectEditorial",
+                    "label": "Collect Editorial",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "source_dir",
+                            "label": "Editorial resources pointer"
+                        },
+                        {
+                            "type": "list",
+                            "key": "extensions",
+                            "label": "Accepted extensions",
+                            "object_type": "text"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
                     "key": "CollectHierarchyInstance",
                     "label": "Collect Instance Hierarchy",
                     "is_group": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -555,6 +555,22 @@
                     "label": "Deadline Priotity"
                 },
                 {
+                    "type": "splitter"
+                },
+                {
+                    "type": "text",
+                    "key": "publishing_script",
+                    "label": "Publishing script path"
+                },
+                {
+                    "type": "list",
+                    "key": "skip_integration_repre_list",
+                    "label": "Skip integration of representation with ext",
+                    "object_type": {
+                        "type": "text"
+                    }
+                },
+                {
                     "type": "dict",
                     "key": "aov_filter",
                     "label": "Reviewable subsets filter",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -594,6 +594,30 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CleanUp",
+            "label": "Clean Up",
+            "is_group": true,
+            "children": [
+                {
+                    "type": "list",
+                    "key": "paterns",
+                    "label": "Paterrns (regex)",
+                    "object_type": {
+                        "type": "text"
+                    }
+                },
+                {
+                    "type": "boolean",
+                    "key": "remove_temp_renders",
+                    "label": "Remove Temp renders",
+                    "default": false
+                }
+
+            ]
         }
     ]
 }


### PR DESCRIPTION
# Description:
Missing settings for some important standalone plugins and others. 

Modifications: 

- [x] global cleanUp patterns
- [x] standalone: editorial
- [x] standalone: editorial instances + fixing resources
- [x] standalone: editorial shot hierarchy
- [x] global: job submission to farm with `publishing_script` and `skip_integration_repre_list`
- [x] adding `standalonepublisher` to hosts for Extract Review presets