### PR TITLE
Fix - enum for color coding in PS

### DIFF
--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -67,7 +67,17 @@
                                         "type": "list",
                                         "key": "color_code",
                                         "label": "Color codes for layers",
-                                        "object_type": "text"
+                                        "type": "enum",
+                                        "multiselection": true,
+                                        "enum_items": [
+                                            { "red": "red" },
+                                            { "orange": "orange" },
+                                            { "yellowColor": "yellow" },
+                                            { "grain": "green" },
+                                            { "blue": "blue" },
+                                            { "violet": "violet" },
+                                            { "gray": "gray" }
+                                        ]
                                     },
                                     {
                                         "type": "list",


### PR DESCRIPTION
Some keys are really weird in PS (grain instead of green etc)

Created explicit enum. Setting needs to be resaved for it to work!