### PR TITLE
Nuke: update video file crassing

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_mov.py
+++ b/openpype/hosts/nuke/plugins/load/load_mov.py
@@ -259,7 +259,8 @@ class LoadMov(api.Loader):
         read_node["last"].setValue(last)
         read_node['frame_mode'].setValue("start at")
 
-        if int(float(self.first_frame)) == int(float(read_node['frame'].value())):
+        if int(float(self.first_frame)) == int(
+                float(read_node['frame'].value())):
             # start at workfile start
             read_node['frame'].setValue(str(self.first_frame))
         else:

--- a/openpype/hosts/nuke/plugins/load/load_mov.py
+++ b/openpype/hosts/nuke/plugins/load/load_mov.py
@@ -259,7 +259,7 @@ class LoadMov(api.Loader):
         read_node["last"].setValue(last)
         read_node['frame_mode'].setValue("start at")
 
-        if int(self.first_frame) == int(read_node['frame'].value()):
+        if int(float(self.first_frame)) == int(float(read_node['frame'].value())):
             # start at workfile start
             read_node['frame'].setValue(str(self.first_frame))
         else:


### PR DESCRIPTION
# testing notes
- open Nuke in some workfile at a task
- open loader and find a subset with mov or mp4
- once you see it is having muiltiple versions reduce the version with enumerator list to lowest version 
- load video file into the nuke script
- open menu/Openpype/Manage
- update to latest version
- all should work as expected and loader should turn to green and latest version should be loaded 