### PR TITLE
Ftrack prepare project structure

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -90,14 +90,12 @@ class PrepareProjectLocal(BaseAction):
 
         items.extend(ca_items)
 
-        # This item will be last (before enumerators)
-        # - sets value of auto synchronization
-        auto_sync_name = "avalon_auto_sync"
+        # Set value of auto synchronization
         auto_sync_value = project_entity["custom_attributes"].get(
             CUST_ATTR_AUTO_SYNC, False
         )
         auto_sync_item = {
-            "name": auto_sync_name,
+            "name": CUST_ATTR_AUTO_SYNC,
             "type": "boolean",
             "value": auto_sync_value,
             "label": "AutoSync to Avalon"

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -246,7 +246,7 @@ class PrepareProjectLocal(BaseAction):
                     multiselect_enumerators.append(self.item_splitter)
                     multiselect_enumerators.append({
                         "type": "label",
-                        "value": in_data["label"]
+                        "value": "<h3>{}</h3>".format(in_data["label"])
                     })
 
                     default = in_data["default"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -393,10 +393,12 @@ class PrepareProjectLocal(BaseAction):
 
         project_settings.save()
 
-        entity = entities[0]
-        for key, value in custom_attribute_values.items():
-            entity["custom_attributes"][key] = value
-            self.log.debug("- Key \"{}\" set to \"{}\"".format(key, value))
+        # Change custom attributes on project
+        if custom_attribute_values:
+            for key, value in custom_attribute_values.items():
+                project_entity["custom_attributes"][key] = value
+                self.log.debug("- Key \"{}\" set to \"{}\"".format(key, value))
+            session.commit()
 
         return True
 

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -24,7 +24,7 @@ class PrepareProjectLocal(BaseAction):
 
     settings_key = "prepare_project"
 
-    # Key to store info about trigerring create folder structure\
+    # Key to store info about trigerring create folder structure
     create_project_structure_key = "create_folder_structure"
     create_project_structure_identifier = "create.project.structure"
     item_splitter = {"type": "label", "value": "---"}

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -136,7 +136,8 @@
                 "Pypeclub",
                 "Administrator",
                 "Project manager"
-            ]
+            ],
+            "create_project_structure_checked": false
         },
         "clean_hierarchical_attr": {
             "enabled": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -441,6 +441,18 @@
                             "key": "role_list",
                             "label": "Roles",
                             "object_type": "text"
+                        },
+                        {
+                          "type": "separator"
+                        },
+                        {
+                          "type": "label",
+                          "label": "Check \"Create project structure\" by default"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "create_project_structure_checked",
+                            "label": "Checked"
                         }
                     ]
                 },


### PR DESCRIPTION
Enhance of https://github.com/pypeclub/OpenPype/pull/1838

## Description
There are differences in local and server prepare project. Server does not have ordered keys. Custom attribute changes are not commited. Local action does not have create project structure.

## Changes
- commit changes of custom attribute values
- update Server action with changes from Local action
- added "Create folder structure" to local action
- local action have in settings default checked value of "Create folder structure"

Closes https://github.com/pypeclub/client/issues/95