### PR TITLE
FFmpeg: Execute ffprobe using list of arguments instead of string command

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -71,18 +71,24 @@ def ffprobe_streams(path_to_file, logger=None):
         "Getting information about input \"{}\".".format(path_to_file)
     )
     args = [
-        "\"{}\"".format(get_ffmpeg_tool_path("ffprobe")),
-        "-v quiet",
-        "-print_format json",
+        get_ffmpeg_tool_path("ffprobe"),
+        "-hide_banner",
+        "-loglevel", "fatal",
+        "-show_error",
         "-show_format",
         "-show_streams",
-        "\"{}\"".format(path_to_file)
+        "-show_programs",
+        "-show_chapters",
+        "-show_private_data",
+        "-print_format", "json",
+        path_to_file
     ]
-    command = " ".join(args)
-    logger.debug("FFprobe command: \"{}\"".format(command))
+
+    logger.debug("FFprobe command: {}".format(
+        subprocess.list2cmdline(args)
+    ))
     popen = subprocess.Popen(
-        command,
-        shell=True,
+        args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )


### PR DESCRIPTION
## Issue
- ffprobe is executed as string which may cause issues on linux machines and older python versions

## Changes
- use list of arguments for ffprobe instead of command as string 
- removed `shell=True` which is not needed when list of arguments is passed