### PR TITLE
[MAYA] Configure pyblish behaviour with environment variable

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -46,7 +46,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
         families_whitelist = os.getenv("PYBLISH_FAMILY_WHITELIST")
         if families_whitelist:
             families_whitelist = families_whitelist.split(',')
-            self.log.info("Whitelisted families : {}".format(families_whitelist))
+            self.log.info("Whitelisted families : {}".format(
+                families_whitelist))
 
         for objset in objectset:
 
@@ -87,7 +88,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             if families_whitelist:
                 if data['family'] not in families_whitelist:
-                    self.log.info("Skipped instance with not whitelisted family: {}".format(data['family']))
+                    self.log.info("Skipped instance with not whitelisted "
+                                  "family: {}".format(data['family']))
                     continue
 
             # temporarily translation of `active` to `publish` till issue has

--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -1,3 +1,4 @@
+import os
 from maya import cmds
 
 import pyblish.api
@@ -41,6 +42,12 @@ class CollectInstances(pyblish.api.ContextPlugin):
         ctx_frame_end_handle = context.data['frameEndHandle']
 
         context.data['objectsets'] = objectset
+
+        families_whitelist = os.getenv("PYBLISH_FAMILY_WHITELIST")
+        if families_whitelist:
+            families_whitelist = families_whitelist.split(',')
+            self.log.info("Whitelisted families : {}".format(families_whitelist))
+
         for objset in objectset:
 
             if not cmds.attributeQuery("id", node=objset, exists=True):
@@ -77,6 +84,11 @@ class CollectInstances(pyblish.api.ContextPlugin):
                     # particular publishing pipeline.
                     value = None
                 data[attr] = value
+
+            if families_whitelist:
+                if data['family'] not in families_whitelist:
+                    self.log.info("Skipped instance with not whitelisted family: {}".format(data['family']))
+                    continue
 
             # temporarily translation of `active` to `publish` till issue has
             # been resolved, https://github.com/pyblish/pyblish-base/issues/307
@@ -151,6 +163,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
                                               int(data["frameEndHandle"]))
 
             instance.data["label"] = label
+
 
             instance.data.update(data)
 

--- a/openpype/hosts/maya/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/maya/plugins/publish/collect_workfile.py
@@ -28,7 +28,8 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
             families_whitelist = families_whitelist.split(',')
         if families_whitelist:
             if 'workfile' not in families_whitelist:
-                self.log.info("Skipped instance with not whitelisted family: {}".format('workfile'))
+                self.log.info("Skipped instance with not whitelisted "
+                              "family: {}".format('workfile'))
                 return
 
         # create instance

--- a/openpype/hosts/maya/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/maya/plugins/publish/collect_workfile.py
@@ -23,6 +23,14 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
         data = {}
 
+        families_whitelist = os.getenv("PYBLISH_FAMILY_WHITELIST")
+        if families_whitelist:
+            families_whitelist = families_whitelist.split(',')
+        if families_whitelist:
+            if 'workfile' not in families_whitelist:
+                self.log.info("Skipped instance with not whitelisted family: {}".format('workfile'))
+                return
+
         # create instance
         instance = context.create_instance(name=filename)
         subset = 'workfile' + task.capitalize()

--- a/openpype/hosts/photoshop/plugins/publish/collect_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_instances.py
@@ -1,3 +1,5 @@
+import os
+
 import pyblish.api
 
 from openpype.hosts.photoshop import api as photoshop
@@ -25,6 +27,11 @@ class CollectInstances(pyblish.api.ContextPlugin):
         layers = stub.get_layers()
         layers_meta = stub.get_layers_metadata()
         instance_names = []
+
+        families_whitelist = os.getenv("PYBLISH_FAMILY_WHITELIST")
+        if families_whitelist:
+            families_whitelist = families_whitelist.split(',')
+
         for layer in layers:
             layer_data = stub.read(layer, layers_meta)
 
@@ -35,6 +42,12 @@ class CollectInstances(pyblish.api.ContextPlugin):
             # Skip containers.
             if "container" in layer_data["id"]:
                 continue
+
+            if families_whitelist:
+                if layer_data["family"] not in families_whitelist:
+                    self.log.info("Skipped instance with not whitelisted "
+                                  "family: {}".format(layer_data["family"]))
+                    continue
 
             # child_layers = [*layer.Layers]
             # self.log.debug("child_layers {}".format(child_layers))

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -12,6 +12,16 @@ class CollectReview(pyblish.api.ContextPlugin):
 
     def process(self, context):
         family = "review"
+
+        families_whitelist = os.getenv("PYBLISH_FAMILY_WHITELIST")
+        if families_whitelist:
+            families_whitelist = families_whitelist.split(',')
+        if families_whitelist:
+            if family not in families_whitelist:
+                self.log.info("Skipped instance with not whitelisted "
+                              "family: {}".format(family))
+                return
+
         task = os.getenv("AVALON_TASK", None)
         subset = family + task.capitalize()
 

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -18,6 +18,15 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         staging_dir = os.path.dirname(file_path)
         base_name = os.path.basename(file_path)
 
+        families_whitelist = os.getenv("PYBLISH_FAMILY_WHITELIST")
+        if families_whitelist:
+            families_whitelist = families_whitelist.split(',')
+        if families_whitelist:
+            if 'workfile' not in families_whitelist:
+                self.log.info("Skipped instance with not whitelisted "
+                              "family: {}".format('workfile'))
+                return
+
         # Create instance
         instance = context.create_instance(subset)
         instance.data.update({

--- a/openpype/tools/pyblish_pype/app.py
+++ b/openpype/tools/pyblish_pype/app.py
@@ -98,7 +98,11 @@ def show(parent=None):
 
         self._window.show()
         self._window.activateWindow()
-        self._window.setWindowTitle(settings.WindowTitle)
+        env_title = os.getenv("PYBLISH_TITLE")
+        if env_title:
+            self._window.setWindowTitle(env_title)
+        else:
+            self._window.setWindowTitle(settings.WindowTitle)
 
         font = QtGui.QFont("Open Sans", 8, QtGui.QFont.Normal)
         self._window.setFont(font)

--- a/openpype/tools/pyblish_pype/model.py
+++ b/openpype/tools/pyblish_pype/model.py
@@ -25,6 +25,8 @@ Roles:
 """
 from __future__ import unicode_literals
 
+import os
+
 import pyblish
 
 from . import settings, util
@@ -110,10 +112,15 @@ class IntentModel(QtGui.QStandardItemModel):
             .get("intent", {})
         )
 
-        default = intents_preset.get("default")
         items = intents_preset.get("items", {})
         if not items:
             return
+
+        env_default_intent = os.getenv("PYBLISH_DEFAULT_INTENT")
+        if env_default_intent and env_default_intent in items.keys():
+            default = env_default_intent
+        else:
+            default = intents_preset.get("default")
 
         for idx, item_value in enumerate(items.keys()):
             if item_value == default:


### PR DESCRIPTION
The goal is to provide environment variables to preset pyblish behaviour before launching it.

Those variables can be used with the maya "Script Menu Definition" for example to create shortcut for the operator to quickly publish, review, or render his work without having to activate/deactivate instances or plugins within pyblish

### Work to come
- [x] "PYBLISH_FAMILY_WHITELIST", force pyblish to only considere whitelisted families
- [x] "PYBLISH_DEFAULT_INTENT", use this value as default intent
- [x] "PYBLISH_TITLE", Override pyblish window title 