### PR TITLE
Prepare for pyside2

### DIFF
--- a/openpype/modules/log_viewer/tray/app.py
+++ b/openpype/modules/log_viewer/tray/app.py
@@ -7,12 +7,13 @@ class LogsWindow(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(LogsWindow, self).__init__(parent)
 
-        self.setStyleSheet(style.load_stylesheet())
+        self.setWindowTitle("Logs viewer")
+
         self.resize(1400, 800)
         log_detail = OutputWidget(parent=self)
         logs_widget = LogsWidget(log_detail, parent=self)
 
-        main_layout = QtWidgets.QHBoxLayout()
+        main_layout = QtWidgets.QHBoxLayout(self)
 
         log_splitter = QtWidgets.QSplitter(self)
         log_splitter.setOrientation(QtCore.Qt.Horizontal)
@@ -24,5 +25,4 @@ class LogsWindow(QtWidgets.QWidget):
         self.logs_widget = logs_widget
         self.log_detail = log_detail
 
-        self.setLayout(main_layout)
-        self.setWindowTitle("Logs")
+        self.setStyleSheet(style.load_stylesheet())

--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -76,6 +76,9 @@ class CustomCombo(QtWidgets.QWidget):
 
         toolbutton.setMenu(toolmenu)
         toolbutton.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
+
+        # Fake popupMenu property as PySide2 does not store it's value as
+        #   integer but as enum object
         toolbutton.setProperty("popup_mode", "1")
 
         layout = QtWidgets.QHBoxLayout(self)

--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -139,7 +139,6 @@ class LogsWidget(QtWidgets.QWidget):
         filter_layout.addWidget(refresh_btn)
 
         view = QtWidgets.QTreeView(self)
-        view.setAllColumnsShowFocus(True)
         view.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -227,9 +226,9 @@ class OutputWidget(QtWidgets.QWidget):
         super(OutputWidget, self).__init__(parent=parent)
         layout = QtWidgets.QVBoxLayout(self)
 
-        show_timecode_checkbox = QtWidgets.QCheckBox("Show timestamp")
+        show_timecode_checkbox = QtWidgets.QCheckBox("Show timestamp", self)
 
-        output_text = QtWidgets.QTextEdit()
+        output_text = QtWidgets.QTextEdit(self)
         output_text.setReadOnly(True)
         # output_text.setLineWrapMode(QtWidgets.QTextEdit.FixedPixelWidth)
 

--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -77,10 +77,6 @@ class CustomCombo(QtWidgets.QWidget):
         toolbutton.setMenu(toolmenu)
         toolbutton.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
 
-        # Fake popupMenu property as PySide2 does not store it's value as
-        #   integer but as enum object
-        toolbutton.setProperty("popup_mode", "1")
-
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(toolbutton)

--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -76,12 +76,11 @@ class CustomCombo(QtWidgets.QWidget):
 
         toolbutton.setMenu(toolmenu)
         toolbutton.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
+        toolbutton.setProperty("popup_mode", "1")
 
-        layout = QtWidgets.QHBoxLayout()
+        layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(toolbutton)
-
-        self.setLayout(layout)
 
         toolmenu.selection_changed.connect(self.selection_changed)
 

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -97,7 +97,7 @@ QToolButton:disabled {
     background: {color:bg-buttons-disabled};
 }
 
-QToolButton[popupMode="1"] {
+QToolButton[popupMode="1"], QToolButton[popup_mode="1"] {
     /* make way for the popup button */
     padding-right: 20px;
     border: 1px solid {color:bg-buttons};

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -340,6 +340,11 @@ QAbstractItemView {
     selection-background-color: transparent;
 }
 
+QAbstractItemView::item {
+    /* `border: none` hide outline of selected item. */
+    border: none;
+}
+
 QAbstractItemView:disabled{
     background: {color:bg-view-disabled};
     alternate-background-color: {color:bg-view-alternate-disabled};

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -97,7 +97,7 @@ QToolButton:disabled {
     background: {color:bg-buttons-disabled};
 }
 
-QToolButton[popupMode="1"], QToolButton[popup_mode="1"] {
+QToolButton[popupMode="1"], QToolButton[popupMode="MenuButtonPopup"] {
     /* make way for the popup button */
     padding-right: 20px;
     border: 1px solid {color:bg-buttons};

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -35,6 +35,10 @@ QWidget:disabled {
     color: {color:font-disabled};
 }
 
+QLabel {
+    background: transparent;
+}
+
 /* Inputs */
 QAbstractSpinBox, QLineEdit, QPlainTextEdit, QTextEdit {
     border: 1px solid {color:border};

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -141,7 +141,10 @@ class MainWidget(QtWidgets.QWidget):
         # Don't show dialog if there are not registered slots for
         #   `trigger_restart` signal.
         # - For example when settings are runnin as standalone tool
-        if self.receivers(self.trigger_restart) < 1:
+        # - PySide2 and PyQt5 compatible way how to find out
+        method_index = self.metaObject().indexOfMethod("trigger_restart()")
+        method = self.metaObject().method(method_index)
+        if not self.isSignalConnected(method):
             return
 
         dialog = RestartDialog(self)

--- a/openpype/tools/standalonepublish/widgets/widget_component_item.py
+++ b/openpype/tools/standalonepublish/widgets/widget_component_item.py
@@ -1,7 +1,6 @@
 import os
 from Qt import QtCore, QtGui, QtWidgets
 from .resources import get_resource
-from avalon import style
 
 
 class ComponentItem(QtWidgets.QFrame):
@@ -61,7 +60,7 @@ class ComponentItem(QtWidgets.QFrame):
             name="menu", size=QtCore.QSize(22, 22)
         )
 
-        self.action_menu = QtWidgets.QMenu()
+        self.action_menu = QtWidgets.QMenu(self.btn_action_menu)
 
         expanding_sizePolicy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
@@ -229,7 +228,6 @@ class ComponentItem(QtWidgets.QFrame):
         if not self.btn_action_menu.isVisible():
             self.btn_action_menu.setVisible(True)
             self.btn_action_menu.clicked.connect(self.show_actions)
-            self.action_menu.setStyleSheet(style.load_stylesheet())
 
     def set_repre_name_valid(self, valid):
         self.has_valid_repre = valid


### PR DESCRIPTION
## Description
Changes required to use PySide2 and keep same (or similar) results as with PyQt5.

## Changes
- stylesheet changes or definitions
- use direct parenting to propagate style as expected
- Qt signals have different receivers access

## How to test
- everything should look and behave the same way