### PR TITLE
Webpublisher: Separate webpublisher logic

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -182,12 +182,11 @@ def remotepublishfromapp(debug, project, path, host, user=None, targets=None):
 @main.command()
 @click.argument("path")
 @click.option("-d", "--debug", is_flag=True, help="Print debug messages")
-@click.option("-h", "--host", help="Host")
 @click.option("-u", "--user", help="User email address")
 @click.option("-p", "--project", help="Project")
 @click.option("-t", "--targets", help="Targets", default=None,
               multiple=True)
-def remotepublish(debug, project, path, host, targets=None, user=None):
+def remotepublish(debug, project, path, user=None, targets=None):
     """Start CLI publishing.
 
     Publish collects json from paths provided as an argument.
@@ -195,7 +194,7 @@ def remotepublish(debug, project, path, host, targets=None, user=None):
     """
     if debug:
         os.environ['OPENPYPE_DEBUG'] = '3'
-    PypeCommands.remotepublish(project, path, host, user, targets=targets)
+    PypeCommands.remotepublish(project, path, user, targets=targets)
 
 
 @main.command()

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -166,7 +166,7 @@ def publish(debug, paths, targets):
 @click.option("-p", "--project", help="Project")
 @click.option("-t", "--targets", help="Targets", default=None,
               multiple=True)
-def remotepublishfromapp(debug, project, path, host, targets=None, user=None):
+def remotepublishfromapp(debug, project, path, host, user=None, targets=None):
     """Start CLI publishing.
 
     Publish collects json from paths provided as an argument.
@@ -174,8 +174,10 @@ def remotepublishfromapp(debug, project, path, host, targets=None, user=None):
     """
     if debug:
         os.environ['OPENPYPE_DEBUG'] = '3'
-    PypeCommands.remotepublishfromapp(project, path, host, user,
-                                      targets=targets)
+    PypeCommands.remotepublishfromapp(
+        project, path, host, user, targets=targets
+    )
+
 
 @main.command()
 @click.argument("path")

--- a/openpype/hosts/webpublisher/plugins/publish/collect_batch_data.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_batch_data.py
@@ -1,0 +1,84 @@
+"""Loads batch context from json and continues in publish process.
+
+Provides:
+    context -> Loaded batch file.
+"""
+
+import os
+
+import pyblish.api
+from avalon import io
+from openpype.lib.plugin_tools import (
+    parse_json,
+    get_batch_asset_task_info
+)
+from openpype.lib.remote_publish import get_webpublish_conn
+
+
+class CollectBatchData(pyblish.api.ContextPlugin):
+    """Collect batch data from json stored in 'OPENPYPE_PUBLISH_DATA' env dir.
+
+    The directory must contain 'manifest.json' file where batch data should be
+    stored.
+    """
+    # must be really early, context values are only in json file
+    order = pyblish.api.CollectorOrder - 0.495
+    label = "Collect batch data"
+    host = ["webpublisher"]
+
+    def process(self, context):
+        batch_dir = os.environ.get("OPENPYPE_PUBLISH_DATA")
+
+        assert batch_dir, (
+            "Missing `OPENPYPE_PUBLISH_DATA`")
+
+        assert os.path.exists(batch_dir), \
+            "Folder {} doesn't exist".format(batch_dir)
+
+        project_name = os.environ.get("AVALON_PROJECT")
+        if project_name is None:
+            raise AssertionError(
+                "Environment `AVALON_PROJECT` was not found."
+                "Could not set project `root` which may cause issues."
+            )
+
+        batch_data = parse_json(os.path.join(batch_dir, "manifest.json"))
+
+        context.data["batchDir"] = batch_dir
+        context.data["batchData"] = batch_data
+
+        asset_name, task_name, task_type = get_batch_asset_task_info(
+            batch_data["context"]
+        )
+
+        os.environ["AVALON_ASSET"] = asset_name
+        io.Session["AVALON_ASSET"] = asset_name
+        os.environ["AVALON_TASK"] = task_name
+        io.Session["AVALON_TASK"] = task_name
+
+        context.data["asset"] = asset_name
+        context.data["task"] = task_name
+        context.data["taskType"] = task_type
+
+        self._set_ctx_path(batch_data)
+
+    def _set_ctx_path(self, batch_data):
+        dbcon = get_webpublish_conn()
+
+        batch_id = batch_data["batch"]
+        ctx_path = batch_data["context"]["path"]
+        self.log.info("ctx_path: {}".format(ctx_path))
+        self.log.info("batch_id: {}".format(batch_id))
+        if ctx_path and batch_id:
+            self.log.info("Updating log record")
+            dbcon.update_one(
+                {
+                    "batch_id": batch_id,
+                    "status": "in_progress"
+                },
+                {
+                    "$set": {
+                        "path": ctx_path
+                    }
+                }
+            )

--- a/openpype/hosts/webpublisher/plugins/publish/collect_fps.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_fps.py
@@ -20,9 +20,8 @@ class CollectFPS(pyblish.api.InstancePlugin):
     hosts = ["webpublisher"]
 
     def process(self, instance):
-        fps = instance.context.data["fps"]
+        instance_fps = instance.data.get("fps")
+        if instance_fps is None:
+            instance.data["fps"] = instance.context.data["fps"]
 
-        instance.data.update({
-            "fps": fps
-        })
         self.log.debug(f"instance.data: {pformat(instance.data)}")

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -29,6 +29,7 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder - 0.490
     label = "Collect rendered frames"
     host = ["webpublisher"]
+    targets = ["filespublish"]
 
     # from Settings
     task_type_to_family = {}

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -1,20 +1,21 @@
-"""Loads publishing context from json and continues in publish process.
+"""Create instances from batch data and continues in publish process.
 
 Requires:
-    anatomy -> context["anatomy"] *(pyblish.api.CollectorOrder - 0.11)
+    CollectBatchData
 
 Provides:
     context, instances -> All data from previous publishing process.
 """
 
 import os
-import json
 import clique
 import tempfile
-
-import pyblish.api
 from avalon import io
-from openpype.lib import prepare_template_data
+import pyblish.api
+from openpype.lib import (
+    prepare_template_data,
+    OpenPypeMongoConnection
+)
 from openpype.lib.plugin_tools import parse_json, get_batch_asset_task_info
 
 
@@ -29,27 +30,26 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
     label = "Collect rendered frames"
     host = ["webpublisher"]
 
-    _context = None
-
     # from Settings
     task_type_to_family = {}
 
-    def _process_batch(self, dir_url):
-        task_subfolders = [
-            os.path.join(dir_url, o)
-            for o in os.listdir(dir_url)
-            if os.path.isdir(os.path.join(dir_url, o))]
+    def process(self, context):
+        batch_dir = context.data["batchDir"]
+        task_subfolders = []
+        for folder_name in os.listdir(batch_dir):
+            full_path = os.path.join(batch_dir, folder_name)
+            if os.path.isdir(full_path):
+                task_subfolders.append(full_path)
+
         self.log.info("task_sub:: {}".format(task_subfolders))
+
+        asset_name = context.data["asset"]
+        task_name = context.data["task"]
+        task_type = context.data["taskType"]
         for task_dir in task_subfolders:
             task_data = parse_json(os.path.join(task_dir,
                                                 "manifest.json"))
             self.log.info("task_data:: {}".format(task_data))
-            ctx = task_data["context"]
-
-            asset, task_name, task_type = get_batch_asset_task_info(ctx)
-
-            if task_name:
-                os.environ["AVALON_TASK"] = task_name
 
             is_sequence = len(task_data["files"]) > 1
 
@@ -60,25 +60,19 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
                 is_sequence,
                 extension.replace(".", ''))
 
-            subset = self._get_subset_name(family, subset_template, task_name,
-                                           task_data["variant"])
+            subset = self._get_subset_name(
+                family, subset_template, task_name, task_data["variant"]
+            )
+            version = self._get_last_version(asset_name, subset) + 1
 
-            os.environ["AVALON_ASSET"] = asset
-            io.Session["AVALON_ASSET"] = asset
-
-            instance = self._context.create_instance(subset)
-            instance.data["asset"] = asset
+            instance = context.create_instance(subset)
+            instance.data["asset"] = asset_name
             instance.data["subset"] = subset
             instance.data["family"] = family
             instance.data["families"] = families
-            instance.data["version"] = \
-                self._get_last_version(asset, subset) + 1
+            instance.data["version"] = version
             instance.data["stagingDir"] = tempfile.mkdtemp()
             instance.data["source"] = "webpublisher"
-
-            # to store logging info into DB openpype.webpublishes
-            instance.data["ctx_path"] = ctx["path"]
-            instance.data["batch_id"] = task_data["batch"]
 
             # to convert from email provided into Ftrack username
             instance.data["user_email"] = task_data["user"]
@@ -230,23 +224,3 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
             return version[0].get("version") or 0
         else:
             return 0
-
-    def process(self, context):
-        self._context = context
-
-        batch_dir = os.environ.get("OPENPYPE_PUBLISH_DATA")
-
-        assert batch_dir, (
-            "Missing `OPENPYPE_PUBLISH_DATA`")
-
-        assert os.path.exists(batch_dir), \
-            "Folder {} doesn't exist".format(batch_dir)
-
-        project_name = os.environ.get("AVALON_PROJECT")
-        if project_name is None:
-            raise AssertionError(
-                "Environment `AVALON_PROJECT` was not found."
-                "Could not set project `root` which may cause issues."
-            )
-
-        self._process_batch(batch_dir)

--- a/openpype/hosts/webpublisher/plugins/publish/integrate_context_to_log.py
+++ b/openpype/hosts/webpublisher/plugins/publish/integrate_context_to_log.py
@@ -28,11 +28,11 @@ class IntegrateContextToLog(pyblish.api.ContextPlugin):
                         "batch_id": instance.data.get("batch_id"),
                         "status": "in_progress"
                     },
-                    {"$set":
-                        {
+                    {
+                        "$set": {
                             "path": instance.data.get("ctx_path")
-
-                        }}
+                        }
+                    }
                 )
 
                 return

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -224,7 +224,7 @@ class WebpublisherBatchPublishEndpoint(_RestApiEndpoint):
             "project": content["project_name"],
             "user": content["user"],
 
-            "targets": None
+            "targets": ["filespublish"]
         }
 
         if content.get("studio_processing"):

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -192,14 +192,6 @@ class WebpublisherBatchPublishEndpoint(_RestApiEndpoint):
         #   - filter defines command and can extend arguments dictionary
         # This is used only if 'studio_processing' is enabled on batch
         studio_processing_filters = [
-            # TVPaint filter
-            {
-                "extensions": [".tvpp"],
-                "command": "remotepublish",
-                "arguments": {
-                    "targets": ["tvpaint"]
-                }
-            },
             # Photoshop filter
             {
                 "extensions": [".psd", ".psb"],

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -242,13 +242,12 @@ class PypeCommands:
             raise RuntimeError("No publish paths specified")
 
         from openpype import install, uninstall
-        from openpype.api import Logger
 
         # Register target and host
         import pyblish.api
         import pyblish.util
 
-        log = Logger.get_logger()
+        log = PypeLogger.get_logger()
 
         log.info("remotepublish command")
 

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -241,8 +241,6 @@ class PypeCommands:
         if not batch_path:
             raise RuntimeError("No publish paths specified")
 
-        from openpype import install, uninstall
-
         # Register target and host
         import pyblish.api
         import pyblish.util
@@ -251,10 +249,10 @@ class PypeCommands:
 
         log.info("remotepublish command")
 
-        install()
+        host_name = "webpublisher"
+        os.environ["AVALON_APP"] = host_name
 
-        if host:
-            pyblish.api.register_host(host)
+        pyblish.api.register_host(host_name)
 
         if targets:
             if isinstance(targets, str):
@@ -264,7 +262,6 @@ class PypeCommands:
 
         os.environ["OPENPYPE_PUBLISH_DATA"] = batch_path
         os.environ["AVALON_PROJECT"] = project
-        os.environ["AVALON_APP"] = host
 
         import avalon.api
         from openpype.hosts.webpublisher import api as webpublisher
@@ -280,7 +277,6 @@ class PypeCommands:
         publish_and_log(dbcon, _id, log)
 
         log.info("Publish finished.")
-        uninstall()
 
     @staticmethod
     def extractenvironments(output_json_path, project, asset, task, app):

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -218,7 +218,7 @@ class PypeCommands:
             time.sleep(0.5)
 
     @staticmethod
-    def remotepublish(project, batch_path, host, user, targets=None):
+    def remotepublish(project, batch_path, user, targets=None):
         """Start headless publishing.
 
         Used to publish rendered assets, workfiles etc.
@@ -230,10 +230,9 @@ class PypeCommands:
                 per call of remotepublish
             batch_path (str): Path batch folder. Contains subfolders with
                 resources (workfile, another subfolder 'renders' etc.)
-            targets (string): What module should be targeted
-                (to choose validator for example)
-            host (string)
             user (string): email address for webpublisher
+            targets (list): Pyblish targets
+                (to choose validator for example)
 
         Raises:
             RuntimeError: When there is no path to process.

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -137,16 +137,13 @@ class PypeCommands:
         SLEEP = 5  # seconds for another loop check for concurrently runs
         WAIT_FOR = 300  # seconds to wait for conc. runs
 
-        from openpype import install, uninstall
         from openpype.api import Logger
+        from openpype.lib import ApplicationManager
 
         log = Logger.get_logger()
 
         log.info("remotepublishphotoshop command")
 
-        install()
-
-        from openpype.lib import ApplicationManager
         application_manager = ApplicationManager()
 
         found_variant_key = find_variant_key(application_manager, host)
@@ -219,8 +216,6 @@ class PypeCommands:
 
         while launched_app.poll() is None:
             time.sleep(0.5)
-
-        uninstall()
 
     @staticmethod
     def remotepublish(project, batch_path, host, user, targets=None):

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -243,12 +243,16 @@ class PypeCommands:
         # Register target and host
         import pyblish.api
         import pyblish.util
+        import avalon.api
+        from openpype.hosts.webpublisher import api as webpublisher
 
         log = PypeLogger.get_logger()
 
         log.info("remotepublish command")
 
         host_name = "webpublisher"
+        os.environ["OPENPYPE_PUBLISH_DATA"] = batch_path
+        os.environ["AVALON_PROJECT"] = project
         os.environ["AVALON_APP"] = host_name
 
         pyblish.api.register_host(host_name)
@@ -258,12 +262,6 @@ class PypeCommands:
                 targets = [targets]
             for target in targets:
                 pyblish.api.register_target(target)
-
-        os.environ["OPENPYPE_PUBLISH_DATA"] = batch_path
-        os.environ["AVALON_PROJECT"] = project
-
-        import avalon.api
-        from openpype.hosts.webpublisher import api as webpublisher
 
         avalon.api.install(webpublisher)
 


### PR DESCRIPTION
## Description
Changes needed to be able add TVPaint to webpublisher. The TVPaint PR is already changing a lot so I needed to separate changes into smaller PRs if possible. Modified how webpublisher handle data and how thinks are launched.

## Changes
- Command `remotepublishfromapp` does not trigger openpype install/uninstall as it's not needed at all and reorganized arguments order in cli to match pype commands
- Command `remotepublish` does not expecte `host` argument which will always be `"webpublisher"` also install is not needed because install is triggered with host installation and uninstall is not needed at the end of process too
    - make sure `AVALON_PROJECT` is set before installation as may affect loaded plugins and their settings
- plugin `CollectFPS` does not override instance `"fps"` if is already set
- plugin `CollectPublishedFiles` was split into 2 plugins `CollectBatchData` and `CollectPublishedFiles`
    - `CollectPublishedFiles` is also registered for `"filespublish"` target to differentiate between different publish targets
    - context is set only once in `CollectBatchData`
- default trigger of `remotepublish` command through webpublisher webservice is registering `"filespublish"` target to trigger `CollectPublishedFiles` plugin