### PR TITLE
PS: Introduced settings for invalid characters to use in ValidateNaming plugin

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -78,7 +78,6 @@ class ValidateNaming(pyblish.api.InstancePlugin):
                                                        help_msg)
         assert not re.search(self.invalid_chars, instance.data["subset"]), msg
 
-
     @classmethod
     def get_replace_chars(cls):
         """Pass values configured in Settings for Repair."""

--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -1,3 +1,5 @@
+import re
+
 import pyblish.api
 import openpype.api
 from avalon import photoshop
@@ -19,20 +21,32 @@ class ValidateNamingRepair(pyblish.api.Action):
                     and result["instance"] not in failed):
                 failed.append(result["instance"])
 
+        invalid_chars, replace_char = plugin.get_replace_chars()
+
         # Apply pyblish.logic to get the instances for the plug-in
         instances = pyblish.api.instances_by_plugin(failed, plugin)
         stub = photoshop.stub()
         for instance in instances:
             self.log.info("validate_naming instance {}".format(instance))
-            name = instance.data["name"].replace(" ", "_")
-            name = name.replace(instance.data["family"], '')
-            instance[0].Name = name
-            data = stub.read(instance[0])
-            data["subset"] = "image" + name
-            stub.imprint(instance[0], data)
+            metadata = stub.read(instance[0])
+            self.log.info("metadata instance {}".format(metadata))
+            layer_name = None
+            if metadata.get("uuid"):
+                layer_data = stub.get_layer(metadata["uuid"])
+                self.log.info("layer_data {}".format(layer_data))
+                if layer_data:
+                    layer_name = re.sub(invalid_chars,
+                                        replace_char,
+                                        layer_name)
 
-            name = stub.PUBLISH_ICON + name
-            stub.rename_layer(instance.data["uuid"], name)
+                    stub.rename_layer(instance.data["uuid"], layer_name)
+
+            subset_name = re.sub(invalid_chars, replace_char,
+                                 instance.data["name"])
+
+            instance[0].Name = layer_name or subset_name
+            metadata["subset"] = subset_name
+            stub.imprint(instance[0], metadata)
 
         return True
 
@@ -49,12 +63,22 @@ class ValidateNaming(pyblish.api.InstancePlugin):
     families = ["image"]
     actions = [ValidateNamingRepair]
 
+    # configured by Settings
+    invalid_chars = ''
+    replace_char = ''
+
     def process(self, instance):
         help_msg = ' Use Repair action (A) in Pyblish to fix it.'
         msg = "Name \"{}\" is not allowed.{}".format(instance.data["name"],
                                                      help_msg)
-        assert " " not in instance.data["name"], msg
+        assert not re.search(self.invalid_chars, instance.data["name"]), msg
 
         msg = "Subset \"{}\" is not allowed.{}".format(instance.data["subset"],
                                                        help_msg)
-        assert " " not in instance.data["subset"], msg
+        assert not re.search(self.invalid_chars, instance.data["subset"]), msg
+
+
+    @classmethod
+    def get_replace_chars(cls):
+        """Pass values configured in Settings for Repair."""
+        return cls.invalid_chars, cls.replace_char

--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -22,6 +22,7 @@ class ValidateNamingRepair(pyblish.api.Action):
                 failed.append(result["instance"])
 
         invalid_chars, replace_char = plugin.get_replace_chars()
+        self.log.info("{} --- {}".format(invalid_chars, replace_char))
 
         # Apply pyblish.logic to get the instances for the plug-in
         instances = pyblish.api.instances_by_plugin(failed, plugin)
@@ -37,7 +38,7 @@ class ValidateNamingRepair(pyblish.api.Action):
                 if layer_data:
                     layer_name = re.sub(invalid_chars,
                                         replace_char,
-                                        layer_name)
+                                        layer_data.name)
 
                     stub.rename_layer(instance.data["uuid"], layer_name)
 

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -7,11 +7,6 @@
         }
     },
     "publish": {
-        "ValidateContainers": {
-            "enabled": true,
-            "optional": true,
-            "active": true
-        },
         "CollectRemoteInstances": {
             "color_code_mapping": [
                 {
@@ -21,6 +16,15 @@
                     "subset_template_name": ""
                 }
             ]
+        },
+        "ValidateContainers": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
+        "ValidateNaming": {
+            "invalid_chars": "[ \\\\/+\\*\\?\\(\\)\\[\\]\\{\\}:,]",
+            "replace_char": "_"
         },
         "ExtractImage": {
             "formats": [

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -34,16 +34,6 @@
             "label": "Publish plugins",
             "children": [
                 {
-                    "type": "schema_template",
-                    "name": "template_publish_plugin",
-                    "template_data": [
-                        {
-                            "key": "ValidateContainers",
-                            "label": "ValidateContainers"
-                        }
-                    ]
-                },
-                {
                     "type": "dict",
                     "collapsible": true,
                     "is_group": true,
@@ -105,6 +95,38 @@
                                     }
                                 ]
                             }
+                        }
+                    ]
+                },
+                {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateContainers",
+                            "label": "ValidateContainers"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "ValidateNaming",
+                    "label": "Validate naming of subsets and layers",
+                    "children": [
+                        {
+                            "type": "label",
+                            "label": "Subset cannot contain invalid characters or extract to file would fail"
+                        },
+                        {
+                            "type": "text",
+                            "key": "invalid_chars",
+                            "label": "Regex pattern of invalid characters"
+                        },
+                        {
+                            "type": "text",
+                            "key": "replace_char",
+                            "label": "Replacement character"
                         }
                     ]
                 },


### PR DESCRIPTION
## Brief description
Repair Action of ValidateNaming pluging was modifying subset name incorrectly.

## Description
If published layer name contained invalid value (whitespace) Repair action mangled subset name (subset didnt contain variant).
This add possibility to configure invalid characters by regular expression and cleaned up replacements

## Additional info
Closes #2275

## Testing notes:
- create layer with invalid name ( "05 walls light" )
- create layer with valid name ("06_walls_light")
- Publish
- ValidateNaming plugin should complain that first subset contains invalid charactes, press `Repair` on them
- run Publish again, this time validate shouldn't trigger
- compare both created subset in `Subset Manager`, focus on presence of family (`image`), variant ('Main`) and format of both subset names