### PR TITLE
TVPaint: EXR Extractor

### DIFF
--- a/pype/plugins/tvpaint/publish/extract_sequence_exr.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence_exr.py
@@ -33,12 +33,13 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
             )
 
             files = []
+            oiio_path = os.environ.get("PYPE_OIIO_PATH", "oiiotool")
             for f in representation["files"]:
                 f = os.path.join(representation["stagingDir"], f)
                 path, ext = os.path.splitext(f)
                 output_path = path + ".exr"
                 args = [
-                    "oiiotool", f,
+                    oiio_path, f,
                     "--compression", "DWAA",
                     "--powc", "2.2,2.2,2.2,1.0",
                     "-o", output_path

--- a/pype/plugins/tvpaint/publish/extract_sequence_exr.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence_exr.py
@@ -41,7 +41,7 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
                 args = [
                     oiio_path, f,
                     "--compression", "DWAA",
-                    "--powc", "2.2,2.2,2.2,1.0",
+                    "--colorconvert", "sRGB", "linear",
                     "-o", output_path
                 ]
                 pype.api.subprocess(args)

--- a/pype/plugins/tvpaint/publish/extract_sequence_exr.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence_exr.py
@@ -11,7 +11,7 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
     order = pyblish.api.ExtractorOrder + 0.1
     label = "Extract Sequence EXR"
     hosts = ["tvpaint"]
-    families = ["renderPass", "renderLayer"]
+    families = ["review", "renderPass", "renderLayer"]
     active = False
 
     def process(self, instance):
@@ -27,7 +27,7 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
                 continue
 
             self.log.info(
-                "Processeing representation: {}".format(
+                "Processing representation: {}".format(
                     json.dumps(representation, sort_keys=True, indent=4)
                 )
             )
@@ -61,7 +61,9 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
 
         instance.data["representations"].extend(new_representations)
         self.log.info(
-            json.dumps(
-                instance.data["representations"], sort_keys=True, indent=4
+            "Representations: {}".format(
+                json.dumps(
+                    instance.data["representations"], sort_keys=True, indent=4
+                )
             )
         )

--- a/pype/plugins/tvpaint/publish/extract_sequence_exr.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence_exr.py
@@ -40,6 +40,7 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
                 args = [
                     "oiiotool", f,
                     "--compression", "DWAA",
+                    "--powc", "2.2,2.2,2.2,1.0",
                     "-o", output_path
                 ]
                 pype.api.subprocess(args)

--- a/pype/plugins/tvpaint/publish/extract_sequence_exr.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence_exr.py
@@ -19,7 +19,7 @@ class ExtractSequenceEXR(pyblish.api.InstancePlugin):
         ignore_extensions = ["mp4"]
         old_representations = instance.data["representations"]
         new_representations = []
-        for count, representation in enumerate(old_representations):
+        for _, representation in enumerate(old_representations):
             if representation["name"] in ignore_names:
                 continue
 

--- a/pype/plugins/tvpaint/publish/extract_sequence_exr.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence_exr.py
@@ -1,0 +1,65 @@
+import os
+import json
+
+import pyblish.api
+import pype.api
+
+
+class ExtractSequenceEXR(pyblish.api.InstancePlugin):
+
+    # Offset to get after ExtractSequence plugin.
+    order = pyblish.api.ExtractorOrder + 0.1
+    label = "Extract Sequence EXR"
+    hosts = ["tvpaint"]
+    families = ["renderPass", "renderLayer"]
+    active = False
+
+    def process(self, instance):
+        ignore_names = ["thumbnail"]
+        ignore_extensions = ["mp4"]
+        old_representations = instance.data["representations"]
+        new_representations = []
+        for count, representation in enumerate(old_representations):
+            if representation["name"] in ignore_names:
+                continue
+
+            if representation["ext"] in ignore_extensions:
+                continue
+
+            self.log.info(
+                "Processeing representation: {}".format(
+                    json.dumps(representation, sort_keys=True, indent=4)
+                )
+            )
+
+            files = []
+            for f in representation["files"]:
+                f = os.path.join(representation["stagingDir"], f)
+                path, ext = os.path.splitext(f)
+                output_path = path + ".exr"
+                args = [
+                    "oiiotool", f,
+                    "--compression", "DWAA",
+                    "-o", output_path
+                ]
+                pype.api.subprocess(args)
+                files.append(output_path)
+
+            new_representations.append(
+                {
+                    "name": "exr",
+                    "ext": "exr",
+                    "files": files,
+                    "stagingDir": representation["stagingDir"],
+                    "tags": representation["tags"]
+                }
+            )
+
+            instance.data["representations"].remove(representation)
+
+        instance.data["representations"].extend(new_representations)
+        self.log.info(
+            json.dumps(
+                instance.data["representations"], sort_keys=True, indent=4
+            )
+        )


### PR DESCRIPTION
**Goal**

Support EXR (DWAA) in TVPaint.

**Motivation**

We are battling large data transfers when using the built image formats. EXR (DWAA) has a very small data footprint compared to TVPaint native image formats.

**Implementation**

This extractor will convert all output (representations) to EXR (DWAA). Its disabled by default but can be enabled with a config:

```
{
  "ExtractSequenceEXR": {
      "active": true
  }
}
```

This would be good to convert to 3.0 when merged, as its just needs a setting under TVPaint.