### PR TITLE
Add support for pyenv-win on windows

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -83,8 +83,12 @@ function Show-PSWarning() {
 function Install-Poetry() {
     Write-Host ">>> " -NoNewline -ForegroundColor Green
     Write-Host "Installing Poetry ... "
+    $python = "python"
+    if (Get-Command "pyenv" -ErrorAction SilentlyContinue) {
+        $python = & pyenv which python
+    }
     $env:POETRY_HOME="$openpype_root\.poetry"
-    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
+    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | & $($python) -
 }
 
 $art = @"

--- a/tools/create_env.ps1
+++ b/tools/create_env.ps1
@@ -48,15 +48,23 @@ function Show-PSWarning() {
 function Install-Poetry() {
     Write-Host ">>> " -NoNewline -ForegroundColor Green
     Write-Host "Installing Poetry ... "
+    $python = "python"
+    if (Get-Command "pyenv" -ErrorAction SilentlyContinue) {
+        $python = & pyenv which python
+    }
     $env:POETRY_HOME="$openpype_root\.poetry"
-    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
+    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | & $($python) -
 }
 
 
 function Test-Python() {
     Write-Host ">>> " -NoNewline -ForegroundColor green
     Write-Host "Detecting host Python ... " -NoNewline
-    if (-not (Get-Command "python" -ErrorAction SilentlyContinue)) {
+    $python = "python"
+    if (Get-Command "pyenv" -ErrorAction SilentlyContinue) {
+        $python = & pyenv which python
+    }
+    if (-not (Get-Command "python3" -ErrorAction SilentlyContinue)) {
         Write-Host "!!! Python not detected" -ForegroundColor red
         Set-Location -Path $current_dir
         Exit-WithCode 1
@@ -66,7 +74,7 @@ import sys
 print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))
 '@
 
-    $p = & python -c $version_command
+    $p = & $python -c $version_command
     $env:PYTHON_VERSION = $p
     $m = $p -match '(\d+)\.(\d+)'
     if(-not $m) {


### PR DESCRIPTION
### Change

this is slightly changing how Python is detected and Poetry is installed. It is first testing for existance of [pyenv-win](https://github.com/pyenv-win/pyenv-win) and it it exists, it will take Python path from it, because powershell `Get-Command` will ignore its shims and it will still use whats in the `PATH`. This allows to use `pyenv` the same way as it is used on linux/darwin.

#### Bonus feature :)

now with bonus feature - ability to select preferred mongodb version on windows when multiple versions are installed.