### PR TITLE
Implement sanity mode to pyblish openpype GUI

### DIFF
--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -216,18 +216,19 @@ class Controller(QtCore.QObject):
                 if order >= pyblish.api.ExtractorOrder - 0.5:
                     continue
                 elif order >= pyblish.api.ValidatorOrder - 0.5:
-                    setattr(plugin, "optional", True)
-                    setattr(plugin, "active", False)
+                    plugin.optional = True
+                    plugin.active = False
                     if self.last_active_plugin.get(plugin.__name__, False):
-                        setattr(plugin, "active", True)
+                        plugin.active = True
 
             _plugins.append(plugin)
         self.plugins = _plugins
 
     def deactivate_validator_plugins(self):
         for plugin in self.plugins:
-            if getattr(plugin, "order", 100) >= pyblish.api.ValidatorOrder - 0.5:
-                setattr(plugin, "active", False)
+            if getattr(plugin, "order", 100) >= \
+                    pyblish.api.ValidatorOrder - 0.5:
+                plugin.active = False
 
 
     def on_published(self):

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -119,11 +119,12 @@ class Window(QtWidgets.QDialog):
 
         presets_button = widgets.ButtonWithMenu(awesome["filter"])
         presets_button.setEnabled(False)
+
         self.change_mode_btn = QtWidgets.QPushButton()
         if self.controller.sanity_mode:
-            self.change_mode_btn.setText("C")
+            self.set_publish_mode_btn()
         else:
-            self.change_mode_btn.setText("S")
+            self.set_validation_mode_btn()
         aditional_btns_layout.addWidget(self.change_mode_btn)
         aditional_btns_layout.addWidget(presets_button)
 
@@ -1132,16 +1133,22 @@ class Window(QtWidgets.QDialog):
     #
     # -------------------------------------------------------------------------
 
-    def change_to_sanity_mode(self):
+    def set_validation_mode_btn(self):
+        self.change_mode_btn.setText("V")
+        self.change_mode_btn.setToolTip("Switch to Validation mode.")
 
-        self.change_mode_btn.setText("C")
+    def set_publish_mode_btn(self):
+        self.change_mode_btn.setText("P")
+        self.change_mode_btn.setToolTip("Switch to Publish mode.")
+
+    def change_to_sanity_mode(self):
+        self.set_publish_mode_btn()
         self.controller.sanity_mode = True
         self.controller.deactivate_validator_plugins()
         self.reset()
 
     def change_to_classic_mode(self):
-
-        self.change_mode_btn.setText("S")
+        self.set_validation_mode_btn()
         self.controller.sanity_mode = False
         self.reset()
 

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -119,6 +119,12 @@ class Window(QtWidgets.QDialog):
 
         presets_button = widgets.ButtonWithMenu(awesome["filter"])
         presets_button.setEnabled(False)
+        self.change_mode_btn = QtWidgets.QPushButton()
+        if self.controller.sanity_mode:
+            self.change_mode_btn.setText("C")
+        else:
+            self.change_mode_btn.setText("S")
+        aditional_btns_layout.addWidget(self.change_mode_btn)
         aditional_btns_layout.addWidget(presets_button)
 
         layout_tab = QtWidgets.QHBoxLayout(header_tab_widget)
@@ -435,6 +441,7 @@ class Window(QtWidgets.QDialog):
         footer_button_reset.clicked.connect(self.on_reset_clicked)
         footer_button_validate.clicked.connect(self.on_validate_clicked)
         footer_button_play.clicked.connect(self.on_play_clicked)
+        self.change_mode_btn.clicked.connect(self.on_change_mode_clicked)
 
         comment_box.textChanged.connect(self.on_comment_entered)
         comment_box.returnPressed.connect(self.on_play_clicked)
@@ -873,6 +880,12 @@ class Window(QtWidgets.QDialog):
     def on_suspend_clicked(self, value=None):
         self.apply_log_suspend_value(not self._suspend_logs)
 
+    def on_change_mode_clicked(self):
+        if self.controller.sanity_mode:
+            self.change_to_classic_mode()
+        else:
+            self.change_to_sanity_mode()
+
     def apply_log_suspend_value(self, value):
         self._suspend_logs = value
         if self.state["current_page"] == "terminal":
@@ -1118,6 +1131,19 @@ class Window(QtWidgets.QDialog):
     # Functions
     #
     # -------------------------------------------------------------------------
+
+    def change_to_sanity_mode(self):
+
+        self.change_mode_btn.setText("C")
+        self.controller.sanity_mode = True
+        self.controller.deactivate_validator_plugins()
+        self.reset()
+
+    def change_to_classic_mode(self):
+
+        self.change_mode_btn.setText("S")
+        self.controller.sanity_mode = False
+        self.reset()
 
     def reset(self):
         """Prepare GUI for reset"""


### PR DESCRIPTION
Here is a first proposition to make the pyblish interface simpler to use and more ergonomic for the user to sanityze his work in progress (with Validators/Actions) according to this issue #2112.

You can now switch between a the Sanity Mode (S) and the Classic pyblish Mode (C) with the top right button.

The environment variable "PYBLISH_SANITY_MODE" can be setted before showing the interface to set the pyblish mode beforehand.
This can be used to add a "sanity" button to the DCC menus to make the workflow more intuitive for the artist.