### PR TITLE
Ftrack: Delete old versions missing settings key

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_old_versions.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_old_versions.py
@@ -23,6 +23,8 @@ class DeleteOldVersions(BaseAction):
     )
     icon = statics_icon("ftrack", "action_icons", "OpenPypeAdmin.svg")
 
+    settings_key = "delete_old_versions"
+
     dbcon = AvalonMongoDB()
 
     inteface_title = "Choose your preferences"


### PR DESCRIPTION
## Issue
Ftrack action that use `valid_roles` method must have set attribute `settings_key` which is missing on `DeleteOldVersions` action.

## Changes
- added missing `settings_key` attribute for delete old versions action