### PR TITLE
Farm publishing: New cleanup plugin for Maya renders on farm

### DIFF
--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
@@ -232,7 +232,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             'publish',
             roothless_metadata_path,
             "--targets", "deadline",
-            "--targets", "filesequence"
+            "--targets", "farm"
         ]
 
         # Generate the payload for Deadline submission

--- a/openpype/plugins/publish/cleanup_farm.py
+++ b/openpype/plugins/publish/cleanup_farm.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Cleanup leftover files from publish."""
+import os
+import shutil
+import pyblish.api
+import avalon.api
+
+
+class CleanUpFarm(pyblish.api.ContextPlugin):
+    """Cleans up the staging directory after a successful publish.
+
+    This will also clean published renders and delete their parent directories.
+    """
+
+    order = pyblish.api.IntegratorOrder + 11
+    label = "Clean Up Farm"
+    enabled = True
+
+    # Keep "filesequence" for backwards compatibility of older jobs
+    targets = ["filesequence", "farm"]
+
+    def process(self, context):
+        """Plugin entry point."""
+        if avalon.api.Session["AVALON_APP"] != "maya":
+            self.log.info("Not in farm publish of maya renders. Skipping")
+            return
+
+        dirpaths_to_remove = set()
+        for instance in context:
+            staging_dir = instance.data.get("stagingDir")
+            if staging_dir:
+                dirpaths_to_remove.add(os.path.normpath(staging_dir))
+
+        # clean dirs which are empty
+        for dirpath in dirpaths_to_remove:
+            if not os.path.exists(dirpath):
+                continue
+
+            try:
+                shutil.rmtree(dirpath)
+            except OSError:
+                self.log.warning(
+                    "Failed to remove directory \"{}\"".format(dirpath),
+                    exc_info=True
+                )

--- a/openpype/plugins/publish/collect_rendered_files.py
+++ b/openpype/plugins/publish/collect_rendered_files.py
@@ -21,7 +21,8 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
 
     """
     order = pyblish.api.CollectorOrder - 0.2
-    targets = ["filesequence"]
+    # Keep "filesequence" for backwards compatibility of older jobs
+    targets = ["filesequence", "farm"]
     label = "Collect rendered frames"
 
     _context = None

--- a/openpype/plugins/publish/validate_filesequences.py
+++ b/openpype/plugins/publish/validate_filesequences.py
@@ -5,7 +5,8 @@ class ValidateFileSequences(pyblish.api.ContextPlugin):
     """Validates whether any file sequences were collected."""
 
     order = pyblish.api.ValidatorOrder
-    targets = ["filesequence"]
+    # Keep "filesequence" for backwards compatibility of older jobs
+    targets = ["filesequence", "farm"]
     label = "Validate File Sequences"
 
     def process(self, context):

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -133,7 +133,7 @@ class PypeCommands:
                 print(f"setting target: {target}")
                 pyblish.api.register_target(target)
         else:
-            pyblish.api.register_target("filesequence")
+            pyblish.api.register_target("farm")
 
         os.environ["OPENPYPE_PUBLISH_DATA"] = os.pathsep.join(paths)
 


### PR DESCRIPTION
## Brief description
Global publish cleanup plugin is not precise in case what should be deleted and what not so farm renders are not removed after publishing.

## Description
As a quick fix is added new publish plugin that is triggered on farm and when maya was a source host from which was farm publishing triggered. The cleanup plugin will remove all staging directories of all instances. This solution is ONLY for maya renders.

## Changes
- renamed `filesequence` target to `farm` 
    - kept `filesequence` in current plugin as filtering option becauses all old jobs would not work
- added new cleaup plugin for farm publishing of maya renders

## Testing notes:
1. Create new farm job for maya renders
2. All files should be removed when publishing job successfully finishes