### PR TITLE
Nuke: inventory update removes all loaded read nodes

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -49,8 +49,11 @@ def get_review_presets_config():
 
 class NukeLoader(api.Loader):
     container_id_knob = "containerId"
-    container_id = ''.join(random.choice(
-        string.ascii_uppercase + string.digits) for _ in range(10))
+    container_id = None
+
+    def reset_container_id(self):
+        self.container_id = ''.join(random.choice(
+            string.ascii_uppercase + string.digits) for _ in range(10))
 
     def get_container_id(self, node):
         id_knob = node.knobs().get(self.container_id_knob)
@@ -67,13 +70,16 @@ class NukeLoader(api.Loader):
         source_id = self.get_container_id(node)
 
         if source_id:
-            node[self.container_id_knob].setValue(self.container_id)
+            node[self.container_id_knob].setValue(source_id)
         else:
             HIDEN_FLAG = 0x00040000
             _knob = anlib.Knobby(
                 "String_Knob",
                 self.container_id,
-                flags=[nuke.READ_ONLY, HIDEN_FLAG])
+                flags=[
+                    nuke.READ_ONLY,
+                    HIDEN_FLAG
+                ])
             knob = _knob.create(self.container_id_knob)
             node.addKnob(knob)
 

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -251,8 +251,7 @@ class LoadClip(plugin.NukeLoader):
                 "handleStart": str(self.handle_start),
                 "handleEnd": str(self.handle_end),
                 "fps": str(version_data.get("fps")),
-                "author": version_data.get("author"),
-                "outputDir": version_data.get("outputDir"),
+                "author": version_data.get("author")
             }
 
             # change color of read_node

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -67,6 +67,9 @@ class LoadClip(plugin.NukeLoader):
 
     def load(self, context, name, namespace, options):
 
+        # reste container id so it is always unique for each instance
+        self.reset_container_id()
+
         is_sequence = len(context["representation"]["files"]) > 1
 
         file = self.fname.replace("\\", "/")

--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -217,8 +217,7 @@ class LoadImage(api.Loader):
             "colorspace": version_data.get("colorspace"),
             "source": version_data.get("source"),
             "fps": str(version_data.get("fps")),
-            "author": version_data.get("author"),
-            "outputDir": version_data.get("outputDir"),
+            "author": version_data.get("author")
         })
 
         # change color of node

--- a/openpype/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/openpype/hosts/nuke/plugins/load/load_script_precomp.py
@@ -135,8 +135,7 @@ class LinkAsGroup(api.Loader):
             "source": version["data"].get("source"),
             "handles": version["data"].get("handles"),
             "fps": version["data"].get("fps"),
-            "author": version["data"].get("author"),
-            "outputDir": version["data"].get("outputDir"),
+            "author": version["data"].get("author")
         })
 
         # Update the imprinted representation


### PR DESCRIPTION
adding to nuke loader plugin abstract class method for securing uniqueness of cotainer id for each loaded container node members