### PR TITLE
Maya : Colorspace configuration 

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1886,7 +1886,7 @@ def set_context_settings():
 
     # Set frame range.
     avalon.maya.interactive.reset_frame_range()
-    
+
     # Set colorspace
     set_colorspace()
 
@@ -2749,11 +2749,11 @@ def iter_shader_edits(relationships, shader_nodes, nodes_by_id, label=None):
 
 def set_colorspace():
     """Set Colorspace from project configuration
-
     """
-    imageio = get_anatomy_settings(os.getenv("AVALON_PROJECT"))["imageio"]["maya"]
+    project_name = os.getenv("AVALON_PROJECT")
+    imageio = get_anatomy_settings(project_name)["imageio"]["maya"]
     root_dict = imageio["colorManagementPreference"]
-    
+
     if not isinstance(root_dict, dict):
         msg = "set_colorspace(): argument should be dictionary"
         log.error(msg)
@@ -2776,21 +2776,18 @@ def set_colorspace():
                 continue
 
         if resolved_path:
-            cmds.colorManagementPrefs(e=True, configFilePath= str(resolved_path).replace("\\", "/") )
+            filepath = str(resolved_path).replace("\\", "/")
+            cmds.colorManagementPrefs(e=True, configFilePath=filepath )
             cmds.colorManagementPrefs(e=True, cmConfigFileEnabled=True)
-            
             log.debug("maya '{}' changed to: {}".format(
                 "configFilePath", resolved_path))
             root_dict.pop("configFilePath")
-        else :
+        else:
             cmds.colorManagementPrefs(e=True, cmConfigFileEnabled=False)
-            cmds.colorManagementPrefs(e=True, configFilePath= "" )
+            cmds.colorManagementPrefs(e=True, configFilePath="" )
 
-
-
-    # third define rendering space and view transform
+    # third set rendering space and view transform
     renderSpace = root_dict["renderSpace"]
     cmds.colorManagementPrefs(e=True, renderingSpaceName=renderSpace)
     viewTransform = root_dict["viewTransform"]
     cmds.colorManagementPrefs(e=True, viewTransformName=viewTransform)
-

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2777,7 +2777,7 @@ def set_colorspace():
 
         if resolved_path:
             filepath = str(resolved_path).replace("\\", "/")
-            cmds.colorManagementPrefs(e=True, configFilePath=filepath )
+            cmds.colorManagementPrefs(e=True, configFilePath=filepath)
             cmds.colorManagementPrefs(e=True, cmConfigFileEnabled=True)
             log.debug("maya '{}' changed to: {}".format(
                 "configFilePath", resolved_path))

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1886,6 +1886,7 @@ def set_context_settings():
 
     # Set frame range.
     avalon.maya.interactive.reset_frame_range()
+    
     # Set colorspace
     set_colorspace()
 
@@ -2781,6 +2782,10 @@ def set_colorspace():
             log.debug("maya '{}' changed to: {}".format(
                 "configFilePath", resolved_path))
             root_dict.pop("configFilePath")
+        else :
+            cmds.colorManagementPrefs(e=True, cmConfigFileEnabled=False)
+            cmds.colorManagementPrefs(e=True, configFilePath= "" )
+
 
 
     # third define rendering space and view transform

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2,6 +2,7 @@
 
 import re
 import os
+import platform
 import uuid
 import math
 
@@ -1885,6 +1886,8 @@ def set_context_settings():
 
     # Set frame range.
     avalon.maya.interactive.reset_frame_range()
+    # Set colorspace
+    set_colorspace()
 
 
 # Valid FPS

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2752,7 +2752,7 @@ def set_colorspace():
 
     """
     imageio = get_anatomy_settings(os.getenv("AVALON_PROJECT"))["imageio"]["maya"]
-    root_dict = imageio["colorManagmentPreference"]
+    root_dict = imageio["colorManagementPreference"]
     
     if not isinstance(root_dict, dict):
         msg = "set_colorspace(): argument should be dictionary"

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -11,6 +11,7 @@ from avalon.maya import pipeline
 from openpype.api import BuildWorkfile
 from openpype.settings import get_project_settings
 from openpype.tools.utils import host_tools
+from openpype.hosts.maya.api import lib
 
 
 log = logging.getLogger(__name__)
@@ -125,6 +126,31 @@ def deferred():
         if project_manager_action is not None:
             system_menu.menu().removeAction(project_manager_action)
 
+    def add_colorspace():
+        # Find the pipeline menu
+        top_menu = _get_menu()
+
+        # Try to find workfile tool action in the menu
+        workfile_action = None
+        for action in top_menu.actions():
+            if action.text() == "Reset Resolution":
+                workfile_action = action
+                break
+
+        # Add at the top of menu if "Work Files" action was not found
+        after_action = ""
+        if workfile_action:
+            # Use action's object name for `insertAfter` argument
+            after_action = workfile_action.objectName()
+
+        # Insert action to menu
+        cmds.menuItem(
+            "Set Colorspace",
+            parent=pipeline._menu,
+            command=lambda *args: lib.set_colorspace(),
+            insertAfter=after_action
+        )
+
     log.info("Attempting to install scripts menu ...")
 
     # add_scripts_menu()
@@ -132,6 +158,7 @@ def deferred():
     add_look_assigner_item()
     modify_workfiles()
     remove_project_manager()
+    add_colorspace()
     add_scripts_menu()
 
 

--- a/openpype/settings/defaults/project_anatomy/imageio.json
+++ b/openpype/settings/defaults/project_anatomy/imageio.json
@@ -174,5 +174,16 @@
                 }
             ]
         }
+    },
+    "maya": {
+        "colorManagmentPreference": {
+            "configFilePath": {
+                "windows": [],
+                "darwin": [],
+                "linux": []
+            },
+            "renderSpace": "scene-linear Rec 709/sRGB",
+            "viewTransform": "sRGB gamma"
+        }
     }
 }

--- a/openpype/settings/defaults/project_anatomy/imageio.json
+++ b/openpype/settings/defaults/project_anatomy/imageio.json
@@ -176,7 +176,7 @@
         }
     },
     "maya": {
-        "colorManagmentPreference": {
+        "colorManagementPreference": {
             "configFilePath": {
                 "windows": [],
                 "darwin": [],

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -358,6 +358,38 @@
                     ]
                 }
             ]
+        },
+        {
+            "key": "maya",
+            "type": "dict",
+            "label": "Maya",
+            "children": [    
+                {
+                    "key": "colorManagmentPreference",
+                    "type": "dict",
+                    "label": "Color Managment Preference",
+                    "collapsible": false,
+                    "children": [
+                        {
+                            "type": "path",
+                            "key": "configFilePath",
+                            "label": "OCIO Config File Path",
+                            "multiplatform": true,
+                            "multipath": true
+                        },
+                        {
+                            "type": "text",
+                            "key": "renderSpace",
+                            "label": "Rendering Space"
+                        },
+                        {
+                            "type": "text",
+                            "key": "viewTransform",
+                            "label": "Viewer Transform"
+                        }
+                    ]
+            }
+            ]
         }
     ]
 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -365,7 +365,7 @@
             "label": "Maya",
             "children": [    
                 {
-                    "key": "colorManagmentPreference",
+                    "key": "colorManagementPreference",
                     "type": "dict",
                     "label": "Color Managment Preference",
                     "collapsible": false,


### PR DESCRIPTION
# Description

Set Colorspace in Maya color management preference from project setting for new scenes and also add menu item for change open scenes .

# Testing Notes

1. Go to ( studio setting >> project >> anatomy >> color management >> Maya ) .
2. Set the OCIO config path in your system. . like `/aces_1.0.2/config.ocio`.
3. Set the Rendering Space .. like `ACES - ACEScg`.
4. Set the Viewer Transform .. like `Raw (ACES)`.
5. Create new Maya scene or open existing Maya scene then from OpenPype menu press `Set Colorspace`.
6.check color management tab from Maya preferences.