### PR TITLE
Global: Define hosts in CollectSceneVersion

### DIFF
--- a/openpype/plugins/publish/collect_scene_version.py
+++ b/openpype/plugins/publish/collect_scene_version.py
@@ -11,14 +11,22 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
 
     order = pyblish.api.CollectorOrder
     label = 'Collect Version'
+    hosts = [
+        "aftereffects",
+        "blender",
+        "celaction",
+        "fusion",
+        "harmony",
+        "hiero",
+        "houdini",
+        "maya",
+        "nuke",
+        "photoshop",
+        "resolve",
+        "tvpaint"
+    ]
 
     def process(self, context):
-        if "standalonepublisher" in context.data.get("host", []):
-            return
-
-        if "unreal" in pyblish.api.registered_hosts():
-            return
-
         assert context.data.get('currentFile'), "Cannot get current file"
         filename = os.path.basename(context.data.get('currentFile'))
 


### PR DESCRIPTION
 ## Changes
- `CollectSceneVersion` plugin has defined hosts for which should be processed instead of excluding them in process method

[cuID:yjx9fq]