### PR TITLE
TVPaint: Creator use context from workfile

### DIFF
--- a/openpype/hosts/tvpaint/api/plugin.py
+++ b/openpype/hosts/tvpaint/api/plugin.py
@@ -3,4 +3,17 @@ from avalon.tvpaint import pipeline
 
 
 class Creator(PypeCreatorMixin, pipeline.Creator):
-    pass
+    @classmethod
+    def get_dynamic_data(cls, *args, **kwargs):
+        dynamic_data = super(Creator, cls).get_dynamic_data(*args, **kwargs)
+
+        # Change asset and name by current workfile context
+        workfile_context = pipeline.get_current_workfile_context()
+        asset_name = workfile_context.get("asset")
+        task_name = workfile_context.get("task")
+        if "asset" not in dynamic_data and asset_name:
+            dynamic_data["asset"] = asset_name
+
+        if "task" not in dynamic_data and task_name:
+            dynamic_data["task"] = task_name
+        return dynamic_data


### PR DESCRIPTION
## Issue
Creators are using context from `avalon.api.Session` which may not be the same as context of current workfile.

## Changes
TVPaint creators set `asset` and `task` keys using dynamic data loaded from currently opened workfile.