### PR TITLE
General: Task types in profiles

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -59,6 +59,11 @@ from .python_module_tools import (
     import_module_from_dirpath
 )
 
+from .profiles_filtering import (
+    compile_list_of_regexes,
+    filter_profiles
+)
+
 from .avalon_context import (
     CURRENT_DOC_SCHEMAS,
     PROJECT_NAME_ALLOWED_SYMBOLS,
@@ -118,12 +123,8 @@ from .applications import (
     prepare_host_environments,
     prepare_context_environments,
     get_app_environments_for_context,
-    apply_project_environments_value,
-
-    compile_list_of_regexes
+    apply_project_environments_value
 )
-
-from .profiles_filtering import filter_profiles
 
 from .plugin_tools import (
     TaskNotSetError,

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1245,6 +1245,9 @@ def prepare_context_environments(data):
     asset_tasks = asset_doc.get("data", {}).get("tasks") or {}
     task_info = asset_tasks.get(task_name) or {}
     task_type = task_info.get("type")
+    # Temp solution how to pass task type to `_prepare_last_workfile`
+    data["task_type"] = task_type
+
     workfile_template_key = get_workfile_template_key(
         task_type,
         app.host_name,
@@ -1321,6 +1324,7 @@ def _prepare_last_workfile(data, workdir, workfile_template_key):
     workdir_data = copy.deepcopy(_workdir_data)
     project_name = data["project_name"]
     task_name = data["task_name"]
+    task_type = data["task_type"]
     start_last_workfile = should_start_last_workfile(
         project_name, app.host_name, task_name
     )

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -25,6 +25,7 @@ from . import (
     PypeLogger,
     Anatomy
 )
+from .profiles_filtering import compile_list_of_regexes
 from .local_settings import get_openpype_username
 from .avalon_context import (
     get_workdir_data,
@@ -1495,22 +1496,3 @@ def should_workfile_tool_start(
 
     return get_option_from_settings(
         startup_presets, host_name, task_name, default_output)
-
-
-def compile_list_of_regexes(in_list):
-    """Convert strings in entered list to compiled regex objects."""
-    regexes = list()
-    if not in_list:
-        return regexes
-
-    for item in in_list:
-        if not item:
-            continue
-        try:
-            regexes.append(re.compile(item))
-        except TypeError:
-            print((
-                "Invalid type \"{}\" value \"{}\"."
-                " Expected string based object. Skipping."
-            ).format(str(type(item)), str(item)))
-    return regexes

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -25,7 +25,7 @@ from . import (
     PypeLogger,
     Anatomy
 )
-from .profiles_filtering import compile_list_of_regexes
+from .profiles_filtering import filter_profiles
 from .local_settings import get_openpype_username
 from .avalon_context import (
     get_workdir_data,
@@ -1326,12 +1326,12 @@ def _prepare_last_workfile(data, workdir, workfile_template_key):
     task_name = data["task_name"]
     task_type = data["task_type"]
     start_last_workfile = should_start_last_workfile(
-        project_name, app.host_name, task_name
+        project_name, app.host_name, task_name, task_type
     )
     data["start_last_workfile"] = start_last_workfile
 
     workfile_startup = should_workfile_tool_start(
-        project_name, app.host_name, task_name
+        project_name, app.host_name, task_name, task_type
     )
     data["workfile_startup"] = workfile_startup
 
@@ -1380,54 +1380,8 @@ def _prepare_last_workfile(data, workdir, workfile_template_key):
     data["last_workfile_path"] = last_workfile_path
 
 
-def get_option_from_settings(
-    startup_presets, host_name, task_name, default_output
-):
-    host_name_lowered = host_name.lower()
-    task_name_lowered = task_name.lower()
-
-    max_points = 2
-    matching_points = -1
-    matching_item = None
-    for item in startup_presets:
-        hosts = item.get("hosts") or tuple()
-        tasks = item.get("tasks") or tuple()
-
-        hosts_lowered = tuple(_host_name.lower() for _host_name in hosts)
-        # Skip item if has set hosts and current host is not in
-        if hosts_lowered and host_name_lowered not in hosts_lowered:
-            continue
-
-        tasks_lowered = tuple(_task_name.lower() for _task_name in tasks)
-        # Skip item if has set tasks and current task is not in
-        if tasks_lowered:
-            task_match = False
-            for task_regex in compile_list_of_regexes(tasks_lowered):
-                if re.match(task_regex, task_name_lowered):
-                    task_match = True
-                    break
-
-            if not task_match:
-                continue
-
-        points = int(bool(hosts_lowered)) + int(bool(tasks_lowered))
-        if points > matching_points:
-            matching_item = item
-            matching_points = points
-
-        if matching_points == max_points:
-            break
-
-    if matching_item is not None:
-        output = matching_item.get("enabled")
-        if output is None:
-            output = default_output
-        return output
-    return default_output
-
-
 def should_start_last_workfile(
-    project_name, host_name, task_name, default_output=False
+    project_name, host_name, task_name, task_type, default_output=False
 ):
     """Define if host should start last version workfile if possible.
 
@@ -1449,7 +1403,7 @@ def should_start_last_workfile(
     """
 
     project_settings = get_project_settings(project_name)
-    startup_presets = (
+    profiles = (
         project_settings
         ["global"]
         ["tools"]
@@ -1457,15 +1411,27 @@ def should_start_last_workfile(
         ["last_workfile_on_startup"]
     )
 
-    if not startup_presets:
+    if not profiles:
         return default_output
 
-    return get_option_from_settings(
-        startup_presets, host_name, task_name, default_output)
+    filter_data = {
+        "tasks": task_name,
+        "task_types": task_type,
+        "hosts": host_name
+    }
+    matching_item = filter_profiles(profiles, filter_data)
+
+    output = None
+    if matching_item:
+        output = matching_item.get("enabled")
+
+    if output is None:
+        return default_output
+    return output
 
 
 def should_workfile_tool_start(
-    project_name, host_name, task_name, default_output=False
+    project_name, host_name, task_name, task_type, default_output=False
 ):
     """Define if host should start workfile tool at host launch.
 
@@ -1487,7 +1453,7 @@ def should_workfile_tool_start(
     """
 
     project_settings = get_project_settings(project_name)
-    startup_presets = (
+    profiles = (
         project_settings
         ["global"]
         ["tools"]
@@ -1495,8 +1461,20 @@ def should_workfile_tool_start(
         ["open_workfile_tool_on_startup"]
     )
 
-    if not startup_presets:
+    if not profiles:
         return default_output
 
-    return get_option_from_settings(
-        startup_presets, host_name, task_name, default_output)
+    filter_data = {
+        "tasks": task_name,
+        "task_types": task_type,
+        "hosts": host_name
+    }
+    matching_item = filter_profiles(profiles, filter_data)
+
+    output = None
+    if matching_item:
+        output = matching_item.get("enabled")
+
+    if output is None:
+        return default_output
+    return output

--- a/openpype/lib/profiles_filtering.py
+++ b/openpype/lib/profiles_filtering.py
@@ -1,8 +1,26 @@
 import re
 import logging
-from .applications import compile_list_of_regexes
 
 log = logging.getLogger(__name__)
+
+
+def compile_list_of_regexes(in_list):
+    """Convert strings in entered list to compiled regex objects."""
+    regexes = list()
+    if not in_list:
+        return regexes
+
+    for item in in_list:
+        if not item:
+            continue
+        try:
+            regexes.append(re.compile(item))
+        except TypeError:
+            print((
+                "Invalid type \"{}\" value \"{}\"."
+                " Expected string based object. Skipping."
+            ).format(str(type(item)), str(item)))
+    return regexes
 
 
 def _profile_exclusion(matching_profiles, logger):

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -165,10 +165,15 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 hierarchy = "/".join(parents)
             anatomy_data["hierarchy"] = hierarchy
 
+        # Make sure task name in anatomy data is same as on instance.data
         task_name = instance.data.get("task")
         if task_name:
             anatomy_data["task"] = task_name
+        else:
+            # Just set 'task_name' variable to context task
+            task_name = anatomy_data["task"]
 
+        # Fill family in anatomy data
         anatomy_data["family"] = instance.data.get("family")
 
         stagingdir = instance.data.get("stagingDir")
@@ -298,7 +303,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         else:
             orig_transfers = list(instance.data['transfers'])
 
-        task_name = io.Session.get("AVALON_TASK")
         family = self.main_family_from_instance(instance)
 
         key_values = {"families": family,

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -184,6 +184,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         ) or {}
         task_info = asset_tasks.get(task_name) or {}
         task_type = task_info.get("type")
+        instance.data["task_type"] = task_type
 
         # Fill family in anatomy data
         anatomy_data["family"] = instance.data.get("family")
@@ -805,10 +806,12 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             instance.data["anatomyData"]["task"]
             or io.Session["AVALON_TASK"]
         )
+        task_type = instance.data["task_type"]
         filtering_criteria = {
             "families": instance.data["family"],
             "hosts": instance.context.data["hostName"],
-            "tasks": task_name
+            "tasks": task_name,
+            "task_types": task_type
         }
         matching_profile = filter_profiles(
             self.subset_grouping_profiles,

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -317,11 +317,17 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
         family = self.main_family_from_instance(instance)
 
-        key_values = {"families": family,
-                      "tasks": task_name,
-                      "hosts": instance.data["anatomyData"]["app"]}
-        profile = filter_profiles(self.template_name_profiles, key_values,
-                                  logger=self.log)
+        key_values = {
+            "families": family,
+            "tasks": task_name,
+            "hosts": instance.context.data["hostName"],
+            "task_types": task_type
+        }
+        profile = filter_profiles(
+            self.template_name_profiles,
+            key_values,
+            logger=self.log
+        )
 
         template_name = "publish"
         if profile:

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -106,12 +106,15 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         "family", "hierarchy", "task", "username"
     ]
     default_template_name = "publish"
-    template_name_profiles = None
+
+    # suffix to denote temporary files, use without '.'
+    TMP_FILE_EXT = 'tmp'
 
     # file_url : file_size of all published and uploaded files
     integrated_file_sizes = {}
 
-    TMP_FILE_EXT = 'tmp'  # suffix to denote temporary files, use without '.'
+    # Attributes set by settings
+    template_name_profiles = None
     subset_grouping_profiles = None
 
     def process(self, instance):

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -112,6 +112,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
     integrated_file_sizes = {}
 
     TMP_FILE_EXT = 'tmp'  # suffix to denote temporary files, use without '.'
+    subset_grouping_profiles = None
 
     def process(self, instance):
         self.integrated_file_sizes = {}

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -177,6 +177,14 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             # Just set 'task_name' variable to context task
             task_name = anatomy_data["task"]
 
+        # Find task type for current task name
+        # - this should be already prepared on instance
+        asset_tasks = (
+            asset_entity.get("data", {}).get("tasks")
+        ) or {}
+        task_info = asset_tasks.get(task_name) or {}
+        task_type = task_info.get("type")
+
         # Fill family in anatomy data
         anatomy_data["family"] = instance.data.get("family")
 

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -738,6 +738,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
             subset = io.find_one({"_id": _id})
 
+        # QUESTION Why is changing of group and updating it's
+        #   families in 'get_subset'?
         self._set_subset_group(instance, subset["_id"])
 
         # Update families on subset.
@@ -761,53 +763,71 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 subset_id (str): DB's subset _id
 
         """
-        # add group if available
-        integrate_new_sett = (instance.context.data["project_settings"]
-                                                   ["global"]
-                                                   ["publish"]
-                                                   ["IntegrateAssetNew"])
+        # Fist look into instance data
+        subset_group = instance.data.get("subsetGroup")
+        if not subset_group:
+            subset_group = self._get_subset_group(instance)
 
-        profiles = integrate_new_sett["subset_grouping_profiles"]
-
-        filtering_criteria = {
-            "families": instance.data["family"],
-            "hosts": instance.data["anatomyData"]["app"],
-            "tasks": instance.data["anatomyData"]["task"] or
-                io.Session["AVALON_TASK"]
-        }
-        matching_profile = filter_profiles(profiles, filtering_criteria)
-
-        filled_template = None
-        if matching_profile:
-            template = matching_profile["template"]
-            fill_pairs = (
-                ("family", filtering_criteria["families"]),
-                ("task", filtering_criteria["tasks"]),
-                ("host", filtering_criteria["hosts"]),
-                ("subset", instance.data["subset"]),
-                ("renderlayer", instance.data.get("renderlayer"))
-            )
-            fill_pairs = prepare_template_data(fill_pairs)
-
-            try:
-                filled_template = \
-                    format_template_with_optional_keys(fill_pairs, template)
-            except KeyError:
-                keys = []
-                if fill_pairs:
-                    keys = fill_pairs.keys()
-
-                msg = "Subset grouping failed. " \
-                      "Only {} are expected in Settings".format(','.join(keys))
-                self.log.warning(msg)
-
-        if instance.data.get("subsetGroup") or filled_template:
-            subset_group = instance.data.get('subsetGroup') or filled_template
-
+        if subset_group:
             io.update_many({
                 'type': 'subset',
                 '_id': io.ObjectId(subset_id)
             }, {'$set': {'data.subsetGroup': subset_group}})
+
+    def _get_subset_group(self, instance):
+        """Look into subset group profiles set by settings.
+
+        Attribute 'subset_grouping_profiles' is defined by OpenPype settings.
+        """
+        # Skip if 'subset_grouping_profiles' is empty
+        if not self.subset_grouping_profiles:
+            return None
+
+        # QUESTION
+        #   - is there a chance that task name is not filled in anatomy
+        #       data?
+        #   - should we use context task in that case?
+        task_name = (
+            instance.data["anatomyData"]["task"]
+            or io.Session["AVALON_TASK"]
+        )
+        filtering_criteria = {
+            "families": instance.data["family"],
+            "hosts": instance.context.data["hostName"],
+            "tasks": task_name
+        }
+        matching_profile = filter_profiles(
+            self.subset_grouping_profiles,
+            filtering_criteria
+        )
+        # Skip if there is not matchin profile
+        if not matching_profile:
+            return None
+
+        filled_template = None
+        template = matching_profile["template"]
+        fill_pairs = (
+            ("family", filtering_criteria["families"]),
+            ("task", filtering_criteria["tasks"]),
+            ("host", filtering_criteria["hosts"]),
+            ("subset", instance.data["subset"]),
+            ("renderlayer", instance.data.get("renderlayer"))
+        )
+        fill_pairs = prepare_template_data(fill_pairs)
+
+        try:
+            filled_template = \
+                format_template_with_optional_keys(fill_pairs, template)
+        except KeyError:
+            keys = []
+            if fill_pairs:
+                keys = fill_pairs.keys()
+
+            msg = "Subset grouping failed. " \
+                  "Only {} are expected in Settings".format(','.join(keys))
+            self.log.warning(msg)
+
+        return filled_template
 
     def create_version(self, subset, version_number, data=None):
         """ Copy given source to destination

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -209,6 +209,7 @@
                         "standalonepublisher"
                     ],
                     "families": [],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": true,
                     "advanced_filtering": []
@@ -221,6 +222,7 @@
                         "matchmove",
                         "shot"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": false,
                     "advanced_filtering": []
@@ -232,6 +234,7 @@
                     "families": [
                         "plate"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": false,
                     "advanced_filtering": [
@@ -256,6 +259,7 @@
                         "rig",
                         "camera"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": true,
                     "advanced_filtering": []
@@ -267,6 +271,7 @@
                     "families": [
                         "renderPass"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": false,
                     "advanced_filtering": []
@@ -276,6 +281,7 @@
                         "tvpaint"
                     ],
                     "families": [],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": true,
                     "advanced_filtering": []
@@ -288,6 +294,7 @@
                         "write",
                         "render"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": false,
                     "advanced_filtering": [
@@ -307,6 +314,7 @@
                         "render",
                         "workfile"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "add_ftrack_family": true,
                     "advanced_filtering": []

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -152,6 +152,7 @@
                 {
                     "families": [],
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "template_name": "publish"
                 },
@@ -162,6 +163,7 @@
                         "prerender"
                     ],
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "template_name": "render"
                 }
@@ -170,6 +172,7 @@
                 {
                     "families": [],
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "template": ""
                 }
@@ -205,6 +208,7 @@
                 {
                     "families": [],
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "template": "{family}{Variant}"
                 },
@@ -213,6 +217,7 @@
                         "render"
                     ],
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "template": "{family}{Task}{Variant}"
                 },
@@ -224,6 +229,7 @@
                     "hosts": [
                         "tvpaint"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "template": "{family}{Task}_{Render_layer}_{Render_pass}"
                 },
@@ -235,6 +241,7 @@
                     "hosts": [
                         "tvpaint"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "template": "{family}{Task}"
                 },
@@ -245,6 +252,7 @@
                     "hosts": [
                         "aftereffects"
                     ],
+                    "task_types": [],
                     "tasks": [],
                     "template": "render{Task}{Variant}"
                 }
@@ -261,6 +269,7 @@
             "last_workfile_on_startup": [
                 {
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "enabled": true
                 }
@@ -268,6 +277,7 @@
             "open_workfile_tool_on_startup": [
                 {
                     "hosts": [],
+                    "task_types": [],
                     "tasks": [],
                     "enabled": false
                 }

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -520,6 +520,7 @@
     "workfile_build": {
         "profiles": [
             {
+                "task_types": [],
                 "tasks": [
                     "Lighting"
                 ],

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -163,6 +163,7 @@
         "builder_on_start": false,
         "profiles": [
             {
+                "task_types": [],
                 "tasks": [],
                 "current_context": [
                     {

--- a/openpype/settings/defaults/project_settings/slack.json
+++ b/openpype/settings/defaults/project_settings/slack.json
@@ -7,8 +7,9 @@
             "profiles": [
                 {
                     "families": [],
-                    "tasks": [],
                     "hosts": [],
+                    "task_types": [],
+                    "tasks": [],
                     "channel_messages": []
                 }
             ]

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -651,6 +651,11 @@
                                         "object_type": "text"
                                     },
                                     {
+                                        "key": "task_types",
+                                        "label": "Task types",
+                                        "type": "task-types-enum"
+                                    },
+                                    {
                                         "key": "tasks",
                                         "label": "Task names",
                                         "type": "list",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
@@ -53,16 +53,21 @@
                                         "object_type": "text"
                                     },
                                     {
-                                        "key": "tasks",
-                                        "label": "Task names",
-                                        "type": "list",
-                                        "object_type": "text"
-                                    },
-                                    {
                                         "type": "hosts-enum",
                                         "key": "hosts",
                                         "label": "Host names",
                                         "multiselection": true
+                                    },
+                                    {
+                                        "key": "task_types",
+                                        "label": "Task types",
+                                        "type": "task-types-enum"
+                                    },
+                                    {
+                                        "key": "tasks",
+                                        "label": "Task names",
+                                        "type": "list",
+                                        "object_type": "text"
                                     },
                                     {
                                         "type": "separator"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -503,6 +503,11 @@
                                 "multiselection": true
                             },
                             {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
+                            },
+                            {
                                 "key": "tasks",
                                 "label": "Task names",
                                 "type": "list",
@@ -542,6 +547,11 @@
                                 "key": "hosts",
                                 "label": "Hosts",
                                 "multiselection": true
+                            },
+                            {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
                             },
                             {
                                 "key": "tasks",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -41,6 +41,11 @@
                                 "multiselection": true
                             },
                             {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
+                            },
+                            {
                                 "key": "tasks",
                                 "label": "Task names",
                                 "type": "list",
@@ -127,6 +132,11 @@
                                   ]
                             },
                             {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
+                            },
+                            {
                                 "key": "tasks",
                                 "label": "Tasks",
                                 "type": "list",
@@ -160,6 +170,12 @@
                                 "hosts_filter": [
                                     "nuke"
                                 ]
+                            },
+                            {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "list",
+                                "object_type": "task-types-enum"
                             },
                             {
                                 "key": "tasks",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -138,7 +138,7 @@
                             },
                             {
                                 "key": "tasks",
-                                "label": "Tasks",
+                                "label": "Task names",
                                 "type": "list",
                                 "object_type": "text"
                             },
@@ -179,7 +179,7 @@
                             },
                             {
                                 "key": "tasks",
-                                "label": "Tasks",
+                                "label": "Task names",
                                 "type": "list",
                                 "object_type": "text"
                             },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_workfile_build.json
@@ -18,7 +18,7 @@
                     },
                     {
                         "key": "tasks",
-                        "label": "Tasks",
+                        "label": "Task names",
                         "type": "list",
                         "object_type": "text"
                     },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_workfile_build.json
@@ -12,6 +12,11 @@
                 "type": "dict",
                 "children": [
                     {
+                        "key": "task_types",
+                        "label": "Task types",
+                        "type": "task-types-enum"
+                    },
+                    {
                         "key": "tasks",
                         "label": "Tasks",
                         "type": "list",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_workfile_options.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_workfile_options.json
@@ -56,6 +56,11 @@
                 "type": "dict",
                 "children": [
                     {
+                        "key": "task_types",
+                        "label": "Task types",
+                        "type": "task-types-enum"
+                    },
+                    {
                         "key": "tasks",
                         "label": "Tasks",
                         "type": "list",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_workfile_options.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_workfile_options.json
@@ -62,7 +62,7 @@
                     },
                     {
                         "key": "tasks",
-                        "label": "Tasks",
+                        "label": "Task names",
                         "type": "list",
                         "object_type": "text"
                     },


### PR DESCRIPTION
## Description
Use rather task types in settings than task names (mainly in profiles).

## Changes
- replaced custom functions handling profiles with function from `openpype.lib.profiles_filtering`
- all settings profiles where was possible to have task name filtering also have task type filter
- modified code where modified settings are used - Affected:
    - `IntegrateNew`
    - `get_subset_name`
    - open last workfile on start
    - workfile tool on startup

### Notes
This has few disadvantages:
- changing of task types in project anatomy is not automatically propagated to enums (comboboxes) storing task type value
    - it is possible to remove task type and store the task type in profiles at the same time
- it is possible (in theory) to have task with type that is not in project config

I've kept task name profiling to not break backwards compatibility and it could make sense to have it there too(?)...

Function `get_subset_name` is now expecting asset id which may be performance issue because it has to query asset document when is called.

Resolves https://github.com/pypeclub/OpenPype/issues/1866