### PR TITLE
Python 2: Unicode to string conversion

### DIFF
--- a/openpype/lib/python_module_tools.py
+++ b/openpype/lib/python_module_tools.py
@@ -22,6 +22,9 @@ def import_filepath(filepath, module_name=None):
     if module_name is None:
         module_name = os.path.splitext(os.path.basename(filepath))[0]
 
+    # Make sure it is not 'unicode' in Python 2
+    module_name = str(module_name)
+
     # Prepare module object where content of file will be parsed
     module = types.ModuleType(module_name)
 


### PR DESCRIPTION
## Issue
ModuleType expect string type in initialization but in Python 2 is used default passed type `unicode` which breaks the creation.

## Changes
- fix Python 2 unicode with conversion to `str`

### How to test
Run Houdini with Python 2 which should raidse unicode error with current develop and work fine with this PR.