### PR TITLE
Documentation: Ftrack launch argsuments update

### DIFF
--- a/website/docs/admin_openpype_commands.md
+++ b/website/docs/admin_openpype_commands.md
@@ -55,7 +55,7 @@ openpype_console tray --debug
 ---
 ### `launch` arguments {#eventserver-arguments}
 You have to set either proper environment variables to provide URL and credentials or use
-option to specify them. If you use `--store_credentials` provided credentials will be stored for later use.
+option to specify them.
 
 | Argument | Description |
 | --- | --- |
@@ -63,16 +63,13 @@ option to specify them. If you use `--store_credentials` provided credentials wi
 | `--ftrack-url` | URL to ftrack server (can be set with `FTRACK_SERVER`) |
 | `--ftrack-user` |user name to log in to ftrack (can be set with `FTRACK_API_USER`) |
 | `--ftrack-api-key` | ftrack api key (can be set with `FTRACK_API_KEY`) |
-| `--ftrack-events-path` | path to event server plugins (can be set with `FTRACK_EVENTS_PATH`) |
-| `--no-stored-credentials` | will use credential specified with options above |
-| `--store-credentials` | will store credentials to file for later use |
 | `--legacy` | run event server without mongo storing |
 | `--clockify-api-key` | Clockify API key (can be set with `CLOCKIFY_API_KEY`) |
 | `--clockify-workspace` | Clockify workspace (can be set with `CLOCKIFY_WORKSPACE`) |
 
 To run ftrack event server:
 ```shell
-openpype_console eventserver --ftrack-url=<url> --ftrack-user=<user> --ftrack-api-key=<key> --ftrack-events-path=<path> --no-stored-credentials --store-credentials
+openpype_console eventserver --ftrack-url=<url> --ftrack-user=<user> --ftrack-api-key=<key>
 ```
 
 ---

--- a/website/docs/module_ftrack.md
+++ b/website/docs/module_ftrack.md
@@ -51,10 +51,7 @@ There are specific launch arguments for event server. With `openpype_console eve
 
 -  **`--ftrack-user "your.username"`** : Ftrack Username
 -   **`--ftrack-api-key "00000aaa-11bb-22cc-33dd-444444eeeee"`** : User's API key
--   **`--store-crededentials`** : Entered credentials will be stored for next launch with this argument _(It is not needed to enter **ftrackuser** and **ftrackapikey** args on next launch)_
--   **`--no-stored-credentials`** : Stored credentials are loaded first so if you want to change credentials use this argument
 -   `--ftrack-url "https://yourdomain.ftrackapp.com/"` : Ftrack server URL _(it is not needed to enter if you have set `FTRACK_SERVER` in OpenPype' environments)_
--   `--ftrack-events-path "//Paths/To/Events/"` : Paths to events folder. May contain multiple paths separated by `;`. _(it is not needed to enter if you have set `FTRACK_EVENTS_PATH` in OpenPype' environments)_
 
 So if you want to use OpenPype's environments then you can launch event server for first time with these arguments `openpype_console.exe eventserver --ftrack-user "my.username" --ftrack-api-key "00000aaa-11bb-22cc-33dd-444444eeeee" --store-credentials`. Since that time, if everything was entered correctly, you can launch event server with `openpype_console.exe eventserver`.
 
@@ -64,8 +61,6 @@ So if you want to use OpenPype's environments then you can launch event server f
 - `FTRACK_API_USER` - Username _("your.username")_
 - `FTRACK_API_KEY` - User's API key _("00000aaa-11bb-22cc-33dd-444444eeeee")_
 - `FTRACK_SERVER` - Ftrack server url _("<https://yourdomain.ftrackapp.com/">)_
-- `FTRACK_EVENTS_PATH` - Paths to events _("//Paths/To/Events/")_
-    We do not recommend you this way.
 
 </TabItem>
 </Tabs>

--- a/website/docs/module_ftrack.md
+++ b/website/docs/module_ftrack.md
@@ -98,10 +98,12 @@ Event server should **not** run more than once! It may cause major issues.
     `sudo vi /opt/openpype/run_event_server.sh`
 -   add content to the file:
 ```sh
-#!/usr/bin/env
-export OPENPYPE_DEBUG=3
-pushd /mnt/pipeline/prod/openpype-setup
-. openpype_console eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key>
+#!/usr/bin/env bash
+export OPENPYPE_DEBUG=1
+export OPENPYPE_MONGO=<openpype-mongo-url>
+
+pushd /mnt/path/to/openpype
+./openpype_console eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key>
 ```
 -   change file permission:
     `sudo chmod 0755 /opt/openpype/run_event_server.sh`
@@ -141,9 +143,11 @@ WantedBy=multi-user.target
 -   add content to the service file: 
 ```sh
 @echo off
-set OPENPYPE_DEBUG=3
-pushd \\path\to\file\
-openpype_console.exe eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key> 
+set OPENPYPE_DEBUG=1
+set OPENPYPE_MONGO=<openpype-mongo-url>
+
+pushd \\path\to\openpype
+openpype_console.exe eventserver --ftrack-user <openpype-admin-user> --ftrack-api-key <api-key>
 ```
 -   download and install `nssm.cc`
 -   create Windows service according to nssm.cc manual


### PR DESCRIPTION
## Changes
- update which arguments can be used for launching of ftrack event server
    - removed `no-credentials`, `store-credentials` and `ftrack-events-path` which are not used anymore
- modified example shell scripts for event server
    - added `OPENPYPE_MONGO` as environment
    - modified value of `OPENPYPE_DEBUG` to `1`
    - `pushd` path is not explicit
    - linux execute command starts with `./openpype_console`