### PR TITLE
Maya: don't add reference members as connections to the container set 📦

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -99,14 +99,24 @@ class ReferenceLoader(api.Loader):
             nodes = self[:]
             if not nodes:
                 return
-
-            loaded_containers.append(containerise(
-                name=name,
-                namespace=namespace,
-                nodes=nodes,
-                context=context,
-                loader=self.__class__.__name__
-            ))
+            # FIXME: there is probably better way to do this for looks.
+            if "look" in self.families:
+                loaded_containers.append(containerise(
+                    name=name,
+                    namespace=namespace,
+                    nodes=nodes,
+                    context=context,
+                    loader=self.__class__.__name__
+                ))
+            else:
+                ref_node = self._get_reference_node(nodes)
+                loaded_containers.append(containerise(
+                    name=name,
+                    namespace=namespace,
+                    nodes=[ref_node],
+                    context=context,
+                    loader=self.__class__.__name__
+                ))
 
             c += 1
             namespace = None
@@ -234,9 +244,6 @@ class ReferenceLoader(api.Loader):
         if cmds.getAttr("{}.verticesOnlySet".format(node)):
             self.log.info("Setting %s.verticesOnlySet to False", node)
             cmds.setAttr("{}.verticesOnlySet".format(node), False)
-
-        # Add new nodes of the reference to the container
-        cmds.sets(content, forceElement=node)
 
         # Remove any placeHolderList attribute entries from the set that
         # are remaining from nodes being removed from the referenced file.


### PR DESCRIPTION
### Fix

This is modifying reference loader behavior so it doesn't add all reference content as a connection to the container set. Those connections make scene much bigger and slower to load (and with heavy rig to the point of unusability). For more details see #1854 

⚠️ this is affecting every point in workflow where references are used
|---|

### Testing

When loading references, you should see only reference node (`*_RN`) under **AVALON_CONTAINERS/your_subset**. To see `AVALON_CONTAINERS` in Maya, check `Ignore 'hiddne in Outliner'` in Outliner options:

![image](https://user-images.githubusercontent.com/33513211/126980499-cdb538a2-bb22-4ad8-8b78-489b5c5d2862.png)


Close #1854 