### PR TITLE
Settings UI: Number with configurable steps

### DIFF
--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -379,6 +379,10 @@ class NumberEntity(InputEntity):
 
         # UI specific attributes
         self.show_slider = self.schema_data.get("show_slider", False)
+        steps = self.schema_data.get("steps", None)
+        if steps is None:
+            steps = 1 / (10 ** self.decimal)
+        self.steps = steps
 
     def _convert_to_valid_type(self, value):
         if isinstance(value, str):

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -379,10 +379,7 @@ class NumberEntity(InputEntity):
 
         # UI specific attributes
         self.show_slider = self.schema_data.get("show_slider", False)
-        steps = self.schema_data.get("steps", None)
-        if steps is None:
-            steps = 1 / (10 ** self.decimal)
-        self.steps = steps
+        self.steps = self.schema_data.get("steps", None)
 
     def _convert_to_valid_type(self, value):
         if isinstance(value, str):

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -379,7 +379,11 @@ class NumberEntity(InputEntity):
 
         # UI specific attributes
         self.show_slider = self.schema_data.get("show_slider", False)
-        self.steps = self.schema_data.get("steps", None)
+        steps = self.schema_data.get("steps", None)
+        # Make sure that steps are not set to `0`
+        if steps == 0:
+            steps = None
+        self.steps = steps
 
     def _convert_to_valid_type(self, value):
         if isinstance(value, str):

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -316,6 +316,7 @@ How output of the schema could look like on save:
     - key `"decimal"` defines how many decimal places will be used, 0 is for integer input (Default: `0`)
     - key `"minimum"` as minimum allowed number to enter (Default: `-99999`)
     - key `"maxium"` as maximum allowed number to enter (Default: `99999`)
+- key `"steps"` will change single step value of UI inputs (using arrows and wheel scroll)
 - for UI it is possible to show slider to enable this option set `show_slider` to `true`
 ```
 {

--- a/openpype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_modules.json
@@ -28,7 +28,8 @@
                     "type": "number",
                     "key": "AVALON_TIMEOUT",
                     "minimum": 0,
-                    "label": "Avalon Mongo Timeout (ms)"
+                    "label": "Avalon Mongo Timeout (ms)",
+                    "steps": 100
                 },
                 {
                     "type": "path",

--- a/openpype/tools/settings/settings/item_widgets.py
+++ b/openpype/tools/settings/settings/item_widgets.py
@@ -411,7 +411,8 @@ class NumberWidget(InputWidget):
         kwargs = {
             "minimum": self.entity.minimum,
             "maximum": self.entity.maximum,
-            "decimal": self.entity.decimal
+            "decimal": self.entity.decimal,
+            "steps": self.entity.steps
         }
         self.input_field = NumberSpinBox(self.content_widget, **kwargs)
         input_field_stretch = 1
@@ -426,6 +427,10 @@ class NumberWidget(InputWidget):
                 int(self.entity.minimum * slider_multiplier),
                 int(self.entity.maximum * slider_multiplier)
             )
+            if self.entity.steps is not None:
+                slider_widget.setSingleStep(
+                    self.entity.steps * slider_multiplier
+                )
 
             self.content_layout.addWidget(slider_widget, 1)
 

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -92,11 +92,15 @@ class NumberSpinBox(QtWidgets.QDoubleSpinBox):
         min_value = kwargs.pop("minimum", -99999)
         max_value = kwargs.pop("maximum", 99999)
         decimals = kwargs.pop("decimal", 0)
+        steps = kwargs.pop("steps", None)
+
         super(NumberSpinBox, self).__init__(*args, **kwargs)
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.setDecimals(decimals)
         self.setMinimum(min_value)
         self.setMaximum(max_value)
+        if steps is not None:
+            self.setSingleStep(steps)
 
     def focusInEvent(self, event):
         super(NumberSpinBox, self).focusInEvent(event)


### PR DESCRIPTION
## Changes
- number entity can have defined `"steps"` which define single step of number input (when using arrows of scroll wheel)

Resolves: https://github.com/pypeclub/OpenPype/issues/1999