### PR TITLE
Tray UI: Message box about missing settings defaults

### DIFF
--- a/openpype/settings/__init__.py
+++ b/openpype/settings/__init__.py
@@ -25,7 +25,8 @@ from .lib import (
 )
 from .entities import (
     SystemSettings,
-    ProjectSettings
+    ProjectSettings,
+    DefaultsNotDefined
 )
 
 
@@ -51,6 +52,8 @@ __all__ = (
     "get_anatomy_settings",
     "get_environments",
     "get_local_settings",
+
     "SystemSettings",
-    "ProjectSettings"
+    "ProjectSettings",
+    "DefaultsNotDefined"
 )

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -119,6 +119,8 @@ class TrayManager:
 
         self.main_thread_timer = main_thread_timer
 
+        # For storing missing settings dialog
+        self._settings_validation_dialog = None
 
         self.execute_in_main_thread(self._startup_validations)
 
@@ -137,6 +139,32 @@ class TrayManager:
 
         if valid:
             return
+
+        title = "Settings miss default values"
+        msg = (
+            "Your OpenPype may not work as expected because have missing"
+            " default settings values. Please contact OpenPype team."
+        )
+        msg_box = QtWidgets.QMessageBox(
+            QtWidgets.QMessageBox.Warning,
+            title,
+            msg,
+            QtWidgets.QMessageBox.Ok,
+            flags=QtCore.Qt.Dialog
+        )
+        icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
+        msg_box.setWindowIcon(icon)
+        msg_box.setStyleSheet(style.load_stylesheet())
+        msg_box.buttonClicked.connect(self._post_validate_settings_defaults)
+
+        self._settings_validation_dialog = msg_box
+
+        msg_box.show()
+
+    def _post_validate_settings_defaults(self):
+        widget = self._settings_validation_dialog
+        self._settings_validation_dialog = None
+        widget.deleteLater()
 
     def show_tray_message(self, title, message, icon=None, msecs=None):
         """Show tray message.

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -17,6 +17,11 @@ from openpype.api import (
 from openpype.lib import get_pype_execute_args
 from openpype.modules import TrayModulesManager
 from openpype import style
+from openpype.settings import (
+    SystemSettings,
+    ProjectSettings,
+    DefaultsNotDefined
+)
 
 from .pype_info_widget import PypeInfoWidget
 
@@ -113,6 +118,18 @@ class TrayManager:
         main_thread_timer.start()
 
         self.main_thread_timer = main_thread_timer
+
+    def _validate_settings_defaults(self):
+        valid = True
+        try:
+            SystemSettings()
+            ProjectSettings()
+
+        except DefaultsNotDefined:
+            valid = False
+
+        if valid:
+            return
 
     def show_tray_message(self, title, message, icon=None, msecs=None):
         """Show tray message.

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -119,6 +119,13 @@ class TrayManager:
 
         self.main_thread_timer = main_thread_timer
 
+
+        self.execute_in_main_thread(self._startup_validations)
+
+    def _startup_validations(self):
+        """Run possible startup validations."""
+        self._validate_settings_defaults()
+
     def _validate_settings_defaults(self):
         valid = True
         try:

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -142,8 +142,9 @@ class TrayManager:
 
         title = "Settings miss default values"
         msg = (
-            "Your OpenPype may not work as expected because have missing"
-            " default settings values. Please contact OpenPype team."
+            "Your OpenPype will not work as expected! \n"
+            "Some default values in settigs are missing. \n\n"
+            "Please contact OpenPype team."
         )
         msg_box = QtWidgets.QMessageBox(
             QtWidgets.QMessageBox.Warning,


### PR DESCRIPTION
## Changes
- tray will show a message saying that default settings are not set

## How to test
- remove any key from default settings and run tray

## Note
Feel free to modify title and message.

Resolves https://github.com/pypeclub/OpenPype/issues/1385