### PR TITLE
Fix - validate takes repre["files"] as list all the time

### DIFF
--- a/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
+++ b/openpype/modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
@@ -181,6 +181,10 @@ class ValidateExpectedFiles(pyblish.api.InstancePlugin):
         """Returns set of file names from metadata.json"""
         expected_files = set()
 
-        for file_name in repre["files"]:
+        files = repre["files"]
+        if not isinstance(files, list):
+            files = [files]
+
+        for file_name in files:
             expected_files.add(file_name)
         return expected_files


### PR DESCRIPTION
repre["files"] might be list or str, loop for string wasn't working