### PR TITLE
[Fix] integrate_inputlinks if no published instance where found

### DIFF
--- a/openpype/plugins/publish/integrate_inputlinks.py
+++ b/openpype/plugins/publish/integrate_inputlinks.py
@@ -118,6 +118,9 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
 
         """
         for instance in instances:
+            if not instance:
+                continue
+
             version_doc = instance.data.get("versionEntity")
             if version_doc is None:
                 continue


### PR DESCRIPTION
integrate_inputlinks throw an error if nothing was published

```
Traceback (most recent call last):
  File "C:\Users\jerome.lorrain\PycharmProjects\OpenPype_build\.venv\lib\site-packages\pyblish\plugin.py", line 522, in __explicit_process
    runner(*args)
  File "C:\Users\jerome.lorrain\PycharmProjects\OpenPype_build\openpype\plugins\publish\integrate_inputlinks.py", line 85, in process
  File "C:\Users\jerome.lorrain\PycharmProjects\OpenPype_build\openpype\plugins\publish\integrate_inputlinks.py", line 121, in write_links_to_database
AttributeError: 'NoneType' object has no attribute 'data'
```

Fix to not throw an error (but still log a warning)