### PR TITLE
Settings UI: Project model refreshing and sorting

### DIFF
--- a/openpype/tools/settings/settings/constants.py
+++ b/openpype/tools/settings/settings/constants.py
@@ -1,0 +1,16 @@
+from Qt import QtCore
+
+
+DEFAULT_PROJECT_LABEL = "< Default >"
+PROJECT_NAME_ROLE = QtCore.Qt.UserRole + 1
+PROJECT_IS_ACTIVE_ROLE = QtCore.Qt.UserRole + 2
+PROJECT_IS_SELECTED_ROLE = QtCore.Qt.UserRole + 3
+
+
+__all__ = (
+    "DEFAULT_PROJECT_LABEL",
+
+    "PROJECT_NAME_ROLE",
+    "PROJECT_IS_ACTIVE_ROLE",
+    "PROJECT_IS_SELECTED_ROLE"
+)

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -677,10 +677,28 @@ class ProjectListView(QtWidgets.QListView):
         super(ProjectListView, self).mouseReleaseEvent(event)
 
 
-class ProjectListSortFilterProxy(QtCore.QSortFilterProxyModel):
+class ProjectSortFilterProxy(QtCore.QSortFilterProxyModel):
     def __init__(self, *args, **kwargs):
-        super(ProjectListSortFilterProxy, self).__init__(*args, **kwargs)
+        super(ProjectSortFilterProxy, self).__init__(*args, **kwargs)
         self._enable_filter = True
+
+    def lessThan(self, left_index, right_index):
+        if left_index.data(PROJECT_NAME_ROLE) is None:
+            return True
+
+        if right_index.data(PROJECT_NAME_ROLE) is None:
+            return False
+
+        left_is_active = left_index.data(PROJECT_IS_ACTIVE_ROLE)
+        right_is_active = right_index.data(PROJECT_IS_ACTIVE_ROLE)
+        if right_is_active == left_is_active:
+            return super(ProjectSortFilterProxy, self).lessThan(
+                left_index, right_index
+            )
+
+        if left_is_active:
+            return True
+        return False
 
     def filterAcceptsRow(self, source_row, source_parent):
         if not self._enable_filter:
@@ -715,7 +733,7 @@ class ProjectListWidget(QtWidgets.QWidget):
 
         project_list = ProjectListView(self)
         project_model = ProjectModel(only_active)
-        project_proxy = ProjectListSortFilterProxy()
+        project_proxy = ProjectSortFilterProxy()
 
         project_proxy.setFilterRole(PROJECT_IS_ACTIVE_ROLE)
         project_proxy.setSourceModel(project_model)


### PR DESCRIPTION
## Issue
Project list in settings may not sort them properly because sorting is based on alphabetical order.

### Screenshot
![image](https://user-images.githubusercontent.com/43494761/135990867-b7d6857d-50a4-4798-861d-0aa6ec8a12c1.png)

## Changes
- project proxy model have custom sorting method to put default project at first place than active projects and inactive projects as last
- project model cares about it's refreshing instead of refreshing out of model
    - refresh of model is real refreshing (does not clear all projects on refresh but only removes not existing and adds new projects)
- roles are constants

## How to test
- create project starting with number
- list should show them under `< Default >` item