### PR TITLE
General: Cloud mongo ca certificate issue

### DIFF
--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -2,7 +2,7 @@
 """Tools used in **Igniter** GUI."""
 import os
 from typing import Union
-from urllib.parse import urlparse, parse_qs, ParseResult
+from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 import platform
 

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -71,10 +71,7 @@ def validate_mongo_string(mongo: str) -> (bool, str):
     """
     if not mongo:
         return True, "empty string"
-    parsed = urlparse(mongo)
-    if parsed.scheme in ["mongodb", "mongodb+srv"]:
-        return validate_mongo_connection(mongo)
-    return False, "not valid mongodb schema"
+    return validate_mongo_connection(mongo)
 
 
 def validate_path_string(path: str) -> (bool, str):

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -22,89 +22,6 @@ from pymongo.errors import (
 )
 
 
-def decompose_url(url: str) -> Dict:
-    """Decompose mongodb url to its separate components.
-
-    Args:
-        url (str): Mongodb url.
-
-    Returns:
-        dict: Dictionary of components.
-
-    """
-    components = {
-        "scheme": None,
-        "host": None,
-        "port": None,
-        "username": None,
-        "password": None,
-        "auth_db": None
-    }
-
-    result = urlparse(url)
-    if result.scheme is None:
-        _url = "mongodb://{}".format(url)
-        result = urlparse(_url)
-
-    components["scheme"] = result.scheme
-    components["host"] = result.hostname
-    try:
-        components["port"] = result.port
-    except ValueError:
-        raise RuntimeError("invalid port specified")
-    components["username"] = result.username
-    components["password"] = result.password
-
-    try:
-        components["auth_db"] = parse_qs(result.query)['authSource'][0]
-    except KeyError:
-        # no auth db provided, mongo will use the one we are connecting to
-        pass
-
-    return components
-
-
-def compose_url(scheme: str = None,
-                host: str = None,
-                username: str = None,
-                password: str = None,
-                port: int = None,
-                auth_db: str = None) -> str:
-    """Compose mongodb url from its individual components.
-
-    Args:
-        scheme (str, optional):
-        host (str, optional):
-        username (str, optional):
-        password (str, optional):
-        port (str, optional):
-        auth_db (str, optional):
-
-    Returns:
-        str: mongodb url
-
-    """
-
-    url = "{scheme}://"
-
-    if username and password:
-        url += "{username}:{password}@"
-
-    url += "{host}"
-    if port:
-        url += ":{port}"
-
-    if auth_db:
-        url += "?authSource={auth_db}"
-
-    return url.format(**{
-        "scheme": scheme,
-        "host": host,
-        "username": username,
-        "password": password,
-        "port": port,
-        "auth_db": auth_db
-    })
 
 
 def validate_mongo_connection(cnx: str) -> (bool, str):
@@ -121,12 +38,14 @@ def validate_mongo_connection(cnx: str) -> (bool, str):
     if parsed.scheme not in ["mongodb", "mongodb+srv"]:
         return False, "Not mongodb schema"
 
+    kwargs = {
+        "serverSelectionTimeoutMS": 2000
+    }
     try:
-        client = MongoClient(
-            cnx,
-            serverSelectionTimeoutMS=2000
-        )
+        client = MongoClient(cnx, **kwargs)
         client.server_info()
+        with client.start_session():
+            pass
         client.close()
     except ServerSelectionTimeoutError as e:
         return False, f"Cannot connect to server {cnx} - {e}"
@@ -196,20 +115,8 @@ def get_openpype_global_settings(url: str) -> dict:
         dict: With settings data. Empty dictionary is returned if not found.
     """
     try:
-        components = decompose_url(url)
-    except RuntimeError:
-        return {}
-    mongo_kwargs = {
-        "host": compose_url(**components),
-        "serverSelectionTimeoutMS": 2000
-    }
-    port = components.get("port")
-    if port is not None:
-        mongo_kwargs["port"] = int(port)
-
-    try:
         # Create mongo connection
-        client = MongoClient(**mongo_kwargs)
+        client = MongoClient(url)
         # Access settings collection
         col = client["openpype"]["settings"]
         # Query global settings

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -79,6 +79,9 @@ def validate_mongo_connection(cnx: str) -> (bool, str):
     kwargs = {
         "serverSelectionTimeoutMS": 2000
     }
+    # Add certificate path if should be required
+    cnx = add_certificate_path_to_mongo_url(cnx)
+
     try:
         client = MongoClient(cnx, **kwargs)
         client.server_info()

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -192,7 +192,7 @@ class OpenPypeMongoConnection:
         return connection
 
     @classmethod
-    def create_connection(cls, mongo_url, timeout=None):
+    def create_connection(cls, mongo_url, timeout=None, retry_attempts=None):
         if timeout is None:
             timeout = int(os.environ.get("AVALON_TIMEOUT") or 1000)
 
@@ -206,8 +206,13 @@ class OpenPypeMongoConnection:
             kwargs["port"] = int(port)
 
         mongo_client = pymongo.MongoClient(**kwargs)
+        if retry_attempts is None:
+            retry_attempts = 3
 
-        for _retry in range(3):
+        elif not retry_attempts:
+            retry_attempts = 1
+
+        for _retry in range(retry_attempts):
             try:
                 t1 = time.time()
                 mongo_client.server_info()

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -128,26 +128,9 @@ def validate_mongo_connection(mongo_uri):
             passed so probably couldn't connect to mongo server.
 
     """
-    parsed = urlparse(mongo_uri)
-    # Force validation of scheme
-    if parsed.scheme not in ["mongodb", "mongodb+srv"]:
-        raise pymongo.errors.InvalidURI((
-            "Invalid URI scheme:"
-            " URI must begin with 'mongodb://' or 'mongodb+srv://'"
-        ))
-    # we have mongo connection string. Let's try if we can connect.
-    components = decompose_url(mongo_uri)
-    mongo_args = {
-        "host": compose_url(**components),
-        "serverSelectionTimeoutMS": 1000
-    }
-    port = components.get("port")
-    if port is not None:
-        mongo_args["port"] = int(port)
-
-    # Create connection
-    client = pymongo.MongoClient(**mongo_args)
-    client.server_info()
+    client = OpenPypeMongoConnection.create_connection(
+        mongo_uri, retry_attempts=1
+    )
     client.close()
 
 

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -3,6 +3,7 @@ import sys
 import time
 import logging
 import pymongo
+import certifi
 
 if sys.version_info[0] == 2:
     from urlparse import urlparse, parse_qs
@@ -91,6 +92,35 @@ def extract_port_from_url(url):
         _url = "mongodb://{}".format(url)
         parsed_url = urlparse(_url)
     return parsed_url.port
+
+
+def should_add_certificate_path_to_mongo_url(mongo_url):
+    """Check if should add ca certificate to mongo url.
+
+    Since 30.9.2021 cloud mongo requires newer certificates that are not
+    available on most of workstation. This adds path to certifi certificate
+    which is valid for it. To add the certificate path url must have scheme
+    'mongodb+srv' or has 'ssl=true' or 'tls=true' in url query.
+    """
+    parsed = urlparse(mongo_url)
+    query = parse_qs(parsed.query)
+    lowered_query_keys = set(key.lower() for key in query.keys())
+    add_certificate = False
+    # Check if url 'ssl' or 'tls' are set to 'true'
+    for key in ("ssl", "tls"):
+        if key in query and "true" in query["ssl"]:
+            add_certificate = True
+            break
+
+    # Check if url contains 'mongodb+srv'
+    if not add_certificate and parsed.scheme == "mongodb+srv":
+        add_certificate = True
+
+    # Check if url does already contain certificate path
+    if add_certificate and "tlscafile" in lowered_query_keys:
+        add_certificate = False
+
+    return add_certificate
 
 
 def validate_mongo_connection(mongo_uri):

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -156,6 +156,8 @@ class OpenPypeMongoConnection:
             # Naive validation of existing connection
             try:
                 connection.server_info()
+                with connection.start_session():
+                    pass
             except Exception:
                 connection = None
 

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -209,9 +209,9 @@ class OpenPypeMongoConnection:
         elif not retry_attempts:
             retry_attempts = 1
 
+        t1 = time.time()
         for _retry in range(retry_attempts):
             try:
-                t1 = time.time()
                 mongo_client.server_info()
 
             except Exception:

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -182,6 +182,8 @@ class OpenPypeMongoConnection:
         kwargs = {
             "serverSelectionTimeoutMS": timeout
         }
+        if should_add_certificate_path_to_mongo_url(mongo_url):
+            kwargs["ssl_ca_certs"] = certifi.where()
 
         mongo_client = pymongo.MongoClient(mongo_url, **kwargs)
 

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -86,14 +86,6 @@ def get_default_components():
     return decompose_url(mongo_url)
 
 
-def extract_port_from_url(url):
-    parsed_url = urlparse(url)
-    if parsed_url.scheme is None:
-        _url = "mongodb://{}".format(url)
-        parsed_url = urlparse(_url)
-    return parsed_url.port
-
-
 def should_add_certificate_path_to_mongo_url(mongo_url):
     """Check if should add ca certificate to mongo url.
 
@@ -201,9 +193,6 @@ class OpenPypeMongoConnection:
             "serverSelectionTimeoutMS": timeout
         }
 
-        port = extract_port_from_url(mongo_url)
-        if port is not None:
-            kwargs["port"] = int(port)
 
         mongo_client = pymongo.MongoClient(**kwargs)
         if retry_attempts is None:

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -185,6 +185,14 @@ class OpenPypeMongoConnection:
 
     @classmethod
     def create_connection(cls, mongo_url, timeout=None, retry_attempts=None):
+        parsed = urlparse(mongo_url)
+        # Force validation of scheme
+        if parsed.scheme not in ["mongodb", "mongodb+srv"]:
+            raise pymongo.errors.InvalidURI((
+                "Invalid URI scheme:"
+                " URI must begin with 'mongodb://' or 'mongodb+srv://'"
+            ))
+
         if timeout is None:
             timeout = int(os.environ.get("AVALON_TIMEOUT") or 1000)
 

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -197,12 +197,11 @@ class OpenPypeMongoConnection:
             timeout = int(os.environ.get("AVALON_TIMEOUT") or 1000)
 
         kwargs = {
-            "host": mongo_url,
             "serverSelectionTimeoutMS": timeout
         }
 
+        mongo_client = pymongo.MongoClient(mongo_url, **kwargs)
 
-        mongo_client = pymongo.MongoClient(**kwargs)
         if retry_attempts is None:
             retry_attempts = 3
 

--- a/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
@@ -40,6 +40,8 @@ def check_mongo_url(mongo_uri, log_error=False):
         # Force connection on a request as the connect=True parameter of
         # MongoClient seems to be useless here
         client.server_info()
+        with client.start_session():
+            pass
         client.close()
     except pymongo.errors.ServerSelectionTimeoutError as err:
         if log_error:

--- a/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_server/event_server_cli.py
@@ -17,7 +17,8 @@ from openpype.lib import (
     get_pype_execute_args,
     OpenPypeMongoConnection,
     get_openpype_version,
-    get_build_version
+    get_build_version,
+    validate_mongo_connection
 )
 from openpype_modules.ftrack import FTRACK_MODULE_DIR
 from openpype_modules.ftrack.lib import credentials
@@ -36,13 +37,15 @@ class MongoPermissionsError(Exception):
 def check_mongo_url(mongo_uri, log_error=False):
     """Checks if mongo server is responding"""
     try:
-        client = pymongo.MongoClient(mongo_uri)
-        # Force connection on a request as the connect=True parameter of
-        # MongoClient seems to be useless here
-        client.server_info()
-        with client.start_session():
-            pass
-        client.close()
+        validate_mongo_connection(mongo_uri)
+
+    except pymongo.errors.InvalidURI as err:
+        if log_error:
+            print("Can't connect to MongoDB at {} because: {}".format(
+                mongo_uri, err
+            ))
+        return False
+
     except pymongo.errors.ServerSelectionTimeoutError as err:
         if log_error:
             print("Can't connect to MongoDB at {} because: {}".format(

--- a/start.py
+++ b/start.py
@@ -102,9 +102,6 @@ import subprocess
 import site
 from pathlib import Path
 
-from igniter.tools import get_openpype_global_settings
-
-
 # OPENPYPE_ROOT is variable pointing to build (or code) directory
 # WARNING `OPENPYPE_ROOT` must be defined before igniter import
 # - igniter changes cwd which cause that filepath of this script won't lead
@@ -192,6 +189,7 @@ else:
 import igniter  # noqa: E402
 from igniter import BootstrapRepos  # noqa: E402
 from igniter.tools import (
+    get_openpype_global_settings,
     get_openpype_path_from_db,
     add_certificate_path_to_mongo_url,
     validate_mongo_connection

--- a/start.py
+++ b/start.py
@@ -193,6 +193,7 @@ import igniter  # noqa: E402
 from igniter import BootstrapRepos  # noqa: E402
 from igniter.tools import (
     get_openpype_path_from_db,
+    add_certificate_path_to_mongo_url,
     validate_mongo_connection
 )  # noqa
 from igniter.bootstrap_repos import OpenPypeVersion  # noqa: E402
@@ -585,7 +586,7 @@ def _determine_mongodb() -> str:
             except ValueError:
                 raise RuntimeError("Missing MongoDB url")
 
-    return openpype_mongo
+    return add_certificate_path_to_mongo_url(openpype_mongo)
 
 
 def _initialize_environment(openpype_version: OpenPypeVersion) -> None:

--- a/start.py
+++ b/start.py
@@ -191,7 +191,6 @@ from igniter import BootstrapRepos  # noqa: E402
 from igniter.tools import (
     get_openpype_global_settings,
     get_openpype_path_from_db,
-    add_certificate_path_to_mongo_url,
     validate_mongo_connection
 )  # noqa
 from igniter.bootstrap_repos import OpenPypeVersion  # noqa: E402
@@ -584,7 +583,7 @@ def _determine_mongodb() -> str:
             except ValueError:
                 raise RuntimeError("Missing MongoDB url")
 
-    return add_certificate_path_to_mongo_url(openpype_mongo)
+    return openpype_mongo
 
 
 def _initialize_environment(openpype_version: OpenPypeVersion) -> None:


### PR DESCRIPTION
## Issue
Since 30.9.2021 does not work cloud mongo connection correctly because of invalid ssl certificates on most of machines. It is issue mainly on Windows machines.

## Changes
- add certifi certificate to creation of mongo connection if `mongodb+srv` scheme is used or when `ssl=true` or `tls=true` is in mongo url query
- add session creation to validation of mongo connection
    - server info does not trigger any mongo server queries which are important to validate
- removed decompose/compose function for mongo parsing from igniter (which removes possibly important attributes)
- fixed import order bug caused by https://github.com/pypeclub/OpenPype/pull/2091#event-5387393877
- validation and mongo connection inside openpype happens on single place through `OpenPypeMongoConnection` class
    - avalon started to use the same method to create connection too

||PR depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/373|