### PR TITLE
Blender: fix texture missing when publishing blend files

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -28,6 +28,16 @@ class ExtractBlend(openpype.api.Extractor):
 
         for obj in instance:
             data_blocks.add(obj)
+            # Pack used images in the blend files.
+            if obj.type == 'MESH':
+                for material_slot in obj.material_slots:
+                    mat = material_slot.material
+                    if mat and mat.use_nodes:
+                        tree = mat.node_tree
+                        if tree.type == 'SHADER':
+                            for node in tree.nodes:
+                                if node.bl_idname == 'ShaderNodeTexImage':
+                                    node.image.pack()
 
         bpy.data.libraries.write(filepath, data_blocks)
 


### PR DESCRIPTION
Blender uses relative paths to track images. So, when publishing assets, the textures are missing. 

To fix the problem, this PR packs images used by the published assets in the blend files.