### PR TITLE
Console interpreter: Handle invalid sizes on initialization

### DIFF
--- a/openpype/modules/default_modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/default_modules/python_console_interpreter/window/widgets.py
@@ -387,8 +387,6 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
         self.setStyleSheet(load_stylesheet())
 
-        self.resize(self.default_width, self.default_height)
-
         self._init_from_registry()
 
         if self._tab_widget.count() < 1:
@@ -396,15 +394,22 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
     def _init_from_registry(self):
         setting_registry = PythonInterpreterRegistry()
-
+        width = None
+        height = None
         try:
             width = setting_registry.get_item("width")
             height = setting_registry.get_item("height")
-            if width is not None and height is not None:
-                self.resize(width, height)
 
         except ValueError:
             pass
+
+        if width is None or width < 200:
+            width = self.default_width
+
+        if height is None or height < 200:
+            height = self.default_height
+
+        self.resize(width, height)
 
         try:
             sizes = setting_registry.get_item("splitter_sizes")


### PR DESCRIPTION
## Issue
Console tool may be hidden on show because of previous invalid size stored in workstation registers.

## Changes
- resize console window only once and make sure it has minimum size

## How to repilace
- I've changed size of console tool on HD resolution to minimum and closed
- restarted tray and showed console tool on 4K monitor
- window was visible in task manager but was not visually visible