### PR TITLE
Add face sets to exported alembics

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -24,6 +24,7 @@ class CreateAnimation(plugin.Creator):
 
         # Write vertex colors with the geometry.
         self.data["writeColorSets"] = False
+        self.data["writeFaceSets"] = False
 
         # Include only renderable visible shapes.
         # Skips locators and empty transforms

--- a/openpype/hosts/maya/plugins/create/create_model.py
+++ b/openpype/hosts/maya/plugins/create/create_model.py
@@ -15,6 +15,7 @@ class CreateModel(plugin.Creator):
 
         # Vertex colors with the geometry
         self.data["writeColorSets"] = False
+        self.data["writeFaceSets"] = False
 
         # Include attributes by attribute name or prefix
         self.data["attr"] = ""

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -20,6 +20,7 @@ class CreatePointCache(plugin.Creator):
         self.data.update(lib.collect_animation_data())
 
         self.data["writeColorSets"] = False  # Vertex colors with the geometry.
+        self.data["writeFaceSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible
         self.data["includeParentHierarchy"] = False  # Include parent groups

--- a/openpype/hosts/maya/plugins/publish/extract_animation.py
+++ b/openpype/hosts/maya/plugins/publish/extract_animation.py
@@ -57,7 +57,8 @@ class ExtractAnimation(openpype.api.Extractor):
             "uvWrite": True,
             "selection": True,
             "worldSpace": instance.data.get("worldSpace", True),
-            "writeColorSets": instance.data.get("writeColorSets", False)
+            "writeColorSets": instance.data.get("writeColorSets", False),
+            "writeFaceSets": instance.data.get("writeFaceSets", False)
         }
 
         if not instance.data.get("includeParentHierarchy", True):

--- a/openpype/hosts/maya/plugins/publish/extract_model.py
+++ b/openpype/hosts/maya/plugins/publish/extract_model.py
@@ -28,6 +28,7 @@ class ExtractModel(openpype.api.Extractor):
     hosts = ["maya"]
     families = ["model"]
     scene_type = "ma"
+    optional = True
 
     def process(self, instance):
         """Plugin entry point."""

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -38,6 +38,7 @@ class ExtractAlembic(openpype.api.Extractor):
 
         # Get extra export arguments
         writeColorSets = instance.data.get("writeColorSets", False)
+        writeFaceSets = instance.data.get("writeFaceSets", False)
 
         self.log.info("Extracting pointcache..")
         dirname = self.staging_dir(instance)
@@ -53,6 +54,7 @@ class ExtractAlembic(openpype.api.Extractor):
             "writeVisibility": True,
             "writeCreases": True,
             "writeColorSets": writeColorSets,
+            "writeFaceSets": writeFaceSets,
             "uvWrite": True,
             "selection": True,
             "worldSpace": instance.data.get("worldSpace", True)


### PR DESCRIPTION
Add possibility to keep facesets in the alembic exports. This technically allows to keep material assignments (not the materials) on the alembic when it gets imported to a different host than maya.