### PR TITLE
Deadline: Fix publish targets

### DIFF
--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
@@ -231,7 +231,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         args = [
             'publish',
             roothless_metadata_path,
-            "--targets {}".format("deadline")
+            "--targets", "deadline",
+            "--targets", "filesequence"
         ]
 
         # Generate the payload for Deadline submission


### PR DESCRIPTION
## Issue
Target "filesequence" is not registered with latest change of `publish` command.

## Changes
- add "filesequence" target when submitting job to deadline