### PR TITLE
Input links: Cleanup and unification of differences

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -273,7 +273,15 @@ def get_linked_asset_ids(asset_doc):
 
     input_links = asset_doc["data"].get("inputsLinks") or []
     if input_links:
-        output = [item["_id"] for item in input_links]
+        for item in input_links:
+            # Backwards compatibility for "_id" key which was replaced with
+            #   "id"
+            if "_id" in item:
+                link_id = item["_id"]
+            else:
+                link_id = item["id"]
+            output.append(link_id)
+
     return output
 
 

--- a/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_links.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_links.py
@@ -113,7 +113,7 @@ class SyncLinksToAvalon(BaseEvent):
                     continue
 
                 links.append({
-                    "_id": ObjectId(link_mongo_id),
+                    "id": ObjectId(link_mongo_id),
                     "linkedBy": "ftrack",
                     "type": "breakdown"
                 })

--- a/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
@@ -1479,7 +1479,7 @@ class SyncEntitiesFactory:
                 mongo_id = self.ftrack_avalon_mapper.get(ftrack_link_id)
                 if mongo_id is not None:
                     input_links.append({
-                        "_id": ObjectId(mongo_id),
+                        "id": ObjectId(mongo_id),
                         "linkedBy": "ftrack",
                         "type": "breakdown"
                     })

--- a/openpype/plugins/publish/integrate_inputlinks.py
+++ b/openpype/plugins/publish/integrate_inputlinks.py
@@ -103,7 +103,7 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
         # future.
         link = OrderedDict()
         link["type"] = link_type
-        link["input"] = io.ObjectId(input_id)
+        link["id"] = io.ObjectId(input_id)
         link["linkedBy"] = "publish"
 
         if "inputLinks" not in version_doc["data"]:

--- a/openpype/plugins/publish/integrate_inputlinks.py
+++ b/openpype/plugins/publish/integrate_inputlinks.py
@@ -55,6 +55,7 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
 
         if workfile is None:
             self.log.warn("No workfile in this publish session.")
+            return
         else:
             workfile_version_doc = workfile.data["versionEntity"]
             # link all loaded versions in scene into workfile

--- a/openpype/plugins/publish/integrate_inputlinks.py
+++ b/openpype/plugins/publish/integrate_inputlinks.py
@@ -56,22 +56,22 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
         if workfile is None:
             self.log.warn("No workfile in this publish session.")
             return
-        else:
-            workfile_version_doc = workfile.data["versionEntity"]
-            # link all loaded versions in scene into workfile
-            for version in context.data.get("loadedVersions", []):
-                self.add_link(
-                    link_type="reference",
-                    input_id=version["version"],
-                    version_doc=workfile_version_doc,
-                )
-            # link workfile to all publishing versions
-            for instance in publishing:
-                self.add_link(
-                    link_type="generative",
-                    input_id=workfile_version_doc["_id"],
-                    version_doc=instance.data["versionEntity"],
-                )
+
+        workfile_version_doc = workfile.data["versionEntity"]
+        # link all loaded versions in scene into workfile
+        for version in context.data.get("loadedVersions", []):
+            self.add_link(
+                link_type="reference",
+                input_id=version["version"],
+                version_doc=workfile_version_doc,
+            )
+        # link workfile to all publishing versions
+        for instance in publishing:
+            self.add_link(
+                link_type="generative",
+                input_id=workfile_version_doc["_id"],
+                version_doc=instance.data["versionEntity"],
+            )
 
         # link versions as dependencies to the instance
         for instance in publishing:

--- a/openpype/plugins/publish/integrate_inputlinks.py
+++ b/openpype/plugins/publish/integrate_inputlinks.py
@@ -55,23 +55,22 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
 
         if workfile is None:
             self.log.warn("No workfile in this publish session.")
-            return
-
-        workfile_version_doc = workfile.data["versionEntity"]
-        # link all loaded versions in scene into workfile
-        for version in context.data.get("loadedVersions", []):
-            self.add_link(
-                link_type="reference",
-                input_id=version["version"],
-                version_doc=workfile_version_doc,
-            )
-        # link workfile to all publishing versions
-        for instance in publishing:
-            self.add_link(
-                link_type="generative",
-                input_id=workfile_version_doc["_id"],
-                version_doc=instance.data["versionEntity"],
-            )
+        else:
+            workfile_version_doc = workfile.data["versionEntity"]
+            # link all loaded versions in scene into workfile
+            for version in context.data.get("loadedVersions", []):
+                self.add_link(
+                    link_type="reference",
+                    input_id=version["version"],
+                    version_doc=workfile_version_doc,
+                )
+            # link workfile to all publishing versions
+            for instance in publishing:
+                self.add_link(
+                    link_type="generative",
+                    input_id=workfile_version_doc["_id"],
+                    version_doc=instance.data["versionEntity"],
+                )
 
         # link versions as dependencies to the instance
         for instance in publishing:
@@ -82,7 +81,8 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
                     version_doc=instance.data["versionEntity"],
                 )
 
-        publishing.append(workfile)
+        if workfile is not None:
+            publishing.append(workfile)
         self.write_links_to_database(publishing)
 
     def add_link(self, link_type, input_id, version_doc):

--- a/openpype/tools/assetlinks/widgets.py
+++ b/openpype/tools/assetlinks/widgets.py
@@ -37,8 +37,13 @@ class SimpleLinkView(QtWidgets.QWidget):
         # inputs
         #
         for link in version_doc["data"].get("inputLinks", []):
+            # Backwards compatibility for "input" key used as "id"
+            if "id" not in link:
+                link_id = link["input"]
+            else:
+                link_id = link["id"]
             version = self.dbcon.find_one(
-                {"_id": link["input"], "type": "version"},
+                {"_id": link_id, "type": "version"},
                 projection={"name": 1, "parent": 1}
             )
             if not version:


### PR DESCRIPTION
## Issue
- we have more variants of "id key" in item of `inpuLinks`
- plugin `IntegrateInputLinks` crashes if workfile is not published (there is a lot of cases when workfile is not published)

## Changes
- plugin `IntegrateInputLinks` skips workfile related linking if is not found
- unified id key to `id` (kept backwards compatibility)

## Notes
- should I add "auto-fix" of id keys
- we should be able to find link even without workfile instance in future