### PR TITLE
Modules: Module can add cli commands

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -57,6 +57,12 @@ def tray(debug=False):
     PypeCommands().launch_tray(debug)
 
 
+@main.group(help="Run command line arguments of OpenPype modules")
+@click.pass_context
+def module(ctx):
+    pass
+
+
 @main.command()
 @click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("--ftrack-url", envvar="FTRACK_SERVER",

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -57,6 +57,7 @@ def tray(debug=False):
     PypeCommands().launch_tray(debug)
 
 
+@PypeCommands.add_modules
 @main.group(help="Run command line arguments of OpenPype modules")
 @click.pass_context
 def module(ctx):

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -61,6 +61,10 @@ def tray(debug=False):
 @main.group(help="Run command line arguments of OpenPype modules")
 @click.pass_context
 def module(ctx):
+    """Module specific commands created dynamically.
+
+    These commands are generated dynamically by currently loaded addon/modules.
+    """
     pass
 
 

--- a/openpype/modules/README.md
+++ b/openpype/modules/README.md
@@ -22,7 +22,7 @@ OpenPype modules should contain separated logic of specific kind of implementati
 - `__init__` should not be overridden and `initialize` should not do time consuming part but only prepare base data about module
  - also keep in mind that they may be initialized in headless mode
 - connection with other modules is made with help of interfaces
-- `cli` method - can add cli commands specific for the module
+- `cli` method - add cli commands specific for the module
     - command line arguments are handled using `click` python module
     - `cli` method should expect single argument which is click group on which can be called any group specific methods (e.g. `add_command` to add another click group as children see `ExampleAddon`)
     - it is possible to add trigger cli commands using `./openpype_console module <module_name> <command> *args`

--- a/openpype/modules/README.md
+++ b/openpype/modules/README.md
@@ -22,6 +22,10 @@ OpenPype modules should contain separated logic of specific kind of implementati
 - `__init__` should not be overridden and `initialize` should not do time consuming part but only prepare base data about module
  - also keep in mind that they may be initialized in headless mode
 - connection with other modules is made with help of interfaces
+- `cli` method - can add cli commands specific for the module
+    - command line arguments are handled using `click` python module
+    - `cli` method should expect single argument which is click group on which can be called any group specific methods (e.g. `add_command` to add another click group as children see `ExampleAddon`)
+    - it is possible to add trigger cli commands using `./openpype_console module <module_name> <command> *args`
 
 ## Addon class `OpenPypeAddOn`
 - inherits from `OpenPypeModule` but is enabled by default and doesn't have to implement `initialize` and `connect_with_modules` methods

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -431,6 +431,28 @@ class OpenPypeModule:
         """
         return {}
 
+    def cli(self, module_click_group):
+        """Add commands to click group.
+
+        The best practise is to create click group for whole module which is
+        used to separate commands.
+
+        class MyPlugin(OpenPypeModule):
+            ...
+            def cli(self, module_click_group):
+                module_click_group.add_command(cli_main)
+
+
+        @click.group(<module name>, help="<Any help shown in cmd>")
+        def cli_main():
+            pass
+
+        @cli_main.command()
+        def mycommand():
+            print("my_command")
+        """
+        pass
+
 
 class OpenPypeAddOn(OpenPypeModule):
     # Enable Addon by default

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -1,8 +1,10 @@
 import os
 import json
 import collections
-from openpype.modules import OpenPypeModule
 
+import click
+
+from openpype.modules import OpenPypeModule
 from openpype_interfaces import (
     ITrayModule,
     IPluginPaths,
@@ -409,3 +411,57 @@ class FtrackModule(
             return 0
         hours_logged = (task_entity["time_logged"] / 60) / 60
         return hours_logged
+
+    def cli(self, click_group):
+        click_group.add_command(cli_main)
+
+
+@click.group(
+    FtrackModule.name,
+    help="Application job server. Can be used as render farm."
+)
+def cli_main():
+    pass
+
+
+@cli_main.command()
+@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
+@click.option("--ftrack-url", envvar="FTRACK_SERVER",
+              help="Ftrack server url")
+@click.option("--ftrack-user", envvar="FTRACK_API_USER",
+              help="Ftrack api user")
+@click.option("--ftrack-api-key", envvar="FTRACK_API_KEY",
+              help="Ftrack api key")
+@click.option("--legacy", is_flag=True,
+              help="run event server without mongo storing")
+@click.option("--clockify-api-key", envvar="CLOCKIFY_API_KEY",
+              help="Clockify API key.")
+@click.option("--clockify-workspace", envvar="CLOCKIFY_WORKSPACE",
+              help="Clockify workspace")
+def eventserver(
+    debug,
+    ftrack_url,
+    ftrack_user,
+    ftrack_api_key,
+    legacy,
+    clockify_api_key,
+    clockify_workspace
+):
+    """Launch ftrack event server.
+
+    This should be ideally used by system service (such us systemd or upstart
+    on linux and window service).
+    """
+    if debug:
+        os.environ["OPENPYPE_DEBUG"] = "3"
+
+    from .ftrack_server.event_server_cli import run_event_server
+
+    return run_event_server(
+        ftrack_url,
+        ftrack_user,
+        ftrack_api_key,
+        legacy,
+        clockify_api_key,
+        clockify_workspace
+    )

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -416,10 +416,7 @@ class FtrackModule(
         click_group.add_command(cli_main)
 
 
-@click.group(
-    FtrackModule.name,
-    help="Application job server. Can be used as render farm."
-)
+@click.group(FtrackModule.name, help="Ftrack module related commands.")
 def cli_main():
     pass
 

--- a/openpype/modules/example_addons/example_addon/addon.py
+++ b/openpype/modules/example_addons/example_addon/addon.py
@@ -8,10 +8,12 @@ in global space here until are required or used.
 """
 
 import os
+import click
 
 from openpype.modules import (
     JsonFilesSettingsDef,
-    OpenPypeAddOn
+    OpenPypeAddOn,
+    ModulesManager
 )
 # Import interface defined by this addon to be able find other addons using it
 from openpype_interfaces import (
@@ -130,3 +132,32 @@ class ExampleAddon(OpenPypeAddOn, IPluginPaths, ITrayAction):
         return {
             "publish": [os.path.join(current_dir, "plugins", "publish")]
         }
+
+    def cli(self, click_group):
+        click_group.add_command(cli_main)
+
+
+@click.group(ExampleAddon.name, help="Example addon dynamic cli commands.")
+def cli_main():
+    pass
+
+
+@cli_main.command()
+def nothing():
+    """Does nothing but print a message."""
+    print("You've triggered \"nothing\" command.")
+
+
+@cli_main.command()
+def show_dialog():
+    """Show ExampleAddon dialog.
+
+    We don't have access to addon directly through cli so we have to create
+    it again.
+    """
+    from openpype.tools.utils.lib import qt_app_context
+
+    manager = ModulesManager()
+    example_addon = manager.modules_by_name[ExampleAddon.name]
+    with qt_app_context():
+        example_addon.show_dialog()

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -49,16 +49,15 @@ class PypeCommands:
         manager = ModulesManager()
         log = PypeLogger.get_logger("AddModulesCLI")
         for module in manager.modules:
-            if hasattr(module, "cli"):
-                try:
-                    module.cli(click_func)
+            try:
+                module.cli(click_func)
 
-                except Exception:
-                    log.warning(
-                        "Failed to add cli command for module \"{}\"".format(
-                            module.name
-                        )
+            except Exception:
+                log.warning(
+                    "Failed to add cli command for module \"{}\"".format(
+                        module.name
                     )
+                )
         return click_func
 
     @staticmethod

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -47,9 +47,18 @@ class PypeCommands:
         from openpype.modules import ModulesManager
 
         manager = ModulesManager()
+        log = PypeLogger.get_logger("AddModulesCLI")
         for module in manager.modules:
             if hasattr(module, "cli"):
-                module.cli(click_func)
+                try:
+                    module.cli(click_func)
+
+                except Exception:
+                    log.warning(
+                        "Failed to add cli command for module \"{}\"".format(
+                            module.name
+                        )
+                    )
         return click_func
 
     @staticmethod

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -42,6 +42,17 @@ class PypeCommands:
         settings.main(user_role)
 
     @staticmethod
+    def add_modules(click_func):
+        """Modules/Addons can add their cli commands dynamically."""
+        from openpype.modules import ModulesManager
+
+        manager = ModulesManager()
+        for module in manager.modules:
+            if hasattr(module, "cli"):
+                module.cli(click_func)
+        return click_func
+
+    @staticmethod
     def launch_eventservercli(*args):
         from openpype_modules.ftrack.ftrack_server.event_server_cli import (
             run_event_server


### PR DESCRIPTION
## Description
Modules should be able to define their cli commands which could help to reduce commands in general openpype commands.

## Changes
- added cli group `module` into general cli commands
- each module has `cli` method which is called on start of openpype and gives ability to add commands to `module` click group
    - method by default does nothing
- example addon has example cli commands
- ftrack adds `eventserver` command (did not remove the old)
    - we can replace `./openpype_console eventserver *arg` with `./openpype_console module ftrack eventserver *args`
- calling the module commands has this order
    - `<op executable> module <module name> <command> *args`
    - `<module name>` is recommendation but can't be forced
    - each of the step can have help