### PR TITLE
Maya : add option to not group reference in ReferenceLoader

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -100,6 +100,13 @@ class ReferenceLoader(api.Loader):
             "offset",
             label="Position Offset",
             help="Offset loaded models for easier selection."
+        ),
+        qargparse.Boolean(
+            "attach_to_root",
+            label="Group imported asset",
+            default=True,
+            help="Should a group be created to encapsulate"
+                 " imported representation ?"
         )
     ]
 

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -75,8 +75,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                     except:  # noqa: E722
                         pass
 
-                if family not in [
-                    "layout", "setdress", "mayaAscii", "mayaScene"]:
+                if family not in ["layout", "setdress",
+                                  "mayaAscii", "mayaScene"]:
                     for root in roots:
                         root.setParent(world=True)
 
@@ -92,9 +92,9 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                 if c is not None:
                     group_node.useOutlinerColor.set(1)
                     group_node.outlinerColor.set(
-                        (float(c[0])/255),
-                        (float(c[1])/255),
-                        (float(c[2])/255))
+                        (float(c[0]) / 255),
+                        (float(c[1]) / 255),
+                        (float(c[2]) / 255))
 
                 cmds.setAttr(group_name + ".displayHandle", 1)
                 # get bounding box

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -40,85 +40,88 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         except ValueError:
             family = "model"
 
+        group_name = "{}:_GRP".format(namespace)
+        # True by default to keep legacy behaviours
+        attach_to_root = options.get("attach_to_root", True)
+
         with maya.maintained_selection():
-            groupName = "{}:_GRP".format(namespace)
             cmds.loadPlugin("AbcImport.mll", quiet=True)
             nodes = cmds.file(self.fname,
                               namespace=namespace,
                               sharedReferenceFile=False,
-                              groupReference=True,
-                              groupName=groupName,
                               reference=True,
-                              returnNewNodes=True)
-
-            # namespace = cmds.referenceQuery(nodes[0], namespace=True)
+                              returnNewNodes=True,
+                              groupReference=attach_to_root,
+                              groupName=group_name)
 
             shapes = cmds.ls(nodes, shapes=True, long=True)
 
-            newNodes = (list(set(nodes) - set(shapes)))
+            new_nodes = (list(set(nodes) - set(shapes)))
 
             current_namespace = pm.namespaceInfo(currentNamespace=True)
 
             if current_namespace != ":":
-                groupName = current_namespace + ":" + groupName
+                group_name = current_namespace + ":" + group_name
 
-            groupNode = pm.PyNode(groupName)
-            roots = set()
+            self[:] = new_nodes
 
-            for node in newNodes:
-                try:
-                    roots.add(pm.PyNode(node).getAllParents()[-2])
-                except:  # noqa: E722
-                    pass
+            if attach_to_root:
+                group_node = pm.PyNode(group_name)
+                roots = set()
 
-            if family not in ["layout", "setdress", "mayaAscii", "mayaScene"]:
+                for node in new_nodes:
+                    try:
+                        roots.add(pm.PyNode(node).getAllParents()[-2])
+                    except:  # noqa: E722
+                        pass
+
+                if family not in [
+                    "layout", "setdress", "mayaAscii", "mayaScene"]:
+                    for root in roots:
+                        root.setParent(world=True)
+
+                group_node.zeroTransformPivots()
                 for root in roots:
-                    root.setParent(world=True)
+                    root.setParent(group_node)
 
-            groupNode.zeroTransformPivots()
-            for root in roots:
-                root.setParent(groupNode)
+                cmds.setAttr(group_name + ".displayHandle", 1)
 
-            cmds.setAttr(groupName + ".displayHandle", 1)
+                settings = get_project_settings(os.environ['AVALON_PROJECT'])
+                colors = settings['maya']['load']['colors']
+                c = colors.get(family)
+                if c is not None:
+                    group_node.useOutlinerColor.set(1)
+                    group_node.outlinerColor.set(
+                        (float(c[0])/255),
+                        (float(c[1])/255),
+                        (float(c[2])/255))
 
-            settings = get_project_settings(os.environ['AVALON_PROJECT'])
-            colors = settings['maya']['load']['colors']
-            c = colors.get(family)
-            if c is not None:
-                groupNode.useOutlinerColor.set(1)
-                groupNode.outlinerColor.set(
-                    (float(c[0])/255),
-                    (float(c[1])/255),
-                    (float(c[2])/255)
-                )
-
-            self[:] = newNodes
-
-            cmds.setAttr(groupName + ".displayHandle", 1)
-            # get bounding box
-            bbox = cmds.exactWorldBoundingBox(groupName)
-            # get pivot position on world space
-            pivot = cmds.xform(groupName, q=True, sp=True, ws=True)
-            # center of bounding box
-            cx = (bbox[0] + bbox[3]) / 2
-            cy = (bbox[1] + bbox[4]) / 2
-            cz = (bbox[2] + bbox[5]) / 2
-            # add pivot position to calculate offset
-            cx = cx + pivot[0]
-            cy = cy + pivot[1]
-            cz = cz + pivot[2]
-            # set selection handle offset to center of bounding box
-            cmds.setAttr(groupName + ".selectHandleX", cx)
-            cmds.setAttr(groupName + ".selectHandleY", cy)
-            cmds.setAttr(groupName + ".selectHandleZ", cz)
+                cmds.setAttr(group_name + ".displayHandle", 1)
+                # get bounding box
+                bbox = cmds.exactWorldBoundingBox(group_name)
+                # get pivot position on world space
+                pivot = cmds.xform(group_name, q=True, sp=True, ws=True)
+                # center of bounding box
+                cx = (bbox[0] + bbox[3]) / 2
+                cy = (bbox[1] + bbox[4]) / 2
+                cz = (bbox[2] + bbox[5]) / 2
+                # add pivot position to calculate offset
+                cx = cx + pivot[0]
+                cy = cy + pivot[1]
+                cz = cz + pivot[2]
+                # set selection handle offset to center of bounding box
+                cmds.setAttr(group_name + ".selectHandleX", cx)
+                cmds.setAttr(group_name + ".selectHandleY", cy)
+                cmds.setAttr(group_name + ".selectHandleZ", cz)
 
             if family == "rig":
                 self._post_process_rig(name, namespace, context, options)
             else:
-                if "translate" in options:
-                    cmds.setAttr(groupName + ".t", *options["translate"])
 
-            return newNodes
+                if "translate" in options:
+                    cmds.setAttr(group_name + ".t", *options["translate"])
+
+            return new_nodes
 
     def switch(self, container, representation):
         self.update(container, representation)


### PR DESCRIPTION
Options added :
- attach_to_root : wether or not a group should contain reference

---
name: Feature request
about: Suggest an idea for this project
title: Add options to ReferenceLoader
labels: enhancement
assignees: ''
---

**Is your feature request related to a problem? Please describe.**
When an asset is referenced, a group  `subset`_`asset`_:_GRP is created
For our workflow already using a root node with a special name this group is
redundant and even an annoyance.

**Describe the solution you'd like**
Loaders have the possibility to receive options yet none were developped for ReferenceLoader.
So the pull request is about adding "attach_to_root" as an option.
Option is set by default as True to keep legacy loader behaviour

**Describe alternatives you've considered**
Huu ... Making another ReferenceLoader not grouping ? 
