### PR TITLE
General: Fix Python 2 breaking line

### DIFF
--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -178,7 +178,9 @@ def _list_path_items(folder_structure):
                 if not isinstance(path, (list, tuple)):
                     path = [path]
 
-                output.append([key, *path])
+                item = [key]
+                item.extend(path)
+                output.append(item)
 
     return output
 


### PR DESCRIPTION
## Issue
- have expanding object `my_list = [1, *args]` where `args` is epxanded does not work in python 2 syntax which is used in openpype.lib right now and is breaking host implementations

## Changes
- modified the line to work in python 2

