### PR TITLE
Ftrack: Show OpenPype versions in event server status

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -160,6 +160,11 @@ from .editorial import (
     make_sequence_collection
 )
 
+from .pype_info import (
+    get_openpype_version,
+    get_build_version
+)
+
 terminal = Terminal
 
 __all__ = [
@@ -280,5 +285,8 @@ __all__ = [
     "frames_to_timecode",
     "make_sequence_collection",
     "create_project_folders",
-    "get_project_basic_paths"
+    "get_project_basic_paths",
+
+    "get_openpype_version",
+    "get_build_version",
 ]

--- a/openpype/lib/pype_info.py
+++ b/openpype/lib/pype_info.py
@@ -11,9 +11,18 @@ from .execute import get_pype_execute_args
 from .local_settings import get_local_site_id
 
 
-def get_pype_version():
+def get_openpype_version():
     """Version of pype that is currently used."""
     return openpype.version.__version__
+
+
+def get_pype_version():
+    """Backwards compatibility. Remove when 100% not used."""
+    print((
+        "Using deprecated function 'openpype.lib.pype_info.get_pype_version'"
+        " replace with 'openpype.lib.pype_info.get_openpype_version'."
+    ))
+    return get_openpype_version()
 
 
 def get_pype_info():
@@ -25,7 +34,7 @@ def get_pype_info():
         version_type = "code"
 
     return {
-        "version": get_pype_version(),
+        "version": get_openpype_version(),
         "version_type": version_type,
         "executable": executable_args[-1],
         "pype_root": os.environ["OPENPYPE_REPOS_ROOT"],
@@ -73,7 +82,7 @@ def extract_pype_info_to_file(dirpath):
         filepath (str): Full path to file where data were extracted.
     """
     filename = "{}_{}_{}.json".format(
-        get_pype_version(),
+        get_openpype_version(),
         get_local_site_id(),
         datetime.datetime.now().strftime("%y%m%d%H%M%S")
     )

--- a/openpype/lib/pype_info.py
+++ b/openpype/lib/pype_info.py
@@ -9,6 +9,7 @@ import openpype.version
 from openpype.settings.lib import get_local_settings
 from .execute import get_pype_execute_args
 from .local_settings import get_local_site_id
+from .python_module_tools import import_filepath
 
 
 def get_openpype_version():
@@ -23,6 +24,25 @@ def get_pype_version():
         " replace with 'openpype.lib.pype_info.get_openpype_version'."
     ))
     return get_openpype_version()
+
+
+def get_build_version():
+    """OpenPype version of build."""
+    # Return OpenPype version if is running from code
+    if not is_running_from_build():
+        return get_openpype_version()
+
+    # Import `version.py` from build directory
+    version_filepath = os.path.join(
+        os.environ["OPENPYPE_ROOT"],
+        "openpype",
+        "version.py"
+    )
+    if not os.path.exists(version_filepath):
+        return None
+
+    module = import_filepath(version_filepath, "openpype_build_version")
+    return getattr(module, "__version__", None)
 
 
 def is_running_from_build():

--- a/openpype/lib/pype_info.py
+++ b/openpype/lib/pype_info.py
@@ -25,10 +25,23 @@ def get_pype_version():
     return get_openpype_version()
 
 
+def is_running_from_build():
+    """Determine if current process is running from build or code.
+
+    Returns:
+        bool: True if running from build.
+    """
+    executable_path = os.environ["OPENPYPE_EXECUTABLE"]
+    executable_filename = os.path.basename(executable_path)
+    if "python" in executable_filename.lower():
+        return False
+    return True
+
+
 def get_pype_info():
     """Information about currently used Pype process."""
     executable_args = get_pype_execute_args()
-    if len(executable_args) == 1:
+    if is_running_from_build():
         version_type = "build"
     else:
         version_type = "code"

--- a/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
@@ -237,13 +237,13 @@ def main_loop(ftrack_url):
         statuser_thread=statuser_thread
     )
 
-    system_name, pc_name = platform.uname()[:2]
     host_name = socket.gethostname()
     main_info = [
         ["created_at", datetime.datetime.now().strftime("%Y.%m.%d %H:%M:%S")],
         ["Username", getpass.getuser()],
         ["Host Name", host_name],
         ["Host IP", socket.gethostbyname(host_name)],
+        ["OpenPype executable", get_pype_execute_args()[-1]],
         ["OpenPype version", get_openpype_version() or "N/A"],
         ["OpenPype build version", get_build_version() or "N/A"]
     ]

--- a/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
@@ -6,7 +6,6 @@ import subprocess
 import socket
 import json
 import platform
-import argparse
 import getpass
 import atexit
 import time
@@ -16,7 +15,9 @@ import ftrack_api
 import pymongo
 from openpype.lib import (
     get_pype_execute_args,
-    OpenPypeMongoConnection
+    OpenPypeMongoConnection,
+    get_openpype_version,
+    get_build_version
 )
 from openpype_modules.ftrack import FTRACK_MODULE_DIR
 from openpype_modules.ftrack.lib import credentials
@@ -238,12 +239,14 @@ def main_loop(ftrack_url):
 
     system_name, pc_name = platform.uname()[:2]
     host_name = socket.gethostname()
-    main_info = {
-        "created_at": datetime.datetime.now().strftime("%Y.%m.%d %H:%M:%S"),
-        "Username": getpass.getuser(),
-        "Host Name": host_name,
-        "Host IP": socket.gethostbyname(host_name)
-    }
+    main_info = [
+        ["created_at", datetime.datetime.now().strftime("%Y.%m.%d %H:%M:%S")],
+        ["Username", getpass.getuser()],
+        ["Host Name", host_name],
+        ["Host IP", socket.gethostbyname(host_name)],
+        ["OpenPype version", get_openpype_version() or "N/A"],
+        ["OpenPype build version", get_build_version() or "N/A"]
+    ]
     main_info_str = json.dumps(main_info)
     # Main loop
     while True:

--- a/openpype/modules/default_modules/ftrack/scripts/sub_event_processor.py
+++ b/openpype/modules/default_modules/ftrack/scripts/sub_event_processor.py
@@ -13,6 +13,11 @@ from openpype_modules.ftrack.ftrack_server.lib import (
 from openpype.modules import ModulesManager
 
 from openpype.api import Logger
+from openpype.lib import (
+    get_openpype_version,
+    get_build_version
+)
+
 
 import ftrack_api
 
@@ -40,9 +45,11 @@ def send_status(event):
     new_event_data = {
         "subprocess_id": subprocess_id,
         "source": "processor",
-        "status_info": {
-            "created_at": subprocess_started.strftime("%Y.%m.%d %H:%M:%S")
-        }
+        "status_info": [
+            ["created_at", subprocess_started.strftime("%Y.%m.%d %H:%M:%S")],
+            ["OpenPype version", get_openpype_version() or "N/A"],
+            ["OpenPype build version", get_build_version() or "N/A"]
+        ]
     }
 
     new_event = ftrack_api.event.base.Event(

--- a/openpype/modules/default_modules/ftrack/scripts/sub_event_status.py
+++ b/openpype/modules/default_modules/ftrack/scripts/sub_event_status.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import threading
+import collections
 import signal
 import socket
 import datetime
@@ -165,7 +166,7 @@ class StatusFactory:
             return
 
         source = event["data"]["source"]
-        data = event["data"]["status_info"]
+        data = collections.OrderedDict(event["data"]["status_info"])
 
         self.update_status_info(source, data)
 
@@ -348,7 +349,7 @@ def heartbeat():
 
 def main(args):
     port = int(args[-1])
-    server_info = json.loads(args[-2])
+    server_info = collections.OrderedDict(json.loads(args[-2]))
 
     # Create a TCP/IP socket
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/openpype/modules/default_modules/ftrack/scripts/sub_event_storer.py
+++ b/openpype/modules/default_modules/ftrack/scripts/sub_event_storer.py
@@ -14,7 +14,11 @@ from openpype_modules.ftrack.ftrack_server.lib import (
     TOPIC_STATUS_SERVER_RESULT
 )
 from openpype_modules.ftrack.lib import get_ftrack_event_mongo_info
-from openpype.lib import OpenPypeMongoConnection
+from openpype.lib import (
+    OpenPypeMongoConnection,
+    get_openpype_version,
+    get_build_version
+)
 from openpype.api import Logger
 
 log = Logger.get_logger("Event storer")
@@ -153,9 +157,11 @@ def send_status(event):
     new_event_data = {
         "subprocess_id": os.environ["FTRACK_EVENT_SUB_ID"],
         "source": "storer",
-        "status_info": {
-            "created_at": subprocess_started.strftime("%Y.%m.%d %H:%M:%S")
-        }
+        "status_info": [
+            ["created_at", subprocess_started.strftime("%Y.%m.%d %H:%M:%S")],
+            ["OpenPype version", get_openpype_version() or "N/A"],
+            ["OpenPype build version", get_build_version() or "N/A"]
+        ]
     }
 
     new_event = ftrack_api.event.base.Event(


### PR DESCRIPTION
## Description
Show OpenPype versions in event server status action for both zip and build. Also show executable path (or path to start.py when running from code).

## Changes
- renamed `get_pype_version` to `get_openpype_version` (`get_pype_version` kept for backwards compatibility of opened PRs)
- added `is_running_from_build` function to be able know it openpype is running from code or build
- added `get_build_version` which should return version of build even if is not currently running version
- use new functions to pass information about processes to statuser
- information about processes are passed as list of lists to keep order
    - statuser was modified to be able handle that situations (require restart of whole event server)

## How to test
- run ftrack event server
- run `OpenPype Admin - Event server Status (...)` action
- all processes should have information about openpype version they're using and main process should have information about executable path (start.py path when running from code)