### PR TITLE
publisher: editorial plugins fixes

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
@@ -182,7 +182,7 @@ class CollectInstances(pyblish.api.InstancePlugin):
                 })
                 for subset, properities in self.subsets.items():
                     version = properities.get("version")
-                    if version and version == 0:
+                    if version == 0:
                         properities.pop("version")
 
                     # adding Review-able instance

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
@@ -37,7 +37,7 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
 
         # return if any
         if entity_type:
-            return {"entityType": entity_type, "entityName": value}
+            return {"entity_type": entity_type, "entity_name": value}
 
     def rename_with_hierarchy(self, instance):
         search_text = ""
@@ -76,8 +76,8 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
         # add current selection context hierarchy from standalonepublisher
         for entity in reversed(visual_hierarchy):
             parents.append({
-                "entityType": entity["data"]["entityType"],
-                "entityName": entity["name"]
+                "entity_type": entity["data"]["entityType"],
+                "entity_name": entity["name"]
             })
 
         if self.shot_add_hierarchy:
@@ -98,7 +98,7 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
 
                 # in case SP context is set to the same folder
                 if (_index == 0) and ("folder" in parent_key) \
-                        and (parents[-1]["entityName"] == parent_filled):
+                        and (parents[-1]["entity_name"] == parent_filled):
                     self.log.debug(f" skiping : {parent_filled}")
                     continue
 
@@ -280,9 +280,9 @@ class CollectHierarchyContext(pyblish.api.ContextPlugin):
 
             for parent in reversed(parents):
                 next_dict = {}
-                parent_name = parent["entityName"]
+                parent_name = parent["entity_name"]
                 next_dict[parent_name] = {}
-                next_dict[parent_name]["entity_type"] = parent["entityType"]
+                next_dict[parent_name]["entity_type"] = parent["entity_type"]
                 next_dict[parent_name]["childs"] = actual
                 actual = next_dict
 

--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_trim_video_audio.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_trim_video_audio.py
@@ -60,7 +60,7 @@ class ExtractTrimVideoAudio(openpype.api.Extractor):
                 ]
 
             args = [
-                ffmpeg_path,
+                f"\"{ffmpeg_path}\"",
                 "-ss", str(start / fps),
                 "-i", f"\"{video_file_path}\"",
                 "-t", str(dur / fps)

--- a/openpype/settings/defaults/project_settings/standalonepublisher.json
+++ b/openpype/settings/defaults/project_settings/standalonepublisher.json
@@ -254,7 +254,7 @@
             },
             "shot_add_tasks": {}
         },
-        "shot_add_tasks": {
+        "CollectInstances": {
             "custom_start_frame": 0,
             "timeline_frame_start": 900000,
             "timeline_frame_offset": 0,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
@@ -327,7 +327,7 @@
                 {
                     "type": "dict",
                     "collapsible": true,
-                    "key": "shot_add_tasks",
+                    "key": "CollectInstances",
                     "label": "Collect Clip Instances",
                     "is_group": true,
                     "children": [


### PR DESCRIPTION
- version detection for locked version on subset properties
- settings with wrong key
- ffmpeg path needed to add quotations around

# testing notes:
- open standalone publisher
- set to context on any task in a project
- set to editorial family
- add any of yours testing edl file to instances area
- publish