### PR TITLE
Maya: Replaced PATH usage with vendored oiio path for maketx utility

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -58,6 +58,11 @@ def maketx(source, destination, *args):
     from openpype.lib import get_oiio_tools_path
 
     maketx_path = get_oiio_tools_path("maketx")
+    if not os.path.exists(maketx_path):
+        print(
+            "OIIO tool not found in {}".format(maketx_path))
+        raise AssertionError("OIIO tool not found")
+
     cmd = [
         maketx_path,
         "-v",  # verbose

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -55,8 +55,11 @@ def maketx(source, destination, *args):
         str: Output of `maketx` command.
 
     """
+    from openpype.lib import get_oiio_tools_path
+
+    maketx_path = get_oiio_tools_path("maketx")
     cmd = [
-        "maketx",
+        maketx_path,
         "-v",  # verbose
         "-u",  # update mode
         # unpremultiply before conversion (recommended when alpha present)


### PR DESCRIPTION
## Brief description
Now it uses path to vendorized OIIO utilities.

## Description
Previously it expected `maketx` utility installed on PATH even we vendor OIIO utilities ourselves. This PR standardizes approach a bit

Closes #2386

## How to test
Run publish in Maya in any of the look workfiles, it shouldn't fail in ExtractReview phase