### PR TITLE
Ftrack: Sync project ftrack id cache issue

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -194,6 +194,7 @@ class SyncToAvalonEvent(BaseEvent):
                 ftrack_id = proj["data"].get("ftrackId")
                 if ftrack_id is None:
                     ftrack_id = self._update_project_ftrack_id()
+                    proj["data"]["ftrackId"] = ftrack_id
                 self._avalon_ents_by_ftrack_id[ftrack_id] = proj
                 for ent in ents:
                     ftrack_id = ent["data"].get("ftrackId")

--- a/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -585,6 +585,10 @@ class SyncToAvalonEvent(BaseEvent):
                     continue
                 ftrack_id = ftrack_id[0]
 
+            # Skip deleted projects
+            if action == "remove" and entityType == "show":
+                return True
+
             # task modified, collect parent id of task, handle separately
             if entity_type.lower() == "task":
                 changes = ent_info.get("changes") or {}


### PR DESCRIPTION
## Issue
PR https://github.com/pypeclub/OpenPype/pull/2203/files was fixing not existing `ftrackId` on project document but the already cached project document was not updated so for rest of work of event is still unset.

## Changes
- store new ftrack id to cached project document