### PR TITLE
Tools: Assets widget

### DIFF
--- a/openpype/tools/context_dialog/window.py
+++ b/openpype/tools/context_dialog/window.py
@@ -6,6 +6,7 @@ from avalon.api import AvalonMongoDB
 
 from openpype import style
 from openpype.tools.utils.lib import center_window
+from openpype.tools.utils.assets_widget import SingleSelectAssetsWidget
 from openpype.tools.utils.widgets import AssetWidget
 from openpype.tools.utils.constants import (
     PROJECT_NAME_ROLE
@@ -65,8 +66,8 @@ class ContextDialog(QtWidgets.QDialog):
         project_combobox.setModel(project_proxy)
 
         # Assets widget
-        assets_widget = AssetWidget(
-            dbcon, multiselection=False, parent=left_side_widget
+        assets_widget = SingleSelectAssetsWidget(
+            dbcon, parent=left_side_widget
         )
 
         left_side_layout = QtWidgets.QVBoxLayout(left_side_widget)
@@ -309,11 +310,8 @@ class ContextDialog(QtWidgets.QDialog):
 
     def _set_asset_to_tasks_widget(self):
         # filter None docs they are silo
-        asset_docs = self._assets_widget.get_selected_assets()
-        asset_ids = [asset_doc["_id"] for asset_doc in asset_docs]
-        asset_id = None
-        if asset_ids:
-            asset_id = asset_ids[0]
+        asset_id = self._assets_widget.get_selected_asset_id()
+
         self._tasks_widget.set_asset_id(asset_id)
 
     def _confirm_values(self):
@@ -334,11 +332,7 @@ class ContextDialog(QtWidgets.QDialog):
 
     def get_selected_asset(self):
         """Currently selected asset in asset widget."""
-        asset_name = None
-        for asset_doc in self._assets_widget.get_selected_assets():
-            asset_name = asset_doc["name"]
-            break
-        return asset_name
+        return self._assets_widget.get_selected_asset_name()
 
     def get_selected_task(self):
         """Currently selected task."""

--- a/openpype/tools/context_dialog/window.py
+++ b/openpype/tools/context_dialog/window.py
@@ -7,7 +7,6 @@ from avalon.api import AvalonMongoDB
 from openpype import style
 from openpype.tools.utils.lib import center_window
 from openpype.tools.utils.assets_widget import SingleSelectAssetsWidget
-from openpype.tools.utils.widgets import AssetWidget
 from openpype.tools.utils.constants import (
     PROJECT_NAME_ROLE
 )

--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -11,7 +11,7 @@ from openpype.tools.loader.widgets import (
     FamilyListView,
     RepresentationWidget
 )
-from openpype.tools.utils.widgets import AssetWidget
+from openpype.tools.utils.assets_widget import MultiSelectAssetsWidget
 
 from openpype.modules import ModulesManager
 
@@ -76,8 +76,8 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         projects_combobox.setItemDelegate(combobox_delegate)
 
         # Assets widget
-        assets_widget = AssetWidget(
-            dbcon, multiselection=True, parent=left_side_splitter
+        assets_widget = MultiSelectAssetsWidget(
+            dbcon, parent=left_side_splitter
         )
 
         # Families widget
@@ -165,7 +165,6 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         )
         assets_widget.selection_changed.connect(self.on_assetschanged)
         assets_widget.refresh_triggered.connect(self.on_assetschanged)
-        assets_widget.view.clicked.connect(self.on_assetview_click)
         subsets_widget.active_changed.connect(self.on_subsetschanged)
         subsets_widget.version_changed.connect(self.on_versionschanged)
         subsets_widget.refreshed.connect(self._on_subset_refresh)
@@ -203,11 +202,6 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         if not self._initial_refresh:
             self._initial_refresh = True
             self.refresh()
-
-    def on_assetview_click(self, *args):
-        selection_model = self._subsets_widget.view.selectionModel()
-        if selection_model.selectedIndexes():
-            selection_model.clearSelection()
 
     def _set_projects(self):
         # Store current project
@@ -348,25 +342,14 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         self._families_filter_view.set_enabled_families(set())
         self._families_filter_view.refresh()
 
-        self._assets_widget.model.stop_fetch_thread()
+        self._assets_widget.stop_refresh()
         self._assets_widget.refresh()
         self._assets_widget.setFocus()
 
     def clear_assets_underlines(self):
         last_asset_ids = self.data["state"]["assetIds"]
-        if not last_asset_ids:
-            return
-
-        assets_model = self._assets_widget.model
-        id_role = assets_model.ObjectIdRole
-
-        for index in tools_lib.iter_model_rows(assets_model, 0):
-            if index.data(id_role) not in last_asset_ids:
-                continue
-
-            assets_model.setData(
-                index, [], assets_model.subsetColorsRole
-            )
+        if last_asset_ids:
+            self._assets_widget.clear_underlines()
 
     def _assetschanged(self):
         """Selected assets have changed"""
@@ -382,12 +365,8 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             )
             return
 
-        # filter None docs they are silo
-        asset_docs = self._assets_widget.get_selected_assets()
-        if len(asset_docs) == 0:
-            return
+        asset_ids = self._assets_widget.get_selected_asset_ids()
 
-        asset_ids = [asset_doc["_id"] for asset_doc in asset_docs]
         # Start loading
         self._subsets_widget.set_loading_state(
             loading=bool(asset_ids),
@@ -402,7 +381,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
 
         # Clear the version information on asset change
         self._version_info_widget.set_version(None)
-        self._thumbnail_widget.set_thumbnail(asset_docs)
+        self._thumbnail_widget.set_thumbnail(asset_ids)
 
         self.data["state"]["assetIds"] = asset_ids
 
@@ -421,7 +400,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             _merged=True, _other=False
         )
 
-        asset_models = {}
+        asset_colors = {}
         asset_ids = []
         for subset_node in selected_subsets:
             asset_ids.extend(subset_node.get("assetIds", []))
@@ -429,30 +408,17 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
 
         for subset_node in selected_subsets:
             for asset_id in asset_ids:
-                if asset_id not in asset_models:
-                    asset_models[asset_id] = []
+                if asset_id not in asset_colors:
+                    asset_colors[asset_id] = []
 
                 color = None
                 if asset_id in subset_node.get("assetIds", []):
                     color = subset_node["subsetColor"]
 
-                asset_models[asset_id].append(color)
+                asset_colors[asset_id].append(color)
 
-        self.clear_assets_underlines()
+        self._assets_widget.set_underline_colors(asset_colors)
 
-        indexes = self._assets_widget.view.selectionModel().selectedRows()
-
-        assets_model = self._assets_widget.model
-        for index in indexes:
-            id = index.data(assets_model.ObjectIdRole)
-            if id not in asset_models:
-                continue
-
-            assets_model.setData(
-                index, asset_models[id], assets_model.subsetColorsRole
-            )
-        # Trigger repaint
-        self._assets_widget.view.updateGeometries()
         # Set version in Version Widget
         self._versionschanged()
 
@@ -489,13 +455,14 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
 
         self._version_info_widget.set_version(version_doc)
 
-        thumbnail_docs = version_docs
-        if not thumbnail_docs:
-            asset_docs = self._assets_widget.get_selected_assets()
-            if len(asset_docs) > 0:
-                thumbnail_docs = asset_docs
+        thumbnail_src_ids = [
+            version_doc["_id"]
+            for version_doc in version_docs
+        ]
+        if not thumbnail_src_ids:
+            thumbnail_src_ids = self._assets_widget.get_selected_asset_ids()
 
-        self._thumbnail_widget.set_thumbnail(thumbnail_docs)
+        self._thumbnail_widget.set_thumbnail(thumbnail_src_ids)
 
         version_ids = [doc["_id"] for doc in version_docs or []]
         if self._repres_widget:
@@ -514,8 +481,8 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             None
         """
 
-        asset = context.get("asset", None)
-        if asset is None:
+        asset_name = context.get("asset", None)
+        if asset_name is None:
             return
 
         if refresh:
@@ -527,7 +494,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             # scheduled refresh and the silo tabs are not shown.
             self._refresh_assets()
 
-        self._assets_widget.select_assets(asset)
+        self._assets_widget.select_asset_by_name(asset_name)
 
     def _on_message_timeout(self):
         self._message_label.setText("")

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -794,19 +794,23 @@ class ThumbnailWidget(QtWidgets.QLabel):
             QtCore.Qt.SmoothTransformation
         )
 
-    def set_thumbnail(self, entity=None):
-        if not entity:
+    def set_thumbnail(self, doc_id=None):
+        if not doc_id:
             self.set_pixmap()
             return
 
-        if isinstance(entity, (list, tuple)):
-            if len(entity) == 1:
-                entity = entity[0]
-            else:
+        if isinstance(doc_id, (list, tuple)):
+            if len(doc_id) < 1:
                 self.set_pixmap()
                 return
+            doc_id = doc_id[0]
 
-        thumbnail_id = entity.get("data", {}).get("thumbnail_id")
+        doc = self.dbcon.find_one(
+            {"_id": doc_id},
+            {"data.thumbnail_id"}
+        )
+
+        thumbnail_id = doc.get("data", {}).get("thumbnail_id")
         if thumbnail_id == self.current_thumb_id:
             if self.current_thumbnail is None:
                 self.set_pixmap()

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -5,6 +5,11 @@ from .views import (
     DeselectableTreeView
 )
 
+ASSET_ID_ROLE = QtCore.Qt.UserRole + 1
+ASSET_NAME_ROLE = QtCore.Qt.UserRole + 2
+ASSET_LABEL_ROLE = QtCore.Qt.UserRole + 3
+ASSET_UNDERLINE_COLORS_ROLE = QtCore.Qt.UserRole + 4
+
 
 class AssetsView(TreeViewSpinner, DeselectableTreeView):
     """Item view.

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -1,9 +1,17 @@
-from Qt import QtWidgets, QtCore
+import Qt
+from Qt import QtWidgets, QtCore, QtGui
+
+from openpype.style import get_objected_colors
 
 from .views import (
     TreeViewSpinner,
     DeselectableTreeView
 )
+
+if Qt.__binding__ == "PySide":
+    from PySide.QtGui import QStyleOptionViewItemV4
+elif Qt.__binding__ == "PyQt4":
+    from PyQt4.QtGui import QStyleOptionViewItemV4
 
 ASSET_ID_ROLE = QtCore.Qt.UserRole + 1
 ASSET_NAME_ROLE = QtCore.Qt.UserRole + 2
@@ -45,3 +53,170 @@ class AssetsView(TreeViewSpinner, DeselectableTreeView):
 
         self.is_loading = loading
         self.is_empty = empty
+
+
+class UnderlinesAssetDelegate(QtWidgets.QItemDelegate):
+    bar_height = 3
+
+    def __init__(self, *args, **kwargs):
+        super(UnderlinesAssetDelegate, self).__init__(*args, **kwargs)
+        asset_view_colors = get_objected_colors()["loader"]["asset-view"]
+        self._selected_color = (
+            asset_view_colors["selected"].get_qcolor()
+        )
+        self._hover_color = (
+            asset_view_colors["hover"].get_qcolor()
+        )
+        self._selected_hover_color = (
+            asset_view_colors["selected-hover"].get_qcolor()
+        )
+
+    def sizeHint(self, option, index):
+        result = super(UnderlinesAssetDelegate, self).sizeHint(option, index)
+        height = result.height()
+        result.setHeight(height + self.bar_height)
+
+        return result
+
+    def paint(self, painter, option, index):
+        # Qt4 compat
+        if Qt.__binding__ in ("PySide", "PyQt4"):
+            option = QStyleOptionViewItemV4(option)
+
+        painter.save()
+
+        item_rect = QtCore.QRect(option.rect)
+        item_rect.setHeight(option.rect.height() - self.bar_height)
+
+        subset_colors = index.data(ASSET_UNDERLINE_COLORS_ROLE) or []
+        subset_colors_width = 0
+        if subset_colors:
+            subset_colors_width = option.rect.width() / len(subset_colors)
+
+        subset_rects = []
+        counter = 0
+        for subset_c in subset_colors:
+            new_color = None
+            new_rect = None
+            if subset_c:
+                new_color = QtGui.QColor(*subset_c)
+
+                new_rect = QtCore.QRect(
+                    option.rect.left() + (counter * subset_colors_width),
+                    option.rect.top() + (
+                        option.rect.height() - self.bar_height
+                    ),
+                    subset_colors_width,
+                    self.bar_height
+                )
+            subset_rects.append((new_color, new_rect))
+            counter += 1
+
+        # Background
+        if option.state & QtWidgets.QStyle.State_Selected:
+            if len(subset_colors) == 0:
+                item_rect.setTop(item_rect.top() + (self.bar_height / 2))
+
+            if option.state & QtWidgets.QStyle.State_MouseOver:
+                bg_color = self._selected_hover_color
+            else:
+                bg_color = self._selected_color
+        else:
+            item_rect.setTop(item_rect.top() + (self.bar_height / 2))
+            if option.state & QtWidgets.QStyle.State_MouseOver:
+                bg_color = self._hover_color
+            else:
+                bg_color = QtGui.QColor()
+                bg_color.setAlpha(0)
+
+        # When not needed to do a rounded corners (easier and without
+        #   painter restore):
+        # painter.fillRect(
+        #     item_rect,
+        #     QtGui.QBrush(bg_color)
+        # )
+        pen = painter.pen()
+        pen.setStyle(QtCore.Qt.NoPen)
+        pen.setWidth(0)
+        painter.setPen(pen)
+        painter.setBrush(QtGui.QBrush(bg_color))
+        painter.drawRoundedRect(option.rect, 3, 3)
+
+        if option.state & QtWidgets.QStyle.State_Selected:
+            for color, subset_rect in subset_rects:
+                if not color or not subset_rect:
+                    continue
+                painter.fillRect(subset_rect, QtGui.QBrush(color))
+
+        painter.restore()
+        painter.save()
+
+        # Icon
+        icon_index = index.model().index(
+            index.row(), index.column(), index.parent()
+        )
+        # - Default icon_rect if not icon
+        icon_rect = QtCore.QRect(
+            item_rect.left(),
+            item_rect.top(),
+            # To make sure it's same size all the time
+            option.rect.height() - self.bar_height,
+            option.rect.height() - self.bar_height
+        )
+        icon = index.model().data(icon_index, QtCore.Qt.DecorationRole)
+
+        if icon:
+            mode = QtGui.QIcon.Normal
+            if not (option.state & QtWidgets.QStyle.State_Enabled):
+                mode = QtGui.QIcon.Disabled
+            elif option.state & QtWidgets.QStyle.State_Selected:
+                mode = QtGui.QIcon.Selected
+
+            if isinstance(icon, QtGui.QPixmap):
+                icon = QtGui.QIcon(icon)
+                option.decorationSize = icon.size() / icon.devicePixelRatio()
+
+            elif isinstance(icon, QtGui.QColor):
+                pixmap = QtGui.QPixmap(option.decorationSize)
+                pixmap.fill(icon)
+                icon = QtGui.QIcon(pixmap)
+
+            elif isinstance(icon, QtGui.QImage):
+                icon = QtGui.QIcon(QtGui.QPixmap.fromImage(icon))
+                option.decorationSize = icon.size() / icon.devicePixelRatio()
+
+            elif isinstance(icon, QtGui.QIcon):
+                state = QtGui.QIcon.Off
+                if option.state & QtWidgets.QStyle.State_Open:
+                    state = QtGui.QIcon.On
+                actual_size = option.icon.actualSize(
+                    option.decorationSize, mode, state
+                )
+                option.decorationSize = QtCore.QSize(
+                    min(option.decorationSize.width(), actual_size.width()),
+                    min(option.decorationSize.height(), actual_size.height())
+                )
+
+            state = QtGui.QIcon.Off
+            if option.state & QtWidgets.QStyle.State_Open:
+                state = QtGui.QIcon.On
+
+            icon.paint(
+                painter, icon_rect,
+                QtCore.Qt.AlignLeft, mode, state
+            )
+
+        # Text
+        text_rect = QtCore.QRect(
+            icon_rect.left() + icon_rect.width() + 2,
+            item_rect.top(),
+            item_rect.width(),
+            item_rect.height()
+        )
+
+        painter.drawText(
+            text_rect, QtCore.Qt.AlignVCenter,
+            index.data(QtCore.Qt.DisplayRole)
+        )
+
+        painter.restore()

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -179,25 +179,16 @@ class UnderlinesAssetDelegate(QtWidgets.QItemDelegate):
 
         # When not needed to do a rounded corners (easier and without
         #   painter restore):
-        # painter.fillRect(
-        #     item_rect,
-        #     QtGui.QBrush(bg_color)
-        # )
-        pen = painter.pen()
-        pen.setStyle(QtCore.Qt.NoPen)
-        pen.setWidth(0)
-        painter.setPen(pen)
-        painter.setBrush(QtGui.QBrush(bg_color))
-        painter.drawRect(option.rect)
+        painter.fillRect(
+            option.rect,
+            QtGui.QBrush(bg_color)
+        )
 
         if option.state & QtWidgets.QStyle.State_Selected:
             for color, subset_rect in subset_rects:
                 if not color or not subset_rect:
                     continue
                 painter.fillRect(subset_rect, QtGui.QBrush(color))
-
-        painter.restore()
-        painter.save()
 
         # Icon
         icon_index = index.model().index(

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -32,8 +32,8 @@ ASSET_UNDERLINE_COLORS_ROLE = QtCore.Qt.UserRole + 4
 class AssetsView(TreeViewSpinner, DeselectableTreeView):
     """Asset items view.
 
-    Adds abilities to deselect, show loading spinner and add flick charm (scroll
-    by mouse/touchpad click and move).
+    Adds abilities to deselect, show loading spinner and add flick charm
+    (scroll by mouse/touchpad click and move).
     """
 
     def __init__(self, parent=None):

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -623,3 +623,58 @@ class SingleSelectAssetsWidget(AssetsWidget):
         for index in indexes:
             return index.data(ASSET_NAME_ROLE)
         return None
+
+
+class MultiSelectAssetsWidget(AssetsWidget):
+    def __init__(self, *args, **kwargs):
+        super(MultiSelectAssetsWidget, self).__init__(*args, **kwargs)
+        delegate = UnderlinesAssetDelegate()
+
+        self._view.setSelectionMode(QtWidgets.QTreeView.ExtendedSelection)
+        self._view.setItemDelegate(delegate)
+
+        self._delegate = delegate
+
+    def get_selected_asset_ids(self):
+        """Return the asset item of the current selection."""
+        selection_model = self._view.selectionModel()
+        indexes = selection_model.selectedRows()
+        return [
+            index.data(ASSET_ID_ROLE)
+            for index in indexes
+        ]
+
+    def get_selected_asset_names(self):
+        """Return the asset document of the current selection."""
+        selection_model = self._view.selectionModel()
+        indexes = selection_model.selectedRows()
+        return [
+            index.data(ASSET_NAME_ROLE)
+            for index in indexes
+        ]
+
+    def select_assets(self, asset_ids):
+        indexes = self._model.get_indexes_by_asset_ids(asset_ids)
+        new_indexes = [
+            self._proxy.mapFromSource(index)
+            for index in indexes
+        ]
+        self._select_indexes(new_indexes)
+
+    def select_assets_by_name(self, asset_names):
+        indexes = self._model.get_indexes_by_asset_names(asset_names)
+        new_indexes = [
+            self._proxy.mapFromSource(index)
+            for index in indexes
+        ]
+        self._select_indexes(new_indexes)
+
+    def clear_underlines(self):
+        self._model.clear_underlines()
+
+        self._view.updateGeometries()
+
+    def set_underline_colors(self, colors_by_asset_id):
+        self._model.set_underline_colors(colors_by_asset_id)
+        # Trigger repaint
+        self._view.updateGeometries()

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -452,7 +452,7 @@ class AssetModel(QtGui.QStandardItemModel):
                 icon = qtawesome.icon(full_icon_name, color=icon_color)
                 item.setData(icon, QtCore.Qt.DecorationRole)
 
-            except Exception as exception:
+            except Exception:
                 pass
 
         self.refreshed.emit(bool(self._items_by_asset_id))

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -169,7 +169,7 @@ class UnderlinesAssetDelegate(QtWidgets.QItemDelegate):
         pen.setWidth(0)
         painter.setPen(pen)
         painter.setBrush(QtGui.QBrush(bg_color))
-        painter.drawRoundedRect(option.rect, 3, 3)
+        painter.drawRect(option.rect)
 
         if option.state & QtWidgets.QStyle.State_Selected:
             for color, subset_rect in subset_rects:

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -383,7 +383,9 @@ class AssetModel(QtGui.QStandardItemModel):
         asset_items_queue = collections.deque()
         asset_items_queue.append((None, root_item))
 
-        removed_asset_ids = set()
+        removed_asset_ids = (
+            set(self._items_by_asset_id.keys()) - set(asset_docs_by_id.keys())
+        )
         while asset_items_queue:
             parent_id, parent_item = asset_items_queue.popleft()
             children_ids = asset_ids_by_parents[parent_id]
@@ -395,8 +397,6 @@ class AssetModel(QtGui.QStandardItemModel):
                 asset_id = child_item.data(ASSET_ID_ROLE)
                 if asset_id not in children_ids:
                     parent_item.removeRow(row)
-                    if asset_id not in asset_docs_by_id:
-                        removed_asset_ids.add(asset_id)
                     continue
 
                 children_ids.remove(asset_id)

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -518,6 +518,7 @@ class AssetsWidget(QtWidgets.QWidget):
         proxy = RecursiveSortFilterProxyModel()
         proxy.setSourceModel(model)
         proxy.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        proxy.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
         view = AssetsView(self)
         view.setModel(proxy)

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -364,6 +364,8 @@ class AssetModel(QtGui.QStandardItemModel):
         if not self._refreshing:
             root_item = self.invisibleRootItem()
             root_item.removeRows(0, root_item.rowCount())
+            self._items_by_asset_id = {}
+            self._items_with_color_by_id = {}
             return
 
         asset_docs = self._doc_payload

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -458,7 +458,7 @@ class AssetModel(QtGui.QStandardItemModel):
         self._stop_fetch_thread()
 
     def _threaded_fetch(self):
-        asset_docs = self._fetch_asset_docs() or []
+        asset_docs = self._fetch_asset_docs()
         if not self._refreshing:
             return
 
@@ -469,14 +469,14 @@ class AssetModel(QtGui.QStandardItemModel):
 
     def _fetch_asset_docs(self):
         if not self.dbcon.Session.get("AVALON_PROJECT"):
-            return
+            return []
 
         project_doc = self.dbcon.find_one(
             {"type": "project"},
             {"_id": True}
         )
         if not project_doc:
-            return
+            return []
 
         # Get all assets sorted by name
         return list(self.dbcon.find(

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -605,3 +605,21 @@ class AssetsWidget(QtWidgets.QWidget):
             self._view.expand(self._proxy.parent(index))
             selection_model.select(index, mode)
         self._view.setCurrentIndex(valid_indexes[0])
+
+
+class SingleSelectAssetsWidget(AssetsWidget):
+    def get_selected_asset_id(self):
+        """Return the asset item of the current selection."""
+        selection_model = self._view.selectionModel()
+        indexes = selection_model.selectedRows()
+        for index in indexes:
+            return index.data(ASSET_ID_ROLE)
+        return None
+
+    def get_selected_asset_name(self):
+        """Return the asset document of the current selection."""
+        selection_model = self._view.selectionModel()
+        indexes = selection_model.selectedRows()
+        for index in indexes:
+            return index.data(ASSET_NAME_ROLE)
+        return None

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -291,6 +291,10 @@ class AssetModel(QtGui.QStandardItemModel):
         self._items_with_color_by_id = {}
         self._items_by_asset_id = {}
 
+    @property
+    def refreshing(self):
+        return self._refreshing
+
     def get_index_by_asset_id(self, asset_id):
         item = self._items_by_asset_id.get(asset_id)
         if item is not None:
@@ -570,6 +574,10 @@ class AssetsWidget(QtWidgets.QWidget):
         self._view = view
 
         self.model_selection = {}
+
+    @property
+    def refreshing(self):
+        return self._model.refreshing
 
     def refresh(self):
         self._refresh_model()

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -265,16 +265,12 @@ class AssetModel(QtGui.QStandardItemModel):
 
     # Asset document projection
     _asset_projection = {
-        "type": 1,
-        "schema": 1,
         "name": 1,
         "parent": 1,
         "data.visualParent": 1,
         "data.label": 1,
-        "data.tags": 1,
         "data.icon": 1,
-        "data.color": 1,
-        "data.deprecated": 1
+        "data.color": 1
     }
 
     def __init__(self, dbcon, parent=None):

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -1,0 +1,42 @@
+from Qt import QtWidgets, QtCore
+
+from .views import (
+    TreeViewSpinner,
+    DeselectableTreeView
+)
+
+
+class AssetsView(TreeViewSpinner, DeselectableTreeView):
+    """Item view.
+    This implements a context menu.
+    """
+
+    def __init__(self, parent=None):
+        super(AssetsView, self).__init__(parent)
+        self.setIndentation(15)
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.setHeaderHidden(True)
+
+    def mousePressEvent(self, event):
+        index = self.indexAt(event.pos())
+        if not index.isValid():
+            modifiers = QtWidgets.QApplication.keyboardModifiers()
+            if modifiers == QtCore.Qt.ShiftModifier:
+                return
+            elif modifiers == QtCore.Qt.ControlModifier:
+                return
+
+        super(AssetsView, self).mousePressEvent(event)
+
+    def set_loading_state(self, loading, empty):
+        if self.is_loading != loading:
+            if loading:
+                self.spinner.repaintNeeded.connect(
+                    self.viewport().update
+                )
+            else:
+                self.spinner.repaintNeeded.disconnect()
+                self.viewport().update()
+
+        self.is_loading = loading
+        self.is_empty = empty

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -1,8 +1,14 @@
+import collections
+
 import Qt
 from Qt import QtWidgets, QtCore, QtGui
 
+from avalon import style
+from avalon.vendor import qtawesome
+
 from openpype.style import get_objected_colors
 
+from .lib import DynamicQThread
 from .views import (
     TreeViewSpinner,
     DeselectableTreeView
@@ -220,3 +226,235 @@ class UnderlinesAssetDelegate(QtWidgets.QItemDelegate):
         )
 
         painter.restore()
+
+
+class AssetModel(QtGui.QStandardItemModel):
+    """A model listing assets in the silo in the active project.
+
+    The assets are displayed in a treeview, they are visually parented by
+    a `visualParent` field in the database containing an `_id` to a parent
+    asset.
+
+    """
+
+    _doc_fetched = QtCore.Signal()
+    refreshed = QtCore.Signal(bool)
+
+    # Asset document projection
+    _asset_projection = {
+        "type": 1,
+        "schema": 1,
+        "name": 1,
+        "parent": 1,
+        "data.visualParent": 1,
+        "data.label": 1,
+        "data.tags": 1,
+        "data.icon": 1,
+        "data.color": 1,
+        "data.deprecated": 1
+    }
+
+    def __init__(self, dbcon, parent=None):
+        super(AssetModel, self).__init__(parent=parent)
+        self.dbcon = dbcon
+
+        self._doc_fetching_thread = None
+        self._doc_fetching_stop = False
+        self._doc_payload = []
+
+        self._doc_fetched.connect(self._on_docs_fetched)
+
+        self._items_with_color_by_id = {}
+        self._items_by_asset_id = {}
+
+    def get_index_by_asset_id(self, asset_id):
+        item = self._items_by_asset_id.get(asset_id)
+        if item is not None:
+            return item.index()
+        return QtCore.QModelIndex()
+
+    def get_indexes_by_asset_ids(self, asset_ids):
+        return [
+            self.get_index_by_asset_id(asset_id)
+            for asset_id in asset_ids
+        ]
+
+    def get_index_by_asset_name(self, asset_name):
+        indexes = self.get_indexes_by_asset_names([asset_name])
+        for index in indexes:
+            if index.isValid():
+                return index
+        return indexes[0]
+
+    def get_indexes_by_asset_names(self, asset_names):
+        asset_ids_by_name = {
+            asset_name: None
+            for asset_name in asset_names
+        }
+
+        for asset_id, item in self._items_by_asset_id.items():
+            asset_name = item.data(ASSET_NAME_ROLE)
+            if asset_name in asset_ids_by_name:
+                asset_ids_by_name[asset_name] = asset_id
+
+        asset_ids = [
+            asset_ids_by_name[asset_name]
+            for asset_name in asset_names
+        ]
+
+        return self.get_indexes_by_asset_ids(asset_ids)
+
+    def refresh(self, force=False):
+        """Refresh the data for the model."""
+        # Skip fetch if there is already other thread fetching documents
+        if self._doc_fetching_thread is not None:
+            if not force:
+                return
+            self._stop_fetch_thread()
+
+        # Fetch documents from mongo
+        # Restart payload
+        self._doc_payload = []
+        self._doc_fetching_stop = False
+        self._doc_fetching_thread = DynamicQThread(self._threaded_fetch)
+        self._doc_fetching_thread.start()
+
+    def clear_underlines(self):
+        for asset_id in tuple(self._items_with_color_by_id.keys()):
+            item = self._items_with_color_by_id.pop(asset_id)
+            item.setData(None, ASSET_UNDERLINE_COLORS_ROLE)
+
+    def set_underline_colors(self, colors_by_asset_id):
+        self.clear_underlines()
+
+        for asset_id, colors in colors_by_asset_id.items():
+            item = self._items_by_asset_id.get(asset_id)
+            if item is None:
+                continue
+            item.setData(colors, ASSET_UNDERLINE_COLORS_ROLE)
+
+    def _on_docs_fetched(self):
+        asset_docs = self._doc_payload
+
+        asset_ids = set()
+        asset_docs_by_id = {}
+        asset_ids_by_parents = collections.defaultdict(set)
+        for asset_doc in asset_docs:
+            asset_id = asset_doc["_id"]
+            asset_data = asset_doc.get("data") or {}
+            parent_id = asset_data.get("visualParent")
+            asset_ids.add(asset_id)
+            asset_docs_by_id[asset_id] = asset_doc
+            asset_ids_by_parents[parent_id].add(asset_id)
+
+        root_item = self.invisibleRootItem()
+        asset_items_queue = collections.deque()
+        asset_items_queue.append((None, root_item))
+
+        removed_asset_ids = set()
+        while asset_items_queue:
+            parent_id, parent_item = asset_items_queue.popleft()
+            children_ids = asset_ids_by_parents[parent_id]
+            if not children_ids:
+                continue
+
+            for row in reversed(range(parent_item.rowCount())):
+                child_item = parent_item.child(row, 0)
+                asset_id = child_item.data(ASSET_ID_ROLE)
+                if asset_id not in children_ids:
+                    parent_item.removeRow(row)
+                    if asset_id not in asset_docs_by_id:
+                        removed_asset_ids.add(asset_id)
+                    continue
+
+                children_ids.remove(asset_id)
+                asset_items_queue.append((asset_id, child_item))
+
+            new_items = []
+            for asset_id in children_ids:
+                item = QtGui.QStandardItem()
+                item.setEditable(False)
+                item.setData(asset_id, ASSET_ID_ROLE)
+                new_items.append(item)
+                self._items_by_asset_id[asset_id] = item
+                asset_items_queue.append((asset_id, item))
+
+            if new_items:
+                parent_item.appendRows(new_items)
+
+        for asset_id in removed_asset_ids:
+            self._items_by_asset_id.pop(asset_id)
+            if asset_id in self._items_with_color_by_id:
+                self._items_with_color_by_id.pop(asset_id)
+
+        # Refresh data
+        for asset_id, item in self._items_by_asset_id.items():
+            asset_doc = asset_docs_by_id[asset_id]
+
+            asset_name = asset_doc["name"]
+            if item.data(ASSET_NAME_ROLE) != asset_name:
+                item.setData(asset_name, ASSET_NAME_ROLE)
+
+            asset_data = asset_doc.get("data") or {}
+            asset_label = asset_data.get("label") or asset_name
+            if item.data(ASSET_LABEL_ROLE) != asset_label:
+                item.setData(asset_label, QtCore.Qt.DisplayRole)
+                item.setData(asset_label, ASSET_LABEL_ROLE)
+
+            icon_color = asset_data.get("color") or style.colors.default
+            icon_name = asset_data.get("icon")
+            if not icon_name:
+                # Use default icons if no custom one is specified.
+                # If it has children show a full folder, otherwise
+                # show an open folder
+                if item.rowCount() > 0:
+                    icon_name = "folder"
+                else:
+                    icon_name = "folder-o"
+
+            try:
+                # font-awesome key
+                full_icon_name = "fa.{0}".format(icon_name)
+                icon = qtawesome.icon(full_icon_name, color=icon_color)
+                item.setData(icon, QtCore.Qt.DecorationRole)
+
+            except Exception as exception:
+                pass
+
+        self.refreshed.emit(bool(self._items_by_asset_id))
+
+        self._stop_fetch_thread()
+
+    def _threaded_fetch(self):
+        asset_docs = self._fetch_asset_docs() or []
+        if self._doc_fetching_stop:
+            return
+
+        self._doc_payload = asset_docs
+
+        # Emit doc fetched only if was not stopped
+        self._doc_fetched.emit()
+
+    def _fetch_asset_docs(self):
+        if not self.dbcon.Session.get("AVALON_PROJECT"):
+            return
+
+        project_doc = self.dbcon.find_one(
+            {"type": "project"},
+            {"_id": True}
+        )
+        if not project_doc:
+            return
+
+        # Get all assets sorted by name
+        return list(self.dbcon.find(
+            {"type": "asset"},
+            self._asset_projection
+        ))
+
+    def _stop_fetch_thread(self):
+        if self._doc_fetching_thread is not None:
+            self._doc_fetching_stop = True
+            while self._doc_fetching_thread.isRunning():
+                time.sleep(0.01)
+            self._doc_fetching_thread = None

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -14,6 +14,7 @@ from .views import (
     TreeViewSpinner,
     DeselectableTreeView
 )
+from .widgets import PlaceholderLineEdit
 from .models import RecursiveSortFilterProxyModel
 from .lib import DynamicQThread
 
@@ -602,7 +603,7 @@ class AssetsWidget(QtWidgets.QWidget):
         refresh_btn.setIcon(refresh_icon)
         refresh_btn.setToolTip("Refresh items")
 
-        filter_input = QtWidgets.QLineEdit(self)
+        filter_input = PlaceholderLineEdit(self)
         filter_input.setPlaceholderText("Filter assets..")
 
         # Header

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -62,19 +62,18 @@ class HostToolsHelper:
             save = True
 
         workfiles_tool = self.get_workfiles_tool(parent)
-        if use_context:
-            context = {
-                "asset": avalon.api.Session["AVALON_ASSET"],
-                "silo": avalon.api.Session["AVALON_SILO"],
-                "task": avalon.api.Session["AVALON_TASK"]
-            }
-            workfiles_tool.set_context(context)
+        workfiles_tool.set_save_enabled(save)
 
-        if save:
-            workfiles_tool.set_save_enabled(save)
+        if not workfiles_tool.isVisible():
+            workfiles_tool.show()
 
-        workfiles_tool.refresh()
-        workfiles_tool.show()
+            if use_context:
+                context = {
+                    "asset": avalon.api.Session["AVALON_ASSET"],
+                    "task": avalon.api.Session["AVALON_TASK"]
+                }
+                workfiles_tool.set_context(context)
+
         # Pull window to the front.
         workfiles_tool.raise_()
         workfiles_tool.activateWindow()

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -445,6 +445,30 @@ class GroupsConfig:
         return ordered_groups, subset_docs_without_group, subset_docs_by_group
 
 
+class DynamicQThread(QtCore.QThread):
+    """QThread which can run any function with argument and kwargs.
+
+    Args:
+        func (function): Function which will be called.
+        args (tuple): Arguments which will be passed to function.
+        kwargs (tuple): Keyword arguments which will be passed to function.
+        parent (QObject): Parent of thread.
+    """
+    def __init__(self, func, args=None, kwargs=None, parent=None):
+        super(DynamicQThread, self).__init__(parent)
+        if args is None:
+            args = tuple()
+        if kwargs is None:
+            kwargs = {}
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+
+    def run(self):
+        """Execute the function with arguments."""
+        self._func(*self._args, **self._kwargs)
+
+
 def create_qthread(func, *args, **kwargs):
     class Thread(QtCore.QThread):
         def run(self):

--- a/openpype/tools/utils/tasks_widget.py
+++ b/openpype/tools/utils/tasks_widget.py
@@ -226,10 +226,6 @@ class TasksWidget(QtWidgets.QWidget):
         self._tasks_model.refresh()
 
     def set_asset_id(self, asset_id):
-        # Asset deselected
-        if asset_id is None:
-            return
-
         # Try and preserve the last selected task and reselect it
         # after switching assets. If there's no currently selected
         # asset keep whatever the "last selected" was prior to it.

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -7,12 +7,35 @@ from Qt import QtWidgets, QtCore, QtGui
 from avalon.vendor import qtawesome, qargparse
 
 from avalon import style
+from openpype.style import get_objected_colors
 
 from .models import AssetModel, RecursiveSortFilterProxyModel
 from .views import AssetsView
 from .delegates import AssetDelegate
 
 log = logging.getLogger(__name__)
+
+
+class PlaceholderLineEdit(QtWidgets.QLineEdit):
+    """Set placeholder color of QLineEdit in Qt 5.12 and higher."""
+    def __init__(self, *args, **kwargs):
+        super(PlaceholderLineEdit, self).__init__(*args, **kwargs)
+        self._first_show = True
+
+    def showEvent(self, event):
+        super(PlaceholderLineEdit, self).showEvent(event)
+        if self._first_show:
+            self._first_show = False
+            filter_palette = self.palette()
+            if hasattr(filter_palette, "PlaceholderText"):
+                color_obj = get_objected_colors()["font"]
+                color = color_obj.get_qcolor()
+                color.setAlpha(67)
+                filter_palette.setColor(
+                    filter_palette.PlaceholderText,
+                    color
+                )
+                self.setPalette(filter_palette)
 
 
 class AssetWidget(QtWidgets.QWidget):

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -12,15 +12,12 @@ from avalon import io, api, pipeline
 
 from openpype import style
 from openpype.tools.utils.lib import (
-    schedule, qt_app_context
+    schedule,
+    qt_app_context
 )
-from openpype.tools.utils.widgets import AssetWidget
+from openpype.tools.utils.assets_widget import SingleSelectAssetsWidget
 from openpype.tools.utils.tasks_widget import TasksWidget
 from openpype.tools.utils.delegates import PrettyTimeDelegate
-
-from .model import FilesModel
-from .view import FilesView
-
 from openpype.lib import (
     Anatomy,
     get_workdir,
@@ -29,6 +26,9 @@ from openpype.lib import (
     save_workfile_data_to_doc,
     get_workfile_template_key
 )
+
+from .model import FilesModel
+from .view import FilesView
 
 log = logging.getLogger(__name__)
 
@@ -326,7 +326,8 @@ class FilesWidget(QtWidgets.QWidget):
         super(FilesWidget, self).__init__(parent=parent)
 
         # Setup
-        self._asset = None
+        self._asset_id = None
+        self._asset_doc = None
         self._task_name = None
         self._task_type = None
 
@@ -422,15 +423,17 @@ class FilesWidget(QtWidgets.QWidget):
         self.btn_browse = btn_browse
         self.btn_save = btn_save
 
-    def set_asset_task(self, asset, task_name, task_type):
-        self._asset = asset
+    def set_asset_task(self, asset_id, task_name, task_type):
+        if asset_id != self._asset_id:
+            self._asset_doc = None
+        self._asset_id = asset_id
         self._task_name = task_name
         self._task_type = task_type
 
         # Define a custom session so we can query the work root
         # for a "Work area" that is not our current Session.
         # This way we can browse it even before we enter it.
-        if self._asset and self._task_name and self._task_type:
+        if self._asset_id and self._task_name and self._task_type:
             session = self._get_session()
             self.root = self.host.work_root(session)
             self.files_model.set_root(self.root)
@@ -446,6 +449,14 @@ class FilesWidget(QtWidgets.QWidget):
             # Manually trigger file selection
             self.on_file_select()
 
+    def _get_asset_doc(self):
+        if self._asset_id is None:
+            return None
+
+        if self._asset_doc is None:
+            self._asset_doc = io.find_one({"_id": self._asset_id})
+        return self._asset_doc
+
     def _get_session(self):
         """Return a modified session for the current asset and task"""
 
@@ -457,7 +468,7 @@ class FilesWidget(QtWidgets.QWidget):
         )
         changes = pipeline.compute_session_changes(
             session,
-            asset=self._asset,
+            asset=self._get_asset_doc(),
             task=self._task_name,
             template_key=self.template_key
         )
@@ -471,7 +482,7 @@ class FilesWidget(QtWidgets.QWidget):
         session = api.Session.copy()
         changes = pipeline.compute_session_changes(
             session,
-            asset=self._asset,
+            asset=self._get_asset_doc(),
             task=self._task_name,
             template_key=self.template_key
         )
@@ -481,7 +492,7 @@ class FilesWidget(QtWidgets.QWidget):
             return
 
         api.update_current_task(
-            asset=self._asset,
+            asset=self._get_asset_doc(),
             task=self._task_name,
             template_key=self.template_key
         )
@@ -628,7 +639,9 @@ class FilesWidget(QtWidgets.QWidget):
         self._enter_session()   # Make sure we are in the right session
         self.host.save_file(file_path)
 
-        self.set_asset_task(self._asset, self._task_name, self._task_type)
+        self.set_asset_task(
+            self._asse_id, self._task_name, self._task_type
+        )
 
         pipeline.emit("after.workfile.save", [file_path])
 
@@ -654,7 +667,7 @@ class FilesWidget(QtWidgets.QWidget):
         session = api.Session.copy()
         changes = pipeline.compute_session_changes(
             session,
-            asset=self._asset,
+            asset=self._get_asset_doc(),
             task=self._task_name,
             template_key=self.template_key
         )
@@ -679,7 +692,7 @@ class FilesWidget(QtWidgets.QWidget):
 
         # Force a full to the asset as opposed to just self.refresh() so
         # that it will actually check again whether the Work directory exists
-        self.set_asset_task(self._asset, self._task_name, self._task_type)
+        self.set_asset_task(self._asset_id, self._task_name, self._task_type)
 
     def refresh(self):
         """Refresh listed files for current selection in the interface"""
@@ -775,10 +788,10 @@ class SidePanelWidget(QtWidgets.QWidget):
         self.on_note_change()
         self.save_clicked.emit()
 
-    def set_context(self, asset_doc, task_name, filepath, workfile_doc):
+    def set_context(self, asset_id, task_name, filepath, workfile_doc):
         # Check if asset, task and file are selected
         # NOTE workfile document is not requirement
-        enabled = bool(asset_doc) and bool(task_name) and bool(filepath)
+        enabled = bool(asset_id) and bool(task_name) and bool(filepath)
 
         self.details_input.setEnabled(enabled)
         self.note_input.setEnabled(enabled)
@@ -856,7 +869,7 @@ class Window(QtWidgets.QMainWindow):
         home_page_widget = QtWidgets.QWidget(pages_widget)
         home_body_widget = QtWidgets.QWidget(home_page_widget)
 
-        assets_widget = AssetWidget(io, parent=home_body_widget)
+        assets_widget = SingleSelectAssetsWidget(io, parent=home_body_widget)
         assets_widget.set_current_asset_btn_visibility(True)
 
         tasks_widget = TasksWidget(io, home_body_widget)
@@ -884,14 +897,21 @@ class Window(QtWidgets.QMainWindow):
         # the files widget has a filter field which tasks does not.
         tasks_widget.setContentsMargins(0, 32, 0, 0)
 
+        # Set context after asset widget is refreshed
+        # - to do so it is necessary to wait until refresh is done
+        set_context_timer = QtCore.QTimer()
+        set_context_timer.setInterval(100)
+
         # Connect signals
-        assets_widget.current_changed.connect(self.on_asset_changed)
+        set_context_timer.timeout.connect(self._on_context_set_timeout)
+        assets_widget.selection_changed.connect(self.on_asset_changed)
         tasks_widget.task_changed.connect(self.on_task_changed)
         files_widget.file_selected.connect(self.on_file_select)
         files_widget.workfile_created.connect(self.on_workfile_create)
         files_widget.file_opened.connect(self._on_file_opened)
         side_panel.save_clicked.connect(self.on_side_panel_save)
 
+        self._set_context_timer = set_context_timer
         self.home_page_widget = home_page_widget
         self.pages_widget = pages_widget
         self.home_body_widget = home_body_widget
@@ -908,11 +928,13 @@ class Window(QtWidgets.QMainWindow):
         self.resize(1200, 600)
 
         self._first_show = True
+        self._context_to_set = None
 
     def showEvent(self, event):
         super(Window, self).showEvent(event)
         if self._first_show:
             self._first_show = False
+            self.refresh()
             self.setStyleSheet(style.load_stylesheet())
 
     def keyPressEvent(self, event):
@@ -936,21 +958,17 @@ class Window(QtWidgets.QMainWindow):
         schedule(self._on_asset_changed, 50, channel="mongo")
 
     def on_file_select(self, filepath):
-        asset_docs = self.assets_widget.get_selected_assets()
-        asset_doc = None
-        if asset_docs:
-            asset_doc = asset_docs[0]
-
+        asset_id = self.assets_widget.get_selected_asset_id()
         task_name = self.tasks_widget.get_selected_task_name()
 
         workfile_doc = None
-        if asset_doc and task_name and filepath:
+        if asset_id and task_name and filepath:
             filename = os.path.split(filepath)[1]
             workfile_doc = get_workfile_doc(
-                asset_doc["_id"], task_name, filename, io
+                asset_id, task_name, filename, io
             )
         self.side_panel.set_context(
-            asset_doc, task_name, filepath, workfile_doc
+            asset_id, task_name, filepath, workfile_doc
         )
 
     def on_workfile_create(self, filepath):
@@ -972,14 +990,13 @@ class Window(QtWidgets.QMainWindow):
         if filepath is None:
             filepath = self.files_widget._get_selected_filepath()
         task_name = self.tasks_widget.get_selected_task_name()
-        asset_docs = self.assets_widget.get_selected_assets()
-        if not task_name or not asset_docs or not filepath:
+        asset_id = self.assets_widget.get_selected_asset_id()
+        if not task_name or not asset_id or not filepath:
             return
 
-        asset_doc = asset_docs[0]
         filename = os.path.split(filepath)[1]
         return get_workfile_doc(
-            asset_doc["_id"], task_name, filename, io
+            asset_id, task_name, filename, io
         )
 
     def _create_workfile_doc(self, filepath, force=False):
@@ -989,29 +1006,10 @@ class Window(QtWidgets.QMainWindow):
 
         if not workfile_doc:
             workdir, filename = os.path.split(filepath)
-            asset_docs = self.assets_widget.get_selected_assets()
-            asset_doc = asset_docs[0]
+            asset_id = self.assets_widget.get_selected_asset_id()
+            asset_doc = io.find_one({"_id": asset_id})
             task_name = self.tasks_widget.get_selected_task_name()
             create_workfile_doc(asset_doc, task_name, filename, workdir, io)
-
-    def set_context(self, context):
-        if "asset" in context:
-            asset = context["asset"]
-            asset_document = io.find_one(
-                {
-                    "name": asset,
-                    "type": "asset"
-                },
-                {"_id": 1}
-            ) or {}
-
-            # Select the asset
-            self.assets_widget.select_assets([asset], expand=True)
-
-            self.tasks_widget.set_asset_id(asset_document.get("_id"))
-
-        if "task" in context:
-            self.tasks_widget.select_task_name(context["task"])
 
     def refresh(self):
         # Refresh asset widget
@@ -1019,32 +1017,57 @@ class Window(QtWidgets.QMainWindow):
 
         self._on_task_changed()
 
+    def set_context(self, context):
+        self._context_to_set = context
+        self._set_context_timer.start()
+
+    def _on_context_set_timeout(self):
+        if self._context_to_set is None:
+            self._set_context_timer.stop()
+            return
+
+        if self.assets_widget.refreshing:
+            return
+
+        self._context_to_set, context = None, self._context_to_set
+        if "asset" in context:
+            asset_doc = io.find_one(
+                {
+                    "name": context["asset"],
+                    "type": "asset"
+                },
+                {"_id": 1}
+            ) or {}
+            asset_id = asset_doc.get("_id")
+            # Select the asset
+            self.assets_widget.select_asset(asset_id)
+            self.tasks_widget.set_asset_id(asset_id)
+
+        if "task" in context:
+            self.tasks_widget.select_task_name(context["task"])
+
     def _on_asset_changed(self):
-        asset = self.assets_widget.get_selected_assets() or None
-        asset_id = None
-        if not asset:
+        asset_id = self.assets_widget.get_selected_asset_id()
+        if asset_id:
+            self.tasks_widget.setEnabled(True)
+        else:
             # Force disable the other widgets if no
             # active selection
             self.tasks_widget.setEnabled(False)
             self.files_widget.setEnabled(False)
-        else:
-            asset = asset[0]
-            asset_id = asset.get("_id")
-            self.tasks_widget.setEnabled(True)
 
         self.tasks_widget.set_asset_id(asset_id)
 
     def _on_task_changed(self):
-        asset = self.assets_widget.get_selected_assets() or None
-        if asset is not None:
-            asset = asset[0]
+        asset_id = self.assets_widget.get_selected_asset_id()
         task_name = self.tasks_widget.get_selected_task_name()
         task_type = self.tasks_widget.get_selected_task_type()
 
-        self.tasks_widget.setEnabled(bool(asset))
+        asset_is_valid = asset_id is not None
+        self.tasks_widget.setEnabled(asset_is_valid)
 
-        self.files_widget.setEnabled(all([bool(task_name), bool(asset)]))
-        self.files_widget.set_asset_task(asset, task_name, task_type)
+        self.files_widget.setEnabled(bool(task_name) and asset_is_valid)
+        self.files_widget.set_asset_task(asset_id, task_name, task_type)
         self.files_widget.refresh()
 
 


### PR DESCRIPTION
## Goals
- separate asset specific logic into one segment and prepare few widgets with public methods ready to use without knowing inner logic
- get rid of accessing inner attributes of asset widget

## Changes
- created `assets_widget.py` file in `openpype.tools.utils` containing all basics related to assets logic
   - important objects are `SingleSelectAssetsWidget` and `MultiSelectAssetsWidget`
- asset widget does not work with asset documents but can return asset names or asset ids
- use new widgets in tools: loader, library loader, workfiles, context dialog and launcher
   - reduced double refreshes in few of them (e.g. workfiles and launcher refreshed assets twice on show)
- implemented `PlaceholderLineEdit` which should fix issue with placeholders in Qt 5.12 and higher

## Notes
- previous AssetWidget kept because is used at some places which need more modifications for special cases (and I'm not sure if are used anywhere?)