### PR TITLE
Ftrack: Base event fix of 'get_project_from_entity' method

### DIFF
--- a/openpype/modules/default_modules/ftrack/lib/ftrack_base_handler.py
+++ b/openpype/modules/default_modules/ftrack/lib/ftrack_base_handler.py
@@ -570,9 +570,15 @@ class BaseHandler(object):
 
         if low_entity_type == "assetversion":
             asset = entity["asset"]
+            parent = None
             if asset:
                 parent = asset["parent"]
-                if parent:
+
+            if parent:
+                if parent.entity_type.lower() == "project":
+                    return parent
+
+                if "project" in parent:
                     return parent["project"]
 
         project_data = entity["link"][0]


### PR DESCRIPTION
## Issue
Method `get_project_from_entity` on base ftrack event handler does not expect cases that parent of `AssetVersion` is project.

## Changes
- fix cases when parent of asset version is project