### PR TITLE
Tray UI: Show menu where first click happened

### DIFF
--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -236,6 +236,7 @@ class SystemTrayIcon(QtWidgets.QSystemTrayIcon):
 
         self._click_timer = click_timer
         self._doubleclick = False
+        self._click_pos = None
 
     def _click_timer_timeout(self):
         self._click_timer.stop()
@@ -248,13 +249,17 @@ class SystemTrayIcon(QtWidgets.QSystemTrayIcon):
             self._show_context_menu()
 
     def _show_context_menu(self):
-        pos = QtGui.QCursor().pos()
+        pos = self._click_pos
+        self._click_pos = None
+        if pos is None:
+            pos = QtGui.QCursor().pos()
         self.contextMenu().popup(pos)
 
     def on_systray_activated(self, reason):
         # show contextMenu if left click
         if reason == QtWidgets.QSystemTrayIcon.Trigger:
             if self.tray_man.doubleclick_callback:
+                self._click_pos = QtGui.QCursor().pos()
                 self._click_timer.start()
             else:
                 self._show_context_menu()


### PR DESCRIPTION
## Description
Tray menu show is offset by few milliseconds because of double-click callback which can cause that menu is not shown at position where mouse clicked. This PR should change that first mouse click position is stored and used to show menu.

## Changes
- show menu at position where first click happened