### PR TITLE
Nuke: proxy mode validator

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/validate_proxy_mode.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_proxy_mode.py
@@ -1,0 +1,33 @@
+import pyblish
+import nuke
+
+
+class FixProxyMode(pyblish.api.Action):
+    """
+    Togger off proxy switch OFF
+    """
+
+    label = "Proxy toggle to OFF"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+        rootNode = nuke.root()
+        rootNode["proxy"].setValue(False)
+
+
+@pyblish.api.log
+class ValidateProxyMode(pyblish.api.ContextPlugin):
+    """Validate active proxy mode"""
+
+    order = pyblish.api.ValidatorOrder
+    label = "Validate Proxy Mode"
+    hosts = ["nuke"]
+    actions = [FixProxyMode]
+
+    def process(self, context):
+
+        rootNode = nuke.root()
+        isProxy = rootNode["proxy"].value()
+
+        assert not isProxy, "Proxy mode should be toggled OFF"


### PR DESCRIPTION
Adding Proxy mode validator for Nuke host

# Testing notes
1. Open your testing scene.
2. Toggle Proxy button on (CTRL+P). 
3. Then open publisher and validate. 
4. It should fail. 
5. Then use repair action to fix it. 
6. Proxy should switch off.