### PR TITLE
Timers manager: Get task time

### DIFF
--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -3,7 +3,7 @@ import json
 import collections
 from abc import ABCMeta, abstractmethod
 import six
-import openpype
+
 from openpype.modules import (
     PypeModule,
     ITrayModule,
@@ -368,3 +368,14 @@ class FtrackModule(
     def set_credentials_to_env(self, username, api_key):
         os.environ["FTRACK_API_USER"] = username or ""
         os.environ["FTRACK_API_KEY"] = api_key or ""
+
+    def get_task_time(self, project_name, asset_name, task_name):
+        session = self.create_ftrack_session()
+        query = (
+            'Task where name is "{}"'
+            ' and parent.name is "{}"'
+            ' and project.full_name is "{}"'
+        ).format(task_name, asset_name, project_name)
+        task_entity = session.query(query).one()
+        hours_logged = (task_entity["time_logged"] / 60) / 60
+        return hours_logged

--- a/openpype/modules/timers_manager/rest_api.py
+++ b/openpype/modules/timers_manager/rest_api.py
@@ -1,3 +1,5 @@
+import json
+
 from aiohttp.web_response import Response
 from openpype.api import Logger
 
@@ -28,6 +30,11 @@ class TimersManagerModuleRestApi:
             self.prefix + "/stop_timer",
             self.stop_timer
         )
+        self.server_manager.add_route(
+            "GET",
+            self.prefix + "/get_task_time",
+            self.get_task_time
+        )
 
     async def start_timer(self, request):
         data = await request.json()
@@ -48,3 +55,17 @@ class TimersManagerModuleRestApi:
     async def stop_timer(self, request):
         self.module.stop_timers()
         return Response(status=200)
+
+    async def get_task_time(self, request):
+        data = await request.json()
+        try:
+            project_name = data['project_name']
+            asset_name = data['asset_name']
+            task_name = data['task_name']
+        except KeyError:
+            log.error("Payload must contain fields 'project_name, " +
+                      "'asset_name', 'task_name'")
+            return Response(status=400)
+
+        time = self.module.get_task_time(project_name, asset_name, task_name)
+        return Response(text=json.dumps(time))

--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -124,6 +124,15 @@ class TimersManager(PypeModule, ITrayService, IIdleManager, IWebServerRoutes):
         }
         self.timer_started(None, data)
 
+    def get_task_time(self, project_name, asset_name, task_name):
+        time = {}
+        for module in self.modules:
+            time[module.name] = module.get_task_time(
+                project_name, asset_name, task_name
+            )
+
+        return time
+
     def timer_started(self, source_id, data):
         for module in self.modules:
             if module.id != source_id:


### PR DESCRIPTION
This PR adds a method for querying the task time from all modules registered.

Currently only Ftrack has the method implemented, because I cant find any docs for setting up the Clockify api. This means currently it'll fail when using Clockify.