### PR TITLE
Workfile tool start at host launch support

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1665,7 +1665,7 @@ def launch_workfiles_app():
     )
     # get all imortant settings
     open_at_start = env_value_to_bool(
-        env_key="WORKFILE_STARTUP",
+        env_key="OPENPYPE_WORKFILE_TOOL_ON_START",
         default=None)
 
     # return if none is defined

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1660,9 +1660,13 @@ def find_free_space_to_paste_nodes(
 def launch_workfiles_app():
     '''Function letting start workfiles after start of host
     '''
-    # get state from settings
-    open_at_start = get_current_project_settings()["nuke"].get(
-        "general", {}).get("open_workfile_at_start")
+    from openpype.lib import (
+        env_value_to_bool
+    )
+    # get all imortant settings
+    open_at_start = env_value_to_bool(
+        env_key="WORKFILE_STARTUP",
+        default=None)
 
     # return if none is defined
     if not open_at_start:

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1302,9 +1302,17 @@ def _prepare_last_workfile(data, workdir):
     )
     data["start_last_workfile"] = start_last_workfile
 
+    workfile_startup = should_workfile_tool_start(
+        project_name, app.host_name, task_name
+    )
+    data["workfile_startup"] = workfile_startup
+
     # Store boolean as "0"(False) or "1"(True)
     data["env"]["AVALON_OPEN_LAST_WORKFILE"] = (
         str(int(bool(start_last_workfile)))
+    )
+    data["env"]["WORKFILE_STARTUP"] = (
+        str(int(bool(workfile_startup)))
     )
 
     _sub_msg = "" if start_last_workfile else " not"
@@ -1344,40 +1352,9 @@ def _prepare_last_workfile(data, workdir):
     data["last_workfile_path"] = last_workfile_path
 
 
-def should_start_last_workfile(
-    project_name, host_name, task_name, default_output=False
+def get_option_from_preset(
+    startup_presets, host_name, task_name, default_output
 ):
-    """Define if host should start last version workfile if possible.
-
-    Default output is `False`. Can be overriden with environment variable
-    `AVALON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
-    `"0", "1", "true", "false", "yes", "no"`.
-
-    Args:
-        project_name (str): Name of project.
-        host_name (str): Name of host which is launched. In avalon's
-            application context it's value stored in app definition under
-            key `"application_dir"`. Is not case sensitive.
-        task_name (str): Name of task which is used for launching the host.
-            Task name is not case sensitive.
-
-    Returns:
-        bool: True if host should start workfile.
-
-    """
-
-    project_settings = get_project_settings(project_name)
-    startup_presets = (
-        project_settings
-        ["global"]
-        ["tools"]
-        ["Workfiles"]
-        ["last_workfile_on_startup"]
-    )
-
-    if not startup_presets:
-        return default_output
-
     host_name_lowered = host_name.lower()
     task_name_lowered = task_name.lower()
 
@@ -1419,6 +1396,82 @@ def should_start_last_workfile(
             output = default_output
         return output
     return default_output
+
+
+def should_start_last_workfile(
+    project_name, host_name, task_name, default_output=False
+):
+    """Define if host should start last version workfile if possible.
+
+    Default output is `False`. Can be overriden with environment variable
+    `AVALON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
+    `"0", "1", "true", "false", "yes", "no"`.
+
+    Args:
+        project_name (str): Name of project.
+        host_name (str): Name of host which is launched. In avalon's
+            application context it's value stored in app definition under
+            key `"application_dir"`. Is not case sensitive.
+        task_name (str): Name of task which is used for launching the host.
+            Task name is not case sensitive.
+
+    Returns:
+        bool: True if host should start workfile.
+
+    """
+
+    project_settings = get_project_settings(project_name)
+    startup_presets = (
+        project_settings
+        ["global"]
+        ["tools"]
+        ["Workfiles"]
+        ["last_workfile_on_startup"]
+    )
+
+    if not startup_presets:
+        return default_output
+
+    return get_option_from_preset(
+        startup_presets, host_name, task_name, default_output)
+
+
+def should_workfile_tool_start(
+    project_name, host_name, task_name, default_output=False
+):
+    """Define if host should start workfile tool at host launch.
+
+    Default output is `False`. Can be overriden with environment variable
+    `WORKFILE_STARTUP`, valid values without case sensitivity are
+    `"0", "1", "true", "false", "yes", "no"`.
+
+    Args:
+        project_name (str): Name of project.
+        host_name (str): Name of host which is launched. In avalon's
+            application context it's value stored in app definition under
+            key `"application_dir"`. Is not case sensitive.
+        task_name (str): Name of task which is used for launching the host.
+            Task name is not case sensitive.
+
+    Returns:
+        bool: True if host should start workfile.
+
+    """
+
+    project_settings = get_project_settings(project_name)
+    startup_presets = (
+        project_settings
+        ["global"]
+        ["tools"]
+        ["Workfiles"]
+        ["open_workfile_tool_on_startup"]
+    )
+
+    if not startup_presets:
+        return default_output
+
+    return get_option_from_preset(
+        startup_presets, host_name, task_name, default_output)
 
 
 def compile_list_of_regexes(in_list):

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1311,7 +1311,7 @@ def _prepare_last_workfile(data, workdir):
     data["env"]["AVALON_OPEN_LAST_WORKFILE"] = (
         str(int(bool(start_last_workfile)))
     )
-    data["env"]["WORKFILE_STARTUP"] = (
+    data["env"]["OPENPYPE_WORKFILE_TOOL_ON_START"] = (
         str(int(bool(workfile_startup)))
     )
 
@@ -1352,7 +1352,7 @@ def _prepare_last_workfile(data, workdir):
     data["last_workfile_path"] = last_workfile_path
 
 
-def get_option_from_preset(
+def get_option_from_settings(
     startup_presets, host_name, task_name, default_output
 ):
     host_name_lowered = host_name.lower()
@@ -1432,7 +1432,7 @@ def should_start_last_workfile(
     if not startup_presets:
         return default_output
 
-    return get_option_from_preset(
+    return get_option_from_settings(
         startup_presets, host_name, task_name, default_output)
 
 
@@ -1442,7 +1442,7 @@ def should_workfile_tool_start(
     """Define if host should start workfile tool at host launch.
 
     Default output is `False`. Can be overriden with environment variable
-    `WORKFILE_STARTUP`, valid values without case sensitivity are
+    `OPENPYPE_WORKFILE_TOOL_ON_START`, valid values without case sensitivity are
     `"0", "1", "true", "false", "yes", "no"`.
 
     Args:
@@ -1470,7 +1470,7 @@ def should_workfile_tool_start(
     if not startup_presets:
         return default_output
 
-    return get_option_from_preset(
+    return get_option_from_settings(
         startup_presets, host_name, task_name, default_output)
 
 

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -260,6 +260,13 @@
                     "enabled": true
                 }
             ],
+            "open_workfile_tool_on_startup": [
+                {
+                    "hosts": [],
+                    "tasks": [],
+                    "enabled": false
+                }
+            ],
             "sw_folders": {
                 "compositing": [
                     "nuke",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -98,6 +98,38 @@
                     }
                 },
                 {
+                    "type": "list",
+                    "key": "open_workfile_tool_on_startup",
+                    "label": "Open workfile tool on launch",
+                    "is_group": true,
+                    "use_label_wrap": true,
+                    "object_type": {
+                        "type": "dict",
+                        "children": [
+                            {
+                                "type": "hosts-enum",
+                                "key": "hosts",
+                                "label": "Hosts",
+                                "multiselection": true
+                            },
+                            {
+                                "key": "tasks",
+                                "label": "Tasks",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "type": "splitter"
+                            },
+                            {
+                                "type": "boolean",
+                                "key": "enabled",
+                                "label": "Enabled"
+                            }
+                        ]
+                    }
+                },
+                {
                     "type": "dict-modifiable",
                     "collapsible": true,
                     "key": "sw_folders",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -125,7 +125,10 @@
                                 "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "multiselection": true
+                                "multiselection": true,
+                                "hosts_filter": [
+                                    "nuke"
+                                ]
                             },
                             {
                                 "key": "tasks",


### PR DESCRIPTION
# Description
In pype2 used to be an option to add env var to launch workfile tool at a host launch. It was missing in openpype.

# Solution
- adding global workfile project settings with an filter on host and task name ([this should be changed to task type in future](https://github.com/pypeclub/OpenPype/pull/1866))
- adding default settings not to open the workfile tool at launch
- adding functionality for filtering by host and task name and adding result to environment variable `WORKFILE_STARTUP`  as it used to be
- refactory nuke's lib function to support this back again

# Testing notes
1. open settings and go to `project/global/tools/workfile/Open workfile tool at launch`
2. create new filter and set host to `nuke` and Enabled to True
3. launch nuke from any of your task
4. workfile tool should be opening

closes https://github.com/pypeclub/client/issues/126