### PR TITLE
Tools: Use Qt context on tools show

### DIFF
--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -5,6 +5,7 @@ use singleton approach with global functions (using helper anyway).
 """
 
 import avalon.api
+from .lib import qt_app_context
 
 
 class HostToolsHelper:
@@ -61,22 +62,23 @@ class HostToolsHelper:
         if save is None:
             save = True
 
-        workfiles_tool = self.get_workfiles_tool(parent)
-        workfiles_tool.set_save_enabled(save)
+        with qt_app_context():
+            workfiles_tool = self.get_workfiles_tool(parent)
+            workfiles_tool.set_save_enabled(save)
 
-        if not workfiles_tool.isVisible():
-            workfiles_tool.show()
+            if not workfiles_tool.isVisible():
+                workfiles_tool.show()
 
-            if use_context:
-                context = {
-                    "asset": avalon.api.Session["AVALON_ASSET"],
-                    "task": avalon.api.Session["AVALON_TASK"]
-                }
-                workfiles_tool.set_context(context)
+                if use_context:
+                    context = {
+                        "asset": avalon.api.Session["AVALON_ASSET"],
+                        "task": avalon.api.Session["AVALON_TASK"]
+                    }
+                    workfiles_tool.set_context(context)
 
-        # Pull window to the front.
-        workfiles_tool.raise_()
-        workfiles_tool.activateWindow()
+            # Pull window to the front.
+            workfiles_tool.raise_()
+            workfiles_tool.activateWindow()
 
     def get_loader_tool(self, parent):
         """Create, cache and return loader tool window."""
@@ -90,20 +92,21 @@ class HostToolsHelper:
 
     def show_loader(self, parent=None, use_context=None):
         """Loader tool for loading representations."""
-        loader_tool = self.get_loader_tool(parent)
+        with qt_app_context():
+            loader_tool = self.get_loader_tool(parent)
 
-        loader_tool.show()
-        loader_tool.raise_()
-        loader_tool.activateWindow()
+            loader_tool.show()
+            loader_tool.raise_()
+            loader_tool.activateWindow()
 
-        if use_context is None:
-            use_context = False
+            if use_context is None:
+                use_context = False
 
-        if use_context:
-            context = {"asset": avalon.api.Session["AVALON_ASSET"]}
-            loader_tool.set_context(context, refresh=True)
-        else:
-            loader_tool.refresh()
+            if use_context:
+                context = {"asset": avalon.api.Session["AVALON_ASSET"]}
+                loader_tool.set_context(context, refresh=True)
+            else:
+                loader_tool.refresh()
 
     def get_creator_tool(self, parent):
         """Create, cache and return creator tool window."""
@@ -117,13 +120,14 @@ class HostToolsHelper:
 
     def show_creator(self, parent=None):
         """Show tool to create new instantes for publishing."""
-        creator_tool = self.get_creator_tool(parent)
-        creator_tool.refresh()
-        creator_tool.show()
+        with qt_app_context():
+            creator_tool = self.get_creator_tool(parent)
+            creator_tool.refresh()
+            creator_tool.show()
 
-        # Pull window to the front.
-        creator_tool.raise_()
-        creator_tool.activateWindow()
+            # Pull window to the front.
+            creator_tool.raise_()
+            creator_tool.activateWindow()
 
     def get_subset_manager_tool(self, parent):
         """Create, cache and return subset manager tool window."""
@@ -139,12 +143,13 @@ class HostToolsHelper:
 
     def show_subset_manager(self, parent=None):
         """Show tool display/remove existing created instances."""
-        subset_manager_tool = self.get_subset_manager_tool(parent)
-        subset_manager_tool.show()
+        with qt_app_context():
+            subset_manager_tool = self.get_subset_manager_tool(parent)
+            subset_manager_tool.show()
 
-        # Pull window to the front.
-        subset_manager_tool.raise_()
-        subset_manager_tool.activateWindow()
+            # Pull window to the front.
+            subset_manager_tool.raise_()
+            subset_manager_tool.activateWindow()
 
     def get_scene_inventory_tool(self, parent):
         """Create, cache and return scene inventory tool window."""
@@ -160,13 +165,14 @@ class HostToolsHelper:
 
     def show_scene_inventory(self, parent=None):
         """Show tool maintain loaded containers."""
-        scene_inventory_tool = self.get_scene_inventory_tool(parent)
-        scene_inventory_tool.show()
-        scene_inventory_tool.refresh()
+        with qt_app_context():
+            scene_inventory_tool = self.get_scene_inventory_tool(parent)
+            scene_inventory_tool.show()
+            scene_inventory_tool.refresh()
 
-        # Pull window to the front.
-        scene_inventory_tool.raise_()
-        scene_inventory_tool.activateWindow()
+            # Pull window to the front.
+            scene_inventory_tool.raise_()
+            scene_inventory_tool.activateWindow()
 
     def get_library_loader_tool(self, parent):
         """Create, cache and return library loader tool window."""
@@ -182,11 +188,12 @@ class HostToolsHelper:
 
     def show_library_loader(self, parent=None):
         """Loader tool for loading representations from library project."""
-        library_loader_tool = self.get_library_loader_tool(parent)
-        library_loader_tool.show()
-        library_loader_tool.raise_()
-        library_loader_tool.activateWindow()
-        library_loader_tool.refresh()
+        with qt_app_context():
+            library_loader_tool = self.get_library_loader_tool(parent)
+            library_loader_tool.show()
+            library_loader_tool.raise_()
+            library_loader_tool.activateWindow()
+            library_loader_tool.refresh()
 
     def show_publish(self, parent=None):
         """Publish UI."""
@@ -207,9 +214,10 @@ class HostToolsHelper:
         """Look manager is Maya specific tool for look management."""
         from avalon import style
 
-        look_assigner_tool = self.get_look_assigner_tool(parent)
-        look_assigner_tool.show()
-        look_assigner_tool.setStyleSheet(style.load_stylesheet())
+        with qt_app_context():
+            look_assigner_tool = self.get_look_assigner_tool(parent)
+            look_assigner_tool.show()
+            look_assigner_tool.setStyleSheet(style.load_stylesheet())
 
     def get_experimental_tools_dialog(self, parent=None):
         """Dialog of experimental tools.
@@ -232,11 +240,12 @@ class HostToolsHelper:
 
     def show_experimental_tools_dialog(self, parent=None):
         """Show dialog with experimental tools."""
-        dialog = self.get_experimental_tools_dialog(parent)
+        with qt_app_context():
+            dialog = self.get_experimental_tools_dialog(parent)
 
-        dialog.show()
-        dialog.raise_()
-        dialog.activateWindow()
+            dialog.show()
+            dialog.raise_()
+            dialog.activateWindow()
 
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.


### PR DESCRIPTION
## Issue
Some hosts don't have Qt Application initialized on start and triggering show of tool cause crash. Currently it broke Unreal integration.

## Changes
- us Qt Application context when showing qt tools