### PR TITLE
Modules: Connect method is not required

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -417,7 +417,6 @@ class OpenPypeModule:
         """
         pass
 
-    @abstractmethod
     def connect_with_modules(self, enabled_modules):
         """Connect with other enabled modules."""
         pass
@@ -436,10 +435,6 @@ class OpenPypeAddOn(OpenPypeModule):
 
     def initialize(self, module_settings):
         """Initialization is not be required for most of addons."""
-        pass
-
-    def connect_with_modules(self, enabled_modules):
-        """Do not require to implement connection with modules for addon."""
         pass
 
 

--- a/openpype/modules/default_modules/avalon_apps/avalon_app.py
+++ b/openpype/modules/default_modules/avalon_apps/avalon_app.py
@@ -71,9 +71,6 @@ class AvalonModule(OpenPypeModule, ITrayModule, IWebServerRoutes):
                 exc_info=True
             )
 
-    def connect_with_modules(self, _enabled_modules):
-        return
-
     def webserver_initialization(self, server_manager):
         """Implementation of IWebServerRoutes interface."""
 

--- a/openpype/modules/default_modules/clockify/clockify_module.py
+++ b/openpype/modules/default_modules/clockify/clockify_module.py
@@ -94,9 +94,6 @@ class ClockifyModule(
             "server": [CLOCKIFY_FTRACK_SERVER_PATH]
         }
 
-    def connect_with_modules(self, *_a, **_kw):
-        return
-
     def clockify_timer_stopped(self):
         self.bool_timer_run = False
         # Call `ITimersManager` method

--- a/openpype/modules/default_modules/deadline/deadline_module.py
+++ b/openpype/modules/default_modules/deadline/deadline_module.py
@@ -26,9 +26,6 @@ class DeadlineModule(OpenPypeModule, IPluginPaths):
                               "not specified. Disabling module."))
             return
 
-    def connect_with_modules(self, *_a, **_kw):
-        return
-
     def get_plugin_paths(self):
         """Deadline plugin paths."""
         current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/openpype/modules/default_modules/log_viewer/log_view_module.py
+++ b/openpype/modules/default_modules/log_viewer/log_view_module.py
@@ -40,10 +40,6 @@ class LogViewModule(OpenPypeModule, ITrayModule):
     def tray_exit(self):
         return
 
-    def connect_with_modules(self, _enabled_modules):
-        """Nothing special."""
-        return
-
     def _show_logs_gui(self):
         if self.window:
             self.window.show()

--- a/openpype/modules/default_modules/muster/muster.py
+++ b/openpype/modules/default_modules/muster/muster.py
@@ -54,9 +54,6 @@ class MusterModule(OpenPypeModule, ITrayModule, IWebServerRoutes):
         """Nothing special for Muster."""
         return
 
-    def connect_with_modules(self, *_a, **_kw):
-        return
-
     # Definition of Tray menu
     def tray_menu(self, parent):
         """Add **change credentials** option to tray menu."""

--- a/openpype/modules/default_modules/project_manager_action.py
+++ b/openpype/modules/default_modules/project_manager_action.py
@@ -17,9 +17,6 @@ class ProjectManagerAction(OpenPypeModule, ITrayAction):
         # Tray attributes
         self.project_manager_window = None
 
-    def connect_with_modules(self, *_a, **_kw):
-        return
-
     def tray_init(self):
         """Initialization in tray implementation of ITrayAction."""
         self.create_project_manager_window()

--- a/openpype/modules/default_modules/python_console_interpreter/module.py
+++ b/openpype/modules/default_modules/python_console_interpreter/module.py
@@ -18,9 +18,6 @@ class PythonInterpreterAction(OpenPypeModule, ITrayAction):
         if self._interpreter_window is not None:
             self._interpreter_window.save_registry()
 
-    def connect_with_modules(self, *args, **kwargs):
-        pass
-
     def create_interpreter_window(self):
         """Initializa Settings Qt window."""
         if self._interpreter_window:

--- a/openpype/modules/default_modules/settings_module/settings_action.py
+++ b/openpype/modules/default_modules/settings_module/settings_action.py
@@ -19,9 +19,6 @@ class SettingsAction(OpenPypeModule, ITrayAction):
         # Tray attributes
         self.settings_window = None
 
-    def connect_with_modules(self, *_a, **_kw):
-        return
-
     def tray_init(self):
         """Initialization in tray implementation of ITrayAction."""
         self.create_settings_window()
@@ -83,9 +80,6 @@ class LocalSettingsAction(OpenPypeModule, ITrayAction):
         # Tray attributes
         self.settings_window = None
         self._first_trigger = True
-
-    def connect_with_modules(self, *_a, **_kw):
-        return
 
     def tray_init(self):
         """Initialization in tray implementation of ITrayAction."""

--- a/openpype/modules/default_modules/slack/slack_module.py
+++ b/openpype/modules/default_modules/slack/slack_module.py
@@ -17,10 +17,6 @@ class SlackIntegrationModule(OpenPypeModule, IPluginPaths, ILaunchHookPaths):
         slack_settings = modules_settings[self.name]
         self.enabled = slack_settings["enabled"]
 
-    def connect_with_modules(self, _enabled_modules):
-        """Nothing special."""
-        return
-
     def get_launch_hook_paths(self):
         """Implementation of `ILaunchHookPaths`."""
         return os.path.join(SLACK_MODULE_DIR, "launch_hooks")

--- a/openpype/modules/default_modules/sync_server/sync_server_module.py
+++ b/openpype/modules/default_modules/sync_server/sync_server_module.py
@@ -680,9 +680,6 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         return sites
 
-    def connect_with_modules(self, *_a, **kw):
-        return
-
     def tray_init(self):
         """
             Actual initialization of Sync Server.


### PR DESCRIPTION
## Changes
- `connect_with_modules` method on modules is not abstract

## Reason
- method make sense only for modules that have defined interface which is not true in most of cases