### PR TITLE
Add a "following workfile versioning" option on publish

### DIFF
--- a/openpype/plugins/publish/collect_anatomy_instance_data.py
+++ b/openpype/plugins/publish/collect_anatomy_instance_data.py
@@ -38,6 +38,8 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder + 0.49
     label = "Collect Anatomy Instance data"
 
+    follow_workfile_version = False
+
     def process(self, context):
         self.log.info("Collecting anatomy data for all instances.")
 
@@ -213,7 +215,10 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
         context_asset_doc = context.data["assetEntity"]
 
         for instance in context:
-            version_number = instance.data.get("version")
+            if self.follow_workfile_version:
+                version_number = context.data('version')
+            else:
+                version_number = instance.data.get("version")
             # If version is not specified for instance or context
             if version_number is None:
                 # TODO we should be able to change default version by studio

--- a/openpype/plugins/publish/validate_version.py
+++ b/openpype/plugins/publish/validate_version.py
@@ -21,8 +21,9 @@ class ValidateVersion(pyblish.api.InstancePlugin):
 
         if latest_version is not None:
             msg = (
-                "Version `{0}` from instance `{1}` that you are trying to publish, already exists"
-                " in the database. Version in database: `{2}`. Please version "
-                "up your workfile to a higher version number than: `{2}`."
+                "Version `{0}` from instance `{1}` that you are trying to"
+                " publish, already exists in the database. Version in"
+                " database: `{2}`. Please version up your workfile to a higher"
+                " version number than: `{2}`."
             ).format(version, instance.data["name"], latest_version)
             assert (int(version) > int(latest_version)), msg

--- a/openpype/plugins/publish/validate_version.py
+++ b/openpype/plugins/publish/validate_version.py
@@ -21,8 +21,8 @@ class ValidateVersion(pyblish.api.InstancePlugin):
 
         if latest_version is not None:
             msg = (
-                "Version `{0}` that you are trying to publish, already exists"
-                " in the database. Version in database: `{1}`. Please version "
-                "up your workfile to a higher version number than: `{1}`."
-            ).format(version, latest_version)
+                "Version `{0}` from instance `{1}` that you are trying to publish, already exists"
+                " in the database. Version in database: `{2}`. Please version "
+                "up your workfile to a higher version number than: `{2}`."
+            ).format(version, instance.data["name"], latest_version)
             assert (int(version) > int(latest_version)), msg

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -1,5 +1,8 @@
 {
     "publish": {
+        "CollectAnatomyInstanceData": {
+            "follow_workfile_version": false
+        },
         "ValidateEditorialAssetName": {
             "enabled": true,
             "optional": false

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -7,6 +7,20 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "CollectAnatomyInstanceData",
+            "label": "Collect Anatomy Instance Data",
+            "is_group": true,
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "follow_workfile_version",
+                    "label": "Follow workfile version"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "checkbox_key": "enabled",
             "key": "ValidateEditorialAssetName",
             "label": "Validate Editorial Asset Name",


### PR DESCRIPTION
Feature which allow to configure Openpype publish to always use the workfile version

### Why
Having the same version number for the workfile, his produced files (review, publish, render, ...) and the tracked version (within Shotgrid, ftrack, ...) can be more simpler to manipulate files and versions

### How
You can activate this option in the global project settings, in the Collect Anatomy Instance Data plugin
![image](https://user-images.githubusercontent.com/7955673/141100578-b6fcfb8e-0428-4d6a-aabe-9bdda1d11130.png)

### Note
The downside of this feature is that you lose the ability to publish multiple times from the same workfile, which is prevented by the plugin ValidateVersion