### PR TITLE
Differentiate jpg sequences from thumbnail

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_sequence.py
+++ b/openpype/hosts/nuke/plugins/load/load_sequence.py
@@ -76,6 +76,8 @@ class LoadSequence(api.Loader):
         file = file.replace("\\", "/")
 
         repr_cont = context["representation"]["context"]
+        assert repr_cont.get("frame"), "Representation is not sequence"
+
         if "#" not in file:
             frame = repr_cont.get("frame")
             if frame:
@@ -170,6 +172,7 @@ class LoadSequence(api.Loader):
         assert read_node.Class() == "Read", "Must be Read"
 
         repr_cont = representation["context"]
+        assert repr_cont.get("frame"), "Representation is not sequence"
 
         file = api.get_representation_path(representation)
 

--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -116,7 +116,7 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
 
         # create new thumbnail representation
         representation = {
-            'name': 'jpg',
+            'name': 'thumbnail',
             'ext': 'jpg',
             'files': filename,
             "stagingDir": staging_dir,


### PR DESCRIPTION
- When subsets are created by standalone publisher and they are `jpg` sequence, `jpg` as thumbnail was created and the name was also `JPG`, so build workflow was chosen randomly. 
- Nuke is reading a single JPG image  a sequence. 