### PR TITLE
Workfiles tool: Fix task formatting

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -100,7 +100,9 @@ class NameWindow(QtWidgets.QDialog):
 
         # Store project anatomy
         self.anatomy = anatomy
-        self.template = anatomy.templates[template_key]["file"]
+        self.template = anatomy.templates[template_key]["file"].replace(
+            "{task}", "{task[name]}"
+        )
         self.template_key = template_key
 
         # Btns widget


### PR DESCRIPTION
## Issue
- workfiles tool can't find latest version because does not expect that templates from anatomy may contain `{task}` but should expect `{task[name]}`

## Changes
- replace `{task}` with `{task[name]}` in loaded template

## How to test
- open workfiles tool
- select context where already are some workfiles
- click of "Save as"
- write any comment to input and the version should be right (before created version 1)