### PR TITLE
Project manager: Filter first item after selection of project

### DIFF
--- a/openpype/tools/project_manager/project_manager/__init__.py
+++ b/openpype/tools/project_manager/project_manager/__init__.py
@@ -5,6 +5,7 @@ __all__ = (
     "HierarchyView",
 
     "ProjectModel",
+    "ProjectProxyFilter",
     "CreateProjectDialog",
 
     "HierarchyModel",
@@ -28,6 +29,7 @@ from .widgets import CreateProjectDialog
 from .view import HierarchyView
 from .model import (
     ProjectModel,
+    ProjectProxyFilter,
 
     HierarchyModel,
     HierarchySelectionModel,

--- a/openpype/tools/project_manager/project_manager/__init__.py
+++ b/openpype/tools/project_manager/project_manager/__init__.py
@@ -1,5 +1,6 @@
 __all__ = (
     "IDENTIFIER_ROLE",
+    "PROJECT_NAME_ROLE",
 
     "HierarchyView",
 
@@ -20,7 +21,8 @@ __all__ = (
 
 
 from .constants import (
-    IDENTIFIER_ROLE
+    IDENTIFIER_ROLE,
+    PROJECT_NAME_ROLE
 )
 from .widgets import CreateProjectDialog
 from .view import HierarchyView

--- a/openpype/tools/project_manager/project_manager/constants.py
+++ b/openpype/tools/project_manager/project_manager/constants.py
@@ -17,6 +17,9 @@ ITEM_TYPE_ROLE = QtCore.Qt.UserRole + 5
 # Item has opened editor (per column)
 EDITOR_OPENED_ROLE = QtCore.Qt.UserRole + 6
 
+# Role for project model
+PROJECT_NAME_ROLE = QtCore.Qt.UserRole + 7
+
 # Allowed symbols for any name
 NAME_ALLOWED_SYMBOLS = "a-zA-Z0-9_"
 NAME_REGEX = re.compile("^[" + NAME_ALLOWED_SYMBOLS + "]*$")

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -58,6 +58,7 @@ class ProjectModel(QtGui.QStandardItemModel):
             project_names.add(project_name)
             if project_name not in self._items_by_name:
                 project_item = QtGui.QStandardItem(project_name)
+                project_item.setData(project_name, PROJECT_NAME_ROLE)
 
                 self._items_by_name[project_name] = project_item
                 new_project_items.append(project_item)

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -74,6 +74,26 @@ class ProjectModel(QtGui.QStandardItemModel):
             root_item.appendRows(new_project_items)
 
 
+class ProjectProxyFilter(QtCore.QSortFilterProxyModel):
+    """Filters default project item."""
+    def __init__(self, *args, **kwargs):
+        super(ProjectProxyFilter, self).__init__(*args, **kwargs)
+        self._filter_default = False
+
+    def set_filter_default(self, enabled=True):
+        """Set if filtering of default item is enabled."""
+        if enabled == self._filter_default:
+            return
+        self._filter_default = enabled
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, row, parent):
+        if not self._filter_default:
+            return True
+
+        model = self.sourceModel()
+        source_index = model.index(row, self.filterKeyColumn(), parent)
+        return source_index.data(PROJECT_NAME_ROLE) is not None
 
 
 class HierarchySelectionModel(QtCore.QItemSelectionModel):

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -7,7 +7,8 @@ from . import (
     HierarchySelectionModel,
     HierarchyView,
 
-    CreateProjectDialog
+    CreateProjectDialog,
+    PROJECT_NAME_ROLE
 )
 from openpype.style import load_stylesheet
 from .style import ResourceCache
@@ -34,9 +35,6 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self._initial_reset = False
         self._password_dialog = None
         self._user_passed = False
-
-        # keep track of the current project PM is viewing
-        self._current_project = None
 
         self.setWindowTitle("OpenPype Project Manager")
         self.setWindowIcon(QtGui.QIcon(resources.get_openpype_icon_filepath()))
@@ -167,6 +165,13 @@ class ProjectManagerWindow(QtWidgets.QWidget):
     def _set_project(self, project_name=None):
         self.hierarchy_view.set_project(project_name)
 
+    def _current_project(self):
+        row = self._project_combobox.currentIndex()
+        if row < 0:
+            return None
+        index = self._project_proxy_model.index(row, 0)
+        return index.data(PROJECT_NAME_ROLE)
+
     def showEvent(self, event):
         super(ProjectManagerWindow, self).showEvent(event)
 
@@ -194,12 +199,13 @@ class ProjectManagerWindow(QtWidgets.QWidget):
             if row >= 0:
                 self._project_combobox.setCurrentIndex(row)
 
-        self._set_project(self._project_combobox.currentText())
+        selected_project = self._current_project()
+
+        self._set_project(selected_project)
 
     def _on_project_change(self):
-        if self._project_combobox.currentIndex() != 0:
-            self._current_project = self._project_combobox.currentText()
-            self._set_project(self._current_project)
+        selected_project = self._current_project()
+        self._set_project(selected_project)
 
     def _on_project_refresh(self):
         self.refresh_projects()
@@ -214,7 +220,8 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self.hierarchy_view.add_task()
 
     def _on_create_folders(self):
-        if not self._current_project:
+        project_name = self._current_project()
+        if not project_name:
             return
 
         qm = QtWidgets.QMessageBox
@@ -225,11 +232,11 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         if ans == qm.Yes:
             try:
                 # Get paths based on presets
-                basic_paths = get_project_basic_paths(self._current_project)
+                basic_paths = get_project_basic_paths(project_name)
                 if not basic_paths:
                     pass
                 # Invoking OpenPype API to create the project folders
-                create_project_folders(basic_paths, self._current_project)
+                create_project_folders(basic_paths, project_name)
             except Exception as exc:
                 self.log.warning(
                     "Cannot create starting folders: {}".format(exc),
@@ -246,11 +253,9 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         if dialog.result() != 1:
             return
 
-        self._current_project = dialog.project_name
-        self.show_message(
-            "Created project \"{}\"".format(self._current_project)
-        )
-        self.refresh_projects(self._current_project)
+        project_name = dialog.project_name
+        self.show_message("Created project \"{}\"".format(project_name))
+        self.refresh_projects(project_name)
 
     def _show_password_dialog(self):
         if self._password_dialog:

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -70,6 +70,7 @@ class ProjectManagerWindow(QtWidgets.QWidget):
             "Create Starting Folders",
             project_widget
         )
+        create_folders_btn.setEnabled(False)
 
         project_layout = QtWidgets.QHBoxLayout(project_widget)
         project_layout.setContentsMargins(0, 0, 0, 0)
@@ -163,6 +164,7 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self.setStyleSheet(load_stylesheet())
 
     def _set_project(self, project_name=None):
+        self._create_folders_btn.setEnabled(project_name is not None)
         self.hierarchy_view.set_project(project_name)
 
     def _current_project(self):


### PR DESCRIPTION
## Changes
- current project is not defined by variable but by combobox selection
- refreshing of projects won't clear whole model but only remove not available and add new
- added sort/filter proxy model for projects to filter `< Select project >` item when any project is selected and to sort projects by name
- disable create folders button when invalid project is selected