### PR TITLE
Disregard publishing time.

### DIFF
--- a/openpype/plugins/publish/start_timer.py
+++ b/openpype/plugins/publish/start_timer.py
@@ -1,0 +1,15 @@
+import pyblish.api
+
+from openpype.api import get_system_settings
+from openpype.lib import change_timer_to_current_context
+
+
+class StartTimer(pyblish.api.ContextPlugin):
+    label = "Start Timer"
+    order = pyblish.api.IntegratorOrder + 1
+    hosts = ["*"]
+
+    def process(self, context):
+        modules_settings = get_system_settings()["modules"]
+        if modules_settings["timers_manager"]["disregard_publishing"]:
+            change_timer_to_current_context()

--- a/openpype/plugins/publish/stop_timer.py
+++ b/openpype/plugins/publish/stop_timer.py
@@ -1,0 +1,19 @@
+import os
+import requests
+
+import pyblish.api
+
+from openpype.api import get_system_settings
+
+
+class StopTimer(pyblish.api.ContextPlugin):
+    label = "Stop Timer"
+    order = pyblish.api.ExtractorOrder - 0.5
+    hosts = ["*"]
+
+    def process(self, context):
+        modules_settings = get_system_settings()["modules"]
+        if modules_settings["timers_manager"]["disregard_publishing"]:
+            webserver_url = os.environ.get("OPENPYPE_WEBSERVER_URL")
+            rest_api_url = "{}/timers_manager/stop_timer".format(webserver_url)
+            requests.post(rest_api_url)

--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -128,7 +128,8 @@
         "enabled": true,
         "auto_stop": true,
         "full_time": 15.0,
-        "message_time": 0.5
+        "message_time": 0.5,
+        "disregard_publishing": false
     },
     "clockify": {
         "enabled": false,

--- a/openpype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_modules.json
@@ -60,6 +60,11 @@
                     "decimal": 2,
                     "key": "message_time",
                     "label": "When dialog will show"
+                },
+                {
+                    "type": "boolean",
+                    "key": "disregard_publishing",
+                    "label": "Disregard Publishing"
                 }
             ]
         },


### PR DESCRIPTION
This feature will stop the timer when publishing and start it again at the end of publishing.

This feature is an optional setting which is disabled by default.

Technically I'm on stopping the timer when reaching the extraction stage of the publishing, which is usually time consuming part. The reason for doing this was because users can often stop the publishing process at the collection stage, so stopping the timer at the collection stage would need complex logic to start the timer again.
Due to the above it might be worth exploring other names for the setting since we technically only disregard the extraction and integration.

Our use case for this, is that we need to measure work hours and not machine hours. Machines can have different specs, so measuring time spent while the machine is processing does not make sense to us.