### PR TITLE
Maya: Add is_static_image_plane and is_in_all_views option in imagePlaneLoader

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -82,7 +82,7 @@ class ImagePlaneLoader(api.Loader):
     icon = "image"
     color = "orange"
 
-    def load(self, context, name, namespace, data, option=None):
+    def load(self, context, name, namespace, data, options=None):
         import pymel.core as pm
 
         new_nodes = []

--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -128,16 +128,12 @@ class ImagePlaneLoader(api.Loader):
 
         # Create image plane
         image_plane_transform, image_plane_shape = pm.imagePlane(
+            fileName=context["representation"]["data"]["path"],
             camera=camera, showInAllViews=is_in_all_views
         )
         image_plane_shape.depth.set(image_plane_depth)
 
-        image_plane_shape.imageName.set(
-            context["representation"]["data"]["path"]
-        )
-
         if is_static_image_plane:
-            image_plane_shape.setMaintainRatio(True)
             image_plane_shape.detach()
             image_plane_transform.setRotation(camera.getRotation())
 

--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -13,10 +13,14 @@ class CameraWindow(QtWidgets.QDialog):
         self.setWindowFlags(self.windowFlags() | QtCore.Qt.FramelessWindowHint)
 
         self.camera = None
+        self.static_image_plane = False
+        self.show_in_all_views = False
 
         self.widgets = {
             "label": QtWidgets.QLabel("Select camera for image plane."),
             "list": QtWidgets.QListWidget(),
+            "staticImagePlane": QtWidgets.QCheckBox(),
+            "showInAllViews": QtWidgets.QCheckBox(),
             "warning": QtWidgets.QLabel("No cameras selected!"),
             "buttons": QtWidgets.QWidget(),
             "okButton": QtWidgets.QPushButton("Ok"),
@@ -31,6 +35,9 @@ class CameraWindow(QtWidgets.QDialog):
         for camera in cameras:
             self.widgets["list"].addItem(camera)
 
+        self.widgets["staticImagePlane"].setText("Make Image Plane Static")
+        self.widgets["showInAllViews"].setText("Show Image Plane in All Views")
+
         # Build buttons.
         layout = QtWidgets.QHBoxLayout(self.widgets["buttons"])
         layout.addWidget(self.widgets["okButton"])
@@ -40,6 +47,8 @@ class CameraWindow(QtWidgets.QDialog):
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(self.widgets["label"])
         layout.addWidget(self.widgets["list"])
+        layout.addWidget(self.widgets["staticImagePlane"])
+        layout.addWidget(self.widgets["showInAllViews"])
         layout.addWidget(self.widgets["buttons"])
         layout.addWidget(self.widgets["warning"])
 
@@ -54,6 +63,8 @@ class CameraWindow(QtWidgets.QDialog):
         if self.camera is None:
             self.widgets["warning"].setVisible(True)
             return
+        self.show_in_all_views = self.widgets["showInAllViews"].isChecked()
+        self.static_image_plane = self.widgets["staticImagePlane"].isChecked()
 
         self.close()
 
@@ -65,15 +76,15 @@ class CameraWindow(QtWidgets.QDialog):
 class ImagePlaneLoader(api.Loader):
     """Specific loader of plate for image planes on selected camera."""
 
-    families = ["plate", "render"]
+    families = ["image", "plate", "render"]
     label = "Load imagePlane."
     representations = ["mov", "exr", "preview", "png"]
     icon = "image"
     color = "orange"
 
-    def load(self, context, name, namespace, data):
+    def load(self, context, name, namespace, data, option=None):
         import pymel.core as pm
-        
+
         new_nodes = []
         image_plane_depth = 1000
         asset = context['asset']['name']
@@ -85,17 +96,15 @@ class ImagePlaneLoader(api.Loader):
 
         # Get camera from user selection.
         camera = None
-        default_cameras = [
-            "frontShape", "perspShape", "sideShape", "topShape"
-        ]
-        cameras = [
-            x for x in pm.ls(type="camera") if x.name() not in default_cameras
-        ]
+        cameras = pm.ls(type="camera")
         camera_names = {x.getParent().name(): x for x in cameras}
         camera_names["Create new camera."] = "create_camera"
         window = CameraWindow(camera_names.keys())
         window.exec_()
         camera = camera_names[window.camera]
+
+        is_static_image_plane = window.static_image_plane
+        is_in_all_views = window.show_in_all_views
 
         if camera == "create_camera":
             camera = pm.createNode("camera")
@@ -111,13 +120,16 @@ class ImagePlaneLoader(api.Loader):
 
         # Create image plane
         image_plane_transform, image_plane_shape = pm.imagePlane(
-            camera=camera, showInAllViews=False
+            camera=camera, showInAllViews=is_in_all_views
         )
         image_plane_shape.depth.set(image_plane_depth)
 
         image_plane_shape.imageName.set(
             context["representation"]["data"]["path"]
         )
+
+        if is_static_image_plane:
+            image_plane_shape.detach()
 
         start_frame = pm.playbackOptions(q=True, min=True)
         end_frame = pm.playbackOptions(q=True, max=True)

--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -96,15 +96,23 @@ class ImagePlaneLoader(api.Loader):
 
         # Get camera from user selection.
         camera = None
-        cameras = pm.ls(type="camera")
-        camera_names = {x.getParent().name(): x for x in cameras}
-        camera_names["Create new camera."] = "create_camera"
-        window = CameraWindow(camera_names.keys())
-        window.exec_()
-        camera = camera_names[window.camera]
+        is_static_image_plane = None
+        is_in_all_views = None
+        if data:
+            camera = pm.PyNode(data.get("camera"))
+            is_static_image_plane = data.get("static_image_plane")
+            is_in_all_views = data.get("in_all_views")
 
-        is_static_image_plane = window.static_image_plane
-        is_in_all_views = window.show_in_all_views
+        if not camera:
+            cameras = pm.ls(type="camera")
+            camera_names = {x.getParent().name(): x for x in cameras}
+            camera_names["Create new camera."] = "create_camera"
+            window = CameraWindow(camera_names.keys())
+            window.exec_()
+            camera = camera_names[window.camera]
+
+            is_static_image_plane = window.static_image_plane
+            is_in_all_views = window.show_in_all_views
 
         if camera == "create_camera":
             camera = pm.createNode("camera")
@@ -129,7 +137,9 @@ class ImagePlaneLoader(api.Loader):
         )
 
         if is_static_image_plane:
+            image_plane_shape.setMaintainRatio(True)
             image_plane_shape.detach()
+            image_plane_transform.setRotation(camera.getRotation())
 
         start_frame = pm.playbackOptions(q=True, min=True)
         end_frame = pm.playbackOptions(q=True, max=True)


### PR DESCRIPTION
I need to import images published of design in maya on the front and side view to serve as blueprint for the modeling. We add the optional possibility of having fixed and visible plane images in all windows.