### PR TITLE
Maya: Fix multi-camera renders

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -174,10 +174,16 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             assert render_products, "no render products generated"
             exp_files = []
             for product in render_products:
-                for camera in layer_render_products.layer_data.cameras:
-                    exp_files.append(
-                        {product.productName: layer_render_products.get_files(
-                            product, camera)})
+                product_name = product.productName
+                if product.camera and layer_render_products.has_camera_token():
+                    product_name = "{}{}".format(
+                        product.camera,
+                        "_" + product_name if product_name else "")
+                exp_files.append(
+                    {
+                        product_name: layer_render_products.get_files(
+                            product)
+                    })
 
             self.log.info("multipart: {}".format(
                 layer_render_products.multipart))

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -205,12 +205,14 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
 
             # replace relative paths with absolute. Render products are
             # returned as list of dictionaries.
+            publish_meta_path = None
             for aov in exp_files:
                 full_paths = []
                 for file in aov[aov.keys()[0]]:
                     full_path = os.path.join(workspace, "renders", file)
                     full_path = full_path.replace("\\", "/")
                     full_paths.append(full_path)
+                    publish_meta_path = os.path.dirname(full_path)
                 aov_dict[aov.keys()[0]] = full_paths
 
             frame_start_render = int(self.get_render_attribute(
@@ -236,6 +238,24 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 frame_end_handle = frame_end_render
 
             full_exp_files.append(aov_dict)
+
+            # find common path to store metadata
+            # so if image prefix is branching to many directories
+            # metadata file will be located in top-most common
+            # directory.
+            # TODO: use `os.path.commonpath()` after switch to Python 3
+            common_publish_meta_path = os.path.splitdrive(
+                publish_meta_path)[0]
+            if common_publish_meta_path:
+                common_publish_meta_path += os.path.sep
+            for part in publish_meta_path.split("/"):
+                common_publish_meta_path = os.path.join(
+                    common_publish_meta_path, part)
+                if part == expected_layer_name:
+                    break
+            common_publish_meta_path = common_publish_meta_path.replace("\\", "/")
+            self.log.info("Publish meta path: {}".format(common_publish_meta_path))
+
             self.log.info(full_exp_files)
             self.log.info("collecting layer: {}".format(layer_name))
             # Get layer specific settings, might be overrides
@@ -268,6 +288,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 # which was submitted originally
                 "source": filepath,
                 "expectedFiles": full_exp_files,
+                "publishRenderMetadataFolder": common_publish_meta_path,
                 "resolutionWidth": cmds.getAttr("defaultResolution.width"),
                 "resolutionHeight": cmds.getAttr("defaultResolution.height"),
                 "pixelAspect": cmds.getAttr("defaultResolution.pixelAspect"),

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -76,7 +76,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
         r'%a|<aov>|<renderpass>', re.IGNORECASE)
     R_LAYER_TOKEN = re.compile(
         r'%l|<layer>|<renderlayer>', re.IGNORECASE)
-    R_CAMERA_TOKEN = re.compile(r'%c|<camera>', re.IGNORECASE)
+    R_CAMERA_TOKEN = re.compile(r'%c|Camera>')
     R_SCENE_TOKEN = re.compile(r'%s|<scene>', re.IGNORECASE)
 
     DEFAULT_PADDING = 4
@@ -126,7 +126,9 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
         if len(cameras) > 1 and not re.search(cls.R_CAMERA_TOKEN, prefix):
             invalid = True
             cls.log.error("Wrong image prefix [ {} ] - "
-                          "doesn't have: '<camera>' token".format(prefix))
+                          "doesn't have: '<Camera>' token".format(prefix))
+            cls.log.error(
+                "Note that to needs to have capital 'C' at the beginning")
 
         # renderer specific checks
         if renderer == "vray":

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -351,6 +351,12 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
                             f.replace(orig_scene, new_scene)
                         )
                     instance.data["expectedFiles"] = [new_exp]
+
+                if instance.data.get("publishRenderMetadataFolder"):
+                    instance.data["publishRenderMetadataFolder"] = \
+                        instance.data["publishRenderMetadataFolder"].replace(
+                            orig_scene, new_scene
+                        )
                 self.log.info("Scene name was switched {} -> {}".format(
                     orig_scene, new_scene
                 ))

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
@@ -385,6 +385,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         """
         task = os.environ["AVALON_TASK"]
         subset = instance_data["subset"]
+        cameras = instance_data.get("cameras", [])
         instances = []
         # go through aovs in expected files
         for aov, files in exp_files[0].items():
@@ -410,7 +411,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 task[0].upper(), task[1:],
                 subset[0].upper(), subset[1:])
 
-            subset_name = '{}_{}'.format(group_name, aov)
+            cam = [c for c in cameras if c in col.head]
+            if cam:
+                subset_name = '{}_{}_{}'.format(group_name, cam, aov)
+            else:
+                subset_name = '{}_{}'.format(group_name, aov)
 
             if isinstance(col, (list, tuple)):
                 staging = os.path.dirname(col[0])


### PR DESCRIPTION
## Fix

This is fixing publishing of multiple cameras render. When more cameras are enabled and `<Camera>` token is in image prefix path, every AOV enabled will be added for each camera and its subset name will be `{family}{Task}{Subser}_<Camera>_<Aov>` .

Close #1850