### PR TITLE
Deadline: Collect deadline server does not check existence of deadline key

### DIFF
--- a/openpype/modules/default_modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
@@ -46,24 +46,25 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
             ["deadline"]
         )
 
-        try:
-            default_servers = deadline_settings["deadline_urls"]
-            project_servers = (
-                render_instance.context.data
-                ["project_settings"]
-                ["deadline"]
-                ["deadline_servers"]
-            )
-            deadline_servers = {
-                k: default_servers[k]
-                for k in project_servers
-                if k in default_servers
-            }
+        default_server = render_instance.context.data["defaultDeadline"]
+        instance_server = render_instance.data.get("deadlineServers")
+        if not instance_server:
+            return default_server
 
-        except AttributeError:
-            # Handle situation were we had only one url for deadline.
-            return render_instance.context.data["defaultDeadline"]
-
+        default_servers = deadline_settings["deadline_urls"]
+        project_servers = (
+            render_instance.context.data
+            ["project_settings"]
+            ["deadline"]
+            ["deadline_servers"]
+        )
+        deadline_servers = {
+            k: default_servers[k]
+            for k in project_servers
+            if k in default_servers
+        }
+        # This is Maya specific and may not reflect real selection of deadline
+        #   url as dictionary keys in Python 2 are not ordered
         return deadline_servers[
             list(deadline_servers.keys())[
                 int(render_instance.data.get("deadlineServers"))


### PR DESCRIPTION
## Issue
Plugin `CollectDeadlineServerFromInstance` does not check if instance data contain `deadlineServers` before use it.

## Changes
- return default deadline url if instance does not containe `deadlineServers`
- removed `AttributeError` check because there is no access to attribute that should not be available

## Note
There is high ability that deadline url selection on created instance does not reflect settings keys order.