### PR TITLE
Duplicate family name.

### DIFF
--- a/pype/plugins/photoshop/create/create_image.py
+++ b/pype/plugins/photoshop/create/create_image.py
@@ -80,7 +80,7 @@ class CreateImage(pype.api.Creator):
                                       replace(stub.LOADED_ICON, '')
                     long_names.append(name)
 
-            self.data.update({"subset": "image" + group.name})
+            self.data.update({"subset": group.name})
             self.data.update({"uuid": str(group.id)})
             self.data.update({"long_name": "_".join(long_names)})
             stub.imprint(group, self.data)


### PR DESCRIPTION
Subset name comes out as "imageImage[name]"