### PR TITLE
General: Don't validate vendor bin with executing them

### DIFF
--- a/start.py
+++ b/start.py
@@ -100,7 +100,7 @@ import platform
 import traceback
 import subprocess
 import site
-import distutils
+import distutils.spawn
 from pathlib import Path
 
 # OPENPYPE_ROOT is variable pointing to build (or code) directory

--- a/start.py
+++ b/start.py
@@ -451,9 +451,8 @@ def _validate_thirdparty_binaries():
     oiio_result = None
     if oiio_tool_path is not None:
         oiio_result = distutils.spawn.find_executable(oiio_tool_path)
-
-    if oiio_result is None:
-        raise RuntimeError(error_msg.format("OpenImageIO"))
+        if oiio_result is None:
+            raise RuntimeError(error_msg.format("OpenImageIO"))
 
 
 def _process_arguments() -> tuple:


### PR DESCRIPTION
## Issue
Vendorized binaries existence is validated by executing their executables which is slow and triggering console windows from openpype gui.

## Changes
- validation happens by checking existence of executables