### PR TITLE
Site Sync settings should contain 'root' key

### DIFF
--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -342,7 +342,7 @@ class HostDirmap:
             log.debug("remote overrides".format(remote_overrides))
             for root_name, active_site_dir in active_overrides.items():
                 remote_site_dir = remote_overrides.get(root_name) or\
-                    sync_settings["sites"][remote_site]["roots"][root_name]
+                    sync_settings["sites"][remote_site]["root"][root_name]
                 if os.path.isdir(active_site_dir):
                     if not mapping.get("destination-path"):
                         mapping["destination-path"] = []

--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -342,7 +342,7 @@ class HostDirmap:
             log.debug("remote overrides".format(remote_overrides))
             for root_name, active_site_dir in active_overrides.items():
                 remote_site_dir = remote_overrides.get(root_name) or\
-                    sync_settings["sites"][remote_site]["root"][root_name]
+                    sync_settings["sites"][remote_site]["roots"][root_name]
                 if os.path.isdir(active_site_dir):
                     if not mapping.get("destination-path"):
                         mapping["destination-path"] = []

--- a/openpype/modules/default_modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/default_modules/sync_server/providers/dropbox.py
@@ -97,7 +97,7 @@ class DropboxHandler(AbstractProvider):
             },
             # roots could be overriden only on Project level, User cannot
             {
-                "key": "roots",
+                "key": "root",
                 "label": "Roots",
                 "type": "dict-roots",
                 "object_type": {
@@ -389,7 +389,7 @@ class DropboxHandler(AbstractProvider):
                      {"root": {"root_ONE": "value", "root_TWO":"value}}
             Format is importing for usage of python's format ** approach
         """
-        return self.presets['roots']
+        return self.presets['root']
 
     def resolve_path(self, path, root_config=None, anatomy=None):
         """

--- a/openpype/modules/default_modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/default_modules/sync_server/providers/gdrive.py
@@ -129,7 +129,7 @@ class GDriveHandler(AbstractProvider):
             },
             # roots could be overriden only on Project leve, User cannot
             {
-                "key": "roots",
+                "key": "root",
                 "label": "Roots",
                 "type": "dict-roots",
                 "object_type": {
@@ -174,7 +174,7 @@ class GDriveHandler(AbstractProvider):
             Format is importing for usage of python's format ** approach
         """
         # GDrive roots cannot be locally overridden
-        return self.presets['roots']
+        return self.presets['root']
 
     def get_tree(self):
         """

--- a/openpype/modules/default_modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/default_modules/sync_server/providers/local_drive.py
@@ -50,7 +50,7 @@ class LocalDriveHandler(AbstractProvider):
         # for non 'studio' sites, 'studio' is configured in Anatomy
         editable = [
             {
-                "key": "roots",
+                "key": "root",
                 "label": "Roots",
                 "type": "dict-roots",
                 "object_type": {
@@ -73,7 +73,7 @@ class LocalDriveHandler(AbstractProvider):
         """
         editable = [
             {
-                'key': "roots",
+                'key': "root",
                 'label': "Roots",
                 'type': 'dict'
             }

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -131,7 +131,7 @@ class SFTPHandler(AbstractProvider):
             },
             # roots could be overriden only on Project leve, User cannot
             {
-                "key": "roots",
+                "key": "root",
                 "label": "Roots",
                 "type": "dict-roots",
                 "object_type": {


### PR DESCRIPTION
It was using 'roots' which resulted in Nuke and Maya chocking on it because dirmap functionality (which looks at Site Sync  Local Settings).

Previously `root` key was used, this PR returns to it as a safer option. (And it follows Anatomy etc.)