### PR TITLE
Fix - Standalone Publish better handling of loading multiple versions…

### DIFF
--- a/pype/plugins/standalonepublisher/publish/collect_texture.py
+++ b/pype/plugins/standalonepublisher/publish/collect_texture.py
@@ -410,8 +410,12 @@ class CollectTextures(pyblish.api.ContextPlugin):
                               "have '{}' key".format(key)
                         raise ValueError(msg)
 
-                    parsed_value = regex_result[0][idx]
-                    return parsed_value
+                    try:
+                        parsed_value = regex_result[0][idx]
+                        return parsed_value
+                    except IndexError:
+                        self.log.warning("Wrong index, probably "
+                                         "wrong name {}".format(name))
 
     def _update_representations(self, upd_representations):
         """Frames dont have sense for textures, add collected udims instead."""

--- a/pype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/pype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -211,7 +211,8 @@ class DropDataFrame(QtWidgets.QFrame):
         folder_path = os.path.dirname(collection.head)
         if file_base[-1] in ['.', '_']:
             file_base = file_base[:-1]
-        file_ext = collection.tail
+        file_ext = os.path.splitext(
+            collection.format('{head}{padding}{tail}'))[1]
         repr_name = file_ext.replace('.', '')
         range = collection.format('{ranges}')
 


### PR DESCRIPTION
… of sequence at same time

Collection had wrong name which resulted in wrong extension, which resulted in nondescript fail in collect_context.
Now extension is parsed correctly, families implementations need to handle this error state.

How to test:
- Unzip 
[textures_bus_test_data.zip](https://github.com/pypeclub/OpenPype/files/6847145/textures_bus_test_data.zip)
- Drag all resources into Standalone Publisher
- Without this fix it should fail in `collect_context`
- With this fix it should fail in Validators 

SP still produces broken instances (it parses sequence once as a sequence - correctly, but it adds second instance as a sequence of dragged versions - wrongly - in test data you could tell by [1-2] in SP right column).
 
Currently we cannot reliably tell what part of names of files is a version number , it could be `_v001` or it could be anything else.
So proper way of publishing should be process issue, artists shouldnt drag multiple versions of published sequences at same time (and it shouldn't probably publish multiple versions at one time at all.)