### PR TITLE
Fix - validators for textures workfiles trigger only for textures workfiles

### DIFF
--- a/pype/plugins/standalonepublisher/publish/collect_texture.py
+++ b/pype/plugins/standalonepublisher/publish/collect_texture.py
@@ -259,7 +259,7 @@ class CollectTextures(pyblish.api.ContextPlugin):
             # store origin
             if family == 'workfile':
                 families = self.workfile_families
-
+                families.append("texture_batch_workfile")
                 new_instance.data["source"] = "standalone publisher"
             else:
                 families = self.textures_families

--- a/pype/plugins/standalonepublisher/publish/validate_texture_batch.py
+++ b/pype/plugins/standalonepublisher/publish/validate_texture_batch.py
@@ -8,7 +8,7 @@ class ValidateTextureBatch(pyblish.api.InstancePlugin):
     label = "Validate Texture Presence"
     hosts = ["standalonepublisher"]
     order = pype.api.ValidateContentsOrder
-    families = ["workfile"]
+    families = ["texture_batch_workfile"]
     optional = False
 
     def process(self, instance):

--- a/pype/plugins/standalonepublisher/publish/validate_texture_name.py
+++ b/pype/plugins/standalonepublisher/publish/validate_texture_name.py
@@ -8,7 +8,7 @@ class ValidateTextureBatchNaming(pyblish.api.InstancePlugin):
     label = "Validate Texture Batch Naming"
     hosts = ["standalonepublisher"]
     order = pype.api.ValidateContentsOrder
-    families = ["workfile", "textures"]
+    families = ["texture_batch_workfile", "textures"]
     optional = False
 
     def process(self, instance):

--- a/pype/plugins/standalonepublisher/publish/validate_texture_workfiles.py
+++ b/pype/plugins/standalonepublisher/publish/validate_texture_workfiles.py
@@ -11,7 +11,7 @@ class ValidateTextureBatchWorkfiles(pyblish.api.InstancePlugin):
     label = "Validate Texture Workfile Has Resources"
     hosts = ["standalonepublisher"]
     order = pype.api.ValidateContentsOrder
-    families = ["workfile"]
+    families = ["texture_batch_workfile"]
     optional = True
 
     def process(self, instance):


### PR DESCRIPTION
Texture validators for workfiles (`Validate Texture Presence`,  `Validate Texture Batch Naming`) triggered for even different families.

How to test is:
- Use same workfile as for Texture testing
- Select different family in middle column of SP (lets say Background Batch)
- Check that Texture validators won't appear anymore (before they would show up and fail)