### PR TITLE
Subset name: Be able to pass asset document to get subset name

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_bulk_mov_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_bulk_mov_instances.py
@@ -3,7 +3,7 @@ import json
 import pyblish.api
 
 from avalon import io
-from openpype.lib import get_subset_name
+from openpype.lib import get_subset_name_with_asset_doc
 
 
 class CollectBulkMovInstances(pyblish.api.InstancePlugin):
@@ -26,16 +26,10 @@ class CollectBulkMovInstances(pyblish.api.InstancePlugin):
         context = instance.context
         asset_name = instance.data["asset"]
 
-        asset_doc = io.find_one(
-            {
-                "type": "asset",
-                "name": asset_name
-            },
-            {
-                "_id": 1,
-                "data.tasks": 1
-            }
-        )
+        asset_doc = io.find_one({
+            "type": "asset",
+            "name": asset_name
+        })
         if not asset_doc:
             raise AssertionError((
                 "Couldn't find Asset document with name \"{}\""
@@ -53,11 +47,11 @@ class CollectBulkMovInstances(pyblish.api.InstancePlugin):
                 task_name = available_task_names[_task_name_low]
                 break
 
-        subset_name = get_subset_name(
+        subset_name = get_subset_name_with_asset_doc(
             self.new_instance_family,
             self.subset_name_variant,
             task_name,
-            asset_doc["_id"],
+            asset_doc,
             io.Session["AVALON_PROJECT"]
         )
         instance_name = f"{asset_name}_{subset_name}"

--- a/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
@@ -4,7 +4,7 @@ import copy
 import pyblish.api
 from avalon import io
 
-from openpype.lib import get_subset_name
+from openpype.lib import get_subset_name_with_asset_doc
 
 
 class CollectInstances(pyblish.api.ContextPlugin):
@@ -70,16 +70,10 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 # - not sure if it's good idea to require asset id in
                 #   get_subset_name?
                 asset_name = context.data["workfile_context"]["asset"]
-                asset_doc = io.find_one(
-                    {
-                        "type": "asset",
-                        "name": asset_name
-                    },
-                    {"_id": 1}
-                )
-                asset_id = None
-                if asset_doc:
-                    asset_id = asset_doc["_id"]
+                asset_doc = io.find_one({
+                    "type": "asset",
+                    "name": asset_name
+                })
 
                 # Project name from workfile context
                 project_name = context.data["workfile_context"]["project"]
@@ -88,11 +82,11 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 # Use empty variant value
                 variant = ""
                 task_name = io.Session["AVALON_TASK"]
-                new_subset_name = get_subset_name(
+                new_subset_name = get_subset_name_with_asset_doc(
                     family,
                     variant,
                     task_name,
-                    asset_id,
+                    asset_doc,
                     project_name,
                     host_name
                 )

--- a/openpype/hosts/tvpaint/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_workfile.py
@@ -3,7 +3,7 @@ import json
 import pyblish.api
 from avalon import io
 
-from openpype.lib import get_subset_name
+from openpype.lib import get_subset_name_with_asset_doc
 
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
@@ -28,16 +28,10 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         #   get_subset_name?
         family = "workfile"
         asset_name = context.data["workfile_context"]["asset"]
-        asset_doc = io.find_one(
-            {
-                "type": "asset",
-                "name": asset_name
-            },
-            {"_id": 1}
-        )
-        asset_id = None
-        if asset_doc:
-            asset_id = asset_doc["_id"]
+        asset_doc = io.find_one({
+            "type": "asset",
+            "name": asset_name
+        })
 
         # Project name from workfile context
         project_name = context.data["workfile_context"]["project"]
@@ -46,11 +40,11 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         # Use empty variant value
         variant = ""
         task_name = io.Session["AVALON_TASK"]
-        subset_name = get_subset_name(
+        subset_name = get_subset_name_with_asset_doc(
             family,
             variant,
             task_name,
-            asset_id,
+            asset_doc,
             project_name,
             host_name
         )

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -130,6 +130,7 @@ from .applications import (
 from .plugin_tools import (
     TaskNotSetError,
     get_subset_name,
+    get_subset_name_with_asset_doc,
     prepare_template_data,
     filter_pyblish_plugins,
     set_plugin_attributes_from_settings,
@@ -249,6 +250,7 @@ __all__ = [
 
     "TaskNotSetError",
     "get_subset_name",
+    "get_subset_name_with_asset_doc",
     "filter_pyblish_plugins",
     "set_plugin_attributes_from_settings",
     "source_hash",


### PR DESCRIPTION
## Description
Right now there is requirement to pass asset id into `get_subset_name` which is used to query asset document and get it's tasks but in most of cases we already have access to asset document which can be passed there.

Issue was created to modify behavior in Creator tool. Since new publisher requires new creators and logic for them this is preparation PR for new publisher.

## Changes
- added new function `get_subset_name_with_asset_doc` which does not require to query asset anymore
    - merged logic of both `get_subset_name` and `get_subset_name_with_asset_doc` into `_get_subset_name`
- use function in collectors where can be used