### PR TITLE
Nuke: fixing menu re-drawing during context change 

### DIFF
--- a/openpype/hosts/nuke/api/__init__.py
+++ b/openpype/hosts/nuke/api/__init__.py
@@ -54,6 +54,10 @@ def install():
     ''' Installing all requarements for Nuke host
     '''
 
+    # remove all registred callbacks form avalon.nuke
+    from avalon import pipeline
+    pipeline._registered_event_handlers.clear()
+
     log.info("Registering Nuke plug-ins..")
     pyblish.api.register_plugin_path(PUBLISH_PATH)
     avalon.api.register_plugin_path(avalon.api.Loader, LOAD_PATH)
@@ -62,6 +66,7 @@ def install():
 
     # Register Avalon event for workfiles loading.
     avalon.api.on("workio.open_file", lib.check_inventory_versions)
+    avalon.api.on("taskChanged", menu.change_context_label)
 
     pyblish.api.register_callback(
         "instanceToggled", on_pyblish_instance_toggled)

--- a/openpype/hosts/nuke/api/menu.py
+++ b/openpype/hosts/nuke/api/menu.py
@@ -10,10 +10,43 @@ from openpype.tools.utils import host_tools
 log = Logger().get_logger(__name__)
 
 menu_label = os.environ["AVALON_LABEL"]
+context_label = None
+
+
+def change_context_label(*args):
+    global context_label
+    menubar = nuke.menu("Nuke")
+    menu = menubar.findItem(menu_label)
+
+    label = "{0}, {1}".format(
+        os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]
+    )
+
+    rm_item = [
+        (i, item) for i, item in enumerate(menu.items())
+        if context_label in item.name()
+    ][0]
+
+    menu.removeItem(rm_item[1].name())
+
+    context_action = menu.addCommand(
+        label,
+        index=(rm_item[0])
+    )
+    context_action.setEnabled(False)
+
+    log.info("Task label changed from `{}` to `{}`".format(
+        context_label, label))
+
+    context_label = label
+
 
 
 def install():
     from openpype.hosts.nuke.api import reload_config
+
+    global context_label
+
     # uninstall original avalon menu
     uninstall()
 
@@ -24,6 +57,7 @@ def install():
     label = "{0}, {1}".format(
         os.environ["AVALON_ASSET"], os.environ["AVALON_TASK"]
     )
+    context_label = label
     context_action = menu.addCommand(label)
     context_action.setEnabled(False)
 


### PR DESCRIPTION
When change of context on running Nuke session is done, the Openpype menu content is rolled back to the original avalon menu content.

Suggested team solution is to completely override avalon menu by openpype menu at start of nuke. 

# Testing
1. open nuke in context and open workfile, but do not change anything in the script
2. notice the context label in Openpype menu on top
3. open workfile and open other workfile from different task or asset
4. notice the context label in openpype menu has changed according to the context 