### PR TITLE
Use crf for quality in burnin

### DIFF
--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -236,6 +236,11 @@ class ExtractBurnin(pype.api.Extractor):
                         decompressed_dir,
                         input_file)
 
+                # Passing crf data to burnin script.
+                for arg in new_repre["outputDef"]["ffmpeg_args"]["output"]:
+                    if "-crf" in arg:
+                        burnin_data["crf"] = int(arg.replace("-crf", ""))
+
                 # Data for burnin script
                 script_data = {
                     "input": temp_data["full_input_path"],

--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -236,21 +236,14 @@ class ExtractBurnin(pype.api.Extractor):
                         decompressed_dir,
                         input_file)
 
-                # Passing crf data to burnin script.
-                cmd = new_repre.get("ffmpeg_cmd", "")
-                args = cmd.split(" ")
-                for count, arg in enumerate(args):
-                    if arg == "-crf":
-                        burnin_data["crf"] = int(args[count + 1])
-                        break
-
                 # Data for burnin script
                 script_data = {
                     "input": temp_data["full_input_path"],
                     "output": temp_data["full_output_path"],
                     "burnin_data": burnin_data,
                     "options": burnin_options,
-                    "values": burnin_values
+                    "values": burnin_values,
+                    "ffmpeg_cmd": new_repre.get("ffmpeg_cmd", "")
                 }
 
                 self.log.debug(

--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -237,9 +237,12 @@ class ExtractBurnin(pype.api.Extractor):
                         input_file)
 
                 # Passing crf data to burnin script.
-                for arg in new_repre["outputDef"]["ffmpeg_args"]["output"]:
-                    if "-crf" in arg:
-                        burnin_data["crf"] = int(arg.replace("-crf", ""))
+                cmd = new_repre.get("ffmpeg_cmd", "")
+                args = cmd.split(" ")
+                for count, arg in enumerate(args):
+                    if arg == "-crf":
+                        burnin_data["crf"] = int(args[count + 1])
+                        break
 
                 # Data for burnin script
                 script_data = {

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -223,7 +223,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
                     "outputName": output_name,
                     "outputDef": output_def,
                     "frameStartFtrack": temp_data["output_frame_start"],
-                    "frameEndFtrack": temp_data["output_frame_end"]
+                    "frameEndFtrack": temp_data["output_frame_end"],
+                    "ffmpeg_cmd": subprcs_cmd
                 })
 
                 # Force to pop these key if are in new repre

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -370,7 +370,8 @@ def example(input_path, output_path):
 
 def burnins_from_data(
     input_path, output_path, data,
-    codec_data=None, options=None, burnin_values=None, overwrite=True
+    codec_data=None, options=None, burnin_values=None, overwrite=True,
+    ffmpeg_cmd=None
 ):
     """This method adds burnins to video/image file based on presets setting.
 
@@ -543,6 +544,14 @@ def burnins_from_data(
         text = value.format(**data)
         burnin.add_text(text, align, frame_start, frame_end)
 
+    # Extract CRF data.
+    args = ffmpeg_cmd.split(" ")
+    crf = ""
+    for count, arg in enumerate(args):
+        if arg == "-crf":
+            crf = args[count + 1]
+            break
+
     ffmpeg_args = []
     if codec_data:
         # Use codec definition from method arguments
@@ -569,7 +578,7 @@ def burnins_from_data(
             ffmpeg_args.append("-profile:v {}".format(profile_name))
 
         bit_rate = ffprobe_data.get("bit_rate")
-        if bit_rate and "crf" not in data:
+        if bit_rate and not crf:
             ffmpeg_args.append("-b:v {}".format(bit_rate))
 
         pix_fmt = ffprobe_data.get("pix_fmt")
@@ -577,8 +586,8 @@ def burnins_from_data(
             ffmpeg_args.append("-pix_fmt {}".format(pix_fmt))
 
     # Getting crf from data if available.
-    if "crf" in data:
-        ffmpeg_args.append("-crf {}".format(data["crf"]))
+    if crf:
+        ffmpeg_args.append("-crf {}".format(crf))
 
     # Use group one (same as `-intra` argument, which is deprecated)
     ffmpeg_args.append("-g 1")
@@ -601,6 +610,7 @@ if __name__ == "__main__":
         in_data["burnin_data"],
         codec_data=in_data.get("codec"),
         options=in_data.get("options"),
-        burnin_values=in_data.get("values")
+        burnin_values=in_data.get("values"),
+        ffmpeg_cmd=in_data.get("ffmpeg_cmd")
     )
     print("* Burnin script has finished")

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -568,6 +568,10 @@ def burnins_from_data(
             profile_name = profile_name.replace(" ", "_").lower()
             ffmpeg_args.append("-profile:v {}".format(profile_name))
 
+        bit_rate = ffprobe_data.get("bit_rate")
+        if bit_rate and "crf" not in data:
+            ffmpeg_args.append("-b:v {}".format(bit_rate))
+
         pix_fmt = ffprobe_data.get("pix_fmt")
         if pix_fmt:
             ffmpeg_args.append("-pix_fmt {}".format(pix_fmt))

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -568,13 +568,13 @@ def burnins_from_data(
             profile_name = profile_name.replace(" ", "_").lower()
             ffmpeg_args.append("-profile:v {}".format(profile_name))
 
-        bit_rate = ffprobe_data.get("bit_rate")
-        if bit_rate:
-            ffmpeg_args.append("-b:v {}".format(bit_rate))
-
         pix_fmt = ffprobe_data.get("pix_fmt")
         if pix_fmt:
             ffmpeg_args.append("-pix_fmt {}".format(pix_fmt))
+
+    # Getting crf from data if available.
+    if "crf" in data:
+        ffmpeg_args.append("-crf {}".format(data["crf"]))
 
     # Use group one (same as `-intra` argument, which is deprecated)
     ffmpeg_args.append("-g 1")


### PR DESCRIPTION
Further to conversations on Discord the burnin script uses bitrate which greatly reduces the visual quality of video when applying burnin effects. Instead the Constant Rate Factor (crf) is a better measure of visual quality.

crf cant be queried by `ffprobe` so its better to use metadata instead. I've opted for getting this metadata through pyblish rather than encoding the metadata onto the video, because metadata for different video formats can get tricky.

Since Openpype ships with `-crf 18` by default, all burnins should get this data.