### PR TITLE
Maya: Validate setdress top group

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_setdress.py
+++ b/openpype/hosts/maya/plugins/create/create_setdress.py
@@ -9,3 +9,8 @@ class CreateSetDress(plugin.Creator):
     family = "setdress"
     icon = "cubes"
     defaults = ["Main", "Anim"]
+
+    def __init__(self, *args, **kwargs):
+        super(CreateSetDress, self).__init__(*args, **kwargs)
+
+        self.data["exactSetMembersOnly"] = True

--- a/openpype/hosts/maya/plugins/publish/validate_setdress_root.py
+++ b/openpype/hosts/maya/plugins/publish/validate_setdress_root.py
@@ -1,0 +1,25 @@
+
+import pyblish.api
+import openpype.api
+
+
+class ValidateSetdressRoot(pyblish.api.InstancePlugin):
+    """
+    """
+
+    order = openpype.api.ValidateContentsOrder
+    label = "SetDress Root"
+    hosts = ["maya"]
+    families = ["setdress"]
+
+    def process(self, instance):
+        from maya import cmds
+
+        if instance.data.get("exactSetMembersOnly"):
+            return
+
+        set_member = instance.data["setMembers"]
+        root = cmds.ls(set_member, assemblies=True, long=True)
+
+        if not root or root[0] not in set_member:
+            raise Exception("Setdress top root node is not being published.")


### PR DESCRIPTION
## Feature
When publishing setdress in Maya, top group node will be checked if it's part of publishing content.

What does that mean ?
Say you have these in Maya outliner, 4 loaded models all parented under one top group node:

```
forestSet_GRP
    + Foo_01:modelMain
    + Foo_02:modelMain
    + Bar_01:modelMain
    + Bar_02:modelMain
```

And you created two `setdress` instances for publish :

```
setdressFoo
    + Foo_01:modelMain
    + Foo_02:modelMain

setdressBar
    + Bar_01:modelMain
    + Bar_02:modelMain
```

Without this new feature, the top group node and all it's child nodes will be published together. Which means all those 4 models will be in both `setdressFoo` and `setdressBar` subsets.

Now with this PR, the unexpected result in above example will not happen.

---
Resolves client ticket [PYPE-1395](https://support.pype.club/helpdesk/tickets/421)