### PR TITLE
Bugfix textures validator versions

### DIFF
--- a/pype/plugins/standalonepublisher/publish/validate_texture_versions.py
+++ b/pype/plugins/standalonepublisher/publish/validate_texture_versions.py
@@ -31,8 +31,8 @@ class ValidateTextureBatchVersions(pyblish.api.InstancePlugin):
                 instance.data["version"], wfile
             )
 
-        present_versions = []
+        present_versions = set()
         for instance in instance.context:
-            present_versions.append(instance.data["version"])
+            present_versions.add(instance.data["version"])
 
         assert len(present_versions) == 1, "Too many versions in a batch!"


### PR DESCRIPTION
Validator fails on multiple batch textures of same version, it shouldnt.

How to test
-------------
- Unpack 
[versions_bug.zip](https://github.com/pypeclub/OpenPype/files/6870008/versions_bug.zip)
- D&D all present files
- Publish (previous version without fix should fail on ValidateTextureBatchVersions)
