### PR TITLE
Ftrack: Session creation and Prepare project

### DIFF
--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -226,8 +226,8 @@ class FtrackModule(
         if not project_name:
             return
 
-        attributes_changes = changes.get("attributes")
-        if not attributes_changes:
+        new_attr_values = new_value.get("attributes")
+        if not new_attr_values:
             return
 
         import ftrack_api
@@ -277,7 +277,7 @@ class FtrackModule(
 
         failed = {}
         missing = {}
-        for key, value in attributes_changes.items():
+        for key, value in new_attr_values.items():
             if key not in ca_keys:
                 continue
 


### PR DESCRIPTION
## Issue
Ftrack session creation always looks into keyring credentials which crashes ftrack event server running on linux and ftrack cares only about changes in anatomy values but changes in settings may not reflect required changes in Ftrack.

## Changes
- ftrack session creation first look for credentials into environments (fixes ftrack event server)
- ftrack callback on anatomy setting changes will check all values stored in attributes and push changes into ftrack