### PR TITLE
TVPaint Start Frame

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
@@ -155,6 +155,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             "sceneMarkInState": mark_in_state == "set",
             "sceneMarkOut": int(mark_out_frame),
             "sceneMarkOutState": mark_out_state == "set",
+            "sceneStartFrame": int(lib.execute_george("tv_startframe")),
             "sceneBgColor": self._get_bg_color()
         }
         self.log.debug(

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -106,7 +106,7 @@ class ExtractSequence(pyblish.api.Extractor):
             self.log.warning((
                 "Lowering representation range to {} frames."
                 " Changed frame end {} -> {}"
-            ).format(output_range + 1, mark_out, new_mark_out))
+            ).format(output_range + 1, mark_out, new_output_frame_end))
             output_frame_end = new_output_frame_end
 
         # -------------------------------------------------------------------

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -49,6 +49,14 @@ class ExtractSequence(pyblish.api.Extractor):
         family_lowered = instance.data["family"].lower()
         mark_in = instance.context.data["sceneMarkIn"]
         mark_out = instance.context.data["sceneMarkOut"]
+
+        # Scene start frame offsets the output files, so we need to offset the
+        # marks.
+        scene_start_frame = instance.context.data["sceneStartFrame"]
+        difference = scene_start_frame - mark_in
+        mark_in += difference
+        mark_out += difference
+
         # Frame start/end may be stored as float
         frame_start = int(instance.data["frameStart"])
         frame_end = int(instance.data["frameEnd"])

--- a/openpype/hosts/tvpaint/plugins/publish/validate_start_frame.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_start_frame.py
@@ -1,0 +1,27 @@
+import pyblish.api
+from avalon.tvpaint import lib
+
+
+class RepairStartFrame(pyblish.api.Action):
+    """Repair start frame."""
+
+    label = "Repair"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+        lib.execute_george("tv_startframe 0")
+
+
+class ValidateStartFrame(pyblish.api.ContextPlugin):
+    """Validate start frame being at frame 0."""
+
+    label = "Validate Start Frame"
+    order = pyblish.api.ValidatorOrder
+    hosts = ["tvpaint"]
+    actions = [RepairStartFrame]
+    optional = True
+
+    def process(self, context):
+        start_frame = lib.execute_george("tv_startframe")
+        assert int(start_frame) == 0, "Start frame has to be frame 0."

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -18,6 +18,11 @@
             "optional": true,
             "active": true
         },
+        "ValidateStartFrame": {
+            "enabled": false,
+            "optional": true,
+            "active": true
+        },
         "ValidateAssetName": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -53,6 +53,17 @@
                     ]
                 },
                 {
+                  "type": "schema_template",
+                  "name": "template_publish_plugin",
+                  "template_data": [
+                      {
+                          "key": "ValidateStartFrame",
+                          "label": "Validate Scene Start Frame",
+                          "docstring": "Validate first frame of scene is set to '0'."
+                      }
+                  ]
+                },
+                {
                     "type": "schema_template",
                     "name": "template_publish_plugin",
                     "template_data": [


### PR DESCRIPTION
## Description
It seems that TVPaint start frame of scene may affect frame indexes during rendering. So start frame should be used as offset for rendered frame indexes.

## Changes
- use scene start frame as offset for rendered frame indexes
- added validator which validates if start frame is set to '0'
    - validator is turned off by default

### How to test
1. Open TVPaint and change start frame of scene to e.g. 2 ([How to](https://www.tvpaint.com/doc/tvp11/index.php?id=lesson-animate-first-steps-work-animation-start-frame))
2. Set MarkIn and MarkOut to match asset frame start/end
3. On each frame add different image so they are easily identified (e.g. paint numbers on them)
4. Create render layer/pass
5. Publish all of that and review
6. Check if rendered frames match frames from scene

||OpenPype 2 PRs|
|---|---|
|OpenPype|https://github.com/pypeclub/OpenPype/pull/1839|