### PR TITLE
Launcher: Minimize button on MacOs

### DIFF
--- a/openpype/tools/launcher/window.py
+++ b/openpype/tools/launcher/window.py
@@ -243,7 +243,11 @@ class LauncherWindow(QtWidgets.QDialog):
 
         # Allow minimize
         self.setWindowFlags(
-            self.windowFlags() | QtCore.Qt.WindowMinimizeButtonHint
+            QtCore.Qt.Window
+            | QtCore.Qt.CustomizeWindowHint
+            | QtCore.Qt.WindowTitleHint
+            | QtCore.Qt.WindowMinimizeButtonHint
+            | QtCore.Qt.WindowCloseButtonHint
         )
 
         project_model = ProjectModel(self.dbcon)


### PR DESCRIPTION
## Issue
Launcher does not have enabled minimize icon on MacOs.

## Changes
- set explicit window hints in launcher