### PR TITLE
Global: add global validators to settings

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/validate_instance_in_context.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_instance_in_context.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Validate if instance asset is the same as context asset."""
+from __future__ import absolute_import
+
+import nuke
+
+import pyblish.api
+import openpype.api
+import avalon.nuke.lib
+import openpype.hosts.nuke.api as nuke_api
+
+
+class SelectInvalidInstances(pyblish.api.Action):
+    """Select invalid instances in Outliner."""
+
+    label = "Select Instances"
+    icon = "briefcase"
+    on = "failed"
+
+    def process(self, context, plugin):
+        """Process invalid validators and select invalid instances."""
+        # Get the errored instances
+        failed = []
+        for result in context.data["results"]:
+            if (
+                result["error"] is None
+                or result["instance"] is None
+                or result["instance"] in failed
+                or result["plugin"] != plugin
+            ):
+                continue
+
+            failed.append(result["instance"])
+
+        # Apply pyblish.logic to get the instances for the plug-in
+        instances = pyblish.api.instances_by_plugin(failed, plugin)
+
+        if instances:
+            self.log.info(
+                "Selecting invalid nodes: %s" % ", ".join(
+                    [str(x) for x in instances]
+                )
+            )
+            self.select(instances)
+        else:
+            self.log.info("No invalid nodes found.")
+            self.deselect()
+
+    def select(self, instances):
+        avalon.nuke.lib.select_nodes(
+            [nuke.toNode(str(x)) for x in instances]
+        )
+
+    def deselect(self):
+        avalon.nuke.lib.reset_selection()
+
+
+class RepairSelectInvalidInstances(pyblish.api.Action):
+    """Repair the instance asset."""
+
+    label = "Repair"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+        # Get the errored instances
+        failed = []
+        for result in context.data["results"]:
+            if (
+                result["error"] is None
+                or result["instance"] is None
+                or result["instance"] in failed
+                or result["plugin"] != plugin
+            ):
+                continue
+
+            failed.append(result["instance"])
+
+        # Apply pyblish.logic to get the instances for the plug-in
+        instances = pyblish.api.instances_by_plugin(failed, plugin)
+
+        context_asset = context.data["assetEntity"]["name"]
+        for instance in instances:
+            origin_node = instance[0]
+            nuke_api.lib.recreate_instance(
+                origin_node, avalon_data={"asset": context_asset}
+            )
+
+
+class ValidateInstanceInContext(pyblish.api.InstancePlugin):
+    """Validator to check if instance asset match context asset.
+
+    When working in per-shot style you always publish data in context of
+    current asset (shot). This validator checks if this is so. It is optional
+    so it can be disabled when needed.
+
+    Action on this validator will select invalid instances in Outliner.
+    """
+
+    order = openpype.api.ValidateContentsOrder
+    label = "Instance in same Context"
+    hosts = ["nuke"]
+    actions = [SelectInvalidInstances, RepairSelectInvalidInstances]
+    optional = True
+
+    def process(self, instance):
+        asset = instance.data.get("asset")
+        context_asset = instance.context.data["assetEntity"]["name"]
+        msg = "{} has asset {}".format(instance.name, asset)
+        assert asset == context_asset, msg

--- a/openpype/plugins/publish/collect_avalon_entities.py
+++ b/openpype/plugins/publish/collect_avalon_entities.py
@@ -22,6 +22,7 @@ class CollectAvalonEntities(pyblish.api.ContextPlugin):
         io.install()
         project_name = api.Session["AVALON_PROJECT"]
         asset_name = api.Session["AVALON_ASSET"]
+        task_name = api.Session["AVALON_TASK"]
 
         project_entity = io.find_one({
             "type": "project",
@@ -47,6 +48,12 @@ class CollectAvalonEntities(pyblish.api.ContextPlugin):
         context.data["assetEntity"] = asset_entity
 
         data = asset_entity['data']
+
+        # Task type
+        asset_tasks = data.get("tasks") or {}
+        task_info = asset_tasks.get(task_name) or {}
+        task_type = task_info.get("type")
+        context.data["taskType"] = task_type
 
         frame_start = data.get("frameStart")
         if frame_start is None:

--- a/openpype/plugins/publish/start_timer.py
+++ b/openpype/plugins/publish/start_timer.py
@@ -1,6 +1,5 @@
 import pyblish.api
 
-from openpype.api import get_system_settings
 from openpype.lib import change_timer_to_current_context
 
 
@@ -10,6 +9,6 @@ class StartTimer(pyblish.api.ContextPlugin):
     hosts = ["*"]
 
     def process(self, context):
-        modules_settings = get_system_settings()["modules"]
+        modules_settings = context.data["system_settings"]["modules"]
         if modules_settings["timers_manager"]["disregard_publishing"]:
             change_timer_to_current_context()

--- a/openpype/plugins/publish/stop_timer.py
+++ b/openpype/plugins/publish/stop_timer.py
@@ -3,8 +3,6 @@ import requests
 
 import pyblish.api
 
-from openpype.api import get_system_settings
-
 
 class StopTimer(pyblish.api.ContextPlugin):
     label = "Stop Timer"
@@ -12,7 +10,7 @@ class StopTimer(pyblish.api.ContextPlugin):
     hosts = ["*"]
 
     def process(self, context):
-        modules_settings = get_system_settings()["modules"]
+        modules_settings = context.data["system_settings"]["modules"]
         if modules_settings["timers_manager"]["disregard_publishing"]:
             webserver_url = os.environ.get("OPENPYPE_WEBSERVER_URL")
             rest_api_url = "{}/timers_manager/stop_timer".format(webserver_url)

--- a/openpype/plugins/publish/validate_containers.py
+++ b/openpype/plugins/publish/validate_containers.py
@@ -1,7 +1,5 @@
 import pyblish.api
-
 import openpype.lib
-from avalon.tools import cbsceneinventory
 
 
 class ShowInventory(pyblish.api.Action):
@@ -11,7 +9,9 @@ class ShowInventory(pyblish.api.Action):
     on = "failed"
 
     def process(self, context, plugin):
-        cbsceneinventory.show()
+        from avalon.tools import sceneinventory
+
+        sceneinventory.show()
 
 
 class ValidateContainers(pyblish.api.ContextPlugin):

--- a/openpype/plugins/publish/validate_intent.py
+++ b/openpype/plugins/publish/validate_intent.py
@@ -1,5 +1,7 @@
-import pyblish.api
 import os
+import pyblish.api
+
+from openpype.lib import filter_profiles
 
 
 class ValidateIntent(pyblish.api.ContextPlugin):
@@ -12,20 +14,49 @@ class ValidateIntent(pyblish.api.ContextPlugin):
     order = pyblish.api.ValidatorOrder
 
     label = "Validate Intent"
-    # TODO: this should be off by default and only activated viac config
-    tasks = ["animation"]
-    hosts = ["harmony"]
-    if os.environ.get("AVALON_TASK") not in tasks:
-        active = False
+    enabled = False
+
+    # Can be modified by settings
+    profiles = [{
+        "hosts": [],
+        "task_types": [],
+        "tasks": [],
+        "validate": False
+    }]
 
     def process(self, context):
+        # Skip if there are no profiles
+        validate = True
+        if self.profiles:
+            # Collect data from context
+            task_name = context.data.get("task")
+            task_type = context.data.get("taskType")
+            host_name = context.data.get("hostName")
+
+            filter_data = {
+                "hosts": host_name,
+                "task_types": task_type,
+                "tasks": task_name
+            }
+            matching_profile = filter_profiles(
+                self.profiles, filter_data, logger=self.log
+            )
+            if matching_profile:
+                validate = matching_profile["validate"]
+
+        if not validate:
+            self.log.debug((
+                "Validation of intent was skipped."
+                " Matching profile for current context disabled validation."
+            ))
+            return
+
         msg = (
             "Please make sure that you select the intent of this publish."
         )
 
-        intent = context.data.get("intent")
-        self.log.debug(intent)
-        assert intent, msg
-
+        intent = context.data.get("intent") or {}
+        self.log.debug(str(intent))
         intent_value = intent.get("value")
-        assert intent is not "", msg
+        if not intent_value:
+            raise AssertionError(msg)

--- a/openpype/plugins/publish/validate_version.py
+++ b/openpype/plugins/publish/validate_version.py
@@ -12,6 +12,9 @@ class ValidateVersion(pyblish.api.InstancePlugin):
     label = "Validate Version"
     hosts = ["nuke", "maya", "blender", "standalonepublisher"]
 
+    optional = False
+    active = True
+
     def process(self, instance):
         version = instance.data.get("version")
         latest_version = instance.data.get("latestVersion")

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -8,6 +8,10 @@
             "enabled": true,
             "optional": false
         },
+        "ValidateIntent": {
+            "enabled": false,
+            "profiles": []
+        },
         "IntegrateHeroVersion": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -6,7 +6,8 @@
         },
         "ValidateVersion": {
             "enabled": true,
-            "optional": false
+            "optional": false,
+            "active": true
         },
         "ValidateIntent": {
             "enabled": false,

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -156,6 +156,11 @@
         "CollectMayaRender": {
             "sync_workfile_version": false
         },
+        "ValidateInstanceInContext": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateContainers": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -38,6 +38,11 @@
                 "render"
             ]
         },
+        "ValidateInstanceInContext": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateContainers": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -25,22 +25,12 @@
             ]
         },
         {
-            "type": "dict",
-            "collapsible": true,
-            "checkbox_key": "enabled",
-            "key": "ValidateVersion",
-            "label": "Validate Version",
-            "is_group": true,
-            "children": [
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
                 {
-                    "type": "boolean",
-                    "key": "enabled",
-                    "label": "Enabled"
-                },
-                {
-                    "type": "boolean",
-                    "key": "optional",
-                    "label": "Optional"
+                    "key": "ValidateVersion",
+                    "label": "Validate Version"
                 }
             ]
         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -46,6 +46,59 @@
         },
         {
             "type": "dict",
+            "label": "Validate Intent",
+            "key": "ValidateIntent",
+            "is_group": true,
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "label",
+                    "label": "Validate if Publishing intent was selected. It is possible to disable validation for specific publishing context with profiles."
+                },
+                {
+                    "type": "list",
+                    "collapsible": true,
+                    "key": "profiles",
+                    "object_type": {
+                        "type": "dict",
+                        "children": [
+                            {
+                                "key": "hosts",
+                                "label": "Host names",
+                                "type": "hosts-enum",
+                                "multiselection": true
+                            },
+                            {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
+                            },
+                            {
+                                "key": "tasks",
+                                "label": "Task names",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "type": "separator"
+                            },
+                            {
+                                "key": "validate",
+                                "label": "Validate",
+                                "type": "boolean"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "dict",
             "collapsible": true,
             "checkbox_key": "enabled",
             "key": "IntegrateHeroVersion",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -33,6 +33,16 @@
             "name": "template_publish_plugin",
             "template_data": [
                 {
+                    "key": "ValidateInstanceInContext",
+                    "label": "Validate Instance In Context"
+                }
+            ]
+        },
+        {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
                     "key": "ValidateContainers",
                     "label": "ValidateContainers"
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -55,6 +55,16 @@
             "name": "template_publish_plugin",
             "template_data": [
                 {
+                    "key": "ValidateInstanceInContext",
+                    "label": "Validate Instance In Context"
+                }
+            ]
+        },
+        {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
                     "key": "ValidateContainers",
                     "label": "ValidateContainers"
                 }


### PR DESCRIPTION
## Changes
- `ValidateInstanceInContext` split into maya and nuke plugin
    - added settings for each of them
- context anatomy collector also stores task type of  context
- start/stop timer plugins are using settings stored in context instead of loading them again
- `ValidateIntent` is for all hosts by default and added profiles to filter validations (by default is plugin disabled)
- `ValidateVersion` added `active` attribute to be able define if is activated by default

## QUESTIONS
- `ValidateContainers` - currently has settings in each host settings and not sure if should be added to global publish plugins settings and if yes than it will probably need profiles but at the same time should have `optional` (maybe) does it make sense to have both `optional` + `active` and `profiles` under that?
- ~~`ValidateResources` I actually don't know why are resources validated?~~ is required does not need settings