### PR TITLE
Fix - make AE workfile publish to Ftrack configurable

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -47,7 +47,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
             "subset": subset,
             "label": scene_file,
             "family": family,
-            "families": [family, "ftrack"],
+            "families": [family],
             "representations": list()
         })
 

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -304,7 +304,8 @@
                         "aftereffects"
                     ],
                     "families": [
-                        "render"
+                        "render",
+                        "workfile"
                     ],
                     "tasks": [],
                     "add_ftrack_family": true,


### PR DESCRIPTION
By default workfile is sent to Ftrack, could be disabled by Settings