### PR TITLE
Loader: Families filtering

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -287,6 +287,15 @@
                     "textures"
                 ]
             }
+        },
+        "loader": {
+            "family_filter_profiles": [
+                {
+                    "hosts": [],
+                    "task_types": [],
+                    "filter_families": []
+                }
+            ]
         }
     },
     "project_folder_structure": "{\"__project_root__\": {\"prod\": {}, \"resources\": {\"footage\": {\"plates\": {}, \"offline\": {}}, \"audio\": {}, \"art_dept\": {}}, \"editorial\": {}, \"assets[ftrack.Library]\": {\"characters[ftrack]\": {}, \"locations[ftrack]\": {}}, \"shots[ftrack.Sequence]\": {\"scripts\": {}, \"editorial[ftrack.Folder]\": {}}}}",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -190,6 +190,48 @@
                     }
                 }
             ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "loader",
+            "label": "Loader",
+            "children": [
+                {
+                    "type": "list",
+                    "key": "family_filter_profiles",
+                    "label": "Family filtering",
+                    "use_label_wrap": true,
+                    "object_type": {
+                        "type": "dict",
+                        "children": [
+                            {
+                                "type": "hosts-enum",
+                                "key": "hosts",
+                                "label": "Hosts",
+                                "multiselection": true
+                            },
+                            {
+                                "type": "task-types-enum",
+                                "key": "task_types",
+                                "label": "Task types"
+                            },
+                            {
+                                "type": "splitter"
+                            },
+                            {
+                                "type": "template",
+                                "name": "template_publish_families",
+                                "template_data": {
+                                    "key": "filter_families",
+                                    "label": "Filter families",
+                                    "multiselection": true
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
         }
     ]
 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_publish_families.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_publish_families.json
@@ -10,11 +10,23 @@
         "multiselection": "{multiselection}",
         "type": "enum",
         "enum_items": [
-            {"family1": "family1"},
-            {"family2": "family2"},
-            {"family3": "family3"},
-            {"family4": "family4"},
-            {"family5": "family5"}
+            {"action": "action"},
+            {"animation": "animation"},
+            {"audio": "audio"},
+            {"camera": "camera"},
+            {"editorial": "editorial"},
+            {"layout": "layout"},
+            {"look": "look"},
+            {"mayaAscii": "mayaAscii"},
+            {"model": "model"},
+            {"pointcache": "pointcache"},
+            {"reference": "reference"},
+            {"render": "render"},
+            {"review": "review"},
+            {"rig": "rig"},
+            {"setdress": "setdress"},
+            {"workfile": "workfile"},
+            {"xgen": "xgen"}
         ]
     }
 ]

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_publish_families.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_publish_families.json
@@ -1,0 +1,20 @@
+[
+    {
+        "__default_values__": {
+            "multiselection": true
+        }
+    },
+    {
+        "key": "{key}",
+        "label": "{label}",
+        "multiselection": "{multiselection}",
+        "type": "enum",
+        "enum_items": [
+            {"family1": "family1"},
+            {"family2": "family2"},
+            {"family3": "family3"},
+            {"family4": "family4"},
+            {"family5": "family5"}
+        ]
+    }
+]

--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -1,5 +1,4 @@
 import sys
-import time
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -9,7 +9,7 @@ from openpype.tools.utils import lib as tools_lib
 from openpype.tools.loader.widgets import (
     ThumbnailWidget,
     VersionWidget,
-    FamilyListWidget,
+    FamilyListView,
     RepresentationWidget
 )
 from openpype.tools.utils.widgets import AssetWidget
@@ -65,7 +65,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         assets = AssetWidget(
             self.dbcon, multiselection=True, parent=self
         )
-        families = FamilyListWidget(
+        families = FamilyListView(
             self.dbcon, self.family_config_cache, parent=self
         )
         subsets = LibrarySubsetWidget(

--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -151,6 +151,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         assets.view.clicked.connect(self.on_assetview_click)
         subsets.active_changed.connect(self.on_subsetschanged)
         subsets.version_changed.connect(self.on_versionschanged)
+        subsets.refreshed.connect(self._on_subset_refresh)
         self.combo_projects.currentTextChanged.connect(self.on_project_change)
 
         self.sync_server = sync_server
@@ -242,6 +243,12 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
                 "Config `%s` has no function `install`" % _config.__name__
             )
 
+        subsets = self.data["widgets"]["subsets"]
+        representations = self.data["widgets"]["representations"]
+
+        subsets.on_project_change(self.dbcon.Session["AVALON_PROJECT"])
+        representations.on_project_change(self.dbcon.Session["AVALON_PROJECT"])
+
         self.family_config_cache.refresh()
         self.groups_config.refresh()
 
@@ -251,12 +258,6 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         project_name = self.dbcon.active_project() or "No project selected"
         title = "{} - {}".format(self.tool_title, project_name)
         self.setWindowTitle(title)
-
-        subsets = self.data["widgets"]["subsets"]
-        subsets.on_project_change(self.dbcon.Session["AVALON_PROJECT"])
-
-        representations = self.data["widgets"]["representations"]
-        representations.on_project_change(self.dbcon.Session["AVALON_PROJECT"])
 
     @property
     def current_project(self):
@@ -288,6 +289,14 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         self.echo("Fetching version..")
         tools_lib.schedule(self._versionschanged, 150, channel="mongo")
 
+    def _on_subset_refresh(self, has_item):
+        subsets_widget = self.data["widgets"]["subsets"]
+        families_view = self.data["widgets"]["families"]
+
+        subsets_widget.set_loading_state(loading=False, empty=not has_item)
+        families = subsets_widget.get_subsets_families()
+        families_view.set_enabled_families(families)
+
     def set_context(self, context, refresh=True):
         self.echo("Setting context: {}".format(context))
         lib.schedule(
@@ -312,12 +321,13 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             assert project_doc, "This is a bug"
 
         assets_widget = self.data["widgets"]["assets"]
+        families_view = self.data["widgets"]["families"]
+        families_view.set_enabled_families(set())
+        families_view.refresh()
+
         assets_widget.model.stop_fetch_thread()
         assets_widget.refresh()
         assets_widget.setFocus()
-
-        families = self.data["widgets"]["families"]
-        families.refresh()
 
     def clear_assets_underlines(self):
         last_asset_ids = self.data["state"]["assetIds"]
@@ -337,8 +347,6 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
 
     def _assetschanged(self):
         """Selected assets have changed"""
-        t1 = time.time()
-
         assets_widget = self.data["widgets"]["assets"]
         subsets_widget = self.data["widgets"]["subsets"]
         subsets_model = subsets_widget.model
@@ -365,14 +373,6 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             empty=True
         )
 
-        def on_refreshed(has_item):
-            empty = not has_item
-            subsets_widget.set_loading_state(loading=False, empty=empty)
-            subsets_model.refreshed.disconnect()
-            self.echo("Duration: %.3fs" % (time.time() - t1))
-
-        subsets_model.refreshed.connect(on_refreshed)
-
         subsets_model.set_assets(asset_ids)
         subsets_widget.view.setColumnHidden(
             subsets_model.Columns.index("asset"),
@@ -386,9 +386,8 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         self.data["state"]["assetIds"] = asset_ids
 
         representations = self.data["widgets"]["representations"]
-        representations.set_version_ids([])  # reset repre list
-
-        self.echo("Duration: %.3fs" % (time.time() - t1))
+        # reset repre list
+        representations.set_version_ids([])
 
     def _subsetschanged(self):
         asset_ids = self.data["state"]["assetIds"]

--- a/openpype/tools/loader/__init__.py
+++ b/openpype/tools/loader/__init__.py
@@ -1,11 +1,11 @@
 from .app import (
-    LoaderWidow,
+    LoaderWindow,
     show,
     cli,
 )
 
 __all__ = (
-    "LoaderWidow",
+    "LoaderWindow",
     "show",
     "cli",
 )

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -221,6 +221,8 @@ class LoaderWidow(QtWidgets.QDialog):
         familis_widget = self.data["widgets"]["families"]
 
         subsets_widget.set_loading_state(loading=False, empty=not has_item)
+        families = subsets_widget.get_subsets_families()
+        familis_widget.set_enabled_families(families)
 
     def _on_load_end(self):
         # Delay hiding as click events happened during loading should be

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -232,8 +232,11 @@ class LoaderWidow(QtWidgets.QDialog):
     # ------------------------------
 
     def on_context_task_change(self, *args, **kwargs):
-        # Change to context asset on context change
         assets_widget = self.data["widgets"]["assets"]
+        families_view = self.data["widgets"]["families"]
+        # Refresh families config
+        families_view.refresh()
+        # Change to context asset on context change
         assets_widget.select_assets(io.Session["AVALON_ASSET"])
 
     def _refresh(self):

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -146,6 +146,7 @@ class LoaderWidow(QtWidgets.QDialog):
         assets.view.clicked.connect(self.on_assetview_click)
         subsets.active_changed.connect(self.on_subsetschanged)
         subsets.version_changed.connect(self.on_versionschanged)
+        subsets.refreshed.connect(self._on_subset_refresh)
 
         subsets.load_started.connect(self._on_load_start)
         subsets.load_ended.connect(self._on_load_end)
@@ -215,6 +216,12 @@ class LoaderWidow(QtWidgets.QDialog):
     def _hide_overlay(self):
         self._overlay_frame.setVisible(False)
 
+    def _on_subset_refresh(self, has_item):
+        subsets_widget = self.data["widgets"]["subsets"]
+        familis_widget = self.data["widgets"]["families"]
+
+        subsets_widget.set_loading_state(loading=False, empty=not has_item)
+
     def _on_load_end(self):
         # Delay hiding as click events happened during loading should be
         #   blocked
@@ -264,8 +271,6 @@ class LoaderWidow(QtWidgets.QDialog):
 
     def _assetschanged(self):
         """Selected assets have changed"""
-        t1 = time.time()
-
         assets_widget = self.data["widgets"]["assets"]
         subsets_widget = self.data["widgets"]["subsets"]
         subsets_model = subsets_widget.model
@@ -282,14 +287,6 @@ class LoaderWidow(QtWidgets.QDialog):
             loading=bool(asset_ids),
             empty=True
         )
-
-        def on_refreshed(has_item):
-            empty = not has_item
-            subsets_widget.set_loading_state(loading=False, empty=empty)
-            subsets_model.refreshed.disconnect()
-            self.echo("Duration: %.3fs" % (time.time() - t1))
-
-        subsets_model.refreshed.connect(on_refreshed)
 
         subsets_model.set_assets(asset_ids)
         subsets_widget.view.setColumnHidden(

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -218,11 +218,11 @@ class LoaderWidow(QtWidgets.QDialog):
 
     def _on_subset_refresh(self, has_item):
         subsets_widget = self.data["widgets"]["subsets"]
-        familis_widget = self.data["widgets"]["families"]
+        families_view = self.data["widgets"]["families"]
 
         subsets_widget.set_loading_state(loading=False, empty=not has_item)
         families = subsets_widget.get_subsets_families()
-        familis_widget.set_enabled_families(families)
+        families_view.set_enabled_families(families)
 
     def _on_load_end(self):
         # Delay hiding as click events happened during loading should be
@@ -247,8 +247,8 @@ class LoaderWidow(QtWidgets.QDialog):
         assets_widget.refresh()
         assets_widget.setFocus()
 
-        families = self.data["widgets"]["families"]
-        families.refresh()
+        families_view = self.data["widgets"]["families"]
+        families_view.refresh()
 
     def clear_assets_underlines(self):
         """Clear colors from asset data to remove colored underlines
@@ -303,7 +303,8 @@ class LoaderWidow(QtWidgets.QDialog):
         self.data["state"]["assetIds"] = asset_ids
 
         representations = self.data["widgets"]["representations"]
-        representations.set_version_ids([])  # reset repre list
+        # reset repre list
+        representations.set_version_ids([])
 
     def _subsetschanged(self):
         asset_ids = self.data["state"]["assetIds"]

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -11,7 +11,7 @@ from openpype.tools.utils import lib
 from .widgets import (
     SubsetWidget,
     VersionWidget,
-    FamilyListWidget,
+    FamilyListView,
     ThumbnailWidget,
     RepresentationWidget,
     OverlayFrame
@@ -64,7 +64,7 @@ class LoaderWidow(QtWidgets.QDialog):
         assets = AssetWidget(io, multiselection=True, parent=self)
         assets.set_current_asset_btn_visibility(True)
 
-        families = FamilyListWidget(io, self.family_config_cache, self)
+        families = FamilyListView(io, self.family_config_cache, self)
         subsets = SubsetWidget(
             io,
             self.groups_config,

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -34,13 +34,13 @@ def on_context_task_change(*args, **kwargs):
 pipeline.on("taskChanged", on_context_task_change)
 
 
-class LoaderWidow(QtWidgets.QDialog):
+class LoaderWindow(QtWidgets.QDialog):
     """Asset loader interface"""
 
     tool_name = "loader"
 
     def __init__(self, parent=None):
-        super(LoaderWidow, self).__init__(parent)
+        super(LoaderWindow, self).__init__(parent)
         title = "Asset Loader 2.1"
         project_name = api.Session.get("AVALON_PROJECT")
         if project_name:
@@ -170,11 +170,11 @@ class LoaderWidow(QtWidgets.QDialog):
             self.resize(1300, 700)
 
     def resizeEvent(self, event):
-        super(LoaderWidow, self).resizeEvent(event)
+        super(LoaderWindow, self).resizeEvent(event)
         self._overlay_frame.resize(self.size())
 
     def moveEvent(self, event):
-        super(LoaderWidow, self).moveEvent(event)
+        super(LoaderWindow, self).moveEvent(event)
         self._overlay_frame.move(0, 0)
 
     # -------------------------------
@@ -457,7 +457,7 @@ class LoaderWidow(QtWidgets.QDialog):
             self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         print("Good bye")
-        return super(LoaderWidow, self).closeEvent(event)
+        return super(LoaderWindow, self).closeEvent(event)
 
     def keyPressEvent(self, event):
         modifiers = event.modifiers()
@@ -469,7 +469,7 @@ class LoaderWidow(QtWidgets.QDialog):
             self.show_grouping_dialog()
             return
 
-        super(LoaderWidow, self).keyPressEvent(event)
+        super(LoaderWindow, self).keyPressEvent(event)
         event.setAccepted(True)  # Avoid interfering other widgets
 
     def show_grouping_dialog(self):
@@ -630,7 +630,7 @@ def show(debug=False, parent=None, use_context=False):
         module.project = any_project["name"]
 
     with lib.application():
-        window = LoaderWidow(parent)
+        window = LoaderWindow(parent)
         window.setStyleSheet(style.load_stylesheet())
         window.show()
 

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -1,5 +1,4 @@
 import sys
-import time
 
 from Qt import QtWidgets, QtCore
 from avalon import api, io, style, pipeline

--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -860,10 +860,9 @@ class SubsetFilterProxyModel(GroupMemberFilterProxyModel):
 class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
     """Filters to specified families"""
 
-    def __init__(self, family_config_cache, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(FamiliesFilterProxyModel, self).__init__(*args, **kwargs)
         self._families = set()
-        self.family_config_cache = family_config_cache
 
     def familyFilter(self):
         return self._families
@@ -894,10 +893,6 @@ class FamiliesFilterProxyModel(GroupMemberFilterProxyModel):
         family = item.get("family")
         if not family:
             return True
-
-        family_config = self.family_config_cache.family_config(family)
-        if family_config.get("hideFilter"):
-            return False
 
         # We want to keep the families which are not in the list
         return family in self._families

--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -190,6 +190,9 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
         self._grouping = state
         self.on_doc_fetched()
 
+    def get_subsets_families(self):
+        return self._doc_payload.get("subset_families") or set()
+
     def setData(self, index, value, role=QtCore.Qt.EditRole):
         # Trigger additional edit when `version` column changed
         # because it also updates the information in other columns

--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -70,7 +70,6 @@ class BaseRepresentationModel(object):
 
 
 class SubsetsModel(TreeModel, BaseRepresentationModel):
-
     doc_fetched = QtCore.Signal()
     refreshed = QtCore.Signal(bool)
 
@@ -354,10 +353,16 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
             },
             self.subset_doc_projection
         )
-        for subset in subset_docs:
+        subset_families = set()
+        for subset_doc in subset_docs:
             if self._doc_fetching_stop:
                 return
-            subset_docs_by_id[subset["_id"]] = subset
+
+            families = subset_doc.get("data", {}).get("families")
+            if families:
+                subset_families.add(families[0])
+
+            subset_docs_by_id[subset_doc["_id"]] = subset_doc
 
         subset_ids = list(subset_docs_by_id.keys())
         _pipeline = [
@@ -428,6 +433,7 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
         self._doc_payload = {
             "asset_docs_by_id": asset_docs_by_id,
             "subset_docs_by_id": subset_docs_by_id,
+            "subset_families": subset_families,
             "last_versions_by_subset_id": last_versions_by_subset_id
         }
 

--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -128,7 +128,7 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
         "name": 1,
         "parent": 1,
         "schema": 1,
-        "families": 1,
+        "data.families": 1,
         "data.subsetGroup": 1
     }
 

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -159,7 +159,7 @@ class SubsetWidget(QtWidgets.QWidget):
             grouping=enable_grouping
         )
         proxy = SubsetFilterProxyModel()
-        family_proxy = FamiliesFilterProxyModel(family_config_cache)
+        family_proxy = FamiliesFilterProxyModel()
         family_proxy.setSourceModel(proxy)
 
         subset_filter = QtWidgets.QLineEdit()

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -247,6 +247,9 @@ class SubsetWidget(QtWidgets.QWidget):
 
         self.model.refresh()
 
+    def get_subsets_families(self):
+        return self.model.get_subsets_families()
+
     def set_family_filters(self, families):
         self.family_proxy.setFamiliesFilter(families)
 

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -905,12 +905,12 @@ class FamilyModel(QtGui.QStandardItemModel):
                     | QtCore.Qt.ItemIsSelectable
                     | QtCore.Qt.ItemIsUserCheckable
                 )
+                new_items.append(item)
+                self._items_by_family[family] = item
 
             else:
                 item = self._items_by_family[label]
                 item.setData(QtCore.Qt.DisplayRole, label)
-                new_items.append(item)
-                self._items_by_family[family] = item
 
             item.setCheckState(state)
 
@@ -942,7 +942,7 @@ class FamilyProxyFiler(QtCore.QSortFilterProxyModel):
     def set_filter_enabled(self, enabled=None):
         if enabled is None:
             enabled = not self._filtering_enabled
-        if self._filtering_enabled == enabled:
+        elif self._filtering_enabled == enabled:
             return
 
         self._filtering_enabled = enabled

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -915,6 +915,7 @@ class FamilyModel(QtGui.QStandardItemModel):
                 item.setIcon(icon)
 
             new_items.append(item)
+            self._items_by_family[family] = item
 
         if new_items:
             root_item.appendRows(new_items)

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -889,11 +889,7 @@ class FamilyModel(QtGui.QStandardItemModel):
 
         new_items = []
         for family in families:
-            if family in self._items_by_family:
-                continue
-
             family_config = self.family_config_cache.family_config(family)
-
             label = family_config.get("label", family)
             icon = family_config.get("icon", None)
 
@@ -902,19 +898,24 @@ class FamilyModel(QtGui.QStandardItemModel):
             else:
                 state = QtCore.Qt.Unchecked
 
-            item = QtGui.QStandardItem(label)
-            item.setFlags(
-                QtCore.Qt.ItemIsEnabled
-                | QtCore.Qt.ItemIsSelectable
-                | QtCore.Qt.ItemIsUserCheckable
-            )
+            if family not in self._items_by_family:
+                item = QtGui.QStandardItem(label)
+                item.setFlags(
+                    QtCore.Qt.ItemIsEnabled
+                    | QtCore.Qt.ItemIsSelectable
+                    | QtCore.Qt.ItemIsUserCheckable
+                )
+
+            else:
+                item = self._items_by_family[label]
+                item.setData(QtCore.Qt.DisplayRole, label)
+                new_items.append(item)
+                self._items_by_family[family] = item
+                
             item.setCheckState(state)
 
             if icon:
                 item.setIcon(icon)
-
-            new_items.append(item)
-            self._items_by_family[family] = item
 
         if new_items:
             root_item.appendRows(new_items)

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -879,12 +879,13 @@ class FamilyModel(QtGui.QStandardItemModel):
                 families = set(result[0]["families"])
 
         root_item = self.invisibleRootItem()
-        self.blockSignals(True)
+
         for family in tuple(self._items_by_family.keys()):
             if family not in families:
                 item = self._items_by_family.pop(family)
                 root_item.removeRow(item.row())
-        self.blockSignals(False)
+
+        self.family_config_cache.refresh()
 
         new_items = []
         for family in families:
@@ -892,8 +893,6 @@ class FamilyModel(QtGui.QStandardItemModel):
                 continue
 
             family_config = self.family_config_cache.family_config(family)
-            if family_config.get("hideFilter"):
-                continue
 
             label = family_config.get("label", family)
             icon = family_config.get("icon", None)

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -911,7 +911,7 @@ class FamilyModel(QtGui.QStandardItemModel):
                 item.setData(QtCore.Qt.DisplayRole, label)
                 new_items.append(item)
                 self._items_by_family[family] = item
-                
+
             item.setCheckState(state)
 
             if icon:

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -910,7 +910,7 @@ class FamilyModel(QtGui.QStandardItemModel):
 
             else:
                 item = self._items_by_family[label]
-                item.setData(QtCore.Qt.DisplayRole, label)
+                item.setData(label, QtCore.Qt.DisplayRole)
 
             item.setCheckState(state)
 

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -122,6 +122,7 @@ class SubsetWidget(QtWidgets.QWidget):
     version_changed = QtCore.Signal()   # version state changed for a subset
     load_started = QtCore.Signal()
     load_ended = QtCore.Signal()
+    refreshed = QtCore.Signal(bool)
 
     default_widths = (
         ("subset", 200),
@@ -242,6 +243,7 @@ class SubsetWidget(QtWidgets.QWidget):
 
         self.filter.textChanged.connect(self.proxy.setFilterRegExp)
         self.filter.textChanged.connect(self.view.expandAll)
+        model.refreshed.connect(self.refreshed)
 
         self.model.refresh()
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -12,9 +12,6 @@ from avalon.vendor import qtawesome
 from openpype.api import get_project_settings
 from openpype.lib import filter_profiles
 
-self = sys.modules[__name__]
-self._jobs = dict()
-
 
 def format_version(value, hero_version=False):
     """Formats integer to displayable version name"""
@@ -58,6 +55,10 @@ def defer(delay, func):
         return func()
 
 
+class SharedObjects:
+    jobs = {}
+
+
 def schedule(func, time, channel="default"):
     """Run `func` at a later `time` in a dedicated `channel`
 
@@ -69,7 +70,7 @@ def schedule(func, time, channel="default"):
     """
 
     try:
-        self._jobs[channel].stop()
+        SharedObjects.jobs[channel].stop()
     except (AttributeError, KeyError, RuntimeError):
         pass
 
@@ -78,7 +79,7 @@ def schedule(func, time, channel="default"):
     timer.timeout.connect(func)
     timer.start(time)
 
-    self._jobs[channel] = timer
+    SharedObjects.jobs[channel] = timer
 
 
 @contextlib.contextmanager

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -296,7 +296,6 @@ class FamilyConfigCache:
             )
         return cls._default_icon
 
-
     def family_config(self, family_name):
         """Get value from config with fallback to default"""
         if self._require_refresh:
@@ -343,9 +342,9 @@ class FamilyConfigCache:
             return
 
         # Update the icons from the project configuration
-        project_name = self.dbcon.Session.get("AVALON_PROJECT")
-        asset_name = self.dbcon.Session.get("AVALON_ASSET")
-        task_name = self.dbcon.Session.get("AVALON_TASK")
+        project_name = os.environ.get("AVALON_PROJECT")
+        asset_name = os.environ.get("AVALON_ASSET")
+        task_name = os.environ.get("AVALON_TASK")
         if not all((project_name, asset_name, task_name)):
             return
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -12,18 +12,6 @@ self = sys.modules[__name__]
 self._jobs = dict()
 
 
-class SharedObjects:
-    # Variable for family cache in global context
-    # QUESTION is this safe? More than one tool can refresh at the same time.
-    family_cache = None
-
-
-def global_family_cache():
-    if SharedObjects.family_cache is None:
-        SharedObjects.family_cache = FamilyConfigCache(io)
-    return SharedObjects.family_cache
-
-
 def format_version(value, hero_version=False):
     """Formats integer to displayable version name"""
     label = "v{0:03d}".format(value)

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -91,7 +91,6 @@ def dummy():
         ..   pass
 
     """
-
     yield
 
 
@@ -297,11 +296,6 @@ class FamilyConfigCache:
             )
         return cls._default_icon
 
-    @classmethod
-    def default_item(cls):
-        return {
-            "icon": cls.default_icon()
-        }
 
     def family_config(self, family_name):
         """Get value from config with fallback to default"""
@@ -310,7 +304,9 @@ class FamilyConfigCache:
 
         item = self.family_configs.get(family_name)
         if not item:
-            item = self.default_item()
+            item = {
+                "icon": self.default_icon()
+            }
             if self._family_filters_set:
                 item["state"] = False
         return item


### PR DESCRIPTION
## Goal
- be able to modify families filtering in loader based on profiles

## Changes
- added Loader section in settings with families filter profiles
- added multiselection enum with (probably) all possible families that can be in loader visible
    - any modifications of the list are welcomed
    - maybe we could add there a list of string and let it change manually?
- family config simplified as most of it is not available in OpenPype
- states of families are defined by profiles from settings

Depends on https://github.com/pypeclub/OpenPype/pull/2038