### PR TITLE
Settings: Conditional dict enum positioning

### DIFF
--- a/openpype/settings/entities/dict_conditional.py
+++ b/openpype/settings/entities/dict_conditional.py
@@ -144,6 +144,13 @@ class DictConditionalEntity(ItemEntity):
 
         self.enum_entity = None
 
+        # GUI attributes
+        self.enum_is_horizontal = self.schema_data.get(
+            "enum_is_horizontal", False
+        )
+        # `enum_on_right` can be used only if
+        self.enum_on_right = self.schema_data.get("enum_on_right", False)
+
         self.highlight_content = self.schema_data.get(
             "highlight_content", False
         )

--- a/openpype/settings/entities/dict_conditional.py
+++ b/openpype/settings/entities/dict_conditional.py
@@ -185,13 +185,13 @@ class DictConditionalEntity(ItemEntity):
         children_def_keys = []
         for children_def in self.enum_children:
             if not isinstance(children_def, dict):
-                raise EntitySchemaError((
+                raise EntitySchemaError(self, (
                     "Children definition under key 'enum_children' must"
                     " be a dictionary."
                 ))
 
             if "key" not in children_def:
-                raise EntitySchemaError((
+                raise EntitySchemaError(self, (
                     "Children definition under key 'enum_children' miss"
                     " 'key' definition."
                 ))

--- a/openpype/settings/entities/dict_conditional.py
+++ b/openpype/settings/entities/dict_conditional.py
@@ -293,7 +293,7 @@ class DictConditionalEntity(ItemEntity):
             "multiselection": False,
             "enum_items": enum_items,
             "key": enum_key,
-            "label": self.enum_label or enum_key
+            "label": self.enum_label
         }
 
         enum_entity = self.create_schema_object(enum_schema, self)

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -204,6 +204,8 @@
     - it is possible to add darker background with `"highlight_content"` (Default: `False`)
         - darker background has limits of maximum applies after 3-4 nested highlighted items there is not difference in the color
     - output is dictionary `{the "key": children values}`
+- for UI porposes was added `enum_is_horizontal` which will make combobox appear next to children inputs instead of on top of them (Default: `False`)
+    - this has extended ability of `enum_on_right` which will move combobox to right side next to children widgets (Default: `False`)
 ```
 # Example
 {

--- a/openpype/settings/entities/schemas/system_schema/example_schema.json
+++ b/openpype/settings/entities/schemas/system_schema/example_schema.json
@@ -11,6 +11,31 @@
         },
         {
             "type": "dict-conditional",
+            "key": "overriden_value",
+            "label": "Overriden value",
+            "enum_key": "overriden",
+            "enum_is_horizontal": true,
+            "enum_children": [
+                {
+                    "key": "overriden",
+                    "label": "Override value",
+                    "children": [
+                        {
+                            "type": "number",
+                            "key": "value",
+                            "label": "value"
+                        }
+                    ]
+                },
+                {
+                    "key": "inherit",
+                    "label": "Inherit value",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "type": "dict-conditional",
             "use_label_wrap": true,
             "collapsible": true,
             "key": "menu_items",


### PR DESCRIPTION
## Description
Sometimes it is better to have combobox of conditional dictionary next to children instead of on top of them.

## Changes
- added attributes to conditional dict item `enum_is_horizontal` which moves combobox next to children instead on top of them
    - also added optional attribute `enum_on_right` which will move the combobox after children on right side (can be enabled only if `enum_is_horizontal` is enabled)
- modified UI to handle that situations

## Screenshots
![image](https://user-images.githubusercontent.com/43494761/127667826-939c9237-ab6f-46eb-a9d7-afeb54a343a9.png)
![image](https://user-images.githubusercontent.com/43494761/127667804-08b689a4-95c8-4fd1-b938-6e0fe6dad985.png)
