### PR TITLE
Workfiles tool: Task selection

### DIFF
--- a/openpype/lib/pype_info.py
+++ b/openpype/lib/pype_info.py
@@ -64,7 +64,7 @@ def is_running_staging():
     Returns:
         bool: True if openpype version containt 'staging'.
     """
-    if "staging" in get_pype_version():
+    if "staging" in get_openpype_version():
         return True
     return False
 

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -376,6 +376,9 @@ class TasksWidget(QtWidgets.QWidget):
             task (str): Name of the task to select.
 
         """
+        task_view_model = self._tasks_view.model()
+        if not task_view_model:
+            return
 
         # Clear selection
         selection_model = self._tasks_view.selectionModel()
@@ -383,8 +386,8 @@ class TasksWidget(QtWidgets.QWidget):
 
         # Select the task
         mode = selection_model.Select | selection_model.Rows
-        for row in range(self._tasks_model.rowCount()):
-            index = self._tasks_model.index(row, 0)
+        for row in range(task_view_model.rowCount()):
+            index = task_view_model.index(row, 0)
             name = index.data(TASK_NAME_ROLE)
             if name == task_name:
                 selection_model.select(index, mode)


### PR DESCRIPTION
## Issue
Auto task selection is not working because for selecting is used index from source model instead of proxy model which is invalid in selection model.

## Changes
- use source model of task view to select task so indexes are valid

## How to test
- open workfiles tool in any host and current task should be preselected when tool is opened