### PR TITLE
General: Fix access to environments from default settings

### DIFF
--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -933,8 +933,10 @@ def get_general_environments():
     # - prevent to use `get_system_settings` where `get_default_settings`
     #   is used
     default_values = load_openpype_default_settings()
+    system_settings = default_values["system_settings"]
     studio_overrides = get_studio_system_settings_overrides()
-    result = apply_overrides(default_values, studio_overrides)
+
+    result = apply_overrides(system_settings, studio_overrides)
     environments = result["general"]["environment"]
 
     clear_metadata_from_settings(environments)


### PR DESCRIPTION
## Brief description
Function `get_general_environments` does not use sytem settings but all default settings which cause crash if overrides do not have set environments.

## Changes
- use system setttings as base for finding environments instead of all default values