### PR TITLE
Nuke: baking representations was not additive

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -42,6 +42,7 @@ class ExtractReviewDataMov(openpype.api.Extractor):
 
         # generate data
         with anlib.maintained_selection():
+            generated_repres = []
             for o_name, o_data in self.outputs.items():
                 f_families = o_data["filter"]["families"]
                 f_task_types = o_data["filter"]["task_types"]
@@ -112,11 +113,13 @@ class ExtractReviewDataMov(openpype.api.Extractor):
                     })
                 else:
                     data = exporter.generate_mov(**o_data)
+                    generated_repres.extend(data["representations"])
 
-                self.log.info(data["representations"])
+                self.log.info(generated_repres)
 
-        # assign to representations
-        instance.data["representations"] += data["representations"]
+        if generated_repres:
+            # assign to representations
+            instance.data["representations"] += generated_repres
 
         self.log.debug(
             "_ representations: {}".format(


### PR DESCRIPTION
## Brief description
Baking representation was not added additive 

## Description
This issue was blocking the plugin to add representations for all baking outputs in case there were multiple.

## Testing notes:
1. open your testing workfile in nuke
2. make sure you have multiple outputs in settings on `project_setings/nuke/publish/ExtractReviewDataMov`
3. publish
4. all outputs should be published