### PR TITLE
Delivery: Check 'frame' key in template for sequence delivery

### DIFF
--- a/openpype/lib/delivery.py
+++ b/openpype/lib/delivery.py
@@ -245,6 +245,27 @@ def process_sequence(
         report_items["Source file was not found"].append(msg)
         return report_items, 0
 
+    delivery_templates = anatomy.templates.get("delivery") or {}
+    delivery_template = delivery_templates.get(template_name)
+    if delivery_template is None:
+        msg = (
+            "Delivery template \"{}\" in anatomy of project \"{}\""
+            " was not found"
+        ).format(template_name, anatomy.project_name)
+        report_items[""].append(msg)
+        return report_items, 0
+
+    # Check if 'frame' key is available in template which is required
+    #   for sequence delivery
+    if "{frame" not in delivery_template:
+        msg = (
+            "Delivery template \"{}\" in anatomy of project \"{}\""
+            "does not contain '{{frame}}' key to fill. Delivery of sequence"
+            " can't be processed."
+        ).format(template_name, anatomy.project_name)
+        report_items[""].append(msg)
+        return report_items, 0
+
     dir_path, file_name = os.path.split(str(src_path))
 
     context = repre["context"]


### PR DESCRIPTION
## Issue
Delivery of sequence require `frame` key in template and delivery function crashes on invalid bug when the key is not available.

## Changes
- added checks of template existence
- added check of having `frame` formatting key in template for sequence delivery