### PR TITLE
Maya: Add Xgen family support

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_xgen.py
+++ b/openpype/hosts/maya/plugins/create/create_xgen.py
@@ -1,0 +1,11 @@
+from openpype.hosts.maya.api import plugin
+
+
+class CreateXgen(plugin.Creator):
+    """Xgen interactive export"""
+
+    name = "xgen"
+    label = "Xgen Interactive"
+    family = "xgen"
+    icon = "pagelines"
+    defaults = ['Main']

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -17,7 +17,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 "layout",
                 "camera",
                 "rig",
-                "camerarig"]
+                "camerarig",
+                "xgen"]
     representations = ["ma", "abc", "fbx", "mb"]
 
     label = "Reference"

--- a/openpype/hosts/maya/plugins/publish/extract_maya_scene_raw.py
+++ b/openpype/hosts/maya/plugins/publish/extract_maya_scene_raw.py
@@ -19,7 +19,8 @@ class ExtractMayaSceneRaw(openpype.api.Extractor):
     families = ["mayaAscii",
                 "setdress",
                 "layout",
-                "camerarig"]
+                "camerarig",
+                "xgen"]
     scene_type = "ma"
 
     def process(self, instance):

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -19,7 +19,8 @@ class ExtractAlembic(openpype.api.Extractor):
     hosts = ["maya"]
     families = ["pointcache",
                 "model",
-                "vrayproxy"]
+                "vrayproxy",
+                "xgen"]
 
     def process(self, instance):
 

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -19,8 +19,7 @@ class ExtractAlembic(openpype.api.Extractor):
     hosts = ["maya"]
     families = ["pointcache",
                 "model",
-                "vrayproxy",
-                "xgen"]
+                "vrayproxy"]
 
     def process(self, instance):
 

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -19,8 +19,8 @@ class ExtractXgenCache(openpype.api.Extractor):
     def process(self, instance):
 
         # Collect the out set nodes
-        out_descriptions = [(node for node in instance
-                            if cmds.nodeType(node) == "xgmSplineDescription")]
+        out_descriptions = [node for node in instance
+                            if cmds.nodeType(node) == "xgmSplineDescription"]
 
         start = 1
         end = 1

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -1,0 +1,69 @@
+import os
+
+from maya import cmds
+
+import avalon.maya
+import openpype.api
+from openpype.hosts.maya.api.lib import extract_alembic
+
+
+class ExtractXgenCache(openpype.api.Extractor):
+    """Produce an alembic of just xgen interactive groom
+
+    """
+
+    label = "Extract Xgen Cache"
+    hosts = ["maya"]
+    families = ["xgen"]
+
+    def process(self, instance):
+
+        # Collect the out set nodes
+        out_descriptions = [node for node in instance if cmds.nodeType(node) == "xgmSplineDescription"]
+
+        self.log.info(out_descriptions)
+
+        out_description = out_descriptions[0]
+        self.log.info(out_description)
+
+        # Include all descendants
+        # nodes = roots + cmds.listRelatives(roots,
+        #                                    allDescendents=True,
+        #                                    fullPath=True) or []
+
+        # Collect the start and end including handles
+        # start = instance.data["frameStart"]
+        # end = instance.data["frameEnd"]
+        start = 1
+        end = 1
+        # handles = instance.data.get("handles", 0) or 0
+        # if handles:
+        #     start -= handles
+        #     end += handles
+
+        self.log.info("Extracting Xgen Cache..")
+        dirname = self.staging_dir(instance)
+
+        parent_dir = self.staging_dir(instance)
+        filename = "{name}.abc".format(**instance.data)
+        path = os.path.join(parent_dir, filename)
+
+        with avalon.maya.suspended_refresh():
+            with avalon.maya.maintained_selection():
+                command = ('-file ' + path + ' -df "ogawa" -fr ' + str(start) + ' ' + str(end) + ' -step 1 -mxf -wfw')
+                for desc in out_descriptions:
+                    command += (" -obj " + desc)
+                cmds.xgmSplineCache(export=True, j=command)
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        representation = {
+            'name': 'abc',
+            'ext': 'abc',
+            'files': filename,
+            "stagingDir": dirname,
+        }
+        instance.data["representations"].append(representation)
+
+        self.log.info("Extracted {} to {}".format(instance, dirname))

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -4,7 +4,6 @@ from maya import cmds
 
 import avalon.maya
 import openpype.api
-from openpype.hosts.maya.api.lib import extract_alembic
 
 
 class ExtractXgenCache(openpype.api.Extractor):
@@ -19,27 +18,11 @@ class ExtractXgenCache(openpype.api.Extractor):
     def process(self, instance):
 
         # Collect the out set nodes
-        out_descriptions = [node for node in instance if cmds.nodeType(node) == "xgmSplineDescription"]
+        out_descriptions = [(node for node in instance
+                            if cmds.nodeType(node) == "xgmSplineDescription")]
 
-        self.log.info(out_descriptions)
-
-        out_description = out_descriptions[0]
-        self.log.info(out_description)
-
-        # Include all descendants
-        # nodes = roots + cmds.listRelatives(roots,
-        #                                    allDescendents=True,
-        #                                    fullPath=True) or []
-
-        # Collect the start and end including handles
-        # start = instance.data["frameStart"]
-        # end = instance.data["frameEnd"]
         start = 1
         end = 1
-        # handles = instance.data.get("handles", 0) or 0
-        # if handles:
-        #     start -= handles
-        #     end += handles
 
         self.log.info("Extracting Xgen Cache..")
         dirname = self.staging_dir(instance)

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -51,11 +51,11 @@ class ExtractXgenCache(openpype.api.Extractor):
         with avalon.maya.suspended_refresh():
             with avalon.maya.maintained_selection():
                 command = (
-                    '-file ' 
-                    + path 
-                    + ' -df "ogawa" -fr ' 
-                    + str(start) 
-                    + ' ' 
+                    '-file '
+                    + path
+                    + ' -df "ogawa" -fr '
+                    + str(start)
+                    + ' '
                     + str(end)
                     + ' -step 1 -mxf -wfw'
                 )

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -50,7 +50,15 @@ class ExtractXgenCache(openpype.api.Extractor):
 
         with avalon.maya.suspended_refresh():
             with avalon.maya.maintained_selection():
-                command = ('-file ' + path + ' -df "ogawa" -fr ' + str(start) + ' ' + str(end) + ' -step 1 -mxf -wfw')
+                command = (
+                    '-file ' 
+                    + path 
+                    + ' -df "ogawa" -fr ' 
+                    + str(start) 
+                    + ' ' 
+                    + str(end)
+                    + ' -step 1 -mxf -wfw'
+                )
                 for desc in out_descriptions:
                     command += (" -obj " + desc)
                 cmds.xgmSplineCache(export=True, j=command)

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -11,9 +11,10 @@ class ExtractXgenCache(openpype.api.Extractor):
 
     """
 
-    label = "Extract Xgen Cache"
+    label = "Extract Xgen ABC Cache"
     hosts = ["maya"]
     families = ["xgen"]
+    optional = true
 
     def process(self, instance):
 

--- a/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_xgen_cache.py
@@ -14,7 +14,7 @@ class ExtractXgenCache(openpype.api.Extractor):
     label = "Extract Xgen ABC Cache"
     hosts = ["maya"]
     families = ["xgen"]
-    optional = true
+    optional = True
 
     def process(self, instance):
 

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -97,7 +97,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 "background",
                 "camerarig",
                 "redshiftproxy",
-                "effect"
+                "effect",
+                "xgen"
                 ]
     exclude_families = ["clip"]
     db_representation_context_keys = [

--- a/website/docs/artist_hosts_maya.md
+++ b/website/docs/artist_hosts_maya.md
@@ -714,6 +714,11 @@ To prepare xgen for publishing just select all the descriptions that should be p
 For actual publishing of your groom to go **OpenPype → Publish** and then press ▶ to publish. This will export `.ma` file containing your grooms with any geometries they are attached to and also a baked cache in `.abc` format 
 
 
+:::tip adding more descriptions
+You can add multiple xgen desctiption into the subset you are about to publish, simply by
+adding them to the maya set that was created for you. Please make sure that only xgen description nodes are present inside of the set and not the scalp geometry. 
+:::
+
 ### Loading Xgen
 
 You can use published xgens by loading them using OpenPype Publisher. You can choose to reference or import xgen. We don't have any automatic mesh linking at the moment and it is expected, that groom is published with a scalp, that can then be manually attached to your animated mesh for example. 

--- a/website/docs/artist_hosts_maya.md
+++ b/website/docs/artist_hosts_maya.md
@@ -701,6 +701,27 @@ under `input_SET`). This mechanism uses *cbId* attribute on those shapes.
 If match is found shapes are connected using their `outMesh` and `outMesh`. Thus you can easily connect existing animation to loaded rig.
 :::
 
+## Working with Xgen in OpenPype
+
+OpenPype support publishing and loading of Xgen interactive grooms. You can publish 
+them as mayaAscii files with scalps that can be loaded into another maya scene, or as
+alembic caches. 
+
+### Publishing Xgen Grooms
+
+To prepare xgen for publishing just select all the descriptions that should be published together and the create Xgen Subset in the scene using - **OpenPype menu** → **Create**... and select **Xgen Interactive**. Leave Use selection checked.
+
+For actual publishing of your groom to go **OpenPype → Publish** and then press ▶ to publish. This will export `.ma` file containing your grooms with any geometries they are attached to and also a baked cache in `.abc` format 
+
+
+### Loading Xgen
+
+You can use published xgens by loading them using OpenPype Publisher. You can choose to reference or import xgen. We don't have any automatic mesh linking at the moment and it is expected, that groom is published with a scalp, that can then be manually attached to your animated mesh for example. 
+
+The alembic representation can be loaded too and it contains the groom converted to curves. Keep in mind that the density of the alembic directly depends on your viewport xgen density at the point of export.
+
+
+
 ## Using Redshift Proxies
 
 OpenPype supports working with Redshift Proxy files. You can create  Redshift Proxy from almost


### PR DESCRIPTION
This PR adds basic support for publishing and loading Xgen in Maya. It only works with interactive grooms, which get published as maya ascii with any attached scalps and at the same time as baked alembic curves.

To test this you need to create a mesh with xgen interactive groom. Then you can create new xgen family with the xgen node selected. When you publish you should end up with .ma and .abc representations. 

At the moment there are no settings, but will need to probably add at least enable/optional settings for the plugins
