### PR TITLE
Maya: Render publishing fails on linux

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -256,9 +256,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     common_publish_meta_path, part)
                 if part == expected_layer_name:
                     break
-            
-            # TODO: replace this terrible linux hotfix with real solution :) 
-            if platform.system() == "Linux":
+
+            # TODO: replace this terrible linux hotfix with real solution :)
+            if platform.system().lower() in ["linux", "darwin"]:
                 common_publish_meta_path = "/" + common_publish_meta_path
 
             self.log.info(

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -41,6 +41,7 @@ Provides:
 
 import re
 import os
+import platform
 import json
 
 from maya import cmds
@@ -255,6 +256,11 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     common_publish_meta_path, part)
                 if part == expected_layer_name:
                     break
+            
+            # TODO: replace this terrible linux hotfix with real solution :) 
+            if platform.system() == "Linux":
+                common_publish_meta_path = "/" + common_publish_meta_path
+
             self.log.info(
                 "Publish meta path: {}".format(common_publish_meta_path))
 


### PR DESCRIPTION
when sending render job from maya on linux, the metadata json path is missing lead / from the path, hence crashing the publish.

This is quite dirty quick fix, we need to find something cleaner