### PR TITLE
Ftrack: Fill missing ftrack id on mongo project

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -193,7 +193,9 @@ class SyncToAvalonEvent(BaseEvent):
             self._avalon_ents_by_ftrack_id = {}
             proj, ents = self.avalon_entities
             if proj:
-                ftrack_id = proj["data"]["ftrackId"]
+                ftrack_id = proj["data"].get("ftrackId")
+                if ftrack_id is None:
+                    ftrack_id = self._update_project_ftrack_id()
                 self._avalon_ents_by_ftrack_id[ftrack_id] = proj
                 for ent in ents:
                     ftrack_id = ent["data"].get("ftrackId")
@@ -201,6 +203,16 @@ class SyncToAvalonEvent(BaseEvent):
                         continue
                     self._avalon_ents_by_ftrack_id[ftrack_id] = ent
         return self._avalon_ents_by_ftrack_id
+
+    def _update_project_ftrack_id(self):
+        ftrack_id = self.cur_project["id"]
+
+        self.dbcon.update_one(
+            {"type": "project"},
+            {"$set": {"data.ftrackId": ftrack_id}}
+        )
+
+        return ftrack_id
 
     @property
     def avalon_subsets_by_parents(self):


### PR DESCRIPTION
## Issue
It seems that it is possible to have missing `ftrackId` on project document but sync to avalon event always expect that the key is filled.

## Changes
- if the `ftrackId` key is missing on project document then is updated directly with current ftrack project