### PR TITLE
Fix broken import in sftp provider

### DIFF
--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -13,9 +13,7 @@ log = Logger().get_logger("SyncServer")
 
 pysftp = None
 try:
-    import pysftp as _pysftp
-
-    pysftp = _pysftp
+    import pysftp
 except (ImportError, SyntaxError):
     pass
     # if six.PY3:

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -16,8 +16,6 @@ try:
     import pysftp
 except (ImportError, SyntaxError):
     pass
-    # if six.PY3:
-    #     six.reraise(*sys.exc_info())
 
     # handle imports from Python 2 hosts - in those only basic methods are used
     log.warning("Import failed, imported from Python 2, operations will fail.")

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -327,8 +327,8 @@ class SFTPHandler(AbstractProvider):
         if not self.file_path_exists(path):
             raise FileNotFoundError("File {} to be deleted doesn't exist."
                                     .format(path))
-        conn = self._get_conn()
-        conn.remove(path)
+
+        self.conn.remove(path)
 
     def list_folder(self, folder_path):
         """

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -11,11 +11,15 @@ from openpype.api import get_system_settings
 from .abstract_provider import AbstractProvider
 log = Logger().get_logger("SyncServer")
 
+pysftp = None
 try:
-    import pysftp
+    import pysftp as _pysftp
+
+    pysftp = _pysftp
 except (ImportError, SyntaxError):
-    if six.PY3:
-        six.reraise(*sys.exc_info())
+    pass
+    # if six.PY3:
+    #     six.reraise(*sys.exc_info())
 
     # handle imports from Python 2 hosts - in those only basic methods are used
     log.warning("Import failed, imported from Python 2, operations will fail.")
@@ -41,7 +45,7 @@ class SFTPHandler(AbstractProvider):
         self.project_name = project_name
         self.site_name = site_name
         self.root = None
-        self.conn = None
+        self._conn = None
 
         self.presets = presets
         if not self.presets:
@@ -63,10 +67,16 @@ class SFTPHandler(AbstractProvider):
         self.sftp_key = provider_presets["sftp_key"]
         self.sftp_key_pass = provider_presets["sftp_key_pass"]
 
-        self.conn = self._get_conn()
-
         self._tree = None
         self.active = True
+
+    @property
+    def conn(self):
+        """SFTP connection, cannot be used in all places though."""
+        if not self._conn:
+            self._conn = self._get_conn()
+
+        return self._conn
 
     def is_active(self):
         """
@@ -321,7 +331,8 @@ class SFTPHandler(AbstractProvider):
         if not self.file_path_exists(path):
             raise FileNotFoundError("File {} to be deleted doesn't exist."
                                     .format(path))
-        self.conn.remove(path)
+        conn = self._get_conn()
+        conn.remove(path)
 
     def list_folder(self, folder_path):
         """
@@ -394,6 +405,9 @@ class SFTPHandler(AbstractProvider):
         Returns:
             pysftp.Connection
         """
+        if not pysftp:
+            raise ImportError
+
         cnopts = pysftp.CnOpts()
         cnopts.hostkeys = None
 

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -8,9 +8,7 @@ import platform
 
 from openpype.api import Logger
 from openpype.api import get_system_settings
-from openpype.modules.default_modules.sync_server.providers.abstract_provider \
-    import AbstractProvider
-
+from .abstract_provider import AbstractProvider
 log = Logger().get_logger("SyncServer")
 
 try:


### PR DESCRIPTION
Bug is manifesting in Maya SceneInventory

During testing another issue was found in Blender 2.93 (only), where Blender's own libraries conflict with a provider. (Issue occured in Loader and Manage.. in OP menu).