### PR TITLE
Tray: Paint splash and tray before initialization logic

### DIFF
--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -370,6 +370,8 @@ class PypeTrayStarter(QtCore.QObject):
             splash = self._get_splash()
             splash.show()
             self._tray_widget.show()
+            # Make sure tray and splash are painted out
+            QtWidgets.QApplication.processEvents()
 
         elif self._timer_counter == 1:
             self._timer_counter += 1

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -374,6 +374,8 @@ class PypeTrayStarter(QtCore.QObject):
             QtWidgets.QApplication.processEvents()
 
         elif self._timer_counter == 1:
+            # Second processing of events to make sure splash is painted
+            QtWidgets.QApplication.processEvents()
             self._timer_counter += 1
             self._tray_widget.initialize_modules()
 


### PR DESCRIPTION
## Description
Sometimes may happen that splash is not painted properly because it's painting is interrupted with triggered logic and don't have process time to do so.

## Changes
- make sure splash and tray icon are painted before triggering initialization logic

### How to test
- run tray on any device
- most visible change is on linux machine Centos 7 GNOME