### PR TITLE
Nuke UI scaling

### DIFF
--- a/openpype/hosts/nuke/__init__.py
+++ b/openpype/hosts/nuke/__init__.py
@@ -21,6 +21,7 @@ def add_implementation_envs(env, _app):
             new_nuke_paths.append(norm_path)
 
     env["NUKE_PATH"] = os.pathsep.join(new_nuke_paths)
+    env.pop("QT_AUTO_SCREEN_SCALE_FACTOR", None)
 
     # Try to add QuickTime to PATH
     quick_time_path = "C:/Program Files (x86)/QuickTime/QTSystem"

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1162,8 +1162,12 @@ def prepare_host_environments(data, implementation_envs=True):
     if final_env is None:
         final_env = loaded_env
 
+    keys_to_remove = set(data["env"].keys()) - set(final_env.keys())
+
     # Update env
     data["env"].update(final_env)
+    for key in keys_to_remove:
+        data["env"].pop(key, None)
 
 
 def apply_project_environments_value(project_name, env, project_settings=None):


### PR DESCRIPTION
## Description
UI scaling in Nuke does not work because `QT_AUTO_SCREEN_SCALE_FACTOR` env is set on nuke start.
![image](https://user-images.githubusercontent.com/43494761/134911076-cde585fb-d7b8-43de-adee-8eb4a2a5242e.png)

## Changes
- environments that are removed during env preparation are also popped from result
- `QT_AUTO_SCREEN_SCALE_FACTOR` is popped from nuke environments
