### PR TITLE
Settings UI: Deffered set value on entity

### DIFF
--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -3,6 +3,7 @@ import json
 from Qt import QtWidgets, QtGui, QtCore
 from openpype.tools.settings import CHILD_OFFSET
 from .widgets import ExpandingWidget
+from .lib import create_deffered_value_change_timer
 
 
 class BaseWidget(QtWidgets.QWidget):
@@ -329,6 +330,20 @@ class BaseWidget(QtWidgets.QWidget):
 
 
 class InputWidget(BaseWidget):
+    def __init__(self, *args, **kwargs):
+        super(InputWidget, self).__init__(*args, **kwargs)
+
+        # Input widgets have always timer available (but may not be used).
+        self._value_change_timer = create_deffered_value_change_timer(
+            self._on_value_change_timer
+        )
+
+    def start_value_timer(self):
+        self._value_change_timer.start()
+
+    def _on_value_change_timer(self):
+        pass
+
     def create_ui(self):
         if self.entity.use_label_wrap:
             label = None

--- a/openpype/tools/settings/settings/dict_mutable_widget.py
+++ b/openpype/tools/settings/settings/dict_mutable_widget.py
@@ -285,7 +285,9 @@ class ModifiableDictItem(QtWidgets.QWidget):
 
         self.confirm_btn = None
 
-        self._key_change_timer = create_deffered_value_change_timer(self._on_timeout)
+        self._key_change_timer = create_deffered_value_change_timer(
+            self._on_timeout
+        )
 
         if collapsible_key:
             self.create_collapsible_ui()

--- a/openpype/tools/settings/settings/dict_mutable_widget.py
+++ b/openpype/tools/settings/settings/dict_mutable_widget.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from Qt import QtWidgets, QtCore, QtGui
 
 from .base import BaseWidget
+from .lib import create_deffered_value_change_timer
 from .widgets import (
     ExpandingWidget,
     IconButton
@@ -284,6 +285,8 @@ class ModifiableDictItem(QtWidgets.QWidget):
 
         self.confirm_btn = None
 
+        self._key_change_timer = create_deffered_value_change_timer(self._on_timeout)
+
         if collapsible_key:
             self.create_collapsible_ui()
         else:
@@ -516,6 +519,10 @@ class ModifiableDictItem(QtWidgets.QWidget):
         if self.ignore_input_changes:
             return
 
+        self._key_change_timer.start()
+
+    def _on_timeout(self):
+        key = self.key_value()
         is_key_duplicated = self.entity_widget.validate_key_duplication(
             self.temp_key, key, self
         )

--- a/openpype/tools/settings/settings/item_widgets.py
+++ b/openpype/tools/settings/settings/item_widgets.py
@@ -400,7 +400,9 @@ class TextWidget(InputWidget):
     def _on_value_change(self):
         if self.ignore_input_changes:
             return
+        self.start_value_timer()
 
+    def _on_value_change_timer(self):
         self.entity.set(self.input_value())
 
 
@@ -474,6 +476,9 @@ class NumberWidget(InputWidget):
         if self.ignore_input_changes:
             return
 
+        self.start_value_timer()
+
+    def _on_value_change_timer(self):
         value = self.input_field.value()
         if self._slider_widget is not None and not self._ignore_input_change:
             self._ignore_slider_change = True
@@ -571,7 +576,9 @@ class RawJsonWidget(InputWidget):
     def _on_value_change(self):
         if self.ignore_input_changes:
             return
+        self.start_value_timer()
 
+    def _on_value_change_timer(self):
         self._is_invalid = self.input_field.has_invalid_value()
         if not self.is_invalid:
             self.entity.set(self.input_field.json_value())
@@ -786,4 +793,7 @@ class PathInputWidget(InputWidget):
     def _on_value_change(self):
         if self.ignore_input_changes:
             return
+        self.start_value_timer()
+
+    def _on_value_change_timer(self):
         self.entity.set(self.input_value())

--- a/openpype/tools/settings/settings/lib.py
+++ b/openpype/tools/settings/settings/lib.py
@@ -1,0 +1,18 @@
+from Qt import QtCore
+
+# Offset of value change trigger in ms
+VALUE_CHANGE_OFFSET_MS = 300
+
+
+def create_deffered_value_change_timer(callback):
+    """Deffer value change callback.
+
+    UI won't trigger all callbacks on each value change but after predefined
+    time. Timer is reset on each start so callback is triggered after user
+    finish editing.
+    """
+    timer = QtCore.QTimer()
+    timer.setSingleShot(True)
+    timer.setInterval(VALUE_CHANGE_OFFSET_MS)
+    timer.timeout.connect(callback)
+    return timer


### PR DESCRIPTION
## Goal
Make UI more responsive when modifying values.

## Changes
- value changes of few inputs are deffered and emitted to entity once per 300ms after last change

## Result
- changes in UI (specially text changes) are more responsive
- styles and validations are applied with 300ms offset after last change