### PR TITLE
Linux : flip updating submodules logic

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -178,10 +178,10 @@ main () {
   fi
 
 if [ "$disable_submodule_update" == 1 ]; then
-  echo -e "${BIGreen}>>>${RST} Making sure submodules are up-to-date ..."
-  git submodule update --init --recursive
+    echo -e "${BIYellow}***${RST} Not updating submodules ..."
   else
-     echo -e "${BIYellow}***${RST} Not updating submodules ..."
+    echo -e "${BIGreen}>>>${RST} Making sure submodules are up-to-date ..."
+    git submodule update --init --recursive
   fi
   echo -e "${BIGreen}>>>${RST} Building ..."
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
This is flipping logic on `--no-submodule-update` as it was wrong in linux build script. It should be same as on windows.