### PR TITLE
Alternate site for site sync doesnt work for sequences

### DIFF
--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -421,7 +421,8 @@ class SFTPHandler(AbstractProvider):
 
         try:
             return pysftp.Connection(**conn_params)
-        except paramiko.ssh_exception.SSHException:
+        except (paramiko.ssh_exception.SSHException,
+                pysftp.exceptions.ConnectionException):
             log.warning("Couldn't connect", exc_info=True)
 
     def _mark_progress(self, collection, file, representation, server, site,

--- a/openpype/modules/default_modules/sync_server/sync_server_module.py
+++ b/openpype/modules/default_modules/sync_server/sync_server_module.py
@@ -1574,6 +1574,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
             Use 'force' to remove existing or raises ValueError
         """
+        reseted_existing = False
         for repre_file in representation.pop().get("files"):
             if file_id and file_id != repre_file["_id"]:
                 continue
@@ -1584,11 +1585,14 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                         self._reset_site_for_file(collection, query,
                                                   elem, repre_file["_id"],
                                                   site_name)
-                        return
+                        reseted_existing = True
                     else:
                         msg = "Site {} already present".format(site_name)
                         log.info(msg)
                         raise ValueError(msg)
+
+        if reseted_existing:
+            return
 
         if not file_id:
             update = {


### PR DESCRIPTION
How to test it:
----------------
- open Sync Queue
- try to do Re-sync active site on representation with a multiple files
- all files should be redownloaded (reuploaded)

Closes https://github.com/pypeclub/OpenPype/issues/2283