### PR TITLE
Enhancement: Settings: Use project settings values from another project

### DIFF
--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -110,9 +110,10 @@ class BaseWidget(QtWidgets.QWidget):
             return
 
         def discard_changes():
-            self.ignore_input_changes.set_ignore(True)
-            self.entity.discard_changes()
-            self.ignore_input_changes.set_ignore(False)
+            with self.category_widget.working_state_context():
+                self.ignore_input_changes.set_ignore(True)
+                self.entity.discard_changes()
+                self.ignore_input_changes.set_ignore(False)
 
         action = QtWidgets.QAction("Discard changes")
         actions_mapping[action] = discard_changes
@@ -124,8 +125,11 @@ class BaseWidget(QtWidgets.QWidget):
         if not self.entity.can_trigger_add_to_studio_default:
             return
 
+        def add_to_studio_default():
+            with self.category_widget.working_state_context():
+                self.entity.add_to_studio_default()
         action = QtWidgets.QAction("Add to studio default")
-        actions_mapping[action] = self.entity.add_to_studio_default
+        actions_mapping[action] = add_to_studio_default
         menu.addAction(action)
 
     def _remove_from_studio_default_action(self, menu, actions_mapping):
@@ -133,9 +137,10 @@ class BaseWidget(QtWidgets.QWidget):
             return
 
         def remove_from_studio_default():
-            self.ignore_input_changes.set_ignore(True)
-            self.entity.remove_from_studio_default()
-            self.ignore_input_changes.set_ignore(False)
+            with self.category_widget.working_state_context():
+                self.ignore_input_changes.set_ignore(True)
+                self.entity.remove_from_studio_default()
+                self.ignore_input_changes.set_ignore(False)
         action = QtWidgets.QAction("Remove from studio default")
         actions_mapping[action] = remove_from_studio_default
         menu.addAction(action)
@@ -144,8 +149,12 @@ class BaseWidget(QtWidgets.QWidget):
         if not self.entity.can_trigger_add_to_project_override:
             return
 
+        def add_to_project_override():
+            with self.category_widget.working_state_context():
+                self.entity.add_to_project_override
+
         action = QtWidgets.QAction("Add to project project override")
-        actions_mapping[action] = self.entity.add_to_project_override
+        actions_mapping[action] = add_to_project_override
         menu.addAction(action)
 
     def _remove_from_project_override_action(self, menu, actions_mapping):
@@ -153,9 +162,11 @@ class BaseWidget(QtWidgets.QWidget):
             return
 
         def remove_from_project_override():
-            self.ignore_input_changes.set_ignore(True)
-            self.entity.remove_from_project_override()
-            self.ignore_input_changes.set_ignore(False)
+            with self.category_widget.working_state_context():
+                self.ignore_input_changes.set_ignore(True)
+                self.entity.remove_from_project_override()
+                self.ignore_input_changes.set_ignore(False)
+
         action = QtWidgets.QAction("Remove from project override")
         actions_mapping[action] = remove_from_project_override
         menu.addAction(action)
@@ -257,14 +268,16 @@ class BaseWidget(QtWidgets.QWidget):
 
         # Simple paste value method
         def paste_value():
-            _set_entity_value(self.entity, value)
+            with self.category_widget.working_state_context():
+                _set_entity_value(self.entity, value)
 
         action = QtWidgets.QAction("Paste", menu)
         output.append((action, paste_value))
 
         # Paste value to matchin entity
         def paste_value_to_path():
-            _set_entity_value(matching_entity, value)
+            with self.category_widget.working_state_context():
+                _set_entity_value(matching_entity, value)
 
         if matching_entity is not None:
             action = QtWidgets.QAction("Paste to same place", menu)

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -299,13 +299,18 @@ class BaseWidget(QtWidgets.QWidget):
         if self.entity.is_dynamic_item or self.entity.is_in_dynamic_item:
             return
 
+        current_project_name = self.category_widget.project_name
+        project_names = []
+        for project_name in self.category_widget.get_project_names():
+            if project_name != current_project_name:
+                project_names.append(project_name)
+
+        if not project_names:
+            return
+
         submenu = QtWidgets.QMenu("Apply values from", menu)
 
-        current_project_name = self.category_widget.project_name
-        for project_name in self.category_widget.get_project_names():
-            if current_project_name == project_name:
-                continue
-
+        for project_name in project_names:
             if project_name is None:
                 project_name = DEFAULT_PROJECT_LABEL
 

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -7,6 +7,7 @@ from openpype.tools.settings import CHILD_OFFSET
 
 from .widgets import ExpandingWidget
 from .lib import create_deffered_value_change_timer
+from .constants import DEFAULT_PROJECT_LABEL
 
 
 class BaseWidget(QtWidgets.QWidget):
@@ -304,7 +305,7 @@ class BaseWidget(QtWidgets.QWidget):
                 continue
 
             if project_name is None:
-                project_name = "< Default >"
+                project_name = DEFAULT_PROJECT_LABEL
 
             action = QtWidgets.QAction(project_name)
             submenu.addAction(action)

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -340,7 +340,7 @@ class BaseWidget(QtWidgets.QWidget):
 
                 # TODO better message
                 title = "Applying values failed"
-                msg = "Using values from project \"{}\" failed.".format(
+                msg = "Applying values from project \"{}\" failed.".format(
                     project_name
                 )
                 detail_msg = "".join(

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -606,6 +606,14 @@ class ProjectWidget(SettingsCategoryWidget):
 
         self.project_list_widget = project_list_widget
 
+    def get_project_names(self):
+        if (
+            self.modify_defaults_checkbox
+            and self.modify_defaults_checkbox.isChecked()
+        ):
+            return []
+        return self.project_list_widget.get_project_names()
+
     def on_saved(self, saved_tab_widget):
         """Callback on any tab widget save.
 

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import traceback
+import contextlib
 from enum import Enum
 from Qt import QtWidgets, QtCore, QtGui
 
@@ -308,6 +309,12 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
                 "`add_widget_to_layout` on Category item can't accept labels"
             )
         self.content_layout.addWidget(widget, 0)
+
+    @contextlib.contextmanager
+    def working_state_context(self):
+        self.set_state(CategoryState.Working)
+        yield
+        self.set_state(CategoryState.Idle)
 
     def save(self):
         if not self.items_are_valid():

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -747,6 +747,13 @@ class ProjectListWidget(QtWidgets.QWidget):
             index, QtCore.QItemSelectionModel.SelectionFlag.SelectCurrent
         )
 
+    def get_project_names(self):
+        output = []
+        for row in range(self.project_proxy.rowCount()):
+            index = self.project_proxy.index(row, 0)
+            output.append(index.data(PROJECT_NAME_ROLE))
+        return output
+
     def refresh(self):
         selected_project = None
         for index in self.project_list.selectedIndexes():


### PR DESCRIPTION
## Goal
Add ability to use values from different project in setting UI.

## Description
Add new action to project settings that will allow on right click use values for the entity from different project. This won't use only overriden values but all values. The menu is available only if entity is not "dynamic entity" and there are projects which ca be used as source. Modifying default values won't show any action items.

## Changes
- Settings UI will show `Apply values from` menu with list of project names from which values can be applied
    - a dialog with message is shown if something goes wrong
- all actions will show `Working...` overlay when are triggered

## Screenshot
![image](https://user-images.githubusercontent.com/43494761/145208193-948ab501-a7da-4eda-8fc1-ed8f1a835983.png)

## Questions
- What should error dialog tell to user? Now tells that something went wrong and traceback is in detail.
- Is `Apply values from` understandable?