### PR TITLE
Ftrack type error fix in sync to avalon event handler

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -1259,7 +1259,7 @@ class SyncToAvalonEvent(BaseEvent):
             self.process_session,
             entity,
             hier_attrs,
-            self.cust_attr_types_by_id
+            self.cust_attr_types_by_id.values()
         )
         for key, val in hier_values.items():
             output[key] = val


### PR DESCRIPTION
## Issue
Function `get_hierarchical_attributes_values` expect as value custom attribute types in list but sync event is passing dictionary mapped by id.

## Changes
- pass right type to `get_hierarchical_attributes_values`