### PR TITLE
Webpublisher: Add target to TVPaint validator

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/validate_tvpaint_workfile_data.py
+++ b/openpype/hosts/webpublisher/plugins/publish/validate_tvpaint_workfile_data.py
@@ -11,6 +11,8 @@ class ValidateWorkfileData(pyblish.api.ContextPlugin):
     label = "Validate Workfile Data"
     order = pyblish.api.ValidatorOrder
 
+    targets = ["tvpaint_worker"]
+
     def process(self, context):
         # Data collected in `CollectAvalonEntities`
         frame_start = context.data["frameStart"]


### PR DESCRIPTION
## Issue
TVPaint validator is enabled for all webpublisher publishing.

## Changes
- add target to tvpaint related publishing