### PR TITLE
Workfiles tool event arguments fix

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -695,14 +695,14 @@ class FilesWidget(QtWidgets.QWidget):
 
         file_path = os.path.join(self.root, work_file)
 
-        pipeline.emit("before.workfile.save", file_path)
+        pipeline.emit("before.workfile.save", [file_path])
 
         self._enter_session()   # Make sure we are in the right session
         self.host.save_file(file_path)
 
         self.set_asset_task(self._asset, self._task)
 
-        pipeline.emit("after.workfile.save", file_path)
+        pipeline.emit("after.workfile.save", [file_path])
 
         self.workfile_created.emit(file_path)
 


### PR DESCRIPTION
## Issue
Avalon event emit expect that second argument is list or tuple of arguments but workfiles tool is sending string which is not expected.

## Changes
- emit workfile arguments as list instead of path

### NOTE
I found it out in maya. When I saved workfile there is an error in scriptsmenu telling that callback did expect only one argument.