### PR TITLE
Maya: Enable publishing render attrib sets (e.g. V-Ray Displacement) with model

### DIFF
--- a/openpype/hosts/maya/api/__init__.py
+++ b/openpype/hosts/maya/api/__init__.py
@@ -35,6 +35,7 @@ def install():
     pyblish.register_plugin_path(PUBLISH_PATH)
     avalon.register_plugin_path(avalon.Loader, LOAD_PATH)
     avalon.register_plugin_path(avalon.Creator, CREATE_PATH)
+    avalon.register_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
     log.info(PUBLISH_PATH)
     menu.install()
 
@@ -97,6 +98,7 @@ def uninstall():
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     avalon.deregister_plugin_path(avalon.Loader, LOAD_PATH)
     avalon.deregister_plugin_path(avalon.Creator, CREATE_PATH)
+    avalon.deregister_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
 
     menu.uninstall()
 

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -1,0 +1,85 @@
+from avalon import api, io
+
+
+class ImportModelRender(api.InventoryAction):
+
+    label = "Import Model Render Sets"
+    icon = "industry"
+    color = "#55DDAA"
+
+    scene_type = "meta.render.ma"
+    look_data_type = "meta.render.json"
+
+    @staticmethod
+    def is_compatible(container):
+        return container.get("loader") == "ReferenceLoader" \
+               and container.get("name", "").startswith("model")
+
+    def process(self, containers):
+        from maya import cmds
+
+        for container in containers:
+            container_name = container["objectName"]
+            nodes = []
+            for n in cmds.sets(container_name, query=True, nodesOnly=True) or []:
+                if cmds.nodeType(n) == "reference":
+                    nodes += cmds.referenceQuery(n, nodes=True)
+                else:
+                    nodes.append(n)
+
+            repr_doc = io.find_one({"_id": io.ObjectId(container["representation"])})
+            version_id = repr_doc["parent"]
+
+            print("Importing render sets for model %r" % container_name)
+            self.assign_model_render_by_version(nodes, version_id)
+
+    def assign_model_render_by_version(self, nodes, version_id):
+        """Assign nodes a specific published model render data version by id.
+
+        This assumes the nodes correspond with the asset.
+
+        Args:
+            nodes(list): nodes to assign render data to
+            version_id (bson.ObjectId): database id of the version of model
+
+        Returns:
+            None
+        """
+        import json
+        from maya import cmds
+        from avalon import maya, io, pipeline
+        from openpype.hosts.maya.api import lib
+
+        # Get representations of shader file and relationships
+        look_representation = io.find_one({"type": "representation",
+                                           "parent": version_id,
+                                           "name": self.scene_type})
+
+        if not look_representation:
+            print("No model render sets for this model version..")
+            return
+
+        json_representation = io.find_one({"type": "representation",
+                                           "parent": version_id,
+                                           "name": self.look_data_type})
+
+        context = pipeline.get_representation_context(look_representation['_id'])
+        maya_file = pipeline.get_representation_path_from_context(context)
+
+        context = pipeline.get_representation_context(json_representation['_id'])
+        json_file = pipeline.get_representation_path_from_context(context)
+
+        # Import the look file
+        with maya.maintained_selection():
+            shader_nodes = cmds.file(maya_file,
+                                     i=True,  # import
+                                     returnNewNodes=True)
+            # imprint context data
+
+        # Load relationships
+        shader_relation = json_file
+        with open(shader_relation, "r") as f:
+            relationships = json.load(f)
+
+        # Assign relationships
+        lib.apply_shaders(relationships, shader_nodes, nodes)

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -19,18 +19,20 @@ class ImportModelRender(api.InventoryAction):
         from maya import cmds
 
         for container in containers:
-            container_name = container["objectName"]
+            con_name = container["objectName"]
             nodes = []
-            for n in cmds.sets(container_name, query=True, nodesOnly=True) or []:
+            for n in cmds.sets(con_name, query=True, nodesOnly=True) or []:
                 if cmds.nodeType(n) == "reference":
                     nodes += cmds.referenceQuery(n, nodes=True)
                 else:
                     nodes.append(n)
 
-            repr_doc = io.find_one({"_id": io.ObjectId(container["representation"])})
+            repr_doc = io.find_one({
+                "_id": io.ObjectId(container["representation"]),
+            })
             version_id = repr_doc["parent"]
 
-            print("Importing render sets for model %r" % container_name)
+            print("Importing render sets for model %r" % con_name)
             self.assign_model_render_by_version(nodes, version_id)
 
     def assign_model_render_by_version(self, nodes, version_id):
@@ -51,22 +53,25 @@ class ImportModelRender(api.InventoryAction):
         from openpype.hosts.maya.api import lib
 
         # Get representations of shader file and relationships
-        look_representation = io.find_one({"type": "representation",
-                                           "parent": version_id,
-                                           "name": self.scene_type})
-
-        if not look_representation:
+        look_repr = io.find_one({
+            "type": "representation",
+            "parent": version_id,
+            "name": self.scene_type,
+        })
+        if not look_repr:
             print("No model render sets for this model version..")
             return
 
-        json_representation = io.find_one({"type": "representation",
-                                           "parent": version_id,
-                                           "name": self.look_data_type})
+        json_repr = io.find_one({
+            "type": "representation",
+            "parent": version_id,
+            "name": self.look_data_type,
+        })
 
-        context = pipeline.get_representation_context(look_representation['_id'])
+        context = pipeline.get_representation_context(look_repr["_id"])
         maya_file = pipeline.get_representation_path_from_context(context)
 
-        context = pipeline.get_representation_context(json_representation['_id'])
+        context = pipeline.get_representation_context(json_repr["_id"])
         json_file = pipeline.get_representation_path_from_context(context)
 
         # Import the look file

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -7,7 +7,7 @@ class ImportModelRender(api.InventoryAction):
     icon = "industry"
     color = "#55DDAA"
 
-    scene_type = "meta.render.ma"
+    scene_type_regex = "meta.render.m[ab]"
     look_data_type = "meta.render.json"
 
     @staticmethod
@@ -58,7 +58,7 @@ class ImportModelRender(api.InventoryAction):
         look_repr = io.find_one({
             "type": "representation",
             "parent": version_id,
-            "name": self.scene_type,
+            "name": {"$regex": self.scene_type_regex},
         })
         if not look_repr:
             print("No model render sets for this model version..")

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -12,8 +12,10 @@ class ImportModelRender(api.InventoryAction):
 
     @staticmethod
     def is_compatible(container):
-        return container.get("loader") == "ReferenceLoader" \
-               and container.get("name", "").startswith("model")
+        return (
+            container.get("loader") == "ReferenceLoader"
+            and container.get("name", "").startswith("model")
+        )
 
     def process(self, containers):
         from maya import cmds

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -152,15 +152,3 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 options={"useSelection": True},
                 data={"dependencies": dependency}
             )
-
-
-class AugmentedModelLoader(ReferenceLoader):
-    """Load augmented model via Maya referencing"""
-
-    families = ["model"]
-    representations = ["fried.ma", "fried.mb"]
-
-    label = "Fried Model"
-    order = -9
-    icon = "code-fork"
-    color = "yellow"

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -152,3 +152,15 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 options={"useSelection": True},
                 data={"dependencies": dependency}
             )
+
+
+class AugmentedModelLoader(ReferenceLoader):
+    """Load augmented model via Maya referencing"""
+
+    families = ["model"]
+    representations = ["fried.ma", "fried.mb"]
+
+    label = "Fried Model"
+    order = -9
+    icon = "code-fork"
+    color = "yellow"

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -568,7 +568,8 @@ class CollectLook(pyblish.api.InstancePlugin):
 class CollectModelRenderSets(CollectLook):
     """Collect render attribute sets for model instance.
 
-    This enables additional render attributes be published with model.
+    Collects additional render attribute sets so they can be
+    published with model.
 
     """
 

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -362,6 +362,8 @@ class CollectLook(pyblish.api.InstancePlugin):
                 "VRayDisplacement",
                 "VRayLightMesh",
                 "VRayObjectProperties",
+                "RedshiftObjectId",
+                "RedshiftMeshParameters",
             ]
             render_sets = cmds.ls(look_sets, type=render_set_types)
             if render_sets:

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -364,7 +364,9 @@ class CollectLook(pyblish.api.InstancePlugin):
             render_sets = cmds.ls(look_sets, type=render_set_types)
             if render_sets:
                 history.extend(
-                    cmds.listHistory(render_sets, future=False, pruneDagObjects=True)
+                    cmds.listHistory(render_sets,
+                                     future=False,
+                                     pruneDagObjects=True)
                     or []
                 )
 
@@ -579,8 +581,9 @@ class CollectModelRenderSets(CollectLook):
     def process(self, instance):
         """Collect the Look in the instance with the correct layer settings"""
         model_nodes = instance[:]
+        renderlayer = instance.data.get("renderlayer", "defaultRenderLayer")
 
-        with lib.renderlayer(instance.data.get("renderlayer", "defaultRenderLayer")):
+        with lib.renderlayer(renderlayer):
             self.collect(instance)
 
         set_nodes = [m for m in instance if m not in model_nodes]

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -223,8 +223,8 @@ class CollectLook(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         """Collect the Look in the instance with the correct layer settings"""
-
-        with lib.renderlayer(instance.data["renderlayer"]):
+        renderlayer = instance.data.get("renderlayer", "defaultRenderLayer")
+        with lib.renderlayer(renderlayer):
             self.collect(instance)
 
     def collect(self, instance):
@@ -578,26 +578,6 @@ class CollectModelRenderSets(CollectLook):
     label = "Collect Model Render Sets"
     hosts = ["maya"]
     maketx = True
-
-    def process(self, instance):
-        """Collect the Look in the instance with the correct layer settings"""
-        model_nodes = instance[:]
-        renderlayer = instance.data.get("renderlayer", "defaultRenderLayer")
-
-        with lib.renderlayer(renderlayer):
-            self.collect(instance)
-
-        set_nodes = [m for m in instance if m not in model_nodes]
-        instance[:] = model_nodes
-
-        if set_nodes:
-            instance.data["modelRenderSets"] = set_nodes
-            instance.data["modelRenderSetsHistory"] = \
-                cmds.listHistory(set_nodes, future=False, pruneDagObjects=True)
-
-            self.log.info("Model render sets collected.")
-        else:
-            self.log.info("No model render sets.")
 
     def collect_sets(self, instance):
         """Collect all related objectSets except shadingEngines

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -360,6 +360,8 @@ class CollectLook(pyblish.api.InstancePlugin):
             # handling render attribute sets
             render_set_types = [
                 "VRayDisplacement",
+                "VRayLightMesh",
+                "VRayObjectProperties",
             ]
             render_sets = cmds.ls(look_sets, type=render_set_types)
             if render_sets:

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -489,9 +489,9 @@ class ExtractLook(openpype.api.Extractor):
 class ExtractModelRenderSets(ExtractLook):
     """Extract model render attribute sets as model metadata
 
-    Only extracts the render attrib sets (NO shadingEngines) alongside a .json file
-    that stores it relationships for the sets and "attribute" data for the
-    instance members.
+    Only extracts the render attrib sets (NO shadingEngines) alongside
+    a .json file that stores it relationships for the sets and "attribute"
+    data for the instance members.
 
     """
 

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -518,21 +518,7 @@ class ExtractAugmentedModel(ExtractLook):
             self.log.info("Model is not render augmented, skip extraction.")
             return
 
-        ext_mapping = (
-            instance.context.data["project_settings"]["maya"]["ext_mapping"]
-        )
-        if ext_mapping:
-            self.log.info("Looking in settings for scene type ...")
-            # use extension mapping for first family found
-            for family in self.families:
-                try:
-                    self.scene_type = ext_mapping[family]
-                    self.log.info(
-                        "Using {} as scene type".format(self.scene_type))
-                    break
-                except KeyError:
-                    # no preset found
-                    pass
+        self.get_maya_scene_type(instance)
 
         if "representations" not in instance.data:
             instance.data["representations"] = []


### PR DESCRIPTION
 This close pypeclub/client#137.

## Feature

Enable extracting render attribute sets (e.g. V-Ray Displacement) while publishing model, as model representation's metadata. So optionally, lookdev artist could use them while working on the model as for a suggestion (or bootstrap) from modeler.


## Workflow

1. Say a modeler have this scene ready to publish a model. There are some simple shading and displacement sets applied to those meshes.

    ![image](https://user-images.githubusercontent.com/3357009/132538850-53c61f4a-89b4-435b-8e9b-76d5d6676b17.png)

2. Modeler published the model, lookdev artist takeover and start to work. Model has been referenced from Loader.

    ![image](https://user-images.githubusercontent.com/3357009/132539108-96c0a162-2b12-448c-9014-fd94e6fe25c9.png)

3. Lookdev artist go to the Scene Inventory tool, trying to apply render attribute sets which has been published with current loaded model, to see if they could help.

   ![image](https://user-images.githubusercontent.com/3357009/132539230-0d8192b9-cdbb-4d61-a274-a33e8a63450a.png)

4. Render attribute sets has been imported, now the lookdev artist can play with them however he/she wants. Even delete or rename those sets, and whether or not to publish look with them.

    ![image](https://user-images.githubusercontent.com/3357009/132539288-f679f491-364a-49b9-89c7-a5a068813bb2.png)


## Implementation

In contrast to previous implementation (90d80dc), this refactored workflow doesn't change the content of current representation nor add new representation.

Well actually there are two new representation types (`meta.render.ma` and `meta.render.json`) be extracted on model publishing since the render attribute sets are being treated as look, just that there are no Loader plugin for them so they won't be *loadable* in Loader action menu.

![image](https://user-images.githubusercontent.com/3357009/132539045-d405040a-a503-4ec7-adff-494c56bc314c.png)


<details>
<summary>original propose from 90d80dc (outdated info) </summary>

### ⚠️ The following description of this PR is outdated.

## What's Changed

A new model family representation was introduced: `fried.ma` (or `fried.mb` if project settings maps the file extension to `mb`).

![image](https://user-images.githubusercontent.com/3357009/130495091-60885d49-f3cb-4d4d-9b8b-270196156ddc.png)

This new representation will not only save extracted un-shaded, clean model, like the regular model representation does, but also `objectSet` nodes (e.g. V-Ray Displacement) which holds rendering attributes that are related to the published models.

Noticed that if there isn't any render attrib objectSet is affecting the model in workfile, this new representation won't be generated from version publishing.

### Fried model ?

The representation name, `fried.*`, is try to express the model is not being shaded, however it could be bumpy due to the displacement node that being published with it, or other render attributes like subdiv-level which contributed from other rendering related objectSets.

### Caveat

* When assigning looks to `fried.*` model via look-assigner tool. If the look also has it's own render attrib sets like fried model does, sets from look may supersede the model's.
* Currently not able to switch into other representation.

## Implementation details

Since this feature in essence is like publishing model with it's look but without shading-groups. So to avoid implementing new logic for this feature, the publishing code path is inherited from look family.

Currently only V-Ray is tested, Redshift and Arnold shall be tested in next couple days.

</details>

[cuID:yjx9fn]