### PR TITLE
Burnins: Use input's bitrate in h624

### DIFF
--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -113,6 +113,10 @@ def _h264_codec_args(ffprobe_data):
 
     output.extend(["-codec:v", "h264"])
 
+    bit_rate = ffprobe_data.get("bit_rate")
+    if bit_rate:
+        output.extend(["-b:v", bit_rate])
+
     pix_fmt = ffprobe_data.get("pix_fmt")
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])


### PR DESCRIPTION
## Issue
Burnins are not using input bitrate when h264 codec is used so output can be much lower quality than input.

## Changes
- use input's bitrate for output for h264 codec