### PR TITLE
Anatomy schema validation

### DIFF
--- a/openpype/settings/entities/anatomy_entities.py
+++ b/openpype/settings/entities/anatomy_entities.py
@@ -1,5 +1,6 @@
 from .dict_immutable_keys_entity import DictImmutableKeysEntity
 from .lib import OverrideState
+from .exceptions import EntitySchemaError
 
 
 class AnatomyEntity(DictImmutableKeysEntity):
@@ -23,3 +24,22 @@ class AnatomyEntity(DictImmutableKeysEntity):
             if not child_obj.has_project_override:
                 child_obj.add_to_project_override()
         return super(AnatomyEntity, self).on_child_change(child_obj)
+
+    def schema_validations(self):
+        non_group_children = []
+        for key, child_obj in self.non_gui_children.items():
+            if not child_obj.is_group:
+                non_group_children.append(key)
+
+        if non_group_children:
+            _non_group_children = [
+                "project_anatomy/{}".format(key)
+                for key in non_group_children
+            ]
+            reason = (
+                "Anatomy must have all children as groups."
+                " Non-group children {}"
+            ).format(", ".join(_non_group_children))
+            raise EntitySchemaError(self, reason)
+
+        return super(AnatomyEntity, self).schema_validations()

--- a/openpype/settings/entities/anatomy_entities.py
+++ b/openpype/settings/entities/anatomy_entities.py
@@ -38,8 +38,11 @@ class AnatomyEntity(DictImmutableKeysEntity):
             ]
             reason = (
                 "Anatomy must have all children as groups."
-                " Non-group children {}"
-            ).format(", ".join(_non_group_children))
+                " Set 'is_group' to `true` on > {}"
+            ).format(", ".join([
+                '"{}"'.format(item)
+                for item in _non_group_children
+            ]))
             raise EntitySchemaError(self, reason)
 
         return super(AnatomyEntity, self).schema_validations()

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -577,6 +577,15 @@ How output of the schema could look like on save:
 }
 ```
 
+## Anatomy
+Anatomy represents data stored on project document.
+
+### anatomy
+- entity works similarly to `dict`
+- anatomy has always all keys overriden with overrides
+    - overrides are not applied as all anatomy data must be available from project document
+    - all children must be groups
+
 ## Proxy wrappers
 - should wraps multiple inputs only visually
 - these does not have `"key"` key and do not allow to have `"is_file"` or `"is_group"` modifiers enabled


### PR DESCRIPTION
## Description
Settings entity `anatomy` should have all children as groups to avoid unresolved overrides.

## Changes
- `anatomy` entity is validating that all it's children are groups otherwise it can break project data

## How to test
1. try to set `is_group` to `True` on entity which is deeper in anatomy settings hierarchy
2. error should appear on settings ui open