### PR TITLE
Standalone: editorial not publishing thumbnails on all subsets

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_resources.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_resources.py
@@ -238,7 +238,7 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
                 })
 
             # exception for mp4 preview
-            if ".mp4" in _reminding_file:
+            if ext in ["mp4", "mov"]:
                 frame_start = 0
                 frame_end = (
                     (instance_data["frameEnd"] - instance_data["frameStart"])
@@ -255,6 +255,7 @@ class CollectInstanceResources(pyblish.api.InstancePlugin):
                     "step": 1,
                     "fps": self.context.data.get("fps"),
                     "name": "review",
+                    "thumbnail": True,
                     "tags": ["review", "ftrackreview", "delete"],
                 })
 


### PR DESCRIPTION
Problem was, that if they were using their own .mp4 (accompanied to exr sequences) then it was not creating thumbnails.