### PR TITLE
Blender 3: Support auto install for new blender version

### DIFF
--- a/openpype/hosts/blender/hooks/pre_pyside_install.py
+++ b/openpype/hosts/blender/hooks/pre_pyside_install.py
@@ -32,7 +32,7 @@ class InstallPySideToBlender(PreLaunchHook):
 
     def inner_execute(self):
         # Get blender's python directory
-        version_regex = re.compile(r"^2\.[0-9]{2}$")
+        version_regex = re.compile(r"^[2-3]\.[0-9]+$")
 
         executable = self.launch_context.executable.executable_path
         if os.path.basename(executable).lower() != "blender.exe":


### PR DESCRIPTION
## Description
Prelaunch hook installing PySide2 into Blender does not work with new 3.0 version and placeholder color set after showing may not be propagated in some cases.

## Changes
- regex searching for versioned subfolder of Blender has been modified to also expect `3.x` version