### PR TITLE
TVPaint Start Frame

### DIFF
--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -153,7 +153,8 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             "sceneMarkIn": int(mark_in_frame),
             "sceneMarkInState": mark_in_state == "set",
             "sceneMarkOut": int(mark_out_frame),
-            "sceneMarkOutState": mark_out_state == "set"
+            "sceneMarkOutState": mark_out_state == "set",
+            "sceneStartFrame": int(lib.execute_george("tv_startframe"))
         }
         self.log.debug(
             "Scene data: {}".format(json.dumps(scene_data, indent=4))

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -47,6 +47,14 @@ class ExtractSequence(pyblish.api.Extractor):
         family_lowered = instance.data["family"].lower()
         mark_in = instance.context.data["sceneMarkIn"]
         mark_out = instance.context.data["sceneMarkOut"]
+
+        # Scene start frame offsets the output files, so we need to offset the
+        # marks.
+        start_frame = instance.context.data["sceneStartFrame"]
+        difference = start_frame - mark_in
+        mark_in += difference
+        mark_out += difference
+
         # Frame start/end may be stored as float
         frame_start = int(instance.data["frameStart"])
         frame_end = int(instance.data["frameEnd"])

--- a/pype/plugins/tvpaint/publish/validate_start_frame.py
+++ b/pype/plugins/tvpaint/publish/validate_start_frame.py
@@ -1,0 +1,27 @@
+import pyblish.api
+from avalon.tvpaint import lib
+
+
+class RepairStartFrame(pyblish.api.Action):
+    """Repair start frame."""
+
+    label = "Repair"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+        lib.execute_george("tv_startframe 0")
+
+
+class ValidateStartFrame(pyblish.api.ContextPlugin):
+    """Validate start frame being at frame 0."""
+
+    label = "Validate Start Frame"
+    order = pyblish.api.ValidatorOrder
+    hosts = ["tvpaint"]
+    actions = [RepairStartFrame]
+    optional = True
+
+    def process(self, context):
+        start_frame = lib.execute_george("tv_startframe")
+        assert int(start_frame) == 0, "Start frame has to be frame 0."


### PR DESCRIPTION
- offset expected renders by start frame
- optional validator to sync start frame and mark in.

@jezscha was this the correct way of naming the branch?

||OpenPype 3 PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1844|