### PR TITLE
Tools: Parenting of tools in Nuke and Hiero

### DIFF
--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -30,6 +30,7 @@ self = sys.modules[__name__]
 self._has_been_setup = False
 self._has_menu = False
 self._registered_gui = None
+self._parent = None
 self.pype_tag_name = "openpypeData"
 self.default_sequence_name = "openpypeSequence"
 self.default_bin_name = "openpypeBin"
@@ -1029,3 +1030,15 @@ def before_project_save(event):
 
     # also mark old versions of loaded containers
     check_inventory_versions()
+
+
+def get_main_window():
+    """Acquire Nuke's main window"""
+    if self._parent is None:
+        top_widgets = QtWidgets.QApplication.topLevelWidgets()
+        name = "Foundry::UI::DockMainWindow"
+        main_window = next(widget for widget in top_widgets if
+                           widget.inherits("QMainWindow") and
+                           widget.metaObject().className() == name)
+        self._parent = main_window
+    return self._parent

--- a/openpype/hosts/hiero/api/menu.py
+++ b/openpype/hosts/hiero/api/menu.py
@@ -37,12 +37,16 @@ def menu_install():
     Installing menu into Hiero
 
     """
+    from Qt import QtGui
     from . import (
         publish, launch_workfiles_app, reload_config,
         apply_colorspace_project, apply_colorspace_clips
     )
+    from .lib import get_main_window
+
+    main_window = get_main_window()
+
     # here is the best place to add menu
-    from avalon.vendor.Qt import QtGui
 
     menu_name = os.environ['AVALON_LABEL']
 
@@ -86,15 +90,21 @@ def menu_install():
 
     creator_action = menu.addAction("Create ...")
     creator_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
-    creator_action.triggered.connect(host_tools.show_creator)
+    creator_action.triggered.connect(
+        lambda: host_tools.show_creator(parent=main_window)
+    )
 
     loader_action = menu.addAction("Load ...")
     loader_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
-    loader_action.triggered.connect(host_tools.show_loader)
+    loader_action.triggered.connect(
+        lambda: host_tools.show_loader(parent=main_window)
+    )
 
     sceneinventory_action = menu.addAction("Manage ...")
     sceneinventory_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
-    sceneinventory_action.triggered.connect(host_tools.show_scene_inventory)
+    sceneinventory_action.triggered.connect(
+        lambda: host_tools.show_scene_inventory(parent=main_window)
+    )
     menu.addSeparator()
 
     if os.getenv("OPENPYPE_DEVELOP"):

--- a/openpype/hosts/hiero/api/pipeline.py
+++ b/openpype/hosts/hiero/api/pipeline.py
@@ -209,9 +209,11 @@ def update_container(track_item, data=None):
 
 def launch_workfiles_app(*args):
     ''' Wrapping function for workfiles launcher '''
+    from .lib import get_main_window
 
+    main_window = get_main_window()
     # show workfile gui
-    host_tools.show_workfiles()
+    host_tools.show_workfiles(parent=main_window)
 
 
 def publish(parent):

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1654,6 +1654,8 @@ def launch_workfiles_app():
     from openpype.lib import (
         env_value_to_bool
     )
+    from avalon.nuke.pipeline import get_main_window
+
     # get all imortant settings
     open_at_start = env_value_to_bool(
         env_key="OPENPYPE_WORKFILE_TOOL_ON_START",
@@ -1665,7 +1667,8 @@ def launch_workfiles_app():
 
     if not opnl.workfiles_launched:
         opnl.workfiles_launched = True
-        host_tools.show_workfiles()
+        main_window = get_main_window()
+        host_tools.show_workfiles(parent=main_window)
 
 
 def process_workfile_builder():

--- a/openpype/hosts/nuke/api/menu.py
+++ b/openpype/hosts/nuke/api/menu.py
@@ -6,11 +6,15 @@ from .lib import WorkfileSettings
 from openpype.api import Logger, BuildWorkfile, get_current_project_settings
 from openpype.tools.utils import host_tools
 
+from avalon.nuke.pipeline import get_main_window
+
 log = Logger().get_logger(__name__)
 
 menu_label = os.environ["AVALON_LABEL"]
 
+
 def install():
+    main_window = get_main_window()
     menubar = nuke.menu("Nuke")
     menu = menubar.findItem(menu_label)
 
@@ -25,7 +29,7 @@ def install():
     menu.removeItem(rm_item[1].name())
     menu.addCommand(
         name,
-        host_tools.show_workfiles,
+        lambda: host_tools.show_workfiles(parent=main_window),
         index=2
     )
     menu.addSeparator(index=3)
@@ -88,7 +92,7 @@ def install():
     menu.addSeparator()
     menu.addCommand(
         "Experimental tools...",
-        host_tools.show_experimental_tools_dialog
+        lambda: host_tools.show_experimental_tools_dialog(parent=main_window)
     )
 
     # adding shortcuts


### PR DESCRIPTION
## Issue
- bad parenting of tools in nuke and hiero may break modality of tools for them

## Changes
- pass right pointer to parent window into tools on callbacks

## How to test
- open e.g. workfiles tool
- call `nuke.message("test")` from script editor
- message should popup in front of opened tool

## Note
- other tools in Nuke may depend on this PR in avalon-core https://github.com/pypeclub/avalon-core/pull/390