### PR TITLE
Burnins: Support mxf metadata

### DIFF
--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -69,10 +69,10 @@ def get_fps(str_value):
     return str(fps)
 
 
-def _prores_codec_args(ffprobe_data, source_ffmpeg_cmd):
+def _prores_codec_args(stream_data, source_ffmpeg_cmd):
     output = []
 
-    tags = ffprobe_data.get("tags") or {}
+    tags = stream_data.get("tags") or {}
     encoder = tags.get("encoder") or ""
     if encoder.endswith("prores_ks"):
         codec_name = "prores_ks"
@@ -85,7 +85,7 @@ def _prores_codec_args(ffprobe_data, source_ffmpeg_cmd):
 
     output.extend(["-codec:v", codec_name])
 
-    pix_fmt = ffprobe_data.get("pix_fmt")
+    pix_fmt = stream_data.get("pix_fmt")
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 
@@ -99,7 +99,7 @@ def _prores_codec_args(ffprobe_data, source_ffmpeg_cmd):
             "ap4h": "4444",
             "ap4x": "4444xq"
         }
-        codec_tag_str = ffprobe_data.get("codec_tag_string")
+        codec_tag_str = stream_data.get("codec_tag_string")
         if codec_tag_str:
             profile = codec_tag_to_profile_map.get(codec_tag_str)
             if profile:
@@ -108,7 +108,7 @@ def _prores_codec_args(ffprobe_data, source_ffmpeg_cmd):
     return output
 
 
-def _h264_codec_args(ffprobe_data, source_ffmpeg_cmd):
+def _h264_codec_args(stream_data, source_ffmpeg_cmd):
     output = ["-codec:v", "h264"]
 
     # Use arguments from source if are available source arguments
@@ -125,7 +125,7 @@ def _h264_codec_args(ffprobe_data, source_ffmpeg_cmd):
             if arg in copy_args:
                 output.extend([arg, args[idx + 1]])
 
-    pix_fmt = ffprobe_data.get("pix_fmt")
+    pix_fmt = stream_data.get("pix_fmt")
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 
@@ -135,11 +135,11 @@ def _h264_codec_args(ffprobe_data, source_ffmpeg_cmd):
     return output
 
 
-def _dnxhd_codec_args(ffprobe_data, source_ffmpeg_cmd):
+def _dnxhd_codec_args(stream_data, source_ffmpeg_cmd):
     output = ["-codec:v", "dnxhd"]
 
     # Use source profile (profiles in metadata are not usable in args directly)
-    profile = ffprobe_data.get("profile") or ""
+    profile = stream_data.get("profile") or ""
     # Lower profile and replace space with underscore
     cleaned_profile = profile.lower().replace(" ", "_")
     dnx_profiles = {
@@ -153,7 +153,7 @@ def _dnxhd_codec_args(ffprobe_data, source_ffmpeg_cmd):
     if cleaned_profile in dnx_profiles:
         output.extend(["-profile:v", cleaned_profile])
 
-    pix_fmt = ffprobe_data.get("pix_fmt")
+    pix_fmt = stream_data.get("pix_fmt")
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -597,6 +597,14 @@ def burnins_from_data(
     if source_timecode is None:
         source_timecode = stream.get("tags", {}).get("timecode")
 
+    if source_timecode is None:
+        # Use "format" key from ffprobe data
+        #   - this is used e.g. in mxf extension
+        input_format = burnin.ffprobe_data.get("format") or {}
+        source_timecode = input_format.get("timecode")
+        if source_timecode is None:
+            source_timecode = input_format.get("tags", {}).get("timecode")
+
     if source_timecode is not None:
         data[SOURCE_TIMECODE_KEY[1:-1]] = SOURCE_TIMECODE_KEY
 

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -494,8 +494,6 @@ def example(input_path, output_path):
         'bg_opacity': 0.5,
         'font_size': 52
     }
-    # First frame in burnin
-    start_frame = 2000
     # Options init sets burnin look
     burnin = ModifiedBurnins(input_path, options_init=options_init)
     # Static text

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -162,28 +162,29 @@ def _dnxhd_codec_args(stream_data, source_ffmpeg_cmd):
 
 
 def get_codec_args(ffprobe_data, source_ffmpeg_cmd):
-    codec_name = ffprobe_data.get("codec_name")
+    stream_data = ffprobe_data["streams"][0]
+    codec_name = stream_data.get("codec_name")
     # Codec "prores"
     if codec_name == "prores":
-        return _prores_codec_args(ffprobe_data, source_ffmpeg_cmd)
+        return _prores_codec_args(stream_data, source_ffmpeg_cmd)
 
     # Codec "h264"
     if codec_name == "h264":
-        return _h264_codec_args(ffprobe_data, source_ffmpeg_cmd)
+        return _h264_codec_args(stream_data, source_ffmpeg_cmd)
 
     # Coded DNxHD
     if codec_name == "dnxhd":
-        return _dnxhd_codec_args(ffprobe_data, source_ffmpeg_cmd)
+        return _dnxhd_codec_args(stream_data, source_ffmpeg_cmd)
 
     output = []
     if codec_name:
         output.extend(["-codec:v", codec_name])
 
-    bit_rate = ffprobe_data.get("bit_rate")
+    bit_rate = stream_data.get("bit_rate")
     if bit_rate:
         output.extend(["-b:v", bit_rate])
 
-    pix_fmt = ffprobe_data.get("pix_fmt")
+    pix_fmt = stream_data.get("pix_fmt")
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 
@@ -685,8 +686,9 @@ def burnins_from_data(
         ffmpeg_args.append("-g 1")
 
     else:
-        ffprobe_data = burnin._streams[0]
-        ffmpeg_args.extend(get_codec_args(ffprobe_data, source_ffmpeg_cmd))
+        ffmpeg_args.extend(
+            get_codec_args(burnin.ffprobe_data, source_ffmpeg_cmd)
+        )
 
     # Use group one (same as `-intra` argument, which is deprecated)
     ffmpeg_args_str = " ".join(ffmpeg_args)


### PR DESCRIPTION
## Issue
- mxf has not stored metadata on "streams" but under "format" key when loaded using ffprobe

## Changes
- store whole result of ffprobe to burnins
- use source timecode from `"format"` key if is available