### PR TITLE
Fix - texture validators for workfiles triggers only for textures workfiles

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
@@ -270,6 +270,7 @@ class CollectTextures(pyblish.api.ContextPlugin):
             # store origin
             if family == 'workfile':
                 families = self.workfile_families
+                families.append("texture_batch_workfile")
 
                 new_instance.data["source"] = "standalone publisher"
             else:

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_batch.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_batch.py
@@ -8,7 +8,7 @@ class ValidateTextureBatch(pyblish.api.InstancePlugin):
     label = "Validate Texture Presence"
     hosts = ["standalonepublisher"]
     order = openpype.api.ValidateContentsOrder
-    families = ["workfile"]
+    families = ["texture_batch_workfile"]
     optional = False
 
     def process(self, instance):

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_name.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_name.py
@@ -8,7 +8,7 @@ class ValidateTextureBatchNaming(pyblish.api.InstancePlugin):
     label = "Validate Texture Batch Naming"
     hosts = ["standalonepublisher"]
     order = openpype.api.ValidateContentsOrder
-    families = ["workfile", "textures"]
+    families = ["texture_batch_workfile", "textures"]
     optional = False
 
     def process(self, instance):

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_workfiles.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_workfiles.py
@@ -11,7 +11,7 @@ class ValidateTextureBatchWorkfiles(pyblish.api.InstancePlugin):
     label = "Validate Texture Workfile Has Resources"
     hosts = ["standalonepublisher"]
     order = openpype.api.ValidateContentsOrder
-    families = ["workfile"]
+    families = ["texture_batch_workfile"]
     optional = True
 
     # from presets


### PR DESCRIPTION
OP version of https://github.com/pypeclub/OpenPype/pull/1913

Texture validators for workfiles (Validate Texture Presence, Validate Texture Batch Naming) triggered for even different families.

How to test is:

Use same workfile as for Texture testing
Select different family in middle column of SP (lets say Background Batch)
Check that Texture validators won't appear anymore (before they would show up and fail)