### PR TITLE
General: Skip module directories without init file

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -333,6 +333,15 @@ def _load_modules():
             # - check manifest and content of manifest
             try:
                 if os.path.isdir(fullpath):
+                    # Module without init file can't be used as OpenPype module
+                    #   because the module class could not be imported
+                    init_file = os.path.join(fullpath, "__init__.py")
+                    if not os.path.exists(init_file):
+                        log.info((
+                            "Skipping module directory because of"
+                            " missing \"__init__.py\" file. \"{}\""
+                        ).format(fullpath))
+                        continue
                     import_module_from_dirpath(dirpath, filename, modules_key)
 
                 elif ext in (".py", ):


### PR DESCRIPTION
## Description
OpenPype addon/module can't be used if does not have `__init__.py` file because in that is not possible to find class inheriting `OpenPypeModule`. At the same time it is possible to filter empty folders without any content or just `.pyc` files which remained after deleted module.

## Changes
- skip module directories without `__init__.py` file when loading modules