### PR TITLE
AfterEffects: Variant 2022 is in defaults but missing in schemas

### DIFF
--- a/openpype/settings/entities/schemas/system_schema/host_settings/schema_aftereffects.json
+++ b/openpype/settings/entities/schemas/system_schema/host_settings/schema_aftereffects.json
@@ -36,6 +36,11 @@
                             "app_variant_label": "2021",
                             "app_variant": "2021",
                             "variant_skip_paths": ["use_python_2"]
+                        },
+                        {
+                            "app_variant_label": "2022",
+                            "app_variant": "2022",
+                            "variant_skip_paths": ["use_python_2"]
                         }
                     ]
                 }


### PR DESCRIPTION
## Brief description
AfterEffects variant 2022 has default values in settings but there are not schemas that would add them or give ability to modify them.

## Changes
- added 2022 variant to schemas