### PR TITLE
General: Reduce vendor imports

### DIFF
--- a/openpype/hosts/aftereffects/api/__init__.py
+++ b/openpype/hosts/aftereffects/api/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from avalon import io
 from avalon import api as avalon
-from avalon.vendor import Qt
+from Qt import QtWidgets
 from openpype import lib, api
 import pyblish.api as pyblish
 import openpype.hosts.aftereffects
@@ -41,10 +41,10 @@ def check_inventory():
 
     # Warn about outdated containers.
     print("Starting new QApplication..")
-    app = Qt.QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
 
-    message_box = Qt.QtWidgets.QMessageBox()
-    message_box.setIcon(Qt.QtWidgets.QMessageBox.Warning)
+    message_box = QtWidgets.QMessageBox()
+    message_box.setIcon(QtWidgets.QMessageBox.Warning)
     msg = "There are outdated containers in the scene."
     message_box.setText(msg)
     message_box.exec_()

--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -1,5 +1,5 @@
 import openpype.api
-from avalon.vendor import Qt
+from Qt import QtWidgets
 from avalon import aftereffects
 
 import logging
@@ -56,7 +56,7 @@ class CreateRender(openpype.api.Creator):
         stub.rename_item(item.id, stub.PUBLISH_ICON + self.data["subset"])
 
     def _show_msg(self, txt):
-        msg = Qt.QtWidgets.QMessageBox()
-        msg.setIcon(Qt.QtWidgets.QMessageBox.Warning)
+        msg = QtWidgets.QMessageBox()
+        msg.setIcon(QtWidgets.QMessageBox.Warning)
         msg.setText(txt)
         msg.exec_()

--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -1,6 +1,6 @@
 import sys
 
-from avalon.vendor.Qt import QtGui
+from Qt import QtGui
 import avalon.fusion
 from avalon import io
 

--- a/openpype/hosts/fusion/plugins/inventory/set_tool_color.py
+++ b/openpype/hosts/fusion/plugins/inventory/set_tool_color.py
@@ -1,5 +1,5 @@
 from avalon import api, style
-from avalon.vendor.Qt import QtGui, QtWidgets
+from Qt import QtGui, QtWidgets
 
 import avalon.fusion
 

--- a/openpype/hosts/fusion/scripts/set_rendermode.py
+++ b/openpype/hosts/fusion/scripts/set_rendermode.py
@@ -1,4 +1,4 @@
-from avalon.vendor.Qt import QtWidgets
+from Qt import QtWidgets
 from avalon.vendor import qtawesome
 import avalon.fusion as avalon
 

--- a/openpype/hosts/fusion/utility_scripts/switch_ui.py
+++ b/openpype/hosts/fusion/utility_scripts/switch_ui.py
@@ -2,12 +2,13 @@ import os
 import glob
 import logging
 
+from Qt import QtWidgets, QtCore
+
 import avalon.io as io
 import avalon.api as api
 import avalon.pipeline as pipeline
 import avalon.fusion
 import avalon.style as style
-from avalon.vendor.Qt import QtWidgets, QtCore
 from avalon.vendor import qtawesome as qta
 
 

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -5,13 +5,13 @@ import os
 import re
 import sys
 import ast
+import shutil
 import hiero
+from Qt import QtWidgets
 import avalon.api as avalon
 import avalon.io
-from avalon.vendor.Qt import QtWidgets
 from openpype.api import (Logger, Anatomy, get_anatomy_settings)
 from . import tags
-import shutil
 from compiler.ast import flatten
 
 try:

--- a/openpype/hosts/maya/api/__init__.py
+++ b/openpype/hosts/maya/api/__init__.py
@@ -138,7 +138,7 @@ def on_save(_):
 def on_open(_):
     """On scene open let's assume the containers have changed."""
 
-    from avalon.vendor.Qt import QtWidgets
+    from Qt import QtWidgets
     from openpype.widgets import popup
 
     cmds.evalDeferred(

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -6,19 +6,19 @@ import platform
 import uuid
 import math
 
-import bson
 import json
 import logging
 import itertools
 import contextlib
 from collections import OrderedDict, defaultdict
 from math import ceil
+from six import string_types
+import bson
 
 from maya import cmds, mel
 import maya.api.OpenMaya as om
 
 from avalon import api, maya, io, pipeline
-from avalon.vendor.six import string_types
 import avalon.maya.lib
 import avalon.maya.interactive
 
@@ -1936,7 +1936,7 @@ def validate_fps():
 
     if current_fps != fps:
 
-        from avalon.vendor.Qt import QtWidgets
+        from Qt import QtWidgets
         from ...widgets import popup
 
         # Find maya main window
@@ -2694,7 +2694,7 @@ def update_content_on_context_change():
 
 
 def show_message(title, msg):
-    from avalon.vendor.Qt import QtWidgets
+    from Qt import QtWidgets
     from openpype.widgets import message_window
 
     # Find maya main window

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -133,7 +133,7 @@ class ImportMayaLoader(api.Loader):
 
         """
 
-        from avalon.vendor.Qt import QtWidgets
+        from Qt import QtWidgets
 
         accept = QtWidgets.QMessageBox.Ok
         buttons = accept | QtWidgets.QMessageBox.Cancel

--- a/openpype/hosts/maya/plugins/publish/collect_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/collect_yeti_rig.py
@@ -275,7 +275,7 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
             list: file sequence.
 
         """
-        from avalon.vendor import clique
+        import clique
 
         escaped = re.escape(filepath)
         re_pattern = escaped.replace(pattern, "-?[0-9]+")

--- a/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
+++ b/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
@@ -1,13 +1,14 @@
 import os
 import json
 import getpass
-import appdirs
 import platform
+
+import appdirs
+import requests
 
 from maya import cmds
 
 from avalon import api
-from avalon.vendor import requests
 
 import pyblish.api
 from openpype.hosts.maya.api import lib

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
@@ -89,8 +89,8 @@ class ValidateAssemblyModelTransforms(pyblish.api.InstancePlugin):
 
         """
 
+        from Qt import QtWidgets
         from openpype.hosts.maya.api import lib
-        from avalon.vendor.Qt import QtWidgets
 
         # Store namespace in variable, cosmetics thingy
         messagebox = QtWidgets.QMessageBox

--- a/openpype/hosts/maya/plugins/publish/validate_muster_connection.py
+++ b/openpype/hosts/maya/plugins/publish/validate_muster_connection.py
@@ -1,9 +1,10 @@
 import os
 import json
+
 import appdirs
+import requests
 
 import pyblish.api
-from avalon.vendor import requests
 from openpype.plugin import contextplugin_should_run
 import openpype.hosts.maya.api.action
 

--- a/openpype/hosts/photoshop/api/__init__.py
+++ b/openpype/hosts/photoshop/api/__init__.py
@@ -2,9 +2,10 @@ import os
 import sys
 import logging
 
+from Qt import QtWidgets
+
 from avalon import io
 from avalon import api as avalon
-from avalon.vendor import Qt
 from openpype import lib
 from pyblish import api as pyblish
 import openpype.hosts.photoshop
@@ -38,10 +39,10 @@ def check_inventory():
 
     # Warn about outdated containers.
     print("Starting new QApplication..")
-    app = Qt.QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
 
-    message_box = Qt.QtWidgets.QMessageBox()
-    message_box.setIcon(Qt.QtWidgets.QMessageBox.Warning)
+    message_box = QtWidgets.QMessageBox()
+    message_box.setIcon(QtWidgets.QMessageBox.Warning)
     msg = "There are outdated containers in the scene."
     message_box.setText(msg)
     message_box.exec_()

--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -1,5 +1,5 @@
+from Qt import QtWidgets
 import openpype.api
-from avalon.vendor import Qt
 from avalon import photoshop
 
 
@@ -26,21 +26,21 @@ class CreateImage(openpype.api.Creator):
             if len(selection) > 1:
                 # Ask user whether to create one image or image per selected
                 # item.
-                msg_box = Qt.QtWidgets.QMessageBox()
-                msg_box.setIcon(Qt.QtWidgets.QMessageBox.Warning)
+                msg_box = QtWidgets.QMessageBox()
+                msg_box.setIcon(QtWidgets.QMessageBox.Warning)
                 msg_box.setText(
                     "Multiple layers selected."
                     "\nDo you want to make one image per layer?"
                 )
                 msg_box.setStandardButtons(
-                    Qt.QtWidgets.QMessageBox.Yes |
-                    Qt.QtWidgets.QMessageBox.No |
-                    Qt.QtWidgets.QMessageBox.Cancel
+                    QtWidgets.QMessageBox.Yes |
+                    QtWidgets.QMessageBox.No |
+                    QtWidgets.QMessageBox.Cancel
                 )
                 ret = msg_box.exec_()
-                if ret == Qt.QtWidgets.QMessageBox.Yes:
+                if ret == QtWidgets.QMessageBox.Yes:
                     multiple_instances = True
-                elif ret == Qt.QtWidgets.QMessageBox.Cancel:
+                elif ret == QtWidgets.QMessageBox.Cancel:
                     return
 
                 if multiple_instances:

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_remote_publish.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_remote_publish.py
@@ -1,10 +1,10 @@
 import os
 import json
 
+import requests
 import hou
 
 from avalon import api, io
-from avalon.vendor import requests
 
 import pyblish.api
 

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -2,8 +2,8 @@ import os
 import json
 import getpass
 
+import requests
 from avalon import api
-from avalon.vendor import requests
 
 import pyblish.api
 

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -1,10 +1,11 @@
 import os
+import re
 import json
 import getpass
 
+import requests
+
 from avalon import api
-from avalon.vendor import requests
-import re
 import pyblish.api
 import nuke
 

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
@@ -5,10 +5,11 @@ import os
 import json
 import re
 from copy import copy, deepcopy
+import requests
+import clique
 import openpype.api
 
 from avalon import api, io
-from avalon.vendor import requests, clique
 
 import pyblish.api
 

--- a/openpype/modules/default_modules/deadline/plugins/publish/validate_deadline_connection.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/validate_deadline_connection.py
@@ -1,7 +1,7 @@
-import pyblish.api
-
-from avalon.vendor import requests
 import os
+import requests
+
+import pyblish.api
 
 
 class ValidateDeadlineConnection(pyblish.api.InstancePlugin):

--- a/openpype/modules/default_modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/validate_expected_and_rendered_files.py
@@ -1,8 +1,8 @@
 import os
 import json
-import pyblish.api
+import requests
 
-from avalon.vendor import requests
+import pyblish.api
 
 from openpype.lib.abstract_submit_deadline import requests_get
 from openpype.lib.delivery import collect_frames

--- a/openpype/modules/default_modules/royal_render/plugins/publish/collect_sequences_from_job.py
+++ b/openpype/modules/default_modules/royal_render/plugins/publish/collect_sequences_from_job.py
@@ -17,7 +17,7 @@ def collect(root,
             frame_end=None):
     """Collect sequence collections in root"""
 
-    from avalon.vendor import clique
+    import clique
 
     files = []
     for filename in os.listdir(root):

--- a/openpype/plugins/load/copy_file.py
+++ b/openpype/plugins/load/copy_file.py
@@ -18,7 +18,7 @@ class CopyFile(api.Loader):
 
     @staticmethod
     def copy_file_to_clipboard(path):
-        from avalon.vendor.Qt import QtCore, QtWidgets
+        from Qt import QtCore, QtWidgets
 
         clipboard = QtWidgets.QApplication.clipboard()
         assert clipboard, "Must have running QApplication instance"

--- a/openpype/plugins/load/copy_file_path.py
+++ b/openpype/plugins/load/copy_file_path.py
@@ -19,7 +19,7 @@ class CopyFilePath(api.Loader):
 
     @staticmethod
     def copy_path_to_clipboard(path):
-        from avalon.vendor.Qt import QtWidgets
+        from Qt import QtWidgets
 
         clipboard = QtWidgets.QApplication.clipboard()
         assert clipboard, "Must have running QApplication instance"

--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -5,9 +5,9 @@ import uuid
 import clique
 from pymongo import UpdateOne
 import ftrack_api
+from Qt import QtWidgets, QtCore
 
 from avalon import api, style
-from avalon.vendor.Qt import QtWidgets, QtCore
 from avalon.vendor import qargparse
 from avalon.api import AvalonMongoDB
 import avalon.pipeline

--- a/openpype/plugins/load/open_djv.py
+++ b/openpype/plugins/load/open_djv.py
@@ -32,7 +32,7 @@ class OpenInDJV(api.Loader):
 
     def load(self, context, name, namespace, data):
         directory = os.path.dirname(self.fname)
-        from avalon.vendor import clique
+        import clique
 
         pattern = clique.PATTERNS["frames"]
         files = os.listdir(directory)

--- a/openpype/plugins/load/open_file.py
+++ b/openpype/plugins/load/open_file.py
@@ -27,7 +27,7 @@ class Openfile(api.Loader):
     color = "orange"
 
     def load(self, context, name, namespace, data):
-        from avalon.vendor import clique
+        import clique
 
         directory = os.path.dirname(self.fname)
         pattern = clique.PATTERNS["frames"]

--- a/openpype/tools/assetcreator/model.py
+++ b/openpype/tools/assetcreator/model.py
@@ -1,8 +1,7 @@
 import re
 import logging
-import collections
 
-from avalon.vendor.Qt import QtCore, QtWidgets
+from Qt import QtCore, QtWidgets
 from avalon.vendor import qtawesome
 from avalon import io
 from avalon import style

--- a/openpype/widgets/message_window.py
+++ b/openpype/widgets/message_window.py
@@ -1,6 +1,6 @@
-from Qt import QtWidgets, QtCore
 import sys
 import logging
+from Qt import QtWidgets, QtCore
 
 log = logging.getLogger(__name__)
 

--- a/openpype/widgets/popup.py
+++ b/openpype/widgets/popup.py
@@ -3,7 +3,7 @@ import logging
 import contextlib
 
 
-from avalon.vendor.Qt import QtCore, QtWidgets, QtGui
+from Qt import QtCore, QtWidgets, QtGui
 
 log = logging.getLogger(__name__)
 

--- a/openpype/widgets/popup.py
+++ b/openpype/widgets/popup.py
@@ -3,7 +3,7 @@ import logging
 import contextlib
 
 
-from Qt import QtCore, QtWidgets, QtGui
+from Qt import QtCore, QtWidgets
 
 log = logging.getLogger(__name__)
 

--- a/openpype/widgets/project_settings.py
+++ b/openpype/widgets/project_settings.py
@@ -1,9 +1,8 @@
-
-
-from avalon.vendor.Qt import QtCore, QtGui, QtWidgets
 import os
 import getpass
 import platform
+
+from Qt import QtCore, QtGui, QtWidgets
 
 from avalon import style
 import ftrack_api


### PR DESCRIPTION
## Changes
- removed imports from avalon vendor and expect that modules are available in sys path
    - modules imported from avalon vendor were `Qt`, `clique`, `six` and `requests`
    - all of them must be in sys path else almost everything wouldn't work