### PR TITLE
Last workfile with multiple work templates

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -430,7 +430,6 @@ class FilesWidget(QtWidgets.QWidget):
         # Pype's anatomy object for current project
         self.anatomy = Anatomy(io.Session["AVALON_PROJECT"])
         # Template key used to get work template from anatomy templates
-        # TODO change template key based on task
         self.template_key = "work"
 
         # This is not root but workfile directory


### PR DESCRIPTION
## Issue
Function looking for last workfile is always using `"work"` template key.
- during start of application may not find last workfile if `"work"` template key is not used

## Changes
- template key is passed to function which handles that