### PR TITLE
TimersManager: Start timer post launch hook

### DIFF
--- a/openpype/hooks/post_start_timer.py
+++ b/openpype/hooks/post_start_timer.py
@@ -1,0 +1,48 @@
+import os
+
+from openpype.api import get_project_settings
+from openpype.lib import PostLaunchHook
+
+
+class PostStartTimerHook(PostLaunchHook):
+    """Start timer with TimersManager module.
+
+    This module requires enabled TimerManager module.
+    """
+    order = None
+
+    def execute(self):
+        project_name = self.data.get("project_name")
+        asset_name = self.data.get("asset_name")
+        task_name = self.data.get("task_name")
+
+        missing_context_keys = set()
+        if not project_name:
+            missing_context_keys.add("project_name")
+        if not asset_name:
+            missing_context_keys.add("asset_name")
+        if not task_name:
+            missing_context_keys.add("task_name")
+
+        if missing_context_keys:
+            missing_keys_str = ", ".join([
+                "\"{}\"".format(key) for key in missing_context_keys
+            ])
+            self.log.debug("Hook {} skipped. Missing data keys: {}".format(
+                self.__class__.__name__, missing_keys_str
+            ))
+            return
+
+        timers_manager = self.modules_manager.modules_by_name.get(
+            "timers_manager"
+        )
+        if not timers_manager or not timers_manager.enabled:
+            self.log.info((
+                "Skipping starting timer because"
+                " TimersManager is not available."
+            ))
+            return
+
+        timers_manager.start_timer_with_webserver(
+            project_name, asset_name, task_name, logger=self.log
+        )

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -640,6 +640,10 @@ class LaunchHook:
     def app_name(self):
         return getattr(self.application, "full_name", None)
 
+    @property
+    def modules_manager(self):
+        return getattr(self.launch_context, "modules_manager", None)
+
     def validate(self):
         """Optional validation of launch hook on initialization.
 
@@ -702,8 +706,12 @@ class ApplicationLaunchContext:
     """
 
     def __init__(self, application, executable, **data):
+        from openpype.modules import ModulesManager
+
         # Application object
         self.application = application
+
+        self.modules_manager = ModulesManager()
 
         # Logger
         logger_name = "{}-{}".format(self.__class__.__name__, self.app_name)
@@ -812,10 +820,7 @@ class ApplicationLaunchContext:
                 paths.append(path)
 
         # Load modules paths
-        from openpype.modules import ModulesManager
-
-        manager = ModulesManager()
-        paths.extend(manager.collect_launch_hook_paths())
+        paths.extend(self.modules_manager.collect_launch_hook_paths())
 
         return paths
 

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1433,7 +1433,11 @@ def get_creator_by_name(creator_name, case_sensitive=False):
 
 @with_avalon
 def change_timer_to_current_context():
-    """Called after context change to change timers"""
+    """Called after context change to change timers.
+
+    TODO:
+    - use TimersManager's static method instead of reimplementing it here
+    """
     webserver_url = os.environ.get("OPENPYPE_WEBSERVER_URL")
     if not webserver_url:
         log.warning("Couldn't find webserver url")
@@ -1448,8 +1452,7 @@ def change_timer_to_current_context():
     data = {
         "project_name": avalon.io.Session["AVALON_PROJECT"],
         "asset_name": avalon.io.Session["AVALON_ASSET"],
-        "task_name": avalon.io.Session["AVALON_TASK"],
-        "hierarchy": get_hierarchy()
+        "task_name": avalon.io.Session["AVALON_TASK"]
     }
 
     requests.post(rest_api_url, json=data)

--- a/openpype/modules/default_modules/ftrack/launch_hooks/post_ftrack_changes.py
+++ b/openpype/modules/default_modules/ftrack/launch_hooks/post_ftrack_changes.py
@@ -52,7 +52,7 @@ class PostFtrackHook(PostLaunchHook):
             )
             if entity:
                 self.ftrack_status_change(session, entity, project_name)
-                self.start_timer(session, entity, ftrack_api)
+
         except Exception:
             self.log.warning(
                 "Couldn't finish Ftrack procedure.", exc_info=True
@@ -160,26 +160,3 @@ class PostFtrackHook(PostLaunchHook):
                     " on Ftrack entity type \"{}\""
                 ).format(next_status_name, entity.entity_type)
                 self.log.warning(msg)
-
-    def start_timer(self, session, entity, _ftrack_api):
-        """Start Ftrack timer on task from context."""
-        self.log.debug("Triggering timer start.")
-
-        user_entity = session.query("User where username is \"{}\"".format(
-            os.environ["FTRACK_API_USER"]
-        )).first()
-        if not user_entity:
-            self.log.warning(
-                "Couldn't find user with username \"{}\" in Ftrack".format(
-                    os.environ["FTRACK_API_USER"]
-                )
-            )
-            return
-
-        try:
-            user_entity.start_timer(entity, force=True)
-            session.commit()
-            self.log.debug("Timer start triggered successfully.")
-
-        except Exception:
-            self.log.warning("Couldn't trigger Ftrack timer.", exc_info=True)

--- a/openpype/modules/default_modules/timers_manager/exceptions.py
+++ b/openpype/modules/default_modules/timers_manager/exceptions.py
@@ -1,0 +1,3 @@
+class InvalidContextError(ValueError):
+    """Context for which the timer should be started is invalid."""
+    pass

--- a/openpype/modules/default_modules/timers_manager/launch_hooks/post_start_timer.py
+++ b/openpype/modules/default_modules/timers_manager/launch_hooks/post_start_timer.py
@@ -1,6 +1,3 @@
-import os
-
-from openpype.api import get_project_settings
 from openpype.lib import PostLaunchHook
 
 

--- a/openpype/modules/default_modules/timers_manager/rest_api.py
+++ b/openpype/modules/default_modules/timers_manager/rest_api.py
@@ -43,14 +43,19 @@ class TimersManagerModuleRestApi:
             asset_name = data["asset_name"]
             task_name = data["task_name"]
         except KeyError:
-            log.error((
+            msg = (
                 "Payload must contain fields 'project_name,"
                 " 'asset_name' and 'task_name'"
-            ))
-            return Response(status=400)
+            )
+            log.error(msg)
+            return Response(status=400, message=msg)
 
         self.module.stop_timers()
-        self.module.start_timer(project_name, asset_name, task_name)
+        try:
+            self.module.start_timer(project_name, asset_name, task_name)
+        except Exception as exc:
+            return Response(status=404, message=str(exc))
+
         return Response(status=200)
 
     async def stop_timer(self, request):

--- a/openpype/modules/default_modules/timers_manager/rest_api.py
+++ b/openpype/modules/default_modules/timers_manager/rest_api.py
@@ -39,17 +39,18 @@ class TimersManagerModuleRestApi:
     async def start_timer(self, request):
         data = await request.json()
         try:
-            project_name = data['project_name']
-            asset_name = data['asset_name']
-            task_name = data['task_name']
-            hierarchy = data['hierarchy']
+            project_name = data["project_name"]
+            asset_name = data["asset_name"]
+            task_name = data["task_name"]
         except KeyError:
-            log.error("Payload must contain fields 'project_name, " +
-                      "'asset_name', 'task_name', 'hierarchy'")
+            log.error((
+                "Payload must contain fields 'project_name,"
+                " 'asset_name' and 'task_name'"
+            ))
             return Response(status=400)
 
         self.module.stop_timers()
-        self.module.start_timer(project_name, asset_name, task_name, hierarchy)
+        self.module.start_timer(project_name, asset_name, task_name)
         return Response(status=200)
 
     async def stop_timer(self, request):

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -306,18 +306,29 @@ class TimersManager(OpenPypeModule, ITrayService):
                 self, server_manager
             )
 
-    def change_timer_from_host(self, project_name, asset_name, task_name):
+    @staticmethod
+    def start_timer_with_webserver(
+        project_name, asset_name, task_name, logger=None
+    ):
         """Prepared method for calling change timers on REST api"""
         webserver_url = os.environ.get("OPENPYPE_WEBSERVER_URL")
         if not webserver_url:
-            self.log.warning("Couldn't find webserver url")
+            msg = "Couldn't find webserver url"
+            if logger is not None:
+                logger.warning(msg)
+            else:
+                print(msg)
             return
 
         rest_api_url = "{}/timers_manager/start_timer".format(webserver_url)
         try:
             import requests
         except Exception:
-            self.log.warning("Couldn't start timer")
+            msg = "Couldn't start timer ('requests' is not available)"
+            if logger is not None:
+                logger.warning(msg)
+            else:
+                print(msg)
             return
         data = {
             "project_name": project_name,

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -167,7 +167,7 @@ class TimersManager(OpenPypeModule, ITrayService, ILaunchHookPaths):
         asset_name = path_items.pop(-1)
         project_name = path_items.pop(0)
         return self.get_timer_data_for_context(
-            project_name, asset_name, task_name
+            project_name, asset_name, task_name, self.log
         )
 
     def get_launch_hook_paths(self):
@@ -177,7 +177,10 @@ class TimersManager(OpenPypeModule, ITrayService, ILaunchHookPaths):
             "launch_hooks"
         )
 
-    def get_timer_data_for_context(self, project_name, asset_name, task_name):
+    @staticmethod
+    def get_timer_data_for_context(
+        project_name, asset_name, task_name, logger=None
+    ):
         """Prepare data for timer related callbacks.
 
         TODO:
@@ -205,9 +208,11 @@ class TimersManager(OpenPypeModule, ITrayService, ILaunchHookPaths):
         try:
             task_type = asset_data["tasks"][task_name]["type"]
         except KeyError:
-            self.log.warning(
-                "Couldn't find task_type for {}".format(task_name)
-            )
+            msg = "Couldn't find task_type for {}".format(task_name)
+            if logger is not None:
+                logger.warning(msg)
+            else:
+                print(msg)
 
         hierarchy_items = asset_data.get("parents") or []
         hierarchy_items.append(asset_name)
@@ -228,7 +233,7 @@ class TimersManager(OpenPypeModule, ITrayService, ILaunchHookPaths):
             task_name (str): Task name
         """
         data = self.get_timer_data_for_context(
-            project_name, asset_name, task_name
+            project_name, asset_name, task_name, self.log
         )
         self.timer_started(None, data)
 

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -189,44 +189,17 @@ class TimersManager(OpenPypeModule, ITrayService):
             "hierarchy": hierarchy_items
         }
 
-    def start_timer(self, project_name, asset_name, task_name, hierarchy):
+    def start_timer(self, project_name, asset_name, task_name):
+        """Start timer for passed context.
+
+        Args:
+            project_name (str): Project name
+            asset_name (str): Asset name
+            task_name (str): Task name
         """
-            Start timer for 'project_name', 'asset_name' and 'task_name'
-
-            Called from REST api by hosts.
-
-            Args:
-                project_name (string)
-                asset_name (string)
-                task_name (string)
-                hierarchy (string)
-        """
-        dbconn = AvalonMongoDB()
-        dbconn.install()
-        dbconn.Session["AVALON_PROJECT"] = project_name
-
-        asset_doc = dbconn.find_one({
-            "type": "asset", "name": asset_name
-        })
-        if not asset_doc:
-            raise ValueError("Uknown asset {}".format(asset_name))
-
-        task_type = ''
-        try:
-            task_type = asset_doc["data"]["tasks"][task_name]["type"]
-        except KeyError:
-            self.log.warning("Couldn't find task_type for {}".
-                             format(task_name))
-
-        hierarchy = hierarchy.split("\\")
-        hierarchy.append(asset_name)
-
-        data = {
-            "project_name": project_name,
-            "task_name": task_name,
-            "task_type": task_type,
-            "hierarchy": hierarchy
-        }
+        data = self.get_timer_data_for_context(
+            project_name, asset_name, task_name
+        )
         self.timer_started(None, data)
 
     def get_task_time(self, project_name, asset_name, task_name):

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -152,7 +152,11 @@ class TimersManager(OpenPypeModule, ITrayService):
             self._idle_manager.wait()
 
     def get_timer_data_for_context(self, project_name, asset_name, task_name):
-        """Prepare data for timer related callbacks."""
+        """Prepare data for timer related callbacks.
+
+        TODO:
+        - return predefined object that has access to asset document etc.
+        """
         dbconn = AvalonMongoDB()
         dbconn.install()
         dbconn.Session["AVALON_PROJECT"] = project_name
@@ -203,6 +207,11 @@ class TimersManager(OpenPypeModule, ITrayService):
         self.timer_started(None, data)
 
     def get_task_time(self, project_name, asset_name, task_name):
+        """Get total time for passed context.
+
+        TODO:
+        - convert context to timer data
+        """
         times = {}
         for module_id, connector in self._connectors_by_module_id.items():
             if hasattr(connector, "get_task_time"):
@@ -213,6 +222,10 @@ class TimersManager(OpenPypeModule, ITrayService):
         return times
 
     def timer_started(self, source_id, data):
+        """Connector triggered that timer has started.
+
+        New timer has started for context in data.
+        """
         for module_id, connector in self._connectors_by_module_id.items():
             if module_id == source_id:
                 continue
@@ -230,6 +243,14 @@ class TimersManager(OpenPypeModule, ITrayService):
         self.is_running = True
 
     def timer_stopped(self, source_id):
+        """Connector triggered that hist timer has stopped.
+
+        Should stop all other timers.
+
+        TODO:
+        - pass context for which timer has stopped to validate if timers are
+            same and valid
+        """
         for module_id, connector in self._connectors_by_module_id.items():
             if module_id == source_id:
                 continue
@@ -248,6 +269,7 @@ class TimersManager(OpenPypeModule, ITrayService):
             self.timer_started(None, self.last_task)
 
     def stop_timers(self):
+        """Stop all timers."""
         if self.is_running is False:
             return
 

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -348,7 +348,18 @@ class TimersManager(OpenPypeModule, ITrayService):
     def start_timer_with_webserver(
         project_name, asset_name, task_name, logger=None
     ):
-        """Prepared method for calling change timers on REST api"""
+        """Prepared method for calling change timers on REST api.
+
+        Webserver must be active. At the moment is Webserver running only when
+        OpenPype Tray is used.
+
+        Args:
+            project_name (str): Project name.
+            asset_name (str): Asset name.
+            task_name (str): Task name.
+            logger (logging.Logger): Logger object. Using 'print' if not
+                passed.
+        """
         webserver_url = os.environ.get("OPENPYPE_WEBSERVER_URL")
         if not webserver_url:
             msg = "Couldn't find webserver url"

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -420,4 +420,4 @@ class TimersManager(OpenPypeModule, ITrayService, ILaunchHookPaths):
             "task_name": task_name
         }
 
-        requests.post(rest_api_url, json=data)
+        return requests.post(rest_api_url, json=data)

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -151,6 +151,22 @@ class TimersManager(OpenPypeModule, ITrayService):
             self._idle_manager.stop()
             self._idle_manager.wait()
 
+    def get_timer_data_for_path(self, task_path):
+        """Convert string path to a timer data.
+
+        It is expected that first item is project name, last item is task name
+        and parent asset name is before task name.
+        """
+        path_items = task_path.split("/")
+        if len(path_items) < 3:
+            raise ValueError("Invalid path")
+        task_name = path_items.pop(-1)
+        asset_name = path_items.pop(-1)
+        project_name = path_items.pop(0)
+        return self.get_timer_data_for_context(
+            project_name, asset_name, task_name
+        )
+
     def get_timer_data_for_context(self, project_name, asset_name, task_name):
         """Prepare data for timer related callbacks.
 

--- a/openpype/modules/default_modules/timers_manager/timers_manager.py
+++ b/openpype/modules/default_modules/timers_manager/timers_manager.py
@@ -1,7 +1,10 @@
 import os
 import platform
 from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayService
+from openpype_interfaces import (
+    ITrayService,
+    ILaunchHookPaths
+)
 from avalon.api import AvalonMongoDB
 
 
@@ -64,7 +67,7 @@ class ExampleTimersManagerConnector:
             self._timers_manager_module.timer_stopped(self._module.id)
 
 
-class TimersManager(OpenPypeModule, ITrayService):
+class TimersManager(OpenPypeModule, ITrayService, ILaunchHookPaths):
     """ Handles about Timers.
 
     Should be able to start/stop all timers at once.
@@ -165,6 +168,13 @@ class TimersManager(OpenPypeModule, ITrayService):
         project_name = path_items.pop(0)
         return self.get_timer_data_for_context(
             project_name, asset_name, task_name
+        )
+
+    def get_launch_hook_paths(self):
+        """Implementation of `ILaunchHookPaths`."""
+        return os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "launch_hooks"
         )
 
     def get_timer_data_for_context(self, project_name, asset_name, task_name):


### PR DESCRIPTION
## Brief description
Currently only post launch hook starting timer is in Ftrack but it can be triggered using TimersManager.

## Changes
- added new post launch hook using webserver to start timer for passed context
- ftrack post launch hook does not start timer
- removed need of `"hierarchy"` in rest api call to start timer
- replaced not used `change_timer_from_host` with static method `start_timer_with_webserver`

Resolves https://github.com/pypeclub/OpenPype/issues/1656