### PR TITLE
Tools: Select Context dialog attribute fix

### DIFF
--- a/openpype/tools/context_dialog/window.py
+++ b/openpype/tools/context_dialog/window.py
@@ -113,9 +113,7 @@ class ContextDialog(QtWidgets.QDialog):
         assets_widget.selection_changed.connect(self._on_asset_change)
         assets_widget.refresh_triggered.connect(self._on_asset_refresh_trigger)
         assets_widget.refreshed.connect(self._on_asset_widget_refresh_finished)
-        tasks_widget.task_changed.selectionChanged.connect(
-            self._on_task_change
-        )
+        tasks_widget.task_changed.connect(self._on_task_change)
         ok_btn.clicked.connect(self._on_ok_click)
 
         self._dbcon = dbcon

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -991,7 +991,7 @@ class Window(QtWidgets.QMainWindow):
             workdir, filename = os.path.split(filepath)
             asset_docs = self.assets_widget.get_selected_assets()
             asset_doc = asset_docs[0]
-            task_name = self.tasks_widget.get_current_task_name()
+            task_name = self.tasks_widget.get_selected_task_name()
             create_workfile_doc(asset_doc, task_name, filename, workdir, io)
 
     def set_context(self, context):


### PR DESCRIPTION
## Issue
- There was accidentally kept `selectionChanged` attribute access which breaks current context select dialog

## Changes
- fix attribute acces in signal registration