### PR TITLE
Maya Look Assigner: Fix Python 3 compatibility

### DIFF
--- a/openpype/tools/mayalookassigner/models.py
+++ b/openpype/tools/mayalookassigner/models.py
@@ -101,7 +101,8 @@ class LookModel(models.TreeModel):
             for look in asset_item["looks"]:
                 look_subsets[look["name"]].append(asset)
 
-        for subset, assets in sorted(look_subsets.iteritems()):
+        for subset in sorted(look_subsets.keys()):
+            assets = look_subsets[subset]
 
             # Define nice label without "look" prefix for readability
             label = subset if not subset.startswith("look") else subset[4:]


### PR DESCRIPTION
## Issue
There is one loop over dictionary where `iteritems` is called which is not Python 3 compatible.

## Changes
- iterate over sorted keys and then get value from dictionary