### PR TITLE
Blender: Fix trying to pack an image when the shader node has no texture

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -37,7 +37,8 @@ class ExtractBlend(openpype.api.Extractor):
                         if tree.type == 'SHADER':
                             for node in tree.nodes:
                                 if node.bl_idname == 'ShaderNodeTexImage':
-                                    node.image.pack()
+                                    if node.image:
+                                        node.image.pack()
 
         bpy.data.libraries.write(filepath, data_blocks)
 


### PR DESCRIPTION
There might be cases where a texture node in the shader has no image. If this happens, an error is thrown because the image in the node should be packed. This PR checks if the image exists, before packing it.