### PR TITLE
Settings UI: Modifiable dictionary can't recognize change on removing key

### DIFF
--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -60,6 +60,12 @@ class DictMutableKeysEntity(EndpointEntity):
     def pop(self, key, *args, **kwargs):
         if key in self.required_keys:
             raise RequiredKeyModified(self.path, key)
+
+        if self._override_state is OverrideState.STUDIO:
+            self._has_studio_override = True
+        elif self._override_state is OverrideState.PROJECT:
+            self._has_project_override = True
+
         result = self.children_by_key.pop(key, *args, **kwargs)
         self.on_change()
         return result


### PR DESCRIPTION
## Brief description
Entity type ~`modifiable-dict`~`dict-modifiable` does not recognize that value has change if does not have overrides and one of keys was removed.

## Changes
- set override state on calling `pop` method.

## Testing notes:
1. Find entity in settings that is modifiable dictionary e.g. `project_anatomy/tasks`
2. Open settings UI
3. Make sure the entity does not have overrides (is using default values)
4. Remove one key from the entity - the UI should change color to blue
5. Save - the reloaded values should be without the key

Resolves https://github.com/pypeclub/OpenPype/issues/2035