### PR TITLE
Resolve path when adding to zip

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -508,7 +508,7 @@ class BootstrapRepos:
                 processed_path = file
                 self._print(f"- processing {processed_path}")
 
-                zip_file.write(file, file.relative_to(openpype_root))
+                zip_file.write(file, file.resolve().relative_to(openpype_root))
 
             # test if zip is ok
             zip_file.testzip()


### PR DESCRIPTION
# "create_zip" script
When adding files to the zip, the file path is not "resolved", resulting in errors in some cases (eg: when using UNC paths).

For example in Windows if OpenPype is installed on a mapped network drive:
- Let's consider the directory "\\\\192.168.1.1\dev" mapped to drive "W" (containing the OpenPype cloned repository).
- In a PowerShell session, if the current directory is "W:\OpenPype", and the script ".\tools\create_zip.ps1" is executed, the following error occurs:
```
ValueError: 'W:\\OpenPype\\igniter\\...\\openpype\\action.py' does not start with '\\\\192.168.1.1\\dev\\OpenPype'
```
and the zip creation is cancelled.
If executing the script in "\\\\192.168.1.1\dev\OpenPype", the error doesn't occur.

By resolving the path, we avoid the issue.