### PR TITLE
Maya: color management policy file to anatomy imageIO attributes

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2818,3 +2818,21 @@ def set_colorspace():
     cmds.colorManagementPrefs(e=True, renderingSpaceName=renderSpace)
     viewTransform = root_dict["viewTransform"]
     cmds.colorManagementPrefs(e=True, viewTransformName=viewTransform)
+
+    # forth set policy path
+    if root_dict.get("policyFilePath"):
+        unresolved_path = root_dict["policyFilePath"]
+        policy_paths = unresolved_path[platform.system().lower()]
+
+        resolved_path = None
+        for policy_p in policy_paths:
+            resolved_path = str(policy_p).format(**os.environ)
+            if not os.path.exists(resolved_path):
+                continue
+
+        if resolved_path:
+            filepath = str(resolved_path).replace("\\", "/")
+            os.environ["MAYA_COLOR_MANAGEMENT_POLICY_FILE"] = filepath
+            log.debug("maya '{}' changed to: {}".format(
+                "policyFilePath", resolved_path))
+            root_dict.pop("policyFilePath")

--- a/openpype/settings/defaults/project_anatomy/imageio.json
+++ b/openpype/settings/defaults/project_anatomy/imageio.json
@@ -181,7 +181,12 @@
                 "linux": []
             },
             "renderSpace": "scene-linear Rec 709/sRGB",
-            "viewTransform": "sRGB gamma"
+            "viewTransform": "sRGB gamma",
+            "policyFilePath": {
+                "windows": [],
+                "darwin": [],
+                "linux": []
+            }
         }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -363,7 +363,7 @@
             "key": "maya",
             "type": "dict",
             "label": "Maya",
-            "children": [    
+            "children": [
                 {
                     "key": "colorManagementPreference",
                     "type": "dict",
@@ -386,6 +386,13 @@
                             "type": "text",
                             "key": "viewTransform",
                             "label": "Viewer Transform"
+                        },
+                        {
+                            "type": "path",
+                            "key": "policyFilePath",
+                            "label": "Maya color managment policy file path",
+                            "multiplatform": true,
+                            "multipath": true
                         }
                     ]
             }


### PR DESCRIPTION
# Description

Add color management policy to `anatomy` >> `Maya` >> `color management` attributes.
by set `MAYA_COLOR_MANAGEMENT_POLICY_FILE` environment variable.

# Testing Notes

1. Set the color management policy path `Create 3d Model`.
2. Open or create Maya work file.

closes https://github.com/pypeclub/OpenPype/issues/2300