### PR TITLE
Pyblish Tool: Fix targets handling

### DIFF
--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -190,7 +190,9 @@ class Controller(QtCore.QObject):
 
         plugins = pyblish.api.discover()
 
-        targets = pyblish.logic.registered_targets() or ["default"]
+        targets = set(pyblish.logic.registered_targets())
+        targets.add("default")
+        targets = list(targets)
         plugins_by_targets = pyblish.logic.plugins_by_targets(plugins, targets)
 
         _plugins = []


### PR DESCRIPTION
## Issue
When there are registered targets `"default"` target is not added to list so all plugins without changed targets are skipped.

## Changes
- make sure targets contain default target