### PR TITLE
Prepare project action enhance

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -26,6 +26,21 @@ class PrepareProjectLocal(BaseAction):
 
     # Key to store info about trigerring create folder structure
     item_splitter = {"type": "label", "value": "---"}
+    _keys_order = (
+        "fps",
+        "frameStart",
+        "frameEnd",
+        "handleStart",
+        "handleEnd",
+        "clipIn",
+        "clipOut",
+        "resolutionHeight",
+        "resolutionWidth",
+        "pixelAspect",
+        "applications",
+        "tools_env",
+        "library_project",
+    )
 
     def discover(self, session, entities, event):
         """Show only on project."""
@@ -211,7 +226,18 @@ class PrepareProjectLocal(BaseAction):
             str([key for key in attributes_to_set])
         ))
 
-        for key, in_data in attributes_to_set.items():
+        attribute_keys = set(attributes_to_set.keys())
+        keys_order = []
+        for key in self._keys_order:
+            if key in attribute_keys:
+                keys_order.append(key)
+
+        attribute_keys = attribute_keys - set(keys_order)
+        for key in sorted(attribute_keys):
+            keys_order.append(key)
+
+        for key in keys_order:
+            in_data = attributes_to_set[key]
             attr = in_data["object"]
 
             # initial item definition

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -65,21 +65,6 @@ class PrepareProjectLocal(BaseAction):
         project_entity = entities[0]
         project_name = project_entity["full_name"]
 
-        # Try to find project document
-        dbcon = AvalonMongoDB()
-        dbcon.install()
-        dbcon.Session["AVALON_PROJECT"] = project_name
-        project_doc = dbcon.find_one({
-            "type": "project"
-        })
-        # Create project if is not available
-        # - creation is required to be able set project anatomy and attributes
-        if not project_doc:
-            project_code = project_entity["name"]
-            create_project(project_name, project_code, dbcon=dbcon)
-
-        dbcon.uninstall()
-
         project_settings = ProjectSettings(project_name)
 
         project_anatom_settings = project_settings["project_anatomy"]
@@ -375,7 +360,27 @@ class PrepareProjectLocal(BaseAction):
 
         self.log.debug("Setting Custom Attribute values")
 
-        project_name = entities[0]["full_name"]
+        project_entity = entities[0]
+        project_name = project_entity["full_name"]
+
+        # Try to find project document
+        dbcon = AvalonMongoDB()
+        dbcon.install()
+        dbcon.Session["AVALON_PROJECT"] = project_name
+        project_doc = dbcon.find_one({
+            "type": "project"
+        })
+        # Create project if is not available
+        # - creation is required to be able set project anatomy and attributes
+        if not project_doc:
+            project_code = project_entity["name"]
+            self.log.info("Creating project \"{} [{}]\"".format(
+                project_name, project_code
+            ))
+            create_project(project_name, project_code, dbcon=dbcon)
+
+        dbcon.uninstall()
+
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data


### PR DESCRIPTION
## Issue
Current implementation of PrepareProject action does not work if project does not exists yet.

## Changes
- project is created if is not available
- added order of attributes shown in widget

### How to test
1. create new Ftrack project
2. run PrepareProject without syncing the project
3. confirm values
4. see if it crashes or not
*. check order of attributes in the action interface