### PR TITLE
Nuke: Anatomy fill data use task as dictionary

### DIFF
--- a/openpype/api.py
+++ b/openpype/api.py
@@ -17,6 +17,7 @@ from .lib import (
     version_up,
     get_asset,
     get_hierarchy,
+    get_workdir_data,
     get_version_from_path,
     get_last_version_from_path,
     get_app_environments_for_context,

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -18,7 +18,7 @@ from openpype.api import (
     BuildWorkfile,
     get_version_from_path,
     get_anatomy_settings,
-    get_hierarchy,
+    get_workdir_data,
     get_asset,
     get_current_project_settings,
     ApplicationManager
@@ -268,15 +268,21 @@ def format_anatomy(data):
     if not version:
         file = script_name()
         data["version"] = get_version_from_path(file)
-    project_document = io.find_one({"type": "project"})
+
+    project_doc = io.find_one({"type": "project"})
+    asset_doc = io.find_one({
+        "type": "asset",
+        "name": data["avalon"]["asset"]
+    })
+    task_name = os.environ["AVALON_TASK"]
+    host_name = os.environ["AVALON_APP"]
+    context_data = get_workdir_data(
+        project_doc, asset_doc, task_name, host_name
+    )
+    data.update(context_data)
     data.update({
         "subset": data["avalon"]["subset"],
-        "asset": data["avalon"]["asset"],
-        "task": os.environ["AVALON_TASK"],
         "family": data["avalon"]["family"],
-        "project": {"name": project_document["name"],
-                    "code": project_document["data"].get("code", '')},
-        "hierarchy": get_hierarchy(),
         "frame": "#" * padding,
     })
     return anatomy.format(data)

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -465,6 +465,7 @@ def get_workfile_template_key(
     return default
 
 
+# TODO rename function as is not just "work" specific
 def get_workdir_data(project_doc, asset_doc, task_name, host_name):
     """Prepare data for workdir template filling from entered information.
 


### PR DESCRIPTION
## Issue
Since PR https://github.com/pypeclub/OpenPype/pull/2157 tasks are used as dictionary which was not modified in nuke's lib function `format_anatomy`.

## Changes
- use `get_workdir_data` in `format_anatomy` function to get context data for filling template