### PR TITLE
Tools: Center loader and library loader on show

### DIFF
--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -198,6 +198,8 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             else:
                 self.resize(1300, 700)
 
+            tools_lib.center_window(self)
+
         if not self._initial_refresh:
             self._initial_refresh = True
             self.refresh()

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -210,6 +210,7 @@ class LoaderWindow(QtWidgets.QDialog):
                 self.resize(1800, 900)
             else:
                 self.resize(1300, 700)
+            lib.center_window(self)
 
     # -------------------------------
     # Delay calling blocking methods

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -20,6 +20,8 @@ def center_window(window):
     screen_geo = desktop.screenGeometry(screen_idx)
     geo = window.frameGeometry()
     geo.moveCenter(screen_geo.center())
+    if geo.y() < screen_geo.y():
+        geo.setY(screen_geo.y())
     window.move(geo.topLeft())
 
 


### PR DESCRIPTION
## Changes
- center window function makes sure that `y` is in screen
- center loader and library loader tools on first show