### PR TITLE
Blender: Toggle system console works on windows

### DIFF
--- a/openpype/hosts/blender/hooks/pre_windows_console.py
+++ b/openpype/hosts/blender/hooks/pre_windows_console.py
@@ -1,0 +1,28 @@
+import subprocess
+from openpype.lib import PreLaunchHook
+
+
+class BlenderConsoleWindows(PreLaunchHook):
+    """Foundry applications have specific way how to launch them.
+
+    Blender is executed "like" python process so it is required to pass
+    `CREATE_NEW_CONSOLE` flag on windows to trigger creation of new console.
+    At the same time the newly created console won't create it's own stdout
+    and stderr handlers so they should not be redirected to DEVNULL.
+    """
+
+    # Should be as last hook because must change launch arguments to string
+    order = 1000
+    app_groups = ["blender"]
+    platforms = ["windows"]
+
+    def execute(self):
+        # Change `creationflags` to CREATE_NEW_CONSOLE
+        # - on Windows will blender create new window using it's console
+        # Set `stdout` and `stderr` to None so new created console does not
+        #   have redirected output to DEVNULL in build
+        self.launch_context.kwargs.update({
+            "creationflags": subprocess.CREATE_NEW_CONSOLE,
+            "stdout": None,
+            "stderr": None
+        })


### PR DESCRIPTION
## Issue
Blender launched from OpenPype does not have ability to show console because we define stdout and stderr to devnull.

## Changes
- launch blender like a python application on windows with windows flag `CREATE_NEW_CONSOLE`

## How to test
- launch blender and it should be possible to show console with `Window -> Toggle System Console`
![image](https://user-images.githubusercontent.com/43494761/130832288-c628991e-911d-4a2a-8826-afb4870797cc.png)
