### PR TITLE
Ftrack: Project settings save custom attributes skip unknown attributes

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_create_cust_attrs.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_create_cust_attrs.py
@@ -10,6 +10,7 @@ from openpype_modules.ftrack.lib import (
     CUST_ATTR_GROUP,
     CUST_ATTR_TOOLS,
     CUST_ATTR_APPLICATIONS,
+    CUST_ATTR_INTENT,
 
     default_custom_attributes_definition,
     app_definitions_from_app_manager,
@@ -431,7 +432,7 @@ class CustomAttributes(BaseAction):
 
         intent_custom_attr_data = {
             "label": "Intent",
-            "key": "intent",
+            "key": CUST_ATTR_INTENT,
             "type": "enumerator",
             "entity_type": "assetversion",
             "group": CUST_ATTR_GROUP,

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -277,15 +277,17 @@ class FtrackModule(
         failed = {}
         missing = {}
         for key, value in attributes_changes.items():
+            if key not in ca_keys:
+                continue
+
             configuration = hier_attrs_by_key.get(key)
             if not configuration:
                 configuration = cust_attr_by_key.get(key)
             if not configuration:
-                if key in ca_keys:
-                    self.log.warning(
-                        "Custom attribute \"{}\" was not found.".format(key)
-                    )
-                    missing[key] = value
+                self.log.warning(
+                    "Custom attribute \"{}\" was not found.".format(key)
+                )
+                missing[key] = value
                 continue
 
             # TODO add add permissions check

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -266,8 +266,8 @@ class FtrackModule(
         project_attrs = ca_defs.get("show") or {}
         ca_keys = (
             set(hierarchical_attrs.keys())
-            + set(project_attrs.keys())
-            + {CUST_ATTR_TOOLS, CUST_ATTR_APPLICATIONS, CUST_ATTR_INTENT}
+            | set(project_attrs.keys())
+            | {CUST_ATTR_TOOLS, CUST_ATTR_APPLICATIONS, CUST_ATTR_INTENT}
         )
 
         cust_attr, hier_attr = get_openpype_attr(session)

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -230,7 +230,13 @@ class FtrackModule(
             return
 
         import ftrack_api
-        from openpype_modules.ftrack.lib import get_openpype_attr
+        from openpype_modules.ftrack.lib import (
+            get_openpype_attr,
+            default_custom_attributes_definition,
+            CUST_ATTR_TOOLS,
+            CUST_ATTR_APPLICATIONS,
+            CUST_ATTR_INTENT
+        )
 
         try:
             session = self.create_ftrack_session()
@@ -255,6 +261,15 @@ class FtrackModule(
 
         project_id = project_entity["id"]
 
+        ca_defs = default_custom_attributes_definition()
+        hierarchical_attrs = ca_defs.get("is_hierarchical") or {}
+        project_attrs = ca_defs.get("show") or {}
+        ca_keys = (
+            set(hierarchical_attrs.keys())
+            + set(project_attrs.keys())
+            + {CUST_ATTR_TOOLS, CUST_ATTR_APPLICATIONS, CUST_ATTR_INTENT}
+        )
+
         cust_attr, hier_attr = get_openpype_attr(session)
         cust_attr_by_key = {attr["key"]: attr for attr in cust_attr}
         hier_attrs_by_key = {attr["key"]: attr for attr in hier_attr}
@@ -266,10 +281,11 @@ class FtrackModule(
             if not configuration:
                 configuration = cust_attr_by_key.get(key)
             if not configuration:
-                self.log.warning(
-                    "Custom attribute \"{}\" was not found.".format(key)
-                )
-                missing[key] = value
+                if key in ca_keys:
+                    self.log.warning(
+                        "Custom attribute \"{}\" was not found.".format(key)
+                    )
+                    missing[key] = value
                 continue
 
             # TODO add add permissions check

--- a/openpype/modules/default_modules/ftrack/lib/__init__.py
+++ b/openpype/modules/default_modules/ftrack/lib/__init__.py
@@ -3,7 +3,8 @@ from .constants import (
     CUST_ATTR_AUTO_SYNC,
     CUST_ATTR_GROUP,
     CUST_ATTR_TOOLS,
-    CUST_ATTR_APPLICATIONS
+    CUST_ATTR_APPLICATIONS,
+    CUST_ATTR_INTENT
 )
 from .settings import (
     get_ftrack_event_mongo_info

--- a/openpype/modules/default_modules/ftrack/lib/constants.py
+++ b/openpype/modules/default_modules/ftrack/lib/constants.py
@@ -10,3 +10,5 @@ CUST_ATTR_AUTO_SYNC = "avalon_auto_sync"
 CUST_ATTR_APPLICATIONS = "applications"
 # Environment tools custom attribute
 CUST_ATTR_TOOLS = "tools_env"
+# Intent custom attribute name
+CUST_ATTR_INTENT = "intent"


### PR DESCRIPTION
## Issue
Ftrack cause warning message on save of project settings becaue `active` custom attribute was not found.

## Changes
- ftrack check only known attributes on save all others are skipped
- intent custom attribute key has constant

## How to test
- enable ftrack module and login
- go to project settings in setting UI
- go to any project that exists on ftrack
- change anything in attributes and save settings
- warning message about `active` custom attribute should not appear