### PR TITLE
Nuke: fixing node name based on switched asset name

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -116,16 +116,7 @@ class LoadClip(plugin.NukeLoader):
                 "Representation id `{}` is failing to load".format(repr_id))
             return
 
-        name_data = {
-            "asset": repr_cont["asset"],
-            "subset": repr_cont["subset"],
-            "representation": context["representation"]["name"],
-            "ext": repr_cont["representation"],
-            "id": context["representation"]["_id"],
-            "class_name": self.__class__.__name__
-        }
-
-        read_name = self.node_name_template.format(**name_data)
+        read_name = self._get_node_name(context["representation"])
 
         # Create the Loader with the filename path set
         read_node = nuke.createNode(
@@ -143,7 +134,7 @@ class LoadClip(plugin.NukeLoader):
             elif iio_colorspace is not None:
                 read_node["colorspace"].setValue(iio_colorspace)
 
-            self.set_range_to_node(read_node, first, last, start_at_workfile)
+            self._set_range_to_node(read_node, first, last, start_at_workfile)
 
             # add additional metadata from the version to imprint Avalon knob
             add_keys = ["frameStart", "frameEnd",
@@ -171,7 +162,7 @@ class LoadClip(plugin.NukeLoader):
                 data=data_imprint)
 
         if version_data.get("retime", None):
-            self.make_retimes(read_node, version_data)
+            self._make_retimes(read_node, version_data)
 
         self.set_as_member(read_node)
 
@@ -230,6 +221,9 @@ class LoadClip(plugin.NukeLoader):
                 "Representation id `{}` is failing to load".format(repr_id))
             return
 
+        read_name = self._get_node_name(representation)
+
+        read_node["name"].setValue(read_name)
         read_node["file"].setValue(file)
 
         # to avoid multiple undo steps for rest of process
@@ -242,7 +236,7 @@ class LoadClip(plugin.NukeLoader):
             elif iio_colorspace is not None:
                 read_node["colorspace"].setValue(iio_colorspace)
 
-            self.set_range_to_node(read_node, first, last, start_at_workfile)
+            self._set_range_to_node(read_node, first, last, start_at_workfile)
 
             updated_dict = {
                 "representation": str(representation["_id"]),
@@ -279,20 +273,11 @@ class LoadClip(plugin.NukeLoader):
             self.log.info("udated to version: {}".format(version.get("name")))
 
         if version_data.get("retime", None):
-            self.make_retimes(read_node, version_data)
+            self._make_retimes(read_node, version_data)
         else:
             self.clear_members(read_node)
 
         self.set_as_member(read_node)
-
-    def set_range_to_node(self, read_node, first, last, start_at_workfile):
-        read_node['origfirst'].setValue(int(first))
-        read_node['first'].setValue(int(first))
-        read_node['origlast'].setValue(int(last))
-        read_node['last'].setValue(int(last))
-
-        # set start frame depending on workfile or version
-        self.loader_shift(read_node, start_at_workfile)
 
     def remove(self, container):
 
@@ -307,7 +292,16 @@ class LoadClip(plugin.NukeLoader):
             for member in members:
                 nuke.delete(member)
 
-    def make_retimes(self, parent_node, version_data):
+    def _set_range_to_node(self, read_node, first, last, start_at_workfile):
+        read_node['origfirst'].setValue(int(first))
+        read_node['first'].setValue(int(first))
+        read_node['origlast'].setValue(int(last))
+        read_node['last'].setValue(int(last))
+
+        # set start frame depending on workfile or version
+        self._loader_shift(read_node, start_at_workfile)
+
+    def _make_retimes(self, parent_node, version_data):
         ''' Create all retime and timewarping nodes with coppied animation '''
         speed = version_data.get('speed', 1)
         time_warp_nodes = version_data.get('timewarps', [])
@@ -360,7 +354,7 @@ class LoadClip(plugin.NukeLoader):
                 for i, n in enumerate(dependent_nodes):
                     last_node.setInput(i, n)
 
-    def loader_shift(self, read_node, workfile_start=False):
+    def _loader_shift(self, read_node, workfile_start=False):
         """ Set start frame of read node to a workfile start
 
         Args:
@@ -371,3 +365,17 @@ class LoadClip(plugin.NukeLoader):
         if workfile_start:
             read_node['frame_mode'].setValue("start at")
             read_node['frame'].setValue(str(self.script_start))
+
+    def _get_node_name(self, representation):
+
+        repr_cont = representation["context"]
+        name_data = {
+            "asset": repr_cont["asset"],
+            "subset": repr_cont["subset"],
+            "representation": representation["name"],
+            "ext": repr_cont["representation"],
+            "id": representation["_id"],
+            "class_name": self.__class__.__name__
+        }
+
+        return self.node_name_template.format(**name_data)


### PR DESCRIPTION
- also improving code

# Testing
- go to settings to your project overides `project_settings/nuke/load/LoadClip/node_name_template` and add following value "Read_{asset}_{subset}_{class_name}_{ext}", and save.
- load a subset X into nuke test scene
- open Manager and right button click at the loaded subset and go to Switch asset. 
- find another subset Y and hit confirm. 
- loader should change to other subset Y and also the name of node should change.  