### PR TITLE
Collectors order

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
@@ -9,7 +9,7 @@ from openpype.lib import get_subset_name
 
 class CollectInstances(pyblish.api.ContextPlugin):
     label = "Collect Instances"
-    order = pyblish.api.CollectorOrder - 1
+    order = pyblish.api.CollectorOrder - 0.4
     hosts = ["tvpaint"]
 
     def process(self, context):

--- a/openpype/hosts/tvpaint/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_workfile.py
@@ -8,7 +8,7 @@ from openpype.lib import get_subset_name
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
     label = "Collect Workfile"
-    order = pyblish.api.CollectorOrder - 1
+    order = pyblish.api.CollectorOrder - 0.4
     hosts = ["tvpaint"]
 
     def process(self, context):

--- a/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
@@ -39,7 +39,7 @@ class ResetTVPaintWorkfileMetadata(pyblish.api.Action):
 
 class CollectWorkfileData(pyblish.api.ContextPlugin):
     label = "Collect Workfile Data"
-    order = pyblish.api.CollectorOrder - 0.5
+    order = pyblish.api.CollectorOrder - 0.45
     hosts = ["tvpaint"]
     actions = [ResetTVPaintWorkfileMetadata]
 

--- a/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
@@ -39,7 +39,7 @@ class ResetTVPaintWorkfileMetadata(pyblish.api.Action):
 
 class CollectWorkfileData(pyblish.api.ContextPlugin):
     label = "Collect Workfile Data"
-    order = pyblish.api.CollectorOrder - 1.01
+    order = pyblish.api.CollectorOrder - 0.5
     hosts = ["tvpaint"]
     actions = [ResetTVPaintWorkfileMetadata]
 

--- a/openpype/plugins/publish/collect_host_name.py
+++ b/openpype/plugins/publish/collect_host_name.py
@@ -14,7 +14,7 @@ class CollectHostName(pyblish.api.ContextPlugin):
     """Collect avalon host name to context."""
 
     label = "Collect Host Name"
-    order = pyblish.api.CollectorOrder - 1
+    order = pyblish.api.CollectorOrder - 0.5
 
     def process(self, context):
         host_name = context.data.get("hostName")


### PR DESCRIPTION
## Issue
Some collectors have order below `-0.5` which is out of range of Collectors order so headless publishing would not process them before collectors.

## Changes
- changed orders to valid orders for `CollectHostName` and TVPaint collectors