### PR TITLE
publisher: missing version in subset prop

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
@@ -181,7 +181,8 @@ class CollectInstances(pyblish.api.InstancePlugin):
                     }
                 })
                 for subset, properities in self.subsets.items():
-                    if properities["version"] == 0:
+                    version = properities.get("version")
+                    if version and version == 0:
                         properities.pop("version")
 
                     # adding Review-able instance


### PR DESCRIPTION
closes https://github.com/pypeclub/client/issues/124

# testing notes
1. open publisher form tray
2. set context to any task
3. set family to Editorial
4. point to any of your editorial testing edl file
5. hit publish

Result: clips should be collected without any error commint from `Collect Editorial Instances`