### PR TITLE
Settings: Default values for enum

### DIFF
--- a/openpype/settings/entities/dict_conditional.py
+++ b/openpype/settings/entities/dict_conditional.py
@@ -141,6 +141,7 @@ class DictConditionalEntity(ItemEntity):
         self.enum_key = self.schema_data.get("enum_key")
         self.enum_label = self.schema_data.get("enum_label")
         self.enum_children = self.schema_data.get("enum_children")
+        self.enum_default = self.schema_data.get("enum_default")
 
         self.enum_entity = None
 
@@ -277,14 +278,21 @@ class DictConditionalEntity(ItemEntity):
             if isinstance(item, dict) and "key" in item:
                 valid_enum_items.append(item)
 
+        enum_keys = []
         enum_items = []
         for item in valid_enum_items:
             item_key = item["key"]
+            enum_keys.append(item_key)
             item_label = item.get("label") or item_key
             enum_items.append({item_key: item_label})
 
         if not enum_items:
             return
+
+        if self.enum_default in enum_keys:
+            default_key = self.enum_default
+        else:
+            default_key = enum_keys[0]
 
         # Create Enum child first
         enum_key = self.enum_key or "invalid"
@@ -293,7 +301,8 @@ class DictConditionalEntity(ItemEntity):
             "multiselection": False,
             "enum_items": enum_items,
             "key": enum_key,
-            "label": self.enum_label
+            "label": self.enum_label,
+            "default": default_key
         }
 
         enum_entity = self.create_schema_object(enum_schema, self)

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -73,21 +73,41 @@ class EnumEntity(BaseEnumEntity):
     def _item_initalization(self):
         self.multiselection = self.schema_data.get("multiselection", False)
         self.enum_items = self.schema_data.get("enum_items")
+        # Default is optional and non breaking attribute
+        enum_default = self.schema_data.get("default")
 
-        valid_keys = set()
+        all_keys = []
         for item in self.enum_items or []:
-            valid_keys.add(tuple(item.keys())[0])
+            key = tuple(item.keys())[0]
+            all_keys.append(key)
 
-        self.valid_keys = valid_keys
+        self.valid_keys = set(all_keys)
 
         if self.multiselection:
             self.valid_value_types = (list, )
-            self.value_on_not_set = []
+            value_on_not_set = []
+            if enum_default:
+                if not isinstance(enum_default, list):
+                    enum_default = [enum_default]
+
+                for item in enum_default:
+                    if item in all_keys:
+                        value_on_not_set.append(item)
+
+            self.value_on_not_set = value_on_not_set
+
         else:
-            for key in valid_keys:
-                if self.value_on_not_set is NOT_SET:
-                    self.value_on_not_set = key
-                    break
+            if isinstance(enum_default, list) and enum_default:
+                enum_default = enum_default[0]
+
+            if enum_default in self.valid_keys:
+                self.value_on_not_set = enum_default
+
+            else:
+                for key in all_keys:
+                    if self.value_on_not_set is NOT_SET:
+                        self.value_on_not_set = key
+                        break
 
             self.valid_value_types = (STRING_TYPE, )
 

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -375,7 +375,7 @@ How output of the schema could look like on save:
         {"ftrackreview": "Add to Ftrack"},
         {"delete": "Delete output"},
         {"slate-frame": "Add slate frame"},
-        {"no-hnadles": "Skip handle frames"}
+        {"no-handles": "Skip handle frames"}
     ]
 }
 ```

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -195,6 +195,7 @@
     - all items in `enum_children` must have at least `key` key which represents value stored under `enum_key`
     - items can define `label` for UI purposes
     - most important part is that item can define `children` key where are definitions of it's children (`children` value works the same way as in `dict`)
+- to set default value for `enum_key` set it with `enum_default`
 - entity must have defined `"label"` if is not used as widget
 - is set as group if any parent is not group
 - if `"label"` is entetered there which will be shown in GUI
@@ -359,6 +360,8 @@ How output of the schema could look like on save:
 - values are defined under value of key `"enum_items"` as list
     - each item in list is simple dictionary where value is label and key is value which will be stored
     - should be possible to enter single dictionary if order of items doesn't matter
+- it is possible to set default selected value/s with `default` attribute
+    - it is recommended to use this option only in single selection mode
 
 ```
 {

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -362,6 +362,7 @@ How output of the schema could look like on save:
     - should be possible to enter single dictionary if order of items doesn't matter
 - it is possible to set default selected value/s with `default` attribute
     - it is recommended to use this option only in single selection mode
+    - at the end this option is used only when defying default settings value or in dynamic items
 
 ```
 {


### PR DESCRIPTION
## Description
- Entity `dict-conditional` may need to have set default enum value.

## Changes
- `enum` entity may have defined default value (even in mutiselection)
    - this is usable only for dynamic items that may not have set default values (like `dict-conditional`)
- `dict-conditional` may have defined default enum

## How to test
- set `"default"` attribute on any `enum` in `list` or `dict-modifiable`
- the default should be selected on adding new item
```
# New list item should always have selected `Add to Ftrack`
{
    "type": "list",
    "key": "test",
    "label": "Test",
    "object_type": {
        "type": "enum",
        "default": "ftrackreview",
        "enum_items": [
            {"burnin": "Add burnins"},
            {"ftrackreview": "Add to Ftrack"}
        ]
    }
}
```