### PR TITLE
Filter hosts in settings host-enum

### DIFF
--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -1,3 +1,4 @@
+import copy
 from .input_entities import InputEntity
 from .exceptions import EntitySchemaError
 from .lib import (
@@ -118,6 +119,22 @@ class HostsEnumEntity(BaseEnumEntity):
     implementation instead of application name.
     """
     schema_types = ["hosts-enum"]
+    all_host_names = [
+        "aftereffects",
+        "blender",
+        "celaction",
+        "fusion",
+        "harmony",
+        "hiero",
+        "houdini",
+        "maya",
+        "nuke",
+        "photoshop",
+        "resolve",
+        "tvpaint",
+        "unreal",
+        "standalonepublisher"
+    ]
 
     def _item_initalization(self):
         self.multiselection = self.schema_data.get("multiselection", True)
@@ -126,22 +143,7 @@ class HostsEnumEntity(BaseEnumEntity):
         )
         custom_labels = self.schema_data.get("custom_labels") or {}
 
-        host_names = [
-            "aftereffects",
-            "blender",
-            "celaction",
-            "fusion",
-            "harmony",
-            "hiero",
-            "houdini",
-            "maya",
-            "nuke",
-            "photoshop",
-            "resolve",
-            "tvpaint",
-            "unreal",
-            "standalonepublisher"
-        ]
+        host_names = copy.deepcopy(self.all_host_names)
         if self.use_empty_value:
             host_names.insert(0, "")
             # Add default label for empty value if not available

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -187,6 +187,44 @@ class HostsEnumEntity(BaseEnumEntity):
         # GUI attribute
         self.placeholder = self.schema_data.get("placeholder")
 
+    def schema_validations(self):
+        if self.hosts_filter:
+            enum_len = len(self.enum_items)
+            if (
+                enum_len == 0
+                or (enum_len == 1 and self.use_empty_value)
+            ):
+                joined_filters = ", ".join([
+                    '"{}"'.format(item)
+                    for item in self.hosts_filter
+                ])
+                reason = (
+                    "All host names were removed after applying"
+                    " host filters. {}"
+                ).format(joined_filters)
+                raise EntitySchemaError(self, reason)
+
+            invalid_filters = set()
+            for item in self.hosts_filter:
+                if item not in self.all_host_names:
+                    invalid_filters.add(item)
+
+            if invalid_filters:
+                joined_filters = ", ".join([
+                    '"{}"'.format(item)
+                    for item in self.hosts_filter
+                ])
+                expected_hosts = ", ".join([
+                    '"{}"'.format(item)
+                    for item in self.all_host_names
+                ])
+                self.log.warning((
+                    "Host filters containt invalid host names:"
+                    " \"{}\" Expected values are {}"
+                ).format(joined_filters, expected_hosts))
+
+        super(HostsEnumEntity, self).schema_validations()
+
 
 class AppsEnumEntity(BaseEnumEntity):
     schema_types = ["apps-enum"]

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -138,9 +138,12 @@ class HostsEnumEntity(BaseEnumEntity):
 
     def _item_initalization(self):
         self.multiselection = self.schema_data.get("multiselection", True)
-        self.use_empty_value = self.schema_data.get(
-            "use_empty_value", not self.multiselection
-        )
+        use_empty_value = False
+        if not self.multiselection:
+            use_empty_value = self.schema_data.get(
+                "use_empty_value", use_empty_value
+            )
+        self.use_empty_value = use_empty_value
         custom_labels = self.schema_data.get("custom_labels") or {}
 
         host_names = copy.deepcopy(self.all_host_names)

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -144,9 +144,18 @@ class HostsEnumEntity(BaseEnumEntity):
                 "use_empty_value", use_empty_value
             )
         self.use_empty_value = use_empty_value
+
+        hosts_filter = self.schema_data.get("hosts_filter") or []
+        self.hosts_filter = hosts_filter
+
         custom_labels = self.schema_data.get("custom_labels") or {}
 
         host_names = copy.deepcopy(self.all_host_names)
+        if hosts_filter:
+            for host_name in tuple(host_names):
+                if host_name not in hosts_filter:
+                    host_names.remove(host_name)
+
         if self.use_empty_value:
             host_names.insert(0, "")
             # Add default label for empty value if not available

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -379,6 +379,9 @@ How output of the schema could look like on save:
 - multiselection can be allowed with setting key `"multiselection"` to `True` (Default: `False`)
 - it is possible to add empty value (represented with empty string) with setting `"use_empty_value"` to `True` (Default: `False`)
 - it is possible to set `"custom_labels"` for host names where key `""` is empty value (Default: `{}`)
+- to filter host names it is required to define `"hosts_filter"` which is list of host names that will be available
+    - do not pass empty string if `use_empty_value` is enabled
+    - ignoring host names would be more dangerous in some cases
 ```
 {
     "key": "host",
@@ -389,7 +392,10 @@ How output of the schema could look like on save:
     "custom_labels": {
         "": "N/A",
         "nuke": "Nuke"
-    }
+    },
+    "hosts_filter": [
+        "nuke"
+    ]
 }
 ```
 

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -78,7 +78,21 @@
                                 "type": "hosts-enum",
                                 "key": "hosts",
                                 "label": "Hosts",
-                                "multiselection": true
+                                "multiselection": true,
+                                "hosts_filter": [
+                                      "aftereffects",
+                                      "blender",
+                                      "celaction",
+                                      "fusion",
+                                      "harmony",
+                                      "hiero",
+                                      "houdini",
+                                      "maya",
+                                      "nuke",
+                                      "photoshop",
+                                      "resolve",
+                                      "tvpaint"
+                                  ]
                             },
                             {
                                 "key": "tasks",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -91,7 +91,8 @@
                                       "nuke",
                                       "photoshop",
                                       "resolve",
-                                      "tvpaint"
+                                      "tvpaint",
+                                      "unreal"
                                   ]
                             },
                             {


### PR DESCRIPTION
## Description
Host enumerator should be used in most of cases when host names should be filled but sometimes it is required to limit host names to only few of them.

## Changes
- `hosts-enum` entity has new attribute `hosts_filter` where can be defined host names which will be available in enum
- hosts filter is validated
    - at least one host must remain from all hosts
    - if host from filter is not available then warning is logged (Should raise and exception?)
- added hosts filter for "workfiles on startup" where `standalonepublisher` is skipped