### PR TITLE
Fix PyQt5 on Windows build.

### DIFF
--- a/tools/build_dependencies.py
+++ b/tools/build_dependencies.py
@@ -135,6 +135,16 @@ progress_bar.close()
 # iterate over frozen libs and create list to delete
 libs_dir = build_dir / "lib"
 
+# On Windows "python3.dll" is needed for PyQt5 from the build.
+if platform.system().lower() == "windows":
+    src = Path(libs_dir / "PyQt5" / "python3.dll")
+    dst = Path(deps_dir / "PyQt5" / "python3.dll")
+    if src.exists():
+        shutil.copyfile(src, dst)
+    else:
+        _print("Could not find {}".format(src), 1)
+        sys.exit(1)
+
 to_delete = []
 # _print("Finding duplicates ...")
 deps_items = list(deps_dir.iterdir())


### PR DESCRIPTION
The file `python3.dll` from the build needs to be copied over to the `dependencies/PyQt5` folder for the build to work on other machines.

Fixes this error:
```
*** No DB connection string specified.
--- launching setup UI ...
Qt.py [warning]: ImportError(QtCore): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtGui): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtHelp): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtMultimedia): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtNetwork): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtOpenGL): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtPrintSupport): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtSql): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtSvg): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtTest): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtWidgets): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtXml): DLL load failed: The specified module could not be found.
Qt.py [warning]: ImportError(QtXmlPatterns): DLL load failed: The specified module could not be found.
Traceback (most recent call last):
  File "C:\Users\tokejepsen\OpenPype\.venv\lib\site-packages\cx_Freeze\initscripts\__startup__.py", line 104, in run
  File "C:\Users\tokejepsen\OpenPype\.venv\lib\site-packages\cx_Freeze\initscripts\Console.py", line 15, in run
  File "start.py", line 941, in <module>
  File "start.py", line 776, in boot
  File "start.py", line 431, in _determine_mongodb
  File "C:\Program Files (x86)\OpenPype\igniter\__init__.py", line 15, in open_dialog
    from Qt import QtWidgets, QtCore
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 668, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 638, in _load_backward_compatible
  File "C:\Users\tokejepsen\OpenPype\.venv\lib\site-packages\Qt.py", line 1924, in <module>
    _install()
  File "C:\Users\tokejepsen\OpenPype\.venv\lib\site-packages\Qt.py", line 1902, in _install
    our_submodule = getattr(Qt, name)
AttributeError: module 'Qt' has no attribute 'QtGui'
```