### PR TITLE
[Fix][MAYA] Handle message type attribute within CollectLook

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -489,6 +489,8 @@ class CollectLook(pyblish.api.InstancePlugin):
                 if not cmds.attributeQuery(attr, node=node, exists=True):
                     continue
                 attribute = "{}.{}".format(node, attr)
+                if cmds.getAttr(attribute, type=True) == "message":
+                    continue
                 node_attributes[attr] = cmds.getAttr(attribute)
 
             attributes.append({"name": node,


### PR DESCRIPTION
CollectLook throw an error when running on a scene using "Message" Attribute

```
File "C:\Users\jlorrain\PycharmProjects\OpenPype_build\.venv\lib\site-packages\pyblish\plugin.py", line 522, in __explicit_process
    runner(*args)
  File "C:\Users\jlorrain\PycharmProjects\OpenPype_build\openpype\hosts\maya\plugins\publish\collect_look.py", line 228, in process
  File "C:\Users\jlorrain\PycharmProjects\OpenPype_build\openpype\hosts\maya\plugins\publish\collect_look.py", line 313, in collect
  File "C:\Users\jlorrain\PycharmProjects\OpenPype_build\openpype\hosts\maya\plugins\publish\collect_look.py", line 493, in collect_attributes_changed
RuntimeError: Message attributes have no data values.
```

Here is a fix