### PR TITLE
Deadline Maya rendering pyblish plugin "override output" option

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -174,6 +174,7 @@ class CreateRender(plugin.Creator):
                     ])
 
             cmds.setAttr("{}.machineList".format(self.instance), lock=True)
+            cmds.setAttr("{}.overrideOutput".format(self.instance), lock=False)
             self._rs = renderSetup.instance()
             layers = self._rs.getRenderLayers()
             if use_selection:
@@ -265,6 +266,7 @@ class CreateRender(plugin.Creator):
         self.data["framesPerTask"] = 1
         self.data["whitelist"] = False
         self.data["machineList"] = ""
+        self.data["overrideOutput"] = ""
         self.data["useMayaBatch"] = False
         self.data["tileRendering"] = False
         self.data["tilesX"] = 2

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -426,6 +426,11 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             key = "Whitelist" if attributes["whitelist"] else "Blacklist"
             options["renderGlobals"][key] = machine_list
 
+        # Override Output
+        override_output = attributes["overrideOutput"]
+        if override_output:
+            options["overrideOutput"] = override_output
+
         # Suspend publish job
         state = "Suspended" if attributes["suspendPublishJob"] else "Active"
         options["publishJobState"] = state

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -90,6 +90,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             return
 
         render_globals = render_instance
+        # Get global overrides and translate to Deadline values
+        overrides = self.parse_options(str(render_globals))
+
         collected_render_layers = render_instance.data["setMembers"]
         filepath = context.data["currentFile"].replace("\\", "/")
         asset = api.Session["AVALON_ASSET"]
@@ -235,8 +238,14 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             for aov in exp_files:
                 full_paths = []
                 for file in aov[aov.keys()[0]]:
-                    full_path = os.path.join(workspace, default_render_file,
-                                             file)
+                    if 'overrideOutput' in overrides:
+                        full_path = os.path.join(overrides['overrideOutput'],
+                                                 default_render_file,
+                                                 file)
+                    else:
+                        full_path = os.path.join(workspace,
+                                                 default_render_file,
+                                                 file)
                     full_path = full_path.replace("\\", "/")
                     full_paths.append(full_path)
                     publish_meta_path = os.path.dirname(full_path)
@@ -380,8 +389,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 data["families"].append("assscene_render")
 
             # Include (optional) global settings
-            # Get global overrides and translate to Deadline values
-            overrides = self.parse_options(str(render_globals))
             data.update(**overrides)
 
             # Define nice label

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -422,7 +422,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         jobname = "%s - %s" % (filename, instance.name)
 
         # Get the variables depending on the renderer
-        render_variables = get_renderer_variables(renderlayer, dirname, override_output)
+        render_variables = get_renderer_variables(renderlayer, dirname,
+                                                  override_output)
         filename_0 = render_variables["filename_0"]
         if self.use_published:
             new_scene = os.path.splitext(filename)[0]


### PR DESCRIPTION
Add an "override output" option to the maya render selection set

### Why
Allow the operator to override the project rendering output path to perform rendering tests.

### How
You can now specify an output path within the Override Output field in the extra attributes of the maya rendering selection set
![image](https://user-images.githubusercontent.com/7955673/142602875-579dbf19-0245-487d-8a4d-24e68de1ff90.png)

This Path will be used to set the "OutputFilePath" and the "OutputDirectory" submission parameters of the deadline Plugin and Job