### PR TITLE
Global: Use environment computation after environments merge

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1138,7 +1138,7 @@ def prepare_host_environments(data, implementation_envs=True):
         # Merge dictionaries
         env_values = _merge_env(tool_env, env_values)
 
-    merged_env = _merge_env(computed_env, data["env"])
+    merged_env = _merge_env(env_values, data["env"])
     loaded_env = acre.compute(merged_env, cleanup=False)
 
     final_env = None

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1138,7 +1138,8 @@ def prepare_host_environments(data, implementation_envs=True):
         # Merge dictionaries
         env_values = _merge_env(tool_env, env_values)
 
-    loaded_env = _merge_env(acre.compute(env_values), data["env"])
+    merged_env = _merge_env(computed_env, data["env"])
+    loaded_env = acre.compute(merged_env, cleanup=False)
 
     final_env = None
     # Add host specific environments
@@ -1189,7 +1190,10 @@ def apply_project_environments_value(project_name, env, project_settings=None):
 
     env_value = project_settings["global"]["project_environments"]
     if env_value:
-        env.update(_merge_env(acre.parse(env_value), env))
+        env.update(acre.compute(
+            _merge_env(acre.parse(env_value), env),
+            cleanup=False
+        ))
     return env
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,7 +11,7 @@ develop = false
 type = "git"
 url = "https://github.com/pypeclub/acre.git"
 reference = "master"
-resolved_reference = "5a812c6dcfd3aada87adb49be98c548c894d6566"
+resolved_reference = "55a7c331e6dc5f81639af50ca4a8cc9d73e9273d"
 
 [[package]]
 name = "aiohttp"

--- a/start.py
+++ b/start.py
@@ -221,9 +221,13 @@ def set_openpype_global_environments() -> None:
         all_env = get_environments()
         general_env = all_env["global"]
 
-    env = acre.merge(
+    merged_env = acre.merge(
         acre.parse(general_env),
         dict(os.environ)
+    )
+    env = acre.compute(
+        merged_env,
+        cleanup=False
     )
     os.environ.clear()
     os.environ.update(env)


### PR DESCRIPTION
## Issue
Environments defined in same environments dictionary may not fill all keys defined in the dictionary. Most visible in general environments where it is not possible to use key from general environments inside it's values.

## Changes
- modification in `acre.merge` - ~~TODO Change acre commit when approved ([PR](https://github.com/pypeclub/acre/pull/3))~~
- compute environments after merging them

Depends on https://github.com/pypeclub/acre/pull/3