### PR TITLE
Maya: Menu actions fix

### DIFF
--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -86,7 +86,7 @@ def deferred():
     def remove_project_manager():
         top_menu = _get_menu()
 
-        # Try to find workfile tool action in the menu
+        # Try to find "System" menu action in the menu
         system_menu = None
         for action in top_menu.actions():
             if action.text() == "System":
@@ -96,12 +96,14 @@ def deferred():
         if system_menu is None:
             return
 
+        # Try to find "Project manager" action in "System" menu
         project_manager_action = None
         for action in system_menu.menu().children():
             if hasattr(action, "text") and action.text() == "Project Manager":
                 project_manager_action = action
                 break
 
+        # Remove "Project manager" action if was found
         if project_manager_action is not None:
             system_menu.menu().removeAction(project_manager_action)
 

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -16,12 +16,10 @@ log = logging.getLogger(__name__)
 
 def _get_menu(menu_name=None):
     """Return the menu instance if it currently exists in Maya"""
-
-    project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
-    _menu = project_settings["maya"]["scriptsmenu"]["name"]
-
     if menu_name is None:
-        menu_name = _menu
+        project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+        menu_name = project_settings["maya"]["scriptsmenu"]["name"]
+
     widgets = dict((
         w.objectName(), w) for w in QtWidgets.QApplication.allWidgets())
     menu = widgets.get(menu_name)

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -56,6 +56,34 @@ def deferred():
                 parent=pipeline._parent
             )
 
+        # Find the pipeline menu
+        top_menu = _get_menu(pipeline._menu)
+
+        # Try to find workfile tool action in the menu
+        workfile_action = None
+        for action in top_menu.actions():
+            if action.text() == "Work Files":
+                workfile_action = action
+                break
+
+        # Add at the top of menu if "Work Files" action was not found
+        after_action = ""
+        if workfile_action:
+            # Use action's object name for `insertAfter` argument
+            after_action = workfile_action.objectName()
+
+        # Insert action to menu
+        cmds.menuItem(
+            "Work Files",
+            parent=pipeline._menu,
+            command=launch_workfiles_app,
+            insertAfter=after_action
+        )
+
+        # Remove replaced action
+        if workfile_action:
+            top_menu.removeAction(workfile_action)
+
     log.info("Attempting to install scripts menu ...")
 
     add_build_workfiles_item()

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -161,7 +161,6 @@ def install():
         log.info("Skipping openpype.menu initialization in batch mode..")
         return
 
-    uninstall()
     # Allow time for uninstallation to finish.
     cmds.evalDeferred(deferred)
 

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -98,11 +98,9 @@ def deferred():
 
         project_manager_action = None
         for action in system_menu.menu().children():
-            if hasattr(action, "text"):
-                print(action.text())
-                if action.text() == "Project Manager":
-                    project_manager_action = action
-                    break
+            if hasattr(action, "text") and action.text() == "Project Manager":
+                project_manager_action = action
+                break
 
         if project_manager_action is not None:
             system_menu.menu().removeAction(project_manager_action)

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -17,8 +17,7 @@ log = logging.getLogger(__name__)
 def _get_menu(menu_name=None):
     """Return the menu instance if it currently exists in Maya"""
     if menu_name is None:
-        project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
-        menu_name = project_settings["maya"]["scriptsmenu"]["name"]
+        menu_name = pipeline._menu
 
     widgets = dict((
         w.objectName(), w) for w in QtWidgets.QApplication.allWidgets())
@@ -57,7 +56,7 @@ def deferred():
             )
 
         # Find the pipeline menu
-        top_menu = _get_menu(pipeline._menu)
+        top_menu = _get_menu()
 
         # Try to find workfile tool action in the menu
         workfile_action = None
@@ -85,7 +84,7 @@ def deferred():
             top_menu.removeAction(workfile_action)
 
     def remove_project_manager():
-        top_menu = _get_menu(pipeline._menu)
+        top_menu = _get_menu()
 
         # Try to find workfile tool action in the menu
         system_menu = None

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -84,11 +84,36 @@ def deferred():
         if workfile_action:
             top_menu.removeAction(workfile_action)
 
+    def remove_project_manager():
+        top_menu = _get_menu(pipeline._menu)
+
+        # Try to find workfile tool action in the menu
+        system_menu = None
+        for action in top_menu.actions():
+            if action.text() == "System":
+                system_menu = action
+                break
+
+        if system_menu is None:
+            return
+
+        project_manager_action = None
+        for action in system_menu.menu().children():
+            if hasattr(action, "text"):
+                print(action.text())
+                if action.text() == "Project Manager":
+                    project_manager_action = action
+                    break
+
+        if project_manager_action is not None:
+            system_menu.menu().removeAction(project_manager_action)
+
     log.info("Attempting to install scripts menu ...")
 
     add_build_workfiles_item()
     add_look_assigner_item()
     modify_workfiles()
+    remove_project_manager()
 
     try:
         import scriptsmenu.launchformaya as launchformaya


### PR DESCRIPTION
## Issue
- there is not used OpenPype workfiles in Maya
- maya menu has unusable project manager action

## Changes
- replaced avalon workfiles with openpype workfiles
- removed project manager action
- `_get_menu` does not care about scripts menu settings
- do not run `uninstall` on `install`

Resolves https://github.com/pypeclub/OpenPype/issues/1944