### PR TITLE
Deadline timeout and logging

### DIFF
--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -59,7 +59,7 @@ def validate_mongo_connection(cnx: str) -> (bool, str):
         return False, "Not mongodb schema"
 
     kwargs = {
-        "serverSelectionTimeoutMS": 2000
+        "serverSelectionTimeoutMS": os.environ.get("AVALON_TIMEOUT", 2000)
     }
     # Add certificate path if should be required
     if should_add_certificate_path_to_mongo_url(cnx):

--- a/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
+++ b/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
@@ -86,7 +86,7 @@ def inject_openpype_environment(deadlinePlugin):
             print(">>> Exception {}".format(e.output))
         import traceback
         print(traceback.format_exc())
-        print("inject_openpype_environment failed")
+        print("!!! Injection failed.")
         RepositoryUtils.FailJob(job)
         raise
 

--- a/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
+++ b/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
@@ -63,6 +63,7 @@ def inject_openpype_environment(deadlinePlugin):
 
         env = os.environ
         env["OPENPYPE_HEADLESS_MODE"] = "1"
+        env["AVALON_TIMEOUT"] = "5000"
 
         print(">>> Executing: {}".format(args))
         std_output = subprocess.check_output(args,

--- a/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
+++ b/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
@@ -28,7 +28,7 @@ def inject_openpype_environment(deadlinePlugin):
                 "The path to the render executable can be configured " +
                 "from the Plugin Configuration in the Deadline Monitor.")
 
-        print("--- penPype executable: {}".format(openpype_app))
+        print("--- OpenPype executable: {}".format(openpype_app))
 
         # tempfile.TemporaryFile cannot be used because of locking
         export_url = os.path.join(tempfile.gettempdir(),


### PR DESCRIPTION
When Deadline nodes are located in the cloud and spun up dynamically it sometimes produces issue of OP not connecting to Mongo resulting in weird failures.

Added more logging to GlobalJobPreload for better debugging, added possibility to drive timeout by AVALON_TIMEOUT, added explicit high timeout to GlobalJobPrelod.

How to test it:
---------------
This is difficult, only just by introducing connection lag to DB which would be noticeable when DL job is triggered.