### PR TITLE
Tvpaint: Deadline

### DIFF
--- a/pype/plugins/tvpaint/publish/collect_deadline_submission.py
+++ b/pype/plugins/tvpaint/publish/collect_deadline_submission.py
@@ -1,0 +1,29 @@
+import os
+
+import pyblish.api
+from avalon.tvpaint import HEADLESS
+
+
+class CollectDeadlineSubmission(pyblish.api.ContextPlugin):
+    label = "Collect Deadline Submission"
+    order = pyblish.api.CollectorOrder
+    hosts = ["tvpaint"]
+    publish = False
+
+    def process(self, context):
+        if HEADLESS:
+            return
+
+        if not context:
+            self.log.debug("No instances were found.")
+            return
+
+        data = {
+            "label": "Deadline Submission",
+            "publish": self.publish,
+            "family": "deadline",
+            # Needed for collect_anatomy_instance_data
+            "asset": os.environ["AVALON_ASSET"],
+            "subset": ""
+        }
+        context.create_instance("deadlineSubmission", **data)

--- a/pype/plugins/tvpaint/publish/collect_instances.py
+++ b/pype/plugins/tvpaint/publish/collect_instances.py
@@ -6,7 +6,7 @@ from avalon import io
 
 class CollectInstances(pyblish.api.ContextPlugin):
     label = "Collect Instances"
-    order = pyblish.api.CollectorOrder - 1
+    order = pyblish.api.CollectorOrder - 0.25
     hosts = ["tvpaint"]
 
     def process(self, context):

--- a/pype/plugins/tvpaint/publish/collect_json_data.py
+++ b/pype/plugins/tvpaint/publish/collect_json_data.py
@@ -1,0 +1,15 @@
+import os
+import json
+
+import pyblish
+
+
+class CollectJsonData(pyblish.api.ContextPlugin):
+    label = "Collect Json Data"
+    order = pyblish.api.CollectorOrder - 0.5
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        if os.environ.get("PYPE_TVPAINT_JSON"):
+            with open(os.environ["PYPE_TVPAINT_JSON"]) as f:
+                context.data.update(json.load(f))

--- a/pype/plugins/tvpaint/publish/collect_layer_behaviors.py
+++ b/pype/plugins/tvpaint/publish/collect_layer_behaviors.py
@@ -1,0 +1,33 @@
+import pyblish.api
+
+from avalon.tvpaint import lib, HEADLESS
+
+
+class CollectLayerBehaviors(pyblish.api.ContextPlugin):
+
+    order = pyblish.api.CollectorOrder
+    label = "Collect Layer Behaviours"
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        # Skip extract if in headless mode.
+        if HEADLESS:
+            return
+
+        # Map layers by position
+        layers_by_position = {}
+        layer_ids = []
+        for layer in context.data["layersData"]:
+            position = layer["position"]
+            layers_by_position[position] = layer
+
+            layer_ids.append(layer["layer_id"])
+
+        # Sort layer positions in reverse order
+        sorted_positions = list(reversed(sorted(layers_by_position.keys())))
+        if not sorted_positions:
+            return [], None
+
+        behavior_by_layer_id = lib.get_layers_pre_post_behavior(layer_ids)
+        context.data["behavior_by_layer_id"] = behavior_by_layer_id
+        context.data["jsonData"]["behavior_by_layer_id"] = behavior_by_layer_id

--- a/pype/plugins/tvpaint/publish/collect_tvpaint_info.py
+++ b/pype/plugins/tvpaint/publish/collect_tvpaint_info.py
@@ -1,0 +1,35 @@
+import re
+
+import pyblish
+from avalon.tvpaint import lib
+
+
+class CollectTVPaintInfo(pyblish.api.ContextPlugin):
+    label = "Collect TVPaint Info"
+    order = pyblish.api.CollectorOrder
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        tv_version = lib.execute_george("tv_version")
+        pattern = re.compile(r"[0-9]+.[0-9]+.[0-9]+")
+        result = pattern.search(tv_version)
+        host_version = result.group(0)
+        major, minor, patch = host_version.split(".")
+        host_type, host_language = tv_version.split(host_version)
+
+        # Remove space between host version and the rest.
+        host_type = host_type[:-1]
+        host_language = host_language[1:]
+
+        # Remove quotation marks on host_type.
+        host_type = host_type[1:-1]
+
+        context.data["hostInfo"] = {
+            "type": host_type,
+            "version": {
+                "major": major,
+                "minor": minor,
+                "patch": patch
+            },
+            "language": host_language
+        }

--- a/pype/plugins/tvpaint/publish/collect_workfile.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile.py
@@ -1,0 +1,52 @@
+import pyblish.api
+import os
+
+from pype import lib
+from avalon.tvpaint import HEADLESS
+
+
+class CollectWorkfile(pyblish.api.ContextPlugin):
+    """Collect current script for publish."""
+
+    order = pyblish.api.CollectorOrder
+    label = "Collect Workfile"
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        if HEADLESS:
+            return
+
+        family = "workfile"
+        task = os.getenv("AVALON_TASK", None)
+        file_path = context.data["currentFile"]
+        staging_dir = os.path.dirname(file_path)
+        base_name = os.path.basename(file_path)
+        subset = lib.get_subset_name(
+            "workfile",
+            "",
+            task,
+            context.data["assetEntity"]["_id"],
+            host_name="tvpaint"
+        )
+
+        # Create instance
+        data = {
+            "subset": subset,
+            "label": base_name,
+            "name": base_name,
+            "family": family,
+            "families": [family],
+            "representations": list(),
+            "asset": os.environ["AVALON_ASSET"]
+        }
+        instance = context.create_instance(**data)
+
+        # creating representation
+        representation = {
+            "name": "tvpp",
+            "ext": "tvpp",
+            "files": base_name,
+            "stagingDir": staging_dir,
+        }
+
+        instance.data["representations"].append(representation)

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -3,7 +3,7 @@ import json
 
 import pyblish.api
 import avalon.api
-from avalon.tvpaint import pipeline, lib
+from avalon.tvpaint import pipeline, lib, HEADLESS
 
 
 class ResetTVPaintWorkfileMetadata(pyblish.api.Action):
@@ -38,11 +38,16 @@ class ResetTVPaintWorkfileMetadata(pyblish.api.Action):
 
 class CollectWorkfileData(pyblish.api.ContextPlugin):
     label = "Collect Workfile Data"
-    order = pyblish.api.CollectorOrder - 1.01
+    order = pyblish.api.CollectorOrder - 0.5
     hosts = ["tvpaint"]
     actions = [ResetTVPaintWorkfileMetadata]
 
     def process(self, context):
+        if HEADLESS:
+            return
+
+        data = {}
+
         current_project_id = lib.execute_george("tv_projectcurrentid")
         lib.execute_george("tv_projectselect {}".format(current_project_id))
 
@@ -96,6 +101,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         self.log.info("Collecting instance data from workfile")
         instance_data = pipeline.list_instances()
         context.data["workfileInstances"] = instance_data
+        data["workfileInstances"] = instance_data
         self.log.debug(
             "Instance data:\"{}".format(json.dumps(instance_data, indent=4))
         )
@@ -110,7 +116,9 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
                 layers_by_name[layer_name] = []
             layers_by_name[layer_name].append(layer)
         context.data["layersData"] = layers_data
+        data["layersData"] = layers_data
         context.data["layersByName"] = layers_by_name
+        data["layersByName"] = layers_by_name
 
         self.log.debug(
             "Layers data:\"{}".format(json.dumps(layers_data, indent=4))
@@ -120,6 +128,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         self.log.info("Collecting groups data from workfile")
         group_data = lib.groups_data()
         context.data["groupsData"] = group_data
+        data["groupsData"] = group_data
         self.log.debug(
             "Group data:\"{}".format(json.dumps(group_data, indent=4))
         )
@@ -160,3 +169,6 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             "Scene data: {}".format(json.dumps(scene_data, indent=4))
         )
         context.data.update(scene_data)
+        data.update(scene_data)
+
+        context.data["jsonData"] = data

--- a/pype/plugins/tvpaint/publish/extract_deadline_submission.py
+++ b/pype/plugins/tvpaint/publish/extract_deadline_submission.py
@@ -1,0 +1,71 @@
+import json
+import os
+import tempfile
+
+import pyblish.api
+from avalon.tvpaint import HEADLESS
+
+
+class ExtractDeadlineSubmission(pyblish.api.ContextPlugin):
+    label = "Extract Deadline Submission"
+    order = pyblish.api.ExtractorOrder
+    hosts = ["tvpaint"]
+    families = ["deadline"]
+
+    def process(self, context):
+        # Skip extract if in headless mode.
+        if HEADLESS:
+            return
+
+        # Adding "deadline" family to all active instances to skip
+        # integration, except workfile.
+        workfile_instance = None
+        for instance in context:
+            families = instance.data.get(
+                "families", [instance.data["family"]]
+            )
+            if "workfile" in families:
+                workfile_instance = instance
+                continue
+
+            if "deadline" not in families:
+                instance.data["families"].append("deadline")
+
+        # Remove instances from workfileInstances that are not marked as
+        # publishable.
+        publish_state_by_uuid = {}
+        for instance in context:
+            uuid = instance.data.get("uuid")
+            if not uuid:
+                continue
+
+            publish_state_by_uuid[uuid] = instance.data["publish"]
+
+        publishable_instances = []
+        for instance in context.data["jsonData"]["workfileInstances"]:
+            if publish_state_by_uuid[instance["uuid"]]:
+                publishable_instances.append(instance)
+        context.data["jsonData"]["workfileInstances"] = publishable_instances
+
+        # Extract data for deadline submission.
+        name = os.path.splitext(workfile_instance.data["name"])[0]
+        basename = "pype_" + name + ".json"
+        path = os.path.join(tempfile.gettempdir(), basename)
+        with open(path, "w") as f:
+            json.dump(
+                context.data["jsonData"], f, sort_keys=True, indent=4
+            )
+        self.log.info(
+            "Extracted submission data to \"{}\":\n{}".format(
+                path, context.data["jsonData"]
+            )
+        )
+
+        workfile_instance.data["representations"].append(
+            {
+                "name": "json",
+                "ext": "json",
+                "files": basename,
+                "stagingDir": tempfile.gettempdir()
+            }
+        )

--- a/pype/plugins/tvpaint/publish/extract_layer_exposure_frames.py
+++ b/pype/plugins/tvpaint/publish/extract_layer_exposure_frames.py
@@ -1,0 +1,29 @@
+import pyblish.api
+
+from avalon.tvpaint import lib, HEADLESS
+
+
+class ExtractLayerExposureFrames(pyblish.api.ContextPlugin):
+
+    order = pyblish.api.ExtractorOrder - 0.49
+    label = "Extract Layer Exposure Frames"
+    hosts = ["tvpaint"]
+
+    def process(self, context):
+        # Skip extract if in headless mode.
+        if HEADLESS:
+            return
+
+        exposure_frames_by_layer_id = {}
+        for layer in context.data["layersData"]:
+            if not layer["visible"]:
+                continue
+
+            layer_id = str(layer["layer_id"])
+            exposure_frames_by_layer_id[layer_id] = lib.get_exposure_frames(
+                layer_id, layer["frame_start"], layer["frame_end"]
+            )
+
+        data = exposure_frames_by_layer_id
+        context.data["exposure_frames_by_layer_id"] = data
+        context.data["jsonData"]["exposure_frames_by_layer_id"] = data

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -16,6 +16,15 @@ class ExtractSequence(pyblish.api.Extractor):
     families = ["review", "renderPass", "renderLayer"]
 
     def process(self, instance):
+        # Ignore if the deadline submission instance is active.
+        for inst in instance.context:
+            if inst.data["family"] != "deadline":
+                continue
+
+            if inst.data["publish"]:
+                self.log.debug("Ignore extraction due to deadline submission.")
+                return
+
         self.log.info(
             "* Processing instance \"{}\"".format(instance.data["label"])
         )
@@ -137,7 +146,9 @@ class ExtractSequence(pyblish.api.Extractor):
             output_filenames, thumbnail_fullpath = self.render(
                 filename_template, output_dir,
                 mark_in, mark_out,
-                filtered_layers
+                filtered_layers,
+                instance.context.data["behavior_by_layer_id"],
+                instance.context.data["exposure_frames_by_layer_id"]
             )
 
         # Sequence of one frame
@@ -310,7 +321,14 @@ class ExtractSequence(pyblish.api.Extractor):
 
         return output_filenames, thumbnail_filepath
 
-    def render(self, filename_template, output_dir, mark_in, mark_out, layers):
+    def render(self,
+               filename_template,
+               output_dir,
+               mark_in,
+               mark_out,
+               layers,
+               behavior_by_layer_id,
+               exposure_frames_by_layer_id):
         """ Export images from TVPaint.
 
         Args:
@@ -343,15 +361,12 @@ class ExtractSequence(pyblish.api.Extractor):
         if not sorted_positions:
             return [], None
 
-        self.log.debug("Collecting pre/post behavior of individual layers.")
-        behavior_by_layer_id = lib.get_layers_pre_post_behavior(layer_ids)
-
         tmp_filename_template = "pos_{pos}." + filename_template
 
         files_by_position = {}
         for position in sorted_positions:
             layer = layers_by_position[position]
-            behavior = behavior_by_layer_id[layer["layer_id"]]
+            behavior = behavior_by_layer_id[str(layer["layer_id"])]
 
             files_by_frames = self._render_layer(
                 layer,
@@ -359,7 +374,8 @@ class ExtractSequence(pyblish.api.Extractor):
                 output_dir,
                 behavior,
                 mark_in,
-                mark_out
+                mark_out,
+                exposure_frames_by_layer_id
             )
             if files_by_frames:
                 files_by_position[position] = files_by_frames
@@ -415,9 +431,10 @@ class ExtractSequence(pyblish.api.Extractor):
         output_dir,
         behavior,
         mark_in_index,
-        mark_out_index
+        mark_out_index,
+        exposure_frames_by_layer_id
     ):
-        layer_id = layer["layer_id"]
+        layer_id = str(layer["layer_id"])
         frame_start_index = layer["frame_start"]
         frame_end_index = layer["frame_end"]
 
@@ -436,15 +453,14 @@ class ExtractSequence(pyblish.api.Extractor):
             if pre_behavior == "none":
                 return {}
 
-        exposure_frames = lib.get_exposure_frames(
-            layer_id, frame_start_index, frame_end_index
-        )
+        exposure_frames = exposure_frames_by_layer_id[layer_id]
 
         if frame_start_index not in exposure_frames:
             exposure_frames.append(frame_start_index)
 
         layer_files_by_frame = {}
         george_script_lines = [
+            "tv_layerset {}".format(layer_id),
             "tv_SaveMode \"PNG\""
         ]
         layer_position = layer["position"]

--- a/pype/plugins/tvpaint/publish/submit_tvpaint_deadline.py
+++ b/pype/plugins/tvpaint/publish/submit_tvpaint_deadline.py
@@ -1,0 +1,155 @@
+import os
+import json
+import getpass
+
+from avalon.tvpaint import HEADLESS
+from avalon.vendor import requests
+import pyblish.api
+
+
+class SubmitTVPaintDeadline(pyblish.api.ContextPlugin):
+    """Submit instance to Deadline.
+
+    Renders are submitted to a Deadline Web Service as
+    supplied via the environment variable DEADLINE_REST_URL
+    """
+
+    label = "Submit to Deadline"
+    order = pyblish.api.IntegratorOrder + 0.1
+    hosts = ["tvpaint"]
+    families = ["deadline"]
+    optional = True
+
+    # presets
+    deadline_priority = 50
+    deadline_pool = ""
+    deadline_pool_secondary = ""
+    deadline_group = ""
+    deadline_department = ""
+    deadline_limit_groups = []
+
+    def process(self, context):
+        # Skip extract if in headless mode.
+        if HEADLESS:
+            return
+
+        DEADLINE_REST_URL = os.environ.get("DEADLINE_REST_URL")
+        assert DEADLINE_REST_URL, "Requires DEADLINE_REST_URL"
+
+        self.deadline_url = "{}/api/jobs".format(DEADLINE_REST_URL)
+        self._deadline_user = context.data.get(
+            "deadlineUser", getpass.getuser()
+        )
+
+        published_paths = {}
+        for item in context:
+            if "workfile" in item.data.get("families", []):
+                msg = "Workfile (scene) must be published along"
+                assert item.data["publish"] is True, msg
+
+                template_data = item.data.get("anatomyData")
+                for rep in item.data.get("representations"):
+                    template_data["representation"] = rep["name"]
+                    template_data["ext"] = rep["name"]
+                    template_data["comment"] = None
+                    anatomy_filled = context.data["anatomy"].format(
+                        template_data
+                    )
+                    template_filled = anatomy_filled["publish"]["path"]
+
+                    published_paths[rep["name"]] = os.path.normpath(
+                        template_filled
+                    )
+
+                break
+
+        self.payload_submit(
+            context, published_paths["tvpp"], published_paths["json"]
+        )
+
+    def payload_submit(self, context, workfile, jsonfile):
+        script_name = os.path.basename(workfile)
+
+        app_pattern = "tvpaint_{version[major]}-{version[minor]}"
+        if "pro" in context.data["hostInfo"]["type"].lower():
+            app_pattern += "pro"
+
+        app_pattern += "_attached"
+
+        payload = {
+            "JobInfo": {
+                # Asset dependency to wait for at least the scene file to sync.
+                "AssetDependency0": workfile,
+                "AssetDependency1": jsonfile,
+
+                # Job name, as seen in Monitor
+                "Name": script_name,
+
+                # Arbitrary username, for visualisation in Monitor
+                "UserName": self._deadline_user,
+
+                "Priority": self.deadline_priority,
+                "ChunkSize": "1",
+                "Department": self.deadline_department,
+
+                "Pool": self.deadline_pool,
+                "SecondaryPool": self.deadline_pool_secondary,
+                "Group": self.deadline_group,
+
+                "Plugin": "OpenPype",
+                "Frames": "0",
+
+                # limiting groups
+                "LimitGroups": ",".join(self.deadline_limit_groups)
+
+            },
+            "PluginInfo": {
+                "Arguments": "launch --app {}".format(
+                    app_pattern.format(**context.data["hostInfo"])
+                )
+            },
+
+            # Mandatory for Deadline, may be empty
+            "AuxFiles": []
+        }
+
+        # Include critical environment variables with submission
+        keys = [
+            "AVALON_PROJECT",
+            "AVALON_ASSET",
+            "AVALON_TASK",
+            "FTRACK_API_USER",
+            "FTRACK_API_KEY",
+            "FTRACK_SERVER"
+        ]
+
+        environment = {
+            key: os.environ[key] for key in keys if key in os.environ
+        }
+
+        environment["PYPE_TVPAINT_PROJECT_FILE"] = workfile
+        environment["PYPE_TVPAINT_JSON"] = jsonfile
+        environment["AVALON_TVPAINT_HEADLESS"] = 1
+
+        payload["JobInfo"].update(
+            {
+                "EnvironmentKeyValue%d" % index: "{key}={value}".format(
+                    key=key,
+                    value=environment[key]
+                ) for index, key in enumerate(environment)
+            }
+        )
+
+        plugin = payload["JobInfo"]["Plugin"]
+        self.log.info("Using render plugin : {}".format(plugin))
+
+        self.log.info("Submitting..")
+        self.log.info(payload)
+        self.log.info(json.dumps(payload, indent=4, sort_keys=True))
+
+        response = requests.post(self.deadline_url, json=payload, timeout=10)
+
+        if not response.ok:
+            raise Exception(response.text)
+
+        return response


### PR DESCRIPTION
**Goal**

To submit TVPaint to Deadline.

**Motivation**

TVPaint licenses cant run multiple session on the same machine. This means artists have to wait on publishing/rendering, while not being able to work. Submitting to Deadline can offset the publishing to a dedicated machine or just queue up job for later.

**Implementation**

Depends on:
- https://github.com/pypeclub/pype-setup/pull/102
- https://github.com/pypeclub/avalon-core/pull/372
- need to use the OpenPype Deadline plugin; https://github.com/pypeclub/OpenPype/tree/develop/vendor/deadline
- to progress any errors to the OpenPype Deadline plugin, we need to make a TVPaint application that is attached. See below toml and bat files:

***toml***
```toml
executable = "tvpaint_11.5pro_attached"
schema = "avalon-core:application-1.0"
application_dir = "tvpaint"
label = "TVPaint Animation Professional"
label_variant = "11.5 Attached"
ftrack_label = "TVPaint Animation Professional"
icon = "app_icons/tvpaint.png"
ftrack_icon = '{}/app_icons/tvpaint.png'
launch_hook = "pype/hooks/tvpaint/prelaunch.py/TvpaintPrelaunchHook"
```
***bat***
```bat
set __app__="TVPaint Animation 11.5 Professional"

set __exe__="C:\Program Files\TVPaint Developpement\TVPaint Animation 11.5 Pro (64bits)\TVPaint Animation 11.5 Pro (64bits).exe"

if not exist %__exe__% goto :missing_app

set "PYPE_SETUP_PATH=%PYPE_SETUP_PATH:\=/%"
%PYPE_PYTHON_EXE% "%PYPE_SETUP_PATH%/repos/avalon-core/avalon/tvpaint/launch_script.py" %__exe__% "%PYPE_TVPAINT_PROJECT_FILE%"

IF %ERRORLEVEL% NEQ 0 (
  echo ERROR: Launching %__app__% failed
  exit /B %ERRORLEVEL%
)

goto :eof

:missing_app
    echo ERROR: %__app__% not found in %__exe__%
    exit /B 1
```

I've opted to do a full publish through Deadline because of all the nice rendering logic that is implemented in OpenPype. Deadline's TVPaint integration is very basic, so we would lose a lot of advantages using it. We could potentially have multiple jobs where we render single frames and duplicate the compositing logic to python jobs, but that is bigger job. Because there arent any render licenses for TVPaint, there is no financial benefit to getting multiple licenses just for rendering, so a studio would most likely just have a single or couple of licenses dedicated to rendering.
The added benefit of running a full TVPaint publish through Deadline is that we have easier full control over the whole process.

The headless mode is the main driver behind which plugins to run. When not in headless mode, the artist gets an optional `Deadline Submission` instance (turned off by default), which determines whether to submit to Deadline or render locally. When submitting to Deadline, we extract all relevant data to a side car json file next to the workfile. This json data gets loaded when in headless mode instead of querying TVPaint (see https://github.com/pypeclub/avalon-core/pull/372 for reasons why).