### PR TITLE
Maya: Aspect ratio

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1851,6 +1851,7 @@ def set_scene_resolution(width, height, pixelAspect):
     cmds.setAttr("%s.deviceAspectRatio" % control_node, deviceAspectRatio)
     cmds.setAttr("%s.pixelAspect" % control_node, pixelAspect)
 
+
 def reset_scene_resolution():
     """Apply the scene resolution  from the project definition
 
@@ -1872,7 +1873,8 @@ def reset_scene_resolution():
 
     width = asset_data.get(width_key, project_data.get(width_key, 1920))
     height = asset_data.get(height_key, project_data.get(height_key, 1080))
-    pixelAspect = asset_data.get(pixelAspect_key, project_data.get(pixelAspect_key, 1))
+    pixelAspect = asset_data.get(pixelAspect_key,
+                                 project_data.get(pixelAspect_key, 1))
 
     set_scene_resolution(width, height, pixelAspect)
 

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1851,6 +1851,31 @@ def set_scene_resolution(width, height, pixelAspect):
     cmds.setAttr("%s.deviceAspectRatio" % control_node, deviceAspectRatio)
     cmds.setAttr("%s.pixelAspect" % control_node, pixelAspect)
 
+def reset_scene_resolution():
+    """Apply the scene resolution  from the project definition
+
+    scene resolution can be overwritten by an asset if the asset.data contains
+    any information regarding scene resolution .
+
+    Returns:
+        None
+    """
+
+    project_doc = io.find_one({"type": "project"})
+    project_data = project_doc["data"]
+    asset_data = lib.get_asset()["data"]
+
+    # Set project resolution
+    width_key = "resolutionWidth"
+    height_key = "resolutionHeight"
+    pixelAspect_key = "pixelAspect"
+
+    width = asset_data.get(width_key, project_data.get(width_key, 1920))
+    height = asset_data.get(height_key, project_data.get(height_key, 1080))
+    pixelAspect = asset_data.get(pixelAspect_key, project_data.get(pixelAspect_key, 1))
+
+    set_scene_resolution(width, height, pixelAspect)
+
 def set_context_settings():
     """Apply the project settings from the project definition
 
@@ -1876,16 +1901,7 @@ def set_context_settings():
     api.Session["AVALON_FPS"] = str(fps)
     set_scene_fps(fps)
 
-    # Set project resolution
-    width_key = "resolutionWidth"
-    height_key = "resolutionHeight"
-    pixelAspect_key = "pixelAspect"
-
-    width = asset_data.get(width_key, project_data.get(width_key, 1920))
-    height = asset_data.get(height_key, project_data.get(height_key, 1080))
-    pixelAspect = asset_data.get(pixelAspect_key, project_data.get(pixelAspect_key, 1))
-
-    set_scene_resolution(width, height, pixelAspect)
+    reset_scene_resolution()
 
     # Set frame range.
     avalon.maya.interactive.reset_frame_range()

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1819,7 +1819,7 @@ def set_scene_fps(fps, update=True):
     cmds.file(modified=True)
 
 
-def set_scene_resolution(width, height):
+def set_scene_resolution(width, height, pixelAspect):
     """Set the render resolution
 
     Args:
@@ -1847,6 +1847,9 @@ def set_scene_resolution(width, height):
     cmds.setAttr("%s.width" % control_node, width)
     cmds.setAttr("%s.height" % control_node, height)
 
+    deviceAspectRatio = ((float(width) / float(height)) * float(pixelAspect))
+    cmds.setAttr("%s.deviceAspectRatio" % control_node, deviceAspectRatio)
+    cmds.setAttr("%s.pixelAspect" % control_node, pixelAspect)
 
 def set_context_settings():
     """Apply the project settings from the project definition
@@ -1876,11 +1879,13 @@ def set_context_settings():
     # Set project resolution
     width_key = "resolutionWidth"
     height_key = "resolutionHeight"
+    pixelAspect_key = "pixelAspect"
 
     width = asset_data.get(width_key, project_data.get(width_key, 1920))
     height = asset_data.get(height_key, project_data.get(height_key, 1080))
+    pixelAspect = asset_data.get(pixelAspect_key, project_data.get(pixelAspect_key, 1))
 
-    set_scene_resolution(width, height)
+    set_scene_resolution(width, height, pixelAspect)
 
     # Set frame range.
     avalon.maya.interactive.reset_frame_range()

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -11,6 +11,7 @@ from avalon.maya import pipeline
 from openpype.api import BuildWorkfile
 from openpype.settings import get_project_settings
 from openpype.tools.utils import host_tools
+from openpype.hosts.maya.api import lib
 
 
 log = logging.getLogger(__name__)
@@ -110,6 +111,35 @@ def deferred():
         if workfile_action:
             top_menu.removeAction(workfile_action)
 
+    def modify_resolution():
+        # Find the pipeline menu
+        top_menu = _get_menu()
+
+        # Try to find resolution tool action in the menu
+        resolution_action = None
+        for action in top_menu.actions():
+            if action.text() == "Reset Resolution":
+                resolution_action = action
+                break
+
+        # Add at the top of menu if "Work Files" action was not found
+        after_action = ""
+        if resolution_action:
+            # Use action's object name for `insertAfter` argument
+            after_action = resolution_action.objectName()
+
+        # Insert action to menu
+        cmds.menuItem(
+            "Reset Resolution",
+            parent=pipeline._menu,
+            command=lambda *args: lib.reset_scene_resolution(),
+            insertAfter=after_action
+        )
+
+        # Remove replaced action
+        if resolution_action:
+            top_menu.removeAction(resolution_action)
+
     def remove_project_manager():
         top_menu = _get_menu()
 
@@ -141,6 +171,7 @@ def deferred():
     add_look_assigner_item()
     add_experimental_item()
     modify_workfiles()
+    modify_resolution()
     remove_project_manager()
     add_scripts_menu()
 


### PR DESCRIPTION
# Description

Set the device aspect ratio and pixel aspect ratio from asset setting in Maya .

# Testing Notes

1. Set resolution and pixel aspect ratio in project manager for asset  .
5. Create new Maya scene or open existing Maya scene then from OpenPype menu press `Reset Resolution`.
6. Check resolution and pixel aspect ratio from Maya render setting.