### PR TITLE
Fix - missed wrong key for sftp provider

### DIFF
--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -192,7 +192,7 @@ class SFTPHandler(AbstractProvider):
             Format is importing for usage of python's format ** approach
         """
         # roots cannot be locally overridden
-        return self.presets['roots']
+        return self.presets['root']
 
     def get_tree(self):
         """


### PR DESCRIPTION
All root keys must be 'root', missed one for sftp provider :/.