### PR TITLE
Settings UI: Breadcrumbs path does not create new entities

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -235,6 +235,11 @@ class BaseItemEntity(BaseEntity):
         """Return system settings entity."""
         pass
 
+    @abstractmethod
+    def has_child_with_key(self, key):
+        """Entity contains key as children."""
+        pass
+
     def schema_validations(self):
         """Validate schema of entity and it's hierachy.
 

--- a/openpype/settings/entities/dict_conditional.py
+++ b/openpype/settings/entities/dict_conditional.py
@@ -107,6 +107,9 @@ class DictConditionalEntity(ItemEntity):
         for _key, _value in new_value.items():
             self.non_gui_children[self.current_enum][_key].set(_value)
 
+    def has_child_with_key(self, key):
+        return key in self.keys()
+
     def _item_initialization(self):
         self._default_metadata = NOT_SET
         self._studio_override_metadata = NOT_SET

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -205,6 +205,9 @@ class DictImmutableKeysEntity(ItemEntity):
         )
         self.show_borders = self.schema_data.get("show_borders", True)
 
+    def has_child_with_key(self, key):
+        return key in self.non_gui_children
+
     def collect_static_entities_by_path(self):
         output = {}
         if self.is_dynamic_item or self.is_in_dynamic_item:

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -191,6 +191,9 @@ class DictMutableKeysEntity(EndpointEntity):
         child_entity = self.children_by_key[key]
         self.set_child_label(child_entity, label)
 
+    def has_child_with_key(self, key):
+        return key in self.children_by_key
+
     def _item_initialization(self):
         self._default_metadata = {}
         self._studio_override_metadata = {}

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -118,6 +118,9 @@ class InputEntity(EndpointEntity):
             return self.value == other.value
         return self.value == other
 
+    def has_child_with_key(self, key):
+        return False
+
     def get_child_path(self, child_obj):
         raise TypeError("{} can't have children".format(
             self.__class__.__name__

--- a/openpype/settings/entities/item_entities.py
+++ b/openpype/settings/entities/item_entities.py
@@ -1,3 +1,7 @@
+import re
+
+import six
+
 from .lib import (
     NOT_SET,
     STRING_TYPE,
@@ -47,6 +51,9 @@ class PathEntity(ItemEntity):
         if not self.multiplatform:
             raise AttributeError(self.attribute_error_msg.format("items"))
         return self.child_obj.items()
+
+    def has_child_with_key(self, key):
+        return self.child_obj.has_child_with_key(key)
 
     def _item_initialization(self):
         if self.group_item is None and not self.is_group:
@@ -197,6 +204,7 @@ class PathEntity(ItemEntity):
 
 class ListStrictEntity(ItemEntity):
     schema_types = ["list-strict"]
+    _key_regex = re.compile(r"[0-9]+")
 
     def __getitem__(self, idx):
         if not isinstance(idx, int):
@@ -215,6 +223,19 @@ class ListStrictEntity(ItemEntity):
         if idx < len(self.children):
             return self.children[idx]
         return default
+
+    def has_child_with_key(self, key):
+        if (
+            key
+            and isinstance(key, six.string_types)
+            and self._key_regex.match(key)
+        ):
+            key = int(key)
+
+        if not isinstance(key, int):
+            return False
+
+        return 0 <= key < len(self.children)
 
     def _item_initialization(self):
         self.valid_value_types = (list, )

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -1,4 +1,6 @@
 import copy
+import six
+import re
 from . import (
     BaseEntity,
     EndpointEntity
@@ -21,6 +23,7 @@ class ListEntity(EndpointEntity):
         "collapsible": True,
         "collapsed": False
     }
+    _key_regex = re.compile(r"[0-9]+")
 
     def __iter__(self):
         for item in self.children:
@@ -143,6 +146,19 @@ class ListEntity(EndpointEntity):
             self.children[index_2], self.children[index_1]
         )
         self.on_change()
+
+    def has_child_with_key(self, key):
+        if (
+            key
+            and isinstance(key, six.string_types)
+            and self._key_regex.match(key)
+        ):
+            key = int(key)
+
+        if not isinstance(key, int):
+            return False
+
+        return 0 <= key < len(self.children)
 
     def _convert_to_valid_type(self, value):
         if isinstance(value, (set, tuple)):

--- a/openpype/settings/entities/root_entities.py
+++ b/openpype/settings/entities/root_entities.py
@@ -127,6 +127,9 @@ class RootEntity(BaseItemEntity):
         for _key, _value in new_value.items():
             self.non_gui_children[_key].set(_value)
 
+    def has_child_with_key(self, key):
+        return key in self.non_gui_children
+
     def keys(self):
         return self.non_gui_children.keys()
 

--- a/openpype/tools/settings/settings/breadcrumbs_widget.py
+++ b/openpype/tools/settings/settings/breadcrumbs_widget.py
@@ -71,17 +71,35 @@ class SettingsBreadcrumbs(BreadcrumbsModel):
                 return True
         return False
 
+    def get_valid_path(self, path):
+        if not path:
+            return ""
+
+        path_items = path.split("/")
+        new_path_items = []
+        entity = self.entity
+        for item in path_items:
+            if not entity.has_child_with_key(item):
+                break
+
+            new_path_items.append(item)
+            entity = entity[item]
+
+        return "/".join(new_path_items)
+
     def is_valid_path(self, path):
         if not path:
             return True
 
         path_items = path.split("/")
-        try:
-            entity = self.entity
-            for item in path_items:
-                entity = entity[item]
-        except Exception:
-            return False
+
+        entity = self.entity
+        for item in path_items:
+            if not entity.has_child_with_key(item):
+                return False
+
+            entity = entity[item]
+
         return True
 
 
@@ -436,6 +454,7 @@ class BreadcrumbsAddressBar(QtWidgets.QFrame):
         self.change_path(path)
 
     def change_path(self, path):
+        path = self._model.get_valid_path(path)
         if self._model and not self._model.is_valid_path(path):
             self._show_address_field()
         else:


### PR DESCRIPTION
## Brief description
Passing path to breadcrumbs path can create new entities which is unwanted in most of cases.

## Description
Path that lead to dynamic entities may create new entities if do not exists. E.g. can create new children in modifiable dictionary or in list. This is not an issue in most of cases but it is possible to have set path to dynamic item which was removed before hitting save. On reloading after save the new entity is created which may be confusing for user.

## Changes
- added new abstract method for settings entities `has_child_with_key` which will check if entity has passed key as child
- breadcrumbs path is not brute forced but is using new method `has_child_with_key` to find out if the path is valid