### PR TITLE
Ftrack: Support multiple reviews

### DIFF
--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -122,4 +122,16 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         # Components data
         component_list = []
         
+
+        def json_obj_parser(obj):
+            return str(obj)
+
+        self.log.debug("Components list: {}".format(
+            json.dumps(
+                component_list,
+                sort_keys=True,
+                indent=4,
+                default=json_obj_parser
+            )
+        ))
         instance.data["ftrackComponentsList"] = component_list

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -144,11 +144,11 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 fps = instance_fps
 
             # Create copy of base comp item and append it
-            component_item = copy.deepcopy(base_component_item)
+            review_item = copy.deepcopy(base_component_item)
             # Change location
-            component_item["component_path"] = repre["published_path"]
+            review_item["component_path"] = repre["published_path"]
             # Change component data
-            component_item["component_data"] = {
+            review_item["component_data"] = {
                 # Default component name is "main".
                 "name": "ftrackreview-mp4",
                 "metadata": {
@@ -163,16 +163,16 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 first_review_repre = False
             else:
                 # Add representation name to asset name of "not first" review
-                component_item["asset_data"]["name"] += repre["name"].title()
+                review_item["asset_data"]["name"] += repre["name"].title()
 
             # Create copy of item before setting location
             src_components_to_add.append(
-                (repre, copy.deepcopy(component_item))
+                (repre, copy.deepcopy(review_item))
             )
             # Set location
-            component_item["component_location"] = ftrack_server_location
+            review_item["component_location"] = ftrack_server_location
             # Add item to component list
-            component_list.append(component_item)
+            component_list.append(review_item)
 
         # Create thumbnail components
         # TODO what if there is multiple thumbnails?
@@ -189,42 +189,42 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 )
 
             # Create copy of base comp item and append it
-            component_item = copy.deepcopy(base_component_item)
-            component_item["component_path"] = repre["published_path"]
-            component_item["component_data"] = {
+            thumbnail_item = copy.deepcopy(base_component_item)
+            thumbnail_item["component_path"] = repre["published_path"]
+            thumbnail_item["component_data"] = {
                 "name": "thumbnail"
             }
-            component_item["thumbnail"] = True
+            thumbnail_item["thumbnail"] = True
             # Create copy of item before setting location
             src_components_to_add.append(
-                (repre, copy.deepcopy(component_item))
+                (repre, copy.deepcopy(thumbnail_item))
             )
             # Set location
-            component_item["component_location"] = ftrack_server_location
+            thumbnail_item["component_location"] = ftrack_server_location
             # Add item to component list
-            component_list.append(component_item)
+            component_list.append(thumbnail_item)
 
         # Add source components for review and thubmnail components
-        for repre, component_item in src_components_to_add:
+        for repre, copy_src_item in src_components_to_add:
             # Make sure thumbnail is disabled
-            component_item["thumbnail"] = False
+            copy_src_item["thumbnail"] = False
             # Set location
-            component_item["component_location"] = unmanaged_location
+            copy_src_item["component_location"] = unmanaged_location
             # Modify name of component to have suffix "_src"
-            component_data = component_item["component_data"]
+            component_data = copy_src_item["component_data"]
             component_name = component_data["name"]
             component_data["name"] = component_name + "_src"
-            component_list.append(component_item)
+            component_list.append(copy_src_item)
 
         # Add others representations as component
         for repre in other_representations:
             # Create copy of base comp item and append it
-            component_item = copy.deepcopy(base_component_item)
-            component_item["component_data"] = {
+            other_item = copy.deepcopy(base_component_item)
+            other_item["component_data"] = {
                 "name": repre["name"]
             }
-            component_item["component_location"] = unmanaged_location
-            component_list.append(component_item)
+            other_item["component_location"] = unmanaged_location
+            component_list.append(other_item)
 
         def json_obj_parser(obj):
             return str(obj)

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -123,6 +123,30 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         component_list = []
         
 
+        # Create thumbnail components
+        # TODO what if there is multiple thumbnails?
+        for repre in thumbnail_representations:
+            if not repre.get("published_path"):
+                comp_files = repre["files"]
+                if isinstance(comp_files, (tuple, list, set)):
+                    filename = comp_files[0]
+                else:
+                    filename = comp_files
+
+                repre["published_path"] = os.path.join(
+                    repre["stagingDir"], filename
+                )
+
+            component_item["component_path"] = repre["published_path"]
+            component_item["component_data"] = {
+                "name": "thumbnail"
+            }
+            component_item["thumbnail"] = True
+            # Set location
+            component_item["component_location"] = ftrack_server_location
+            # Add item to component list
+            component_list.append(component_item)
+
         # Add others representations as component
         for repre in other_representations:
             # Create copy of base comp item and append it

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -188,6 +188,8 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                     repre["stagingDir"], filename
                 )
 
+            # Create copy of base comp item and append it
+            component_item = copy.deepcopy(base_component_item)
             component_item["component_path"] = repre["published_path"]
             component_item["component_data"] = {
                 "name": "thumbnail"

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -123,6 +123,16 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         component_list = []
         
 
+        # Add others representations as component
+        for repre in other_representations:
+            # Create copy of base comp item and append it
+            component_item = copy.deepcopy(base_component_item)
+            component_item["component_data"] = {
+                "name": repre["name"]
+            }
+            component_item["component_location"] = unmanaged_location
+            component_list.append(component_item)
+
         def json_obj_parser(obj):
             return str(obj)
 

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -121,7 +121,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         # Components data
         component_list = []
-        
+        # Components that will be duplicated to unmanaged location
+        src_components_to_add = []
+
         # Create review components
         # Change asset name of each new component for review
         first_review_repre = True
@@ -163,6 +165,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 # Add representation name to asset name of "not first" review
                 component_item["asset_data"]["name"] += repre["name"].title()
 
+            # Create copy of item before setting location
+            src_components_to_add.append(
+                (repre, copy.deepcopy(component_item))
+            )
             # Set location
             component_item["component_location"] = ftrack_server_location
             # Add item to component list
@@ -187,9 +193,25 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 "name": "thumbnail"
             }
             component_item["thumbnail"] = True
+            # Create copy of item before setting location
+            src_components_to_add.append(
+                (repre, copy.deepcopy(component_item))
+            )
             # Set location
             component_item["component_location"] = ftrack_server_location
             # Add item to component list
+            component_list.append(component_item)
+
+        # Add source components for review and thubmnail components
+        for repre, component_item in src_components_to_add:
+            # Make sure thumbnail is disabled
+            component_item["thumbnail"] = False
+            # Set location
+            component_item["component_location"] = unmanaged_location
+            # Modify name of component to have suffix "_src"
+            component_data = component_item["component_data"]
+            component_name = component_data["name"]
+            component_data["name"] = component_name + "_src"
             component_list.append(component_item)
 
         # Add others representations as component

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -95,6 +95,22 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         componentList = []
         ft_session = instance.context.data["ftrackSession"]
 
+        # Filter types of representations
+        review_representations = []
+        thumbnail_representations = []
+        other_representations = []
+        for repre in instance_repres:
+            self.log.debug("Representation {}".format(repre))
+            repre_tags = repre.get("tags") or []
+            if repre.get("thumbnail") or "thumbnail" in repre_tags:
+                thumbnail_representations.append(repre)
+
+            elif "ftrackreview" in repre_tags:
+                review_representations.append(repre)
+
+            else:
+                other_representations.append(repre)
+
         for comp in instance.data['representations']:
             self.log.debug('component {}'.format(comp))
 

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -111,6 +111,14 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             else:
                 other_representations.append(repre)
 
+        # Prepare ftrack locations
+        unmanaged_location = ft_session.query(
+            "Location where name is \"ftrack.unmanaged\""
+        ).one()
+        ftrack_server_location = ft_session.query(
+            "Location where name is \"ftrack.server\""
+        ).one()
+
         for comp in instance.data['representations']:
             self.log.debug('component {}'.format(comp))
 

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -66,6 +66,32 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             ).format(str(instance)))
             return
 
+        # Prepare FPS
+        instance_fps = instance.data.get("fps")
+        if instance_fps is None:
+            instance_fps = instance.context.data["fps"]
+
+        # Base of component item data
+        # - create a copy of this object when want to use it
+        base_component_item = {
+            "assettype_data": {
+                "short": asset_type,
+            },
+            "asset_data": {
+                "name": instance.data["subset"],
+            },
+            "assetversion_data": {
+                "version": version_number,
+                "comment": instance.context.data.get("comment") or ""
+            },
+            "component_overwrite": False,
+            # This can be change optionally
+            "thumbnail": False,
+            # These must be changed for each component
+            "component_data": None,
+            "component_path": None,
+            "component_location": None
+        }
         componentList = []
         ft_session = instance.context.data["ftrackSession"]
 

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -1,5 +1,6 @@
 import os
 import json
+import copy
 import pyblish.api
 
 
@@ -35,7 +36,6 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
     }
 
     def process(self, instance):
-        self.ftrack_locations = {}
         self.log.debug("instance {}".format(instance))
 
         instance_version = instance.data.get("version")
@@ -121,151 +121,5 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         # Components data
         component_list = []
-        for comp in instance.data['representations']:
-            self.log.debug('component {}'.format(comp))
-
-            if comp.get('thumbnail') or ("thumbnail" in comp.get('tags', [])):
-                location = self.get_ftrack_location(
-                    'ftrack.server', ft_session
-                )
-                component_data = {
-                    "name": "thumbnail"  # Default component name is "main".
-                }
-                comp['thumbnail'] = True
-                comp_files = comp["files"]
-                if isinstance(comp_files, (tuple, list, set)):
-                    filename = comp_files[0]
-                else:
-                    filename = comp_files
-
-                comp['published_path'] = os.path.join(
-                    comp['stagingDir'], filename
-                    )
-
-            elif comp.get('ftrackreview') or ("ftrackreview" in comp.get('tags', [])):
-                '''
-                Ftrack bug requirement:
-                    - Start frame must be 0
-                    - End frame must be {duration}
-                EXAMPLE: When mov has 55 frames:
-                    - Start frame should be 0
-                    - End frame should be 55 (do not ask why please!)
-                '''
-                start_frame = 0
-                end_frame = 1
-                if 'frameEndFtrack' in comp and 'frameStartFtrack' in comp:
-                    end_frame += (
-                        comp['frameEndFtrack'] - comp['frameStartFtrack']
-                    )
-                else:
-                    end_frame += (
-                        instance.data["frameEnd"] - instance.data["frameStart"]
-                    )
-
-                fps = comp.get('fps')
-                if fps is None:
-                    fps = instance.data.get(
-                        "fps", instance.context.data['fps']
-                    )
-
-                comp['fps'] = fps
-
-                location = self.get_ftrack_location(
-                    'ftrack.server', ft_session
-                )
-                component_data = {
-                    # Default component name is "main".
-                    "name": "ftrackreview-mp4",
-                    "metadata": {'ftr_meta': json.dumps({
-                                 'frameIn': int(start_frame),
-                                 'frameOut': int(end_frame),
-                                 'frameRate': float(comp['fps'])})}
-                }
-                comp['thumbnail'] = False
-            else:
-                component_data = {
-                    "name": comp['name']
-                }
-                location = self.get_ftrack_location(
-                    'ftrack.unmanaged', ft_session
-                )
-                comp['thumbnail'] = False
-
-            self.log.debug('location {}'.format(location))
-
-            component_item = {
-                "assettype_data": {
-                    "short": asset_type,
-                },
-                "asset_data": {
-                    "name": instance.data["subset"],
-                },
-                "assetversion_data": {
-                    "version": version_number,
-                    "comment": instance.context.data.get("comment", "")
-                },
-                "component_data": component_data,
-                "component_path": comp['published_path'],
-                'component_location': location,
-                "component_overwrite": False,
-                "thumbnail": comp['thumbnail']
-            }
-
-            # Add custom attributes for AssetVersion
-            assetversion_cust_attrs = {}
-            intent_val = instance.context.data.get("intent")
-            if intent_val and isinstance(intent_val, dict):
-                intent_val = intent_val.get("value")
-
-            if intent_val:
-                assetversion_cust_attrs["intent"] = intent_val
-
-            component_item["assetversion_data"]["custom_attributes"] = (
-                assetversion_cust_attrs
-            )
-
-            componentList.append(component_item)
-            # Create copy with ftrack.unmanaged location if thumb or prev
-            if comp.get('thumbnail') or comp.get('preview') \
-                    or ("preview" in comp.get('tags', [])) \
-                    or ("review" in comp.get('tags', [])) \
-                    or ("thumbnail" in comp.get('tags', [])):
-                unmanaged_loc = self.get_ftrack_location(
-                    'ftrack.unmanaged', ft_session
-                )
-
-                component_data_src = component_data.copy()
-                name = component_data['name'] + '_src'
-                component_data_src['name'] = name
-
-                component_item_src = {
-                    "assettype_data": {
-                        "short": asset_type,
-                    },
-                    "asset_data": {
-                        "name": instance.data["subset"],
-                    },
-                    "assetversion_data": {
-                        "version": version_number,
-                    },
-                    "component_data": component_data_src,
-                    "component_path": comp['published_path'],
-                    'component_location': unmanaged_loc,
-                    "component_overwrite": False,
-                    "thumbnail": False
-                }
-
-                componentList.append(component_item_src)
-
-        self.log.debug('componentsList: {}'.format(str(componentList)))
+        
         instance.data["ftrackComponentsList"] = component_list
-
-    def get_ftrack_location(self, name, session):
-        if name in self.ftrack_locations:
-            return self.ftrack_locations[name]
-
-        location = session.query(
-            'Location where name is "{}"'.format(name)
-        ).one()
-        self.ftrack_locations[name] = location
-        return location

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -1,54 +1,55 @@
-import pyblish.api
-import json
 import os
+import json
+import pyblish.api
 
 
 class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
-    """Collect ftrack component data
+    """Collect ftrack component data (not integrate yet).
 
     Add ftrack component list to instance.
-
-
     """
 
     order = pyblish.api.IntegratorOrder + 0.48
-    label = 'Integrate Ftrack Component'
+    label = "Integrate Ftrack Component"
     families = ["ftrack"]
 
-    family_mapping = {'camera': 'cam',
-                      'look': 'look',
-                      'mayaascii': 'scene',
-                      'model': 'geo',
-                      'rig': 'rig',
-                      'setdress': 'setdress',
-                      'pointcache': 'cache',
-                      'render': 'render',
-                      'render2d': 'render',
-                      'nukescript': 'comp',
-                      'write': 'render',
-                      'review': 'mov',
-                      'plate': 'img',
-                      'audio': 'audio',
-                      'workfile': 'scene',
-                      'animation': 'cache',
-                      'image': 'img',
-                      'reference': 'reference'
-                      }
+    family_mapping = {
+        "camera": "cam",
+        "look": "look",
+        "mayaascii": "scene",
+        "model": "geo",
+        "rig": "rig",
+        "setdress": "setdress",
+        "pointcache": "cache",
+        "render": "render",
+        "render2d": "render",
+        "nukescript": "comp",
+        "write": "render",
+        "review": "mov",
+        "plate": "img",
+        "audio": "audio",
+        "workfile": "scene",
+        "animation": "cache",
+        "image": "img",
+        "reference": "reference"
+    }
 
     def process(self, instance):
         self.ftrack_locations = {}
-        self.log.debug('instance {}'.format(instance))
+        self.log.debug("instance {}".format(instance))
 
-        if instance.data.get('version'):
-            version_number = int(instance.data.get('version'))
-        else:
+        instance_version = instance.data.get("version")
+        if instance_version is None:
             raise ValueError("Instance version not set")
 
-        family = instance.data['family'].lower()
+        version_number = int(instance_version)
+
+        family = instance.data["family"]
+        family_low = instance.data["family"].lower()
 
         asset_type = instance.data.get("ftrackFamily")
-        if not asset_type and family in self.family_mapping:
-            asset_type = self.family_mapping[family]
+        if not asset_type and family_low in self.family_mapping:
+            asset_type = self.family_mapping[family_low]
 
         # Ignore this instance if neither "ftrackFamily" or a family mapping is
         # found.

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -54,6 +54,16 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         # Ignore this instance if neither "ftrackFamily" or a family mapping is
         # found.
         if not asset_type:
+            self.log.info((
+                "Family \"{}\" does not match any asset type mapping"
+            ).format(family))
+            return
+
+        instance_repres = instance.data.get("representations")
+        if not instance_repres:
+            self.log.info((
+                "Skipping instance. Does not have any representations {}"
+            ).format(str(instance)))
             return
 
         componentList = []

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -92,7 +92,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             "component_path": None,
             "component_location": None
         }
-        componentList = []
+
         ft_session = instance.context.data["ftrackSession"]
 
         # Filter types of representations
@@ -119,6 +119,8 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             "Location where name is \"ftrack.server\""
         ).one()
 
+        # Components data
+        component_list = []
         for comp in instance.data['representations']:
             self.log.debug('component {}'.format(comp))
 
@@ -256,7 +258,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 componentList.append(component_item_src)
 
         self.log.debug('componentsList: {}'.format(str(componentList)))
-        instance.data["ftrackComponentsList"] = componentList
+        instance.data["ftrackComponentsList"] = component_list
 
     def get_ftrack_location(self, name, session):
         if name in self.ftrack_locations:


### PR DESCRIPTION
## Changes
- rewritten plugin to easier find out thumbnail, review and others representations
- first review representation is published as before
    - all following review representations will be published to different ftrack asset
    - ftrack asset name in that case is made up with concatenation of subset name and representation name

OpenPype 3 version of https://github.com/pypeclub/OpenPype/pull/1374