### PR TITLE
CI: change release numbering triggers

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -47,7 +47,7 @@ jobs:
         enhancementLabel: '**🚀 Enhancements**'
         bugsLabel: '**🐛 Bug fixes**'
         deprecatedLabel: '**⚠️ Deprecations**'
-        addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["documentation"]},"tests":{"prefix":"### ✅ Testing","labels":["tests"]}}'
+        addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["documentation"]},"tests":{"prefix":"### ✅ Testing","labels":["tests"]},"feature":{"prefix":"### 🆕 New features","labels":["feature"]},}'
         issues: false
         issuesWoLabels: false
         sinceTag: "3.0.0"

--- a/tools/ci_tools.py
+++ b/tools/ci_tools.py
@@ -36,7 +36,7 @@ def get_log_since_tag(version):
 
 def release_type(log):
     regex_minor = ["feature/", "(feat)"]
-    regex_patch = ["bugfix/", "fix/", "(fix)"]
+    regex_patch = ["bugfix/", "fix/", "(fix)", "enhancement/"]
     for reg in regex_minor:
         if re.search(reg, log):
             return "minor"


### PR DESCRIPTION
 Right now we are automatically rising minor version every time an `enhancement` is merged into the develop. Due to the speed that we are adding things, that are technically enhancement, but they are very small, it effectivelly means, that `patch` versioning never kicks in. We practically never have only a bugfix release. 

This PR proposes a shift in this strategy. We'll divide all PRs into `Features`, `Enhancements` and `Bugs`

`Feature` - adds new functionality that specifically affects user.
`Enhancement` - improves on existing functionality, adds new things that don't directly affects what user sees (most of the backend changes)
`Bug` - Fixing an issue with existing functionality. 

Separation between these is of course somewhat arbitrary and if you're unclear if what you are submitting is Enhancement or a Feature, let's discuss and clarify as we go along.

 The target here is, that minor version bumps should tell the user that there is something new for them, whereas patch bumps is more about improving on existing feature set.

[cuID:yjx9en]