### PR TITLE
#1894 - adds host to template_name_profiles for filtering

### DIFF
--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -300,7 +300,9 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         task_name = io.Session.get("AVALON_TASK")
         family = self.main_family_from_instance(instance)
 
-        key_values = {"families": family, "tasks": task_name}
+        key_values = {"families": family,
+                      "tasks": task_name,
+                      "hosts": instance.data["anatomyData"]["app"]}
         profile = filter_profiles(self.template_name_profiles, key_values,
                                   logger=self.log)
 

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -497,6 +497,12 @@
                                 "object_type": "text"
                             },
                             {
+                                "type": "hosts-enum",
+                                "key": "hosts",
+                                "label": "Hosts",
+                                "multiselection": true
+                            },
+                            {
                                 "key": "tasks",
                                 "label": "Task names",
                                 "type": "list",


### PR DESCRIPTION
 Closes #1894 

How to test;
-------------
- configure selection with selected application of specific template in `Setting > Project > Global > Publish plugins > IntegrateAssetNew > Template name profiles` (for example you can set 'workfile' family to 'work' template instead standard 'publish' for Standalone Publisher)

[cuID:yjx9d9]