### PR TITLE
Tools: Workfiles tool don't use avalon widgets

### DIFF
--- a/openpype/tools/mayalookassigner/app.py
+++ b/openpype/tools/mayalookassigner/app.py
@@ -7,7 +7,7 @@ from Qt import QtWidgets, QtCore
 from openpype.hosts.maya.api.lib import assign_look_by_version
 
 from avalon import style, io
-from avalon.tools import lib
+from openpype.tools.utils.lib import qt_app_context
 
 from maya import cmds
 # old api for MFileIO
@@ -258,7 +258,7 @@ def show():
     mainwindow = next(widget for widget in top_level_widgets
                       if widget.objectName() == "MayaWindow")
 
-    with lib.application():
+    with qt_app_context():
         window = App(parent=mainwindow)
         window.setStyleSheet(style.load_stylesheet())
         window.show()

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -34,6 +34,7 @@ def qt_app_context():
         print("Using existing QApplication..")
         yield app
 
+
 # Backwards compatibility
 application = qt_app_context
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -22,7 +22,7 @@ def format_version(value, hero_version=False):
 
 
 @contextlib.contextmanager
-def application():
+def qt_app_context():
     app = QtWidgets.QApplication.instance()
 
     if not app:
@@ -33,6 +33,9 @@ def application():
     else:
         print("Using existing QApplication..")
         yield app
+
+# Backwards compatibility
+application = qt_app_context
 
 
 class SharedObjects:

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -10,9 +10,11 @@ import Qt
 from Qt import QtWidgets, QtCore
 from avalon import style, io, api, pipeline
 
-from avalon.tools import lib as tools_lib
-from avalon.tools.widgets import AssetWidget
-from avalon.tools.delegates import PrettyTimeDelegate
+from openpype.tools.utils.lib import (
+    schedule, qt_app_context
+)
+from openpype.tools.utils.widgets import AssetWidget
+from openpype.tools.utils.delegates import PrettyTimeDelegate
 
 from .model import (
     TASK_NAME_ROLE,
@@ -786,7 +788,7 @@ class FilesWidget(QtWidgets.QWidget):
         self.files_model.refresh()
 
         if self.auto_select_latest_modified:
-            tools_lib.schedule(self._select_last_modified_file, 100)
+            schedule(self._select_last_modified_file, 100)
 
     def on_context_menu(self, point):
         index = self.files_view.indexAt(point)
@@ -1023,10 +1025,10 @@ class Window(QtWidgets.QMainWindow):
 
     def on_task_changed(self):
         # Since we query the disk give it slightly more delay
-        tools_lib.schedule(self._on_task_changed, 100, channel="mongo")
+        schedule(self._on_task_changed, 100, channel="mongo")
 
     def on_asset_changed(self):
-        tools_lib.schedule(self._on_asset_changed, 50, channel="mongo")
+        schedule(self._on_asset_changed, 50, channel="mongo")
 
     def on_file_select(self, filepath):
         asset_docs = self.assets_widget.get_selected_assets()
@@ -1181,7 +1183,7 @@ def show(root=None, debug=False, parent=None, use_context=True, save=True):
         api.Session["AVALON_ASSET"] = "Mock"
         api.Session["AVALON_TASK"] = "Testing"
 
-    with tools_lib.application():
+    with qt_app_context():
         window = Window(parent=parent)
         window.refresh()
 


### PR DESCRIPTION
## Issue
Workfiles tool still use removed files from avalon tools.

## Changes
- use functions/classes already moved to openpype in workfiles tool (and one in look assigner)