### PR TITLE
Ftrack: Check existence of object type on recreation

### DIFF
--- a/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
@@ -2502,7 +2502,13 @@ class SyncEntitiesFactory:
         parent_entity = self.entities_dict[parent_id]["entity"]
 
         _name = av_entity["name"]
-        _type = av_entity["data"].get("entityType", "folder")
+        _type = av_entity["data"].get("entityType")
+        # Check existence of object type
+        if _type and _type not in self.object_types_by_name:
+            _type = None
+
+        if not _type:
+            _type = "Folder"
 
         self.log.debug((
             "Re-ceating deleted entity {} <{}>"

--- a/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
@@ -360,6 +360,8 @@ class SyncEntitiesFactory:
         self._subsets_by_parent_id = None
         self._changeability_by_mongo_id = None
 
+        self._object_types_by_name = None
+
         self.all_filtered_entities = {}
         self.filtered_ids = []
         self.not_selected_ids = []
@@ -652,6 +654,18 @@ class SyncEntitiesFactory:
         return self._changeability_by_mongo_id
 
     @property
+    def object_types_by_name(self):
+        if self._object_types_by_name is None:
+            object_types_by_name = self.session.query(
+                "select id, name from ObjectType"
+            ).all()
+            self._object_types_by_name = {
+                object_type["name"]: object_type
+                for object_type in object_types_by_name
+            }
+        return self._object_types_by_name
+
+    @property
     def all_ftrack_names(self):
         """
             Returns lists of names of all entities in Ftrack
@@ -880,10 +894,7 @@ class SyncEntitiesFactory:
         custom_attrs, hier_attrs = get_openpype_attr(
             self.session, query_keys=self.cust_attr_query_keys
         )
-        ent_types = self.session.query("select id, name from ObjectType").all()
-        ent_types_by_name = {
-            ent_type["name"]: ent_type["id"] for ent_type in ent_types
-        }
+        ent_types_by_name = self.object_types_by_name
         # Custom attribute types
         cust_attr_types = self.session.query(
             "select id, name from CustomAttributeType"


### PR DESCRIPTION
## Brief description
Sync to avalon does not check object type on recreation which can cause crash because of missing object type on ftrack server.

## Description
This is edge case issue which can happen when object type was removed or renamed in ftrack and entity with published stuff was removed. On recreation it tries to use entity type which was stored to avalon at the moment of last sync but it is not available anymore.

## Changes
- check existence of entity type before recreation and use default `"Folder"` object type if the stored one is not available

## How to test
1. Create new ObjectType in ftrack for testing purposes
2. Create ftrack entity that has the new ObjectType
3. Run sync to avalon
4. Publish something in the entity
5. Delete the entity and the OPbjectType from ftrack
6. Run sync to avalon which should recreate the entity as `"Folder"` type