### PR TITLE
Settings: Fix state change of wrapper label

### DIFF
--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -1071,8 +1071,8 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 #ExpandLabel[state="overriden-modified"]:hover, #SettingsLabel[state="overriden-modified"]:hover {
     color: {color:settings:modified-light};
 }
-#ExpandLabel[state="overriden"], #SettingsLabel[state="overriden"] {color: {
-    color:settings:project-mid};
+#ExpandLabel[state="overriden"], #SettingsLabel[state="overriden"] {
+    color: {color:settings:project-mid};
 }
 #ExpandLabel[state="overriden"]:hover, #SettingsLabel[state="overriden"]:hover {
     color: {color:settings:project-light};

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -1044,16 +1044,45 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
     color: {color:settings:label-fg};
 }
 #SettingsLabel:hover {color: {color:settings:label-fg-hover};}
-#SettingsLabel[state="studio"] {color: {color:settings:studio-light};}
-#SettingsLabel[state="studio"]:hover {color: {color:settings:studio-label-hover};}
-#SettingsLabel[state="modified"] {color: {color:settings:modified-mid};}
-#SettingsLabel[state="modified"]:hover {color: {color:settings:modified-light};}
-#SettingsLabel[state="overriden-modified"] {color: {color:settings:modified-mid};}
-#SettingsLabel[state="overriden-modified"]:hover {color: {color:settings:modified-light};}
-#SettingsLabel[state="overriden"] {color: {color:settings:project-mid};}
-#SettingsLabel[state="overriden"]:hover {color: {color:settings:project-light};}
-#SettingsLabel[state="invalid"] {color:{color:settings:invalid-dark};}
-#SettingsLabel[state="invalid"]:hover {color: {color:settings:invalid-dark};}
+
+#ExpandLabel {
+    font-weight: bold;
+    color: {color:settings:label-fg};
+}
+#ExpandLabel:hover {
+    color: {color:settings:label-fg-hover};
+}
+
+#ExpandLabel[state="studio"], #SettingsLabel[state="studio"] {
+    color: {color:settings:studio-light};
+}
+#ExpandLabel[state="studio"]:hover, #SettingsLabel[state="studio"]:hover {
+    color: {color:settings:studio-label-hover};
+}
+#ExpandLabel[state="modified"], #SettingsLabel[state="modified"] {
+    color: {color:settings:modified-mid};
+}
+#ExpandLabel[state="modified"]:hover, #SettingsLabel[state="modified"]:hover {
+    color: {color:settings:modified-light};
+}
+#ExpandLabel[state="overriden-modified"], #SettingsLabel[state="overriden-modified"] {
+    color: {color:settings:modified-mid};
+}
+#ExpandLabel[state="overriden-modified"]:hover, #SettingsLabel[state="overriden-modified"]:hover {
+    color: {color:settings:modified-light};
+}
+#ExpandLabel[state="overriden"], #SettingsLabel[state="overriden"] {color: {
+    color:settings:project-mid};
+}
+#ExpandLabel[state="overriden"]:hover, #SettingsLabel[state="overriden"]:hover {
+    color: {color:settings:project-light};
+}
+#ExpandLabel[state="invalid"], #SettingsLabel[state="invalid"] {
+    color:{color:settings:invalid-dark};
+}
+#ExpandLabel[state="invalid"]:hover, #SettingsLabel[state="invalid"]:hover {
+    color: {color:settings:invalid-dark};
+}
 
 /* TODO Replace these with explicit widget types if possible */
 #SettingsMainWidget QWidget[input-state="modified"] {
@@ -1084,14 +1113,6 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 
 #DictKey[state="modified"] {border-color: {color:settings:modified-mid};}
 #DictKey[state="invalid"] {border-color: {color:settings:invalid-dark};}
-
-#ExpandLabel {
-    font-weight: bold;
-    color: {color:settings:label-fg};
-}
-#ExpandLabel:hover {
-    color: {color:settings:label-fg-hover};
-}
 
 #ContentWidget {
     background-color: transparent;


### PR DESCRIPTION
## Brief description
Label color of group or in-group settings entity does not change by real state.

## Changes
- add the color changes tp styleshet for the label of wrapper

## Screenshot
![image](https://user-images.githubusercontent.com/43494761/145806154-53111603-1eef-40de-8207-890deeaae18b.png)


## Testing notes:
1. open settings ui
2. change something in group or add something to overrides
3. the wrapper label should change color based on the state of entity