### PR TITLE
Ftrack: Sync to avalon actions have jobs

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_server/action_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/action_sync_to_avalon.py
@@ -74,7 +74,7 @@ class SyncToAvalonServer(ServerAction):
         try:
             result = self.synchronization(event, project_name)
 
-        except Exception as exc:
+        except Exception:
             self.log.error(
                 "Synchronization failed due to code error", exc_info=True
             )

--- a/openpype/modules/default_modules/ftrack/event_handlers_server/action_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/action_sync_to_avalon.py
@@ -52,17 +52,21 @@ class SyncToAvalonServer(ServerAction):
         return False
 
     def launch(self, session, in_entities, event):
+        project_entity = self.get_project_from_entity(in_entities[0])
+        project_name = project_entity["full_name"]
+        result = self.synchronization(
+            session, in_entities, event, project_name
+        )
+
+        return result
+
+    def synchronization(self, session, in_entities, event, project_name):
         time_start = time.time()
 
         self.show_message(event, "Synchronization - Preparing data", True)
-        # Get ftrack project
-        if in_entities[0].entity_type.lower() == "project":
-            ft_project_name = in_entities[0]["full_name"]
-        else:
-            ft_project_name = in_entities[0]["project"]["full_name"]
 
         try:
-            output = self.entities_factory.launch_setup(ft_project_name)
+            output = self.entities_factory.launch_setup(project_name)
             if output is not None:
                 return output
 
@@ -72,7 +76,7 @@ class SyncToAvalonServer(ServerAction):
             time_2 = time.time()
 
             # This must happen before all filtering!!!
-            self.entities_factory.prepare_avalon_entities(ft_project_name)
+            self.entities_factory.prepare_avalon_entities(project_name)
             time_3 = time.time()
 
             self.entities_factory.filter_by_ignore_sync()
@@ -118,7 +122,7 @@ class SyncToAvalonServer(ServerAction):
             report = self.entities_factory.report()
             if report and report.get("items"):
                 default_title = "Synchronization report ({}):".format(
-                    ft_project_name
+                    project_name
                 )
                 self.show_interface(
                     items=report["items"],
@@ -135,7 +139,6 @@ class SyncToAvalonServer(ServerAction):
                 "Synchronization failed due to code error", exc_info=True
             )
             msg = "An error has happened during synchronization"
-            title = "Synchronization report ({}):".format(ft_project_name)
             items = []
             items.append({
                 "type": "label",
@@ -160,6 +163,7 @@ class SyncToAvalonServer(ServerAction):
                 report = self.entities_factory.report()
             except Exception:
                 pass
+            title = "Synchronization report ({}):".format(project_name)
 
             _items = report.get("items", [])
             if _items:

--- a/openpype/modules/default_modules/ftrack/event_handlers_server/action_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/action_sync_to_avalon.py
@@ -1,4 +1,6 @@
 import time
+import sys
+import json
 import traceback
 
 from openpype_modules.ftrack.lib import ServerAction
@@ -52,6 +54,20 @@ class SyncToAvalonServer(ServerAction):
         return False
 
     def launch(self, session, in_entities, event):
+        self.log.debug("{}: Creating job".format(self.label))
+
+        user_entity = session.query(
+            "User where id is {}".format(event["source"]["user"]["id"])
+        ).one()
+        job_entity = session.create("Job", {
+            "user": user_entity,
+            "status": "running",
+            "data": json.dumps({
+                "description": "Sync to avalon is running..."
+            })
+        })
+        session.commit()
+
         project_entity = self.get_project_from_entity(in_entities[0])
         project_name = project_entity["full_name"]
 
@@ -62,12 +78,24 @@ class SyncToAvalonServer(ServerAction):
             self.log.error(
                 "Synchronization failed due to code error", exc_info=True
             )
+
+            description = "Sync to avalon Crashed (Download traceback)"
+            self.add_traceback_to_job(
+                job_entity, session, sys.exc_info(), description
+            )
+
             msg = "An error has happened during synchronization"
             title = "Synchronization report ({}):".format(project_name)
             items = []
             items.append({
                 "type": "label",
                 "value": "# {}".format(msg)
+            })
+            items.append({
+                "type": "label",
+                "value": (
+                    "<p>Download report from job for more information.</p>"
+                )
             })
 
             report = {}
@@ -84,6 +112,12 @@ class SyncToAvalonServer(ServerAction):
             self.show_interface(items, title, event, submit_btn_label="Ok")
 
             return {"success": True, "message": msg}
+
+        job_entity["status"] = "done"
+        job_entity["data"] = json.dumps({
+            "description": "Sync to avalon finished."
+        })
+        session.commit()
 
         return result
 

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py
@@ -78,7 +78,7 @@ class SyncToAvalonLocal(BaseAction):
         try:
             result = self.synchronization(event, project_name)
 
-        except Exception as exc:
+        except Exception:
             self.log.error(
                 "Synchronization failed due to code error", exc_info=True
             )

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py
@@ -65,15 +65,40 @@ class SyncToAvalonLocal(BaseAction):
     def launch(self, session, in_entities, event):
         project_entity = self.get_project_from_entity(in_entities[0])
         project_name = project_entity["full_name"]
-        
-        result = self.synchronization(
-            session, in_entities, event, project_name
-        )
 
+        try:
+            result = self.synchronization(event, project_name)
+
+        except Exception as exc:
+            self.log.error(
+                "Synchronization failed due to code error", exc_info=True
+            )
+            msg = "An error has happened during synchronization"
+            title = "Synchronization report ({}):".format(project_name)
+            items = []
+            items.append({
+                "type": "label",
+                "value": "# {}".format(msg)
+            })
+
+            report = {}
+            try:
+                report = self.entities_factory.report()
+            except Exception:
+                pass
+
+            _items = report.get("items") or []
+            if _items:
+                items.append(self.entities_factory.report_splitter)
+                items.extend(_items)
+
+            self.show_interface(items, title, event, submit_btn_label="Ok")
+
+            return {"success": True, "message": msg}
 
         return result
 
-    def synchronization(self, session, in_entities, event, project_name):
+    def synchronization(self, event, project_name):
         time_start = time.time()
 
         self.show_message(event, "Synchronization - Preparing data", True)
@@ -147,46 +172,6 @@ class SyncToAvalonLocal(BaseAction):
                 "message": "Synchronization Finished"
             }
 
-        except Exception:
-            self.log.error(
-                "Synchronization failed due to code error", exc_info=True
-            )
-            msg = "An error occurred during synchronization"
-            items = []
-            items.append({
-                "type": "label",
-                "value": "# {}".format(msg)
-            })
-            items.append({
-                "type": "label",
-                "value": "## Traceback of the error"
-            })
-            items.append({
-                "type": "label",
-                "value": "<p>{}</p>".format(
-                    str(traceback.format_exc()).replace(
-                        "\n", "<br>").replace(
-                        " ", "&nbsp;"
-                    )
-                )
-            })
-
-            report = {"items": []}
-            try:
-                report = self.entities_factory.report()
-            except Exception:
-                pass
-
-            _items = report.get("items", [])
-            if _items:
-                items.append(self.entities_factory.report_splitter)
-                items.extend(_items)
-
-            self.show_interface(items, title, event)
-
-            return {"success": True, "message": msg}
-
-            title = "Synchronization report ({}):".format(project_name)
         finally:
             try:
                 self.entities_factory.dbcon.uninstall()

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py
@@ -32,17 +32,10 @@ class SyncToAvalonLocal(BaseAction):
         - or do it manually (Not recommended)
     """
 
-    #: Action identifier.
     identifier = "sync.to.avalon.local"
-    #: Action label.
     label = "OpenPype Admin"
-    #: Action variant
     variant = "- Sync To Avalon (Local)"
-    #: Action description.
-    description = "Send data from Ftrack to Avalon"
-    #: priority
     priority = 200
-    #: roles that are allowed to register this action
     icon = statics_icon("ftrack", "action_icons", "OpenPypeAdmin.svg")
 
     settings_key = "sync_to_avalon_local"

--- a/openpype/modules/default_modules/ftrack/lib/ftrack_base_handler.py
+++ b/openpype/modules/default_modules/ftrack/lib/ftrack_base_handler.py
@@ -384,8 +384,8 @@ class BaseHandler(object):
         )
 
     def show_interface(
-        self, items, title='',
-        event=None, user=None, username=None, user_id=None
+        self, items, title="", event=None, user=None,
+        username=None, user_id=None, submit_btn_label=None
     ):
         """
         Shows interface to user
@@ -428,14 +428,18 @@ class BaseHandler(object):
             'applicationId=ftrack.client.web and user.id="{0}"'
         ).format(user_id)
 
+        event_data = {
+            "type": "widget",
+            "items": items,
+            "title": title
+        }
+        if submit_btn_label:
+            event_data["submit_button_label"] = submit_btn_label
+
         self.session.event_hub.publish(
             ftrack_api.event.base.Event(
                 topic='ftrack.action.trigger-user-interface',
-                data=dict(
-                    type='widget',
-                    items=items,
-                    title=title
-                ),
+                data=event_data,
                 target=target
             ),
             on_error='ignore'
@@ -443,7 +447,7 @@ class BaseHandler(object):
 
     def show_interface_from_dict(
         self, messages, title="", event=None,
-        user=None, username=None, user_id=None
+        user=None, username=None, user_id=None, submit_btn_label=None
     ):
         if not messages:
             self.log.debug("No messages to show! (messages dict is empty)")
@@ -469,7 +473,9 @@ class BaseHandler(object):
                 message = {'type': 'label', 'value': '<p>{}</p>'.format(value)}
                 items.append(message)
 
-        self.show_interface(items, title, event, user, username, user_id)
+        self.show_interface(
+            items, title, event, user, username, user_id, submit_btn_label
+        )
 
     def trigger_action(
         self, action_name, event=None, session=None,


### PR DESCRIPTION
## Changes
- sync to avalon actions (local and server) create job on start
    - job has uploaded file with traceback if job crashes
- removed traceback message from report to user
- methos `show_interface` have ability to modify submit button label

## How to test
One possible way is to raise exception before `self.synchronize(...)` in `openpype/modules/default_modules/ftrack/event_handlers_user/action_sync_to_avalon.py` (line 78).

```
try:
    raise ValueError("Test")
    result = self.synchronization(event, project_name)
except Exception:
    ...
```

Closes https://github.com/pypeclub/OpenPype/issues/1310