### PR TITLE
Maya : validate unique names

### DIFF
--- a/openpype/plugins/publish/validate_unique_names.py
+++ b/openpype/plugins/publish/validate_unique_names.py
@@ -1,0 +1,39 @@
+from maya import cmds
+
+import pyblish.api
+import openpype.api
+import openpype.hosts.maya.api.action
+
+
+class ValidateUniqueNames(pyblish.api.Validator):
+    """transform names should be unique
+
+    ie: using cmds.ls(someNodeName) should always return shortname
+
+    """
+
+    order = openpype.api.ValidateContentsOrder
+    hosts = ["maya"]
+    families = ["model"]
+    label = "Unique transform name"
+    actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
+
+    @staticmethod
+    def get_invalid(instance):
+        """Returns the invalid transforms in the instance.
+
+        Returns:
+            list: Non unique name transforms
+
+        """
+
+        return [tr for tr in cmds.ls(instance, type="transform")
+                if '|' in tr]
+
+    def process(self, instance):
+        """Process all the nodes in the instance "objectSet"""
+
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise ValueError("Nodes found with none unique names. "
+                             "values: {0}".format(invalid))

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -315,6 +315,11 @@
             "optional": true,
             "active": true
         },
+        "ValidateUniqueNames": {
+            "enabled": false,
+            "optional": true,
+            "active": true
+        },
         "ValidateRigContents": {
             "enabled": false,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -323,6 +323,10 @@
                         {
                             "key": "ValidateTransformZero",
                             "label": "ValidateTransformZero"
+                        },
+                        {
+                            "key": "ValidateUniqueNames",
+                            "label": "ValidateUniqueNames"
                         }
                     ]
                 }


### PR DESCRIPTION
Hello,

A maya validator checking that each transform has a unique name (ie: assuring cmds never raise the error "More than one object matches name: pCube1")