### PR TITLE
Settings: Site sync project settings improvement

### DIFF
--- a/openpype/modules/default_modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/default_modules/sync_server/providers/dropbox.py
@@ -106,7 +106,7 @@ class DropboxHandler(AbstractProvider):
                 "type": "dict-roots",
                 "object_type": {
                     "type": "path",
-                    "multiplatform": False,
+                    "multiplatform": True,
                     "multipath": False
                 }
             }

--- a/openpype/modules/default_modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/default_modules/sync_server/providers/dropbox.py
@@ -101,9 +101,14 @@ class DropboxHandler(AbstractProvider):
             },
             # roots could be overriden only on Project level, User cannot
             {
-                'key': "roots",
-                'label': "Roots",
-                'type': 'dict'
+                "key": "roots",
+                "label": "Roots",
+                "type": "dict-roots",
+                "object_type": {
+                    "type": "path",
+                    "multiplatform": False,
+                    "multipath": False
+                }
             }
         ]
 

--- a/openpype/modules/default_modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/default_modules/sync_server/providers/gdrive.py
@@ -131,9 +131,14 @@ class GDriveHandler(AbstractProvider):
             },
             # roots could be overriden only on Project leve, User cannot
             {
-                 'key': "roots",
-                 'label': "Roots",
-                 'type': 'dict'
+                "key": "roots",
+                "label": "Roots",
+                "type": "dict-roots",
+                "object_type": {
+                    "type": "path",
+                    "multiplatform": False,
+                    "multipath": False
+                }
             }
         ]
         return editable

--- a/openpype/modules/default_modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/default_modules/sync_server/providers/gdrive.py
@@ -136,7 +136,7 @@ class GDriveHandler(AbstractProvider):
                 "type": "dict-roots",
                 "object_type": {
                     "type": "path",
-                    "multiplatform": False,
+                    "multiplatform": True,
                     "multipath": False
                 }
             }

--- a/openpype/modules/default_modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/default_modules/sync_server/providers/local_drive.py
@@ -50,9 +50,14 @@ class LocalDriveHandler(AbstractProvider):
         # for non 'studio' sites, 'studio' is configured in Anatomy
         editable = [
             {
-                'key': "roots",
-                'label': "Roots",
-                'type': 'dict'
+                "key": "roots",
+                "label": "Roots",
+                "type": "dict-roots",
+                "object_type": {
+                    "type": "path",
+                    "multiplatform": True,
+                    "multipath": False
+                }
             }
         ]
         return editable

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -139,9 +139,14 @@ class SFTPHandler(AbstractProvider):
             },
             # roots could be overriden only on Project leve, User cannot
             {
-                 'key': "roots",
-                 'label': "Roots",
-                 'type': 'dict'
+                "key": "roots",
+                "label": "Roots",
+                "type": "dict-roots",
+                "object_type": {
+                    "type": "path",
+                    "multiplatform": False,
+                    "multipath": False
+                }
             }
         ]
         return editable

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -144,7 +144,7 @@ class SFTPHandler(AbstractProvider):
                 "type": "dict-roots",
                 "object_type": {
                     "type": "path",
-                    "multiplatform": False,
+                    "multiplatform": True,
                     "multipath": False
                 }
             }

--- a/openpype/settings/entities/__init__.py
+++ b/openpype/settings/entities/__init__.py
@@ -112,7 +112,8 @@ from .enum_entity import (
 from .list_entity import ListEntity
 from .dict_immutable_keys_entity import (
     DictImmutableKeysEntity,
-    RootsDictEntity
+    RootsDictEntity,
+    SyncServerSites
 )
 from .dict_mutable_keys_entity import DictMutableKeysEntity
 from .dict_conditional import (
@@ -173,6 +174,7 @@ __all__ = (
 
     "DictImmutableKeysEntity",
     "RootsDictEntity",
+    "SyncServerSites",
 
     "DictMutableKeysEntity",
 

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -793,7 +793,7 @@ class SyncServerSites(DictImmutableKeysEntity):
             sites_entity = sync_server_settings_entity["sites"]
             for site_name, provider_entity in sites_entity.items():
                 provider_name = provider_entity["provider"].value
-                provider_children = (
+                provider_children = copy.deepcopy(
                     project_settings_schema.get(provider_name)
                 ) or []
                 provider_children.insert(0, copy.deepcopy(checkbox_child))

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -782,8 +782,6 @@ class SyncServerSites(DictImmutableKeysEntity):
     def _get_children(self):
         from openpype_modules import sync_server
 
-        from openpype_modules.sync_server.providers import lib as lib_providers
-
         # Load system settings to find out all created sites
         modules_entity = self.get_entity_from_path("system_settings/modules")
         sync_server_settings_entity = modules_entity.get("sync_server")

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -572,7 +572,7 @@ class RootsDictEntity(DictImmutableKeysEntity):
             object_type = {"type": object_type}
         self.object_type = object_type
 
-        if not self.is_group:
+        if self.group_item is None and not self.is_group:
             self.is_group = True
 
         schema_data = copy.deepcopy(self.schema_data)
@@ -733,7 +733,7 @@ class SyncServerSites(DictImmutableKeysEntity):
     schema_types = ["sync-server-sites"]
 
     def _item_initialization(self):
-        if not self.is_group:
+        if self.group_item is None and not self.is_group:
             self.is_group = True
 
         self._studio_overrides_should_be_overriden = False

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -754,22 +754,12 @@ class SyncServerSites(DictImmutableKeysEntity):
         children = self._get_children()
         schema_data["children"] = children
 
-        studio_overrides_should_be_overriden = False
-        if state is OverrideState.STUDIO:
-            studio_overrides_should_be_overriden = bool(children)
-
         self._add_children(schema_data)
 
         self._sites_changed = False
         self._set_children_values(state, ignore_missing_defaults)
 
         super(SyncServerSites, self).set_override_state(state, True)
-
-        # Make sure studio overrides are set if should be
-        #   - defaults does not contain any children
-        #       project settings are based on studio settings
-        if studio_overrides_should_be_overriden:
-            self.add_to_studio_default()
 
     @property
     def has_unsaved_changes(self):

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -629,7 +629,7 @@ class RootsDictEntity(DictImmutableKeysEntity):
 
         self._add_children(schema_data)
 
-        self._set_children_values(state)
+        self._set_children_values(state, ignore_missing_defaults)
 
         super(RootsDictEntity, self).set_override_state(
             state, True
@@ -652,11 +652,14 @@ class RootsDictEntity(DictImmutableKeysEntity):
 
         return super(RootsDictEntity, self).on_child_change(child_obj)
 
-    def _set_children_values(self, state):
+    def _set_children_values(self, state, ignore_missing_defaults):
         if state >= OverrideState.DEFAULTS:
             default_value = self._default_value
             if default_value is NOT_SET:
-                if state > OverrideState.DEFAULTS:
+                if (
+                    not ignore_missing_defaults
+                    and state > OverrideState.DEFAULTS
+                ):
                     raise DefaultsNotDefined(self)
                 else:
                     default_value = {}

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -767,7 +767,23 @@ class SyncServerSites(DictImmutableKeysEntity):
         if studio_overrides_should_be_overriden:
             self.add_to_studio_default()
 
+    @property
+    def has_unsaved_changes(self):
+        if self._sites_changed:
+            return True
+        return super(SyncServerSites, self).has_unsaved_changes
 
+    @property
+    def has_studio_override(self):
+        if self._sites_changed:
+            return True
+        return super(SyncServerSites, self).has_studio_override
+
+    @property
+    def has_project_override(self):
+        if self._sites_changed:
+            return True
+        return super(SyncServerSites, self).has_project_override
 
     def _get_children(self):
         from openpype_modules import sync_server

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -727,3 +727,7 @@ class RootsDictEntity(DictImmutableKeysEntity):
         self._project_value = value
         self._project_override_metadata = {}
         self.had_project_override = value is not NOT_SET
+
+
+class SyncServerSites(DictImmutableKeysEntity):
+    schema_types = ["sync-server-sites"]

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -737,6 +737,7 @@ class SyncServerSites(DictImmutableKeysEntity):
             self.is_group = True
 
         self.schema_data["children"] = []
+        self._sites_changed = False
 
         super(SyncServerSites, self)._item_initialization()
 
@@ -755,6 +756,7 @@ class SyncServerSites(DictImmutableKeysEntity):
 
         self._add_children(schema_data)
 
+        self._sites_changed = False
         self._set_children_values(state, ignore_missing_defaults)
 
         super(SyncServerSites, self).set_override_state(state, True)
@@ -808,6 +810,8 @@ class SyncServerSites(DictImmutableKeysEntity):
         return children
 
     def _set_children_values(self, state, ignore_missing_defaults):
+        current_site_names = set(self.non_gui_children.keys())
+
         if state >= OverrideState.DEFAULTS:
             default_value = self._default_value
             if default_value is NOT_SET:
@@ -832,6 +836,10 @@ class SyncServerSites(DictImmutableKeysEntity):
                 child_value = value.get(key, NOT_SET)
                 child_obj.update_studio_value(child_value)
 
+            if state is OverrideState.STUDIO:
+                value_keys = set(value.keys())
+                self._sites_changed = value_keys != current_site_names
+
         if state >= OverrideState.PROJECT:
             value = self._project_value
             if value is NOT_SET:
@@ -840,6 +848,10 @@ class SyncServerSites(DictImmutableKeysEntity):
             for key, child_obj in self.non_gui_children.items():
                 child_value = value.get(key, NOT_SET)
                 child_obj.update_project_value(child_value)
+
+            if state is OverrideState.PROJECT:
+                value_keys = set(value.keys())
+                self._sites_changed = value_keys != current_site_names
 
     def _update_current_metadata(self):
         """Override this method as this entity should not have metadata."""

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -730,13 +730,25 @@ class RootsDictEntity(DictImmutableKeysEntity):
 
 
 class SyncServerSites(DictImmutableKeysEntity):
-    """Dictionary enity for sync sites."""
+    """Dictionary enity for sync sites.
+
+    Can be used only in project settings.
+
+    Is loading sites from system settings. Uses site name as key and by site's
+    provider loads project settings schemas calling method
+    `get_project_settings_schema` on provider.
+
+    Each provider have `enabled` boolean entity to be able know if site should
+    be enabled for the project. Enabled is by default set to False.
+    """
     schema_types = ["sync-server-sites"]
 
     def _item_initialization(self):
+        # Make sure this is a group
         if self.group_item is None and not self.is_group:
             self.is_group = True
 
+        # Fake children for `dict` validations
         self.schema_data["children"] = []
         # Site names changed or were removed
         #   - to find out that site names was removed so project values
@@ -746,11 +758,14 @@ class SyncServerSites(DictImmutableKeysEntity):
         super(SyncServerSites, self)._item_initialization()
 
     def set_override_state(self, state, ignore_missing_defaults):
+        # Cleanup children related attributes
         self.children = []
         self.non_gui_children = {}
         self.gui_layout = []
 
+        # Create copy of schema
         schema_data = copy.deepcopy(self.schema_data)
+        # Collect children
         children = self._get_children()
         schema_data["children"] = children
 

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -730,6 +730,7 @@ class RootsDictEntity(DictImmutableKeysEntity):
 
 
 class SyncServerSites(DictImmutableKeysEntity):
+    """Dictionary enity for sync sites."""
     schema_types = ["sync-server-sites"]
 
     def _item_initialization(self):
@@ -737,6 +738,9 @@ class SyncServerSites(DictImmutableKeysEntity):
             self.is_group = True
 
         self.schema_data["children"] = []
+        # Site names changed or were removed
+        #   - to find out that site names was removed so project values
+        #       contain more data than should
         self._sites_changed = False
 
         super(SyncServerSites, self)._item_initialization()
@@ -802,6 +806,8 @@ class SyncServerSites(DictImmutableKeysEntity):
         )
 
         children = []
+        # Add 'enabled' for each site to be able know if should be used for
+        #   the project
         checkbox_child = {
             "type": "boolean",
             "key": "enabled",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json
@@ -39,100 +39,11 @@
             ]
         },
         {
-            "type": "dict-modifiable",
+            "type": "sync-server-sites",
             "collapsible": true,
             "key": "sites",
             "label": "Sites",
-            "collapsible_key": false,
-            "object_type": {
-                "type": "dict",
-                "children": [
-                    {
-                        "type": "dict",
-                        "key": "gdrive",
-                        "label": "Google Drive",
-                        "collapsible": true,
-                        "children": [
-                            {
-                              "type": "path",
-                              "key": "credentials_url",
-                              "label": "Credentials url",
-                              "multiplatform": true
-                            }
-                        ]
-                    },
-                    {
-                        "type": "dict",
-                        "key": "dropbox",
-                        "label": "Dropbox",
-                        "collapsible": true,
-                        "children": [
-                            {
-                              "type": "text",
-                              "key": "token",
-                              "label": "Access Token"
-                            },
-                            {
-                              "type": "text",
-                              "key": "team_folder_name",
-                              "label": "Team Folder Name"
-                            },
-                            {
-                              "type": "text",
-                              "key": "acting_as_member",
-                              "label": "Acting As Member"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "dict",
-                        "key": "sftp",
-                        "label": "SFTP",
-                        "collapsible": true,
-                        "children": [
-                            {
-                                "type": "text",
-                                "key": "sftp_host",
-                                "label": "SFTP host"
-                            },
-                            {
-                                "type": "number",
-                                "key": "sftp_port",
-                                "label": "SFTP port"
-                            },
-                            {
-                                "type": "text",
-                                "key": "sftp_user",
-                                "label": "SFTP user"
-                            },
-                            {
-                                "type": "text",
-                                "key": "sftp_pass",
-                                "label": "SFTP pass"
-                            },
-                                                    {
-                                "type": "path",
-                                "key": "sftp_key",
-                                "label": "SFTP user ssh key",
-                                "multiplatform": true
-                            },
-                            {
-                                "type": "text",
-                                "key": "sftp_key_pass",
-                                "label": "SFTP user ssh key password"
-                            }
-                        ]
-                    },
-                    {
-                        "type": "dict-modifiable",
-                        "key": "root",
-                        "label": "Roots",
-                        "collapsable": false,
-                        "collapsable_key": false,
-                        "object_type": "text"
-                    }
-                ]
-            }
+            "collapsible_key": false
         }
     ]
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json
@@ -39,11 +39,100 @@
             ]
         },
         {
-            "type": "sync-server-sites",
+            "type": "dict-modifiable",
             "collapsible": true,
             "key": "sites",
             "label": "Sites",
-            "collapsible_key": false
+            "collapsible_key": false,
+            "object_type": {
+                "type": "dict",
+                "children": [
+                    {
+                        "type": "dict",
+                        "key": "gdrive",
+                        "label": "Google Drive",
+                        "collapsible": true,
+                        "children": [
+                            {
+                              "type": "path",
+                              "key": "credentials_url",
+                              "label": "Credentials url",
+                              "multiplatform": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "dict",
+                        "key": "dropbox",
+                        "label": "Dropbox",
+                        "collapsible": true,
+                        "children": [
+                            {
+                              "type": "text",
+                              "key": "token",
+                              "label": "Access Token"
+                            },
+                            {
+                              "type": "text",
+                              "key": "team_folder_name",
+                              "label": "Team Folder Name"
+                            },
+                            {
+                              "type": "text",
+                              "key": "acting_as_member",
+                              "label": "Acting As Member"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "dict",
+                        "key": "sftp",
+                        "label": "SFTP",
+                        "collapsible": true,
+                        "children": [
+                            {
+                                "type": "text",
+                                "key": "sftp_host",
+                                "label": "SFTP host"
+                            },
+                            {
+                                "type": "number",
+                                "key": "sftp_port",
+                                "label": "SFTP port"
+                            },
+                            {
+                                "type": "text",
+                                "key": "sftp_user",
+                                "label": "SFTP user"
+                            },
+                            {
+                                "type": "text",
+                                "key": "sftp_pass",
+                                "label": "SFTP pass"
+                            },
+                                                    {
+                                "type": "path",
+                                "key": "sftp_key",
+                                "label": "SFTP user ssh key",
+                                "multiplatform": true
+                            },
+                            {
+                                "type": "text",
+                                "key": "sftp_key_pass",
+                                "label": "SFTP user ssh key password"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "dict-modifiable",
+                        "key": "root",
+                        "label": "Roots",
+                        "collapsable": false,
+                        "collapsable_key": false,
+                        "object_type": "text"
+                    }
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
## Description
Reduce settings of sites for sync server in project settings. Now it shows settings for all providers for each site name and site names must be manually added.

## Changes
- added new settings entity `sync-server-sites`
- entity works as dictionary children based on sync server system settings
- all site names are always available in project settings
    - each site have `enabled` boolean to know if should be enabled for the project
- other schemas  for value are get from providers using `get_project_settings_schema`

## TODO
Use this entity and replace current `site` item in settings. That require to modify how sync server module uses settings and probably will have to keep backwards compatibility. So it should be done in different PR.

### How to test
Change sites in project settings schemas to this:
```
{
    "type": "sync-server-sites",
    "collapsible": true,
    "key": "sites",
    "label": "Sites",
    "collapsible_key": false
}
```
File `~/openpype/settings/entities/schemas/projects_schema/schema_project_syncserver.json`