### PR TITLE
Global: Avalon Host name collector

### DIFF
--- a/openpype/plugins/publish/collect_host_name.py
+++ b/openpype/plugins/publish/collect_host_name.py
@@ -1,0 +1,21 @@
+"""
+Requires:
+    None
+Provides:
+    context -> host (str)
+"""
+import os
+import pyblish.api
+
+
+class CollectHostName(pyblish.api.ContextPlugin):
+    """Collect avalon host name to context."""
+
+    label = "Collect Host Name"
+    order = pyblish.api.CollectorOrder
+
+    def process(self, context):
+        # Don't override value if is already set
+        host_name = context.data.get("host")
+        if not host_name:
+            context.data["host"] = os.environ.get("AVALON_APP")


### PR DESCRIPTION
## Description
We don't have 100% unified where from should be host name used.

## Changes
- add collector which collects host name which can be used across all plugins

## Note
- second step is to replace current host name usage in plugins where host name is used
- maybe order change will be required