### PR TITLE
Centos 7 dependency compatibility

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -41,6 +41,8 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 	    ncurses \
 	    ncurses-devel \
         qt5-qtbase-devel \
+        xcb-util-wm \
+        xcb-util-renderutil
     && yum clean all
 
 # we need to build our own patchelf
@@ -92,7 +94,8 @@ RUN source $HOME/.bashrc \
 RUN cp /usr/lib64/libffi* ./build/exe.linux-x86_64-3.7/lib \
     && cp /usr/lib64/libssl* ./build/exe.linux-x86_64-3.7/lib \
     && cp /usr/lib64/libcrypto* ./build/exe.linux-x86_64-3.7/lib \
-    && cp /root/.pyenv/versions/${OPENPYPE_PYTHON_VERSION}/lib/libpython* ./build/exe.linux-x86_64-3.7/lib
+    && cp /root/.pyenv/versions/${OPENPYPE_PYTHON_VERSION}/lib/libpython* ./build/exe.linux-x86_64-3.7/lib \
+    && cp /usr/lib64/libxcb* ./build/exe.linux-x86_64-3.7/vendor/python/PySide2/Qt/lib
 
 RUN cd /opt/openpype \
     rm -rf ./vendor/bin

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -42,7 +42,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 	    ncurses-devel \
         qt5-qtbase-devel \
         xcb-util-wm \
-        xcb-util-renderutil
+        xcb-util-renderutil \
     && yum clean all
 
 # we need to build our own patchelf


### PR DESCRIPTION
## Centos 7 compatibility

Add xcb libs directly to OpenPype during docker build.

Centos 7 might miss some libraries needed for Qt to work. They would need to be installed on every machine OpenPype runs on. This is copying these libraries directly to bundled PySide2 so it can find them and work with them without installing them separately.

This is quite hackich approach but since we are doing it anyway with other libs, lets close both eyes and keep it that way. At least until someone finds better solution.