### PR TITLE
Add startup script for Houdini Core. 

### DIFF
--- a/openpype/hosts/houdini/startup/scripts/houdinicore.py
+++ b/openpype/hosts/houdini/startup/scripts/houdinicore.py
@@ -1,0 +1,9 @@
+from avalon import api, houdini
+
+
+def main():
+    print("Installing OpenPype ...")
+    api.install(houdini)
+
+
+main()


### PR DESCRIPTION
Adding an equivalent to 123.py for Houdini Core.
123.py is only read by Houdini FX, whereas Houdini Core expects a `houdinicore.py` file. 

See docs here: https://www.sidefx.com/docs/houdini/hom/locations.html#startup