### PR TITLE
Independent general environments

### DIFF
--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -321,11 +321,20 @@ def load_openpype_default_settings():
 
 
 def reset_default_settings():
+    """Reset cache of default settings. Can't be used now."""
     global _DEFAULT_SETTINGS
     _DEFAULT_SETTINGS = None
 
 
 def get_default_settings():
+    """Get default settings.
+
+    Todo:
+        Cache loaded defaults.
+
+    Returns:
+        dict: Loaded default settings.
+    """
     # TODO add cacher
     return load_openpype_default_settings()
     # global _DEFAULT_SETTINGS

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -315,6 +315,11 @@ class DuplicatedEnvGroups(Exception):
         super(DuplicatedEnvGroups, self).__init__(msg)
 
 
+def load_openpype_default_settings():
+    """Load openpype default settings."""
+    return load_jsons_from_dir(DEFAULTS_DIR)
+
+
 def reset_default_settings():
     global _DEFAULT_SETTINGS
     _DEFAULT_SETTINGS = None
@@ -322,7 +327,7 @@ def reset_default_settings():
 
 def get_default_settings():
     # TODO add cacher
-    return load_jsons_from_dir(DEFAULTS_DIR)
+    return load_openpype_default_settings()
     # global _DEFAULT_SETTINGS
     # if _DEFAULT_SETTINGS is None:
     #     _DEFAULT_SETTINGS = load_jsons_from_dir(DEFAULTS_DIR)

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -873,6 +873,25 @@ def get_environments():
     return find_environments(get_system_settings(False))
 
 
+def get_general_environments():
+    """Get general environments.
+
+    Function is implemented to be able load general environments without using
+    `get_default_settings`.
+    """
+    # Use only openpype defaults.
+    # - prevent to use `get_system_settings` where `get_default_settings`
+    #   is used
+    default_values = load_openpype_default_settings()
+    studio_overrides = get_studio_system_settings_overrides()
+    result = apply_overrides(default_values, studio_overrides)
+    environments = result["general"]["environment"]
+
+    clear_metadata_from_settings(environments)
+
+    return environments
+
+
 def clear_metadata_from_settings(values):
     """Remove all metadata keys from loaded settings."""
     if isinstance(values, dict):

--- a/start.py
+++ b/start.py
@@ -208,14 +208,21 @@ def set_openpype_global_environments() -> None:
     """Set global OpenPype's environments."""
     import acre
 
-    from openpype.settings import get_environments
+    try:
+        from openpype.settings import get_general_environments
 
-    all_env = get_environments()
+        general_env = get_general_environments()
 
-    # TODO Global environments will be stored in "general" settings so loading
-    #   will be modified and can be done in igniter.
+    except Exception:
+        # Backwards compatibility for OpenPype versions where
+        #   `get_general_environments` does not exists yet
+        from openpype.settings import get_environments
+
+        all_env = get_environments()
+        general_env = all_env["global"]
+
     env = acre.merge(
-        acre.parse(all_env["global"]),
+        acre.parse(general_env),
         dict(os.environ)
     )
     os.environ.clear()


### PR DESCRIPTION
## Description
First step to be able think about implementation of OpenPype Addons with their settings. Load general environments from settings without using api functions which should load settings also from addons. This must be done separatelly as this part must be done before Addons are loaded.

## Changes
- added function `get_general_environments` which return environments from general settings which is used in start.py

## How to test
General environments must load
- if build was created with this PR without any zip
- if build was created with this PR and zip is from older OpenPype
- if build was created before this PR and this PR is used as zip

## Notes
- to apply this change new build must be distributted
    - modifications are forwards and backwards compatible
    - new build is not required until addons are really implemented and used