### PR TITLE
Timers Manager: Disable auto stop timer on linux platform

### DIFF
--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -95,8 +95,10 @@ class TimersManager(OpenPypeModule, ITrayService):
         message_time = int(timers_settings["message_time"] * 60)
 
         auto_stop = timers_settings["auto_stop"]
+        platform_name = platform.system().lower()
         # Turn of auto stop on MacOs because pynput requires root permissions
-        if platform.system().lower() == "darwin" or full_time <= 0:
+        #    and on linux can cause thread locks on application close
+        if full_time <= 0 or platform_name in ("darwin", "linux"):
             auto_stop = False
 
         self.auto_stop = auto_stop


### PR DESCRIPTION
## Issue
Threads listening for mouse and keyboard events may cause thread lock on linux platform which cause that main process won't exit. It can cause that next process of OpenPype tray won't be initialized properly.

## Changes
- disable auto stop timer for linux platform

## Note
Python module `pynput` is not written in a way we need to use it so we should check for different solution of this feature.