### PR TITLE
imageio: fix grouping 

### DIFF
--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -3,6 +3,7 @@
     "key": "imageio",
     "label": "Color Management and Output Formats",
     "is_file": true,
+    "is_group": true,
     "children": [
         {
             "key": "hiero",
@@ -14,7 +15,6 @@
                     "type": "dict",
                     "label": "Workfile",
                     "collapsible": false,
-                    "is_group": true,
                     "children": [
                         {
                             "type": "form",
@@ -89,7 +89,6 @@
                     "type": "dict",
                     "label": "Colorspace on Inputs by regex detection",
                     "collapsible": true,
-                    "is_group": true,
                     "children": [
                         {
                             "type": "list",
@@ -124,7 +123,6 @@
                     "type": "dict",
                     "label": "Viewer",
                     "collapsible": false,
-                    "is_group": true,
                     "children": [
                         {
                             "type": "text",
@@ -138,7 +136,6 @@
                     "type": "dict",
                     "label": "Workfile",
                     "collapsible": false,
-                    "is_group": true,
                     "children": [
                         {
                             "type": "form",
@@ -236,7 +233,6 @@
                     "type": "dict",
                     "label": "Nodes",
                     "collapsible": true,
-                    "is_group": true,
                     "children": [
                         {
                             "key": "requiredNodes",
@@ -339,7 +335,6 @@
                     "type": "dict",
                     "label": "Colorspace on Inputs by regex detection",
                     "collapsible": true,
-                    "is_group": true,
                     "children": [
                         {
                             "type": "list",


### PR DESCRIPTION
# Problem
Image Io section in project anatomy settings was not defined as group, instead children were using those in misunderstanding of the concept. 

# Solution
Removing all children `is_group` attributes and placing one at root  of the imageio section. 
