### PR TITLE
Project Manager: Fix copying of tasks

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1456,7 +1456,11 @@ class HierarchyModel(QtCore.QAbstractItemModel):
             return
 
         raw_data = mime_data.data("application/copy_task")
-        encoded_data = QtCore.QByteArray.fromRawData(raw_data)
+        if isinstance(raw_data, QtCore.QByteArray):
+            # Raw data are already QByteArrat and we don't have to load them
+            encoded_data = raw_data
+        else:
+            encoded_data = QtCore.QByteArray.fromRawData(raw_data)
         stream = QtCore.QDataStream(encoded_data, QtCore.QIODevice.ReadOnly)
         text = stream.readQString()
         try:


### PR DESCRIPTION
## Issue
PySide2 returns `QByteArray` from mime data which is not the same as in PyQt5. That causes error:
```
Traceback (most recent call last):
  File "C:\Users\iLLiCiT\PycharmProjects\pype3\openpype\tools\project_manager\project_manager\view.py", line 338, in keyPressEvent
    self._paste_items()
  File "C:\Users\iLLiCiT\PycharmProjects\pype3\openpype\tools\project_manager\project_manager\view.py", line 381, in _paste_items
    self._source_model.paste_mime_data(index, mime_data)
  File "C:\Users\iLLiCiT\PycharmProjects\pype3\openpype\tools\project_manager\project_manager\model.py", line 1463, in paste_mime_data
    encoded_data = QtCore.QByteArray.fromRawData(raw_data)
TypeError: 'PySide2.QtCore.QByteArray.fromRawData' called with wrong argument types:
  PySide2.QtCore.QByteArray.fromRawData(QByteArray)
Supported signatures:
  PySide2.QtCore.QByteArray.fromRawData(bytes, int)
```

## Changes
- don't try to convert mime data to `QByteArray` if it already is `QByteArray`