### PR TITLE
Bug: fixed python detection

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -80,17 +80,6 @@ function Show-PSWarning() {
     }
 }
 
-function Install-Poetry() {
-    Write-Host ">>> " -NoNewline -ForegroundColor Green
-    Write-Host "Installing Poetry ... "
-    $python = "python"
-    if (Get-Command "pyenv" -ErrorAction SilentlyContinue) {
-        $python = & pyenv which python
-    }
-    $env:POETRY_HOME="$openpype_root\.poetry"
-    (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | & $($python) -
-}
-
 $art = @"
 
              . .   ..     .    ..

--- a/tools/create_env.ps1
+++ b/tools/create_env.ps1
@@ -62,9 +62,12 @@ function Test-Python() {
     Write-Host "Detecting host Python ... " -NoNewline
     $python = "python"
     if (Get-Command "pyenv" -ErrorAction SilentlyContinue) {
-        $python = & pyenv which python
+        $pyenv_python = & pyenv which python
+        if (Test-Path -PathType Leaf -Path "$($pyenv_python)") {
+            $python = $pyenv_python
+        }
     }
-    if (-not (Get-Command "python3" -ErrorAction SilentlyContinue)) {
+    if (-not (Get-Command $python -ErrorAction SilentlyContinue)) {
         Write-Host "!!! Python not detected" -ForegroundColor red
         Set-Location -Path $current_dir
         Exit-WithCode 1


### PR DESCRIPTION
## Bug

fixed python command detection. Python from **pyenv-win** will be used only if installed and is set explicitly, `python3` is not used on windows by default.