### PR TITLE
Maya: Deadline - fix limit groups

### DIFF
--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -288,6 +288,22 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
                 "pluginInfo", {})
         )
 
+        self.limit_groups = (
+            context.data["project_settings"].get(
+                "deadline", {}).get(
+                "publish", {}).get(
+                "MayaSubmitDeadline", {}).get(
+                "limit", [])
+        )
+
+        self.group = (
+            context.data["project_settings"].get(
+                "deadline", {}).get(
+                "publish", {}).get(
+                "MayaSubmitDeadline", {}).get(
+                "group", "none")
+        )
+
         context = instance.context
         workspace = context.data["workspaceDir"]
         anatomy = context.data['anatomy']


### PR DESCRIPTION
## Bug

Submitting job from Maya to Deadline was ignoring Limits and Groups set in Settings.

Close #2172