### PR TITLE
Settings UI: Hyperlinks to settings

### DIFF
--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -554,7 +554,9 @@ class GUIWidget(BaseWidget):
     def _create_label_ui(self):
         label = self.entity["label"]
         label_widget = QtWidgets.QLabel(label, self)
+        label_widget.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
         label_widget.setObjectName("SettingsLabel")
+        label_widget.linkActivated.connect(self._on_link_activate)
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 5, 0, 5)
@@ -569,6 +571,14 @@ class GUIWidget(BaseWidget):
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(5, 5, 5, 5)
         layout.addWidget(splitter_item)
+
+    def _on_link_activate(self, url):
+        if not url.startswith("settings://"):
+            QtGui.QDesktopServices.openUrl(url)
+            return
+
+        path = url.replace("settings://", "")
+        self.category_widget.go_to_fullpath(path)
 
     def set_entity_value(self):
         pass

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -269,6 +269,37 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
             # Scroll to widget
             self.scroll_widget.ensureWidgetVisible(widget)
 
+    def go_to_fullpath(self, full_path):
+        """Full path of settings entity which can lead to different category.
+
+        Args:
+            full_path (str): Full path to settings entity. It is expected that
+                path starts with category name ("system_setting" etc.).
+        """
+        if not full_path:
+            return
+        items = full_path.split("/")
+        category = items[0]
+        path = ""
+        if len(items) > 1:
+            path = "/".join(items[1:])
+        self.full_path_requested.emit(category, path)
+
+    def contain_category_key(self, category):
+        """Parent widget ask if category of full path lead to this widget.
+
+        Args:
+            category (str): The category name.
+
+        Returns:
+            bool: Passed category lead to this widget.
+        """
+        return False
+
+    def set_category_path(self, category, path):
+        """Change path of widget based on category full path."""
+        pass
+
     def set_path(self, path):
         self.breadcrumbs_widget.set_path(path)
 

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -587,6 +587,14 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
 
 
 class SystemWidget(SettingsCategoryWidget):
+    def contain_category_key(self, category):
+        if category == "system_settings":
+            return True
+        return False
+
+    def set_category_path(self, category, path):
+        self.breadcrumbs_widget.change_path(path)
+
     def _create_root_entity(self):
         self.entity = SystemSettings(set_studio_state=False)
         self.entity.on_change_callbacks.append(self._on_entity_change)
@@ -623,6 +631,21 @@ class SystemWidget(SettingsCategoryWidget):
 
 
 class ProjectWidget(SettingsCategoryWidget):
+    def contain_category_key(self, category):
+        if category in ("project_settings", "project_anatomy"):
+            return True
+        return False
+
+    def set_category_path(self, category, path):
+        if path:
+            path_items = path.split("/")
+            if path_items[0] not in ("project_settings", "project_anatomy"):
+                path = "/".join([category, path])
+        else:
+            path = category
+
+        self.breadcrumbs_widget.change_path(path)
+
     def initialize_attributes(self):
         self.project_name = None
 

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -82,6 +82,7 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
     state_changed = QtCore.Signal()
     saved = QtCore.Signal(QtWidgets.QWidget)
     restart_required_trigger = QtCore.Signal()
+    full_path_requested = QtCore.Signal(str, str)
 
     def __init__(self, user_role, parent=None):
         super(SettingsCategoryWidget, self).__init__(parent)

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -63,7 +63,9 @@ class MainWidget(QtWidgets.QWidget):
             tab_widget.restart_required_trigger.connect(
                 self._on_restart_required
             )
+            tab_widget.full_path_requested.connect(self._on_full_path_request)
 
+        self._header_tab_widget = header_tab_widget
         self.tab_widgets = tab_widgets
 
     def _on_tab_save(self, source_widget):
@@ -89,6 +91,14 @@ class MainWidget(QtWidgets.QWidget):
         app = QtWidgets.QApplication.instance()
         if app:
             app.processEvents()
+
+    def _on_full_path_request(self, category, path):
+        for tab_widget in self.tab_widgets:
+            if tab_widget.contain_category_key(category):
+                idx = self._header_tab_widget.indexOf(tab_widget)
+                self._header_tab_widget.setCurrentIndex(idx)
+                tab_widget.set_category_path(category, path)
+                break
 
     def showEvent(self, event):
         super(MainWidget, self).showEvent(event)


### PR DESCRIPTION
## Brief description
Settings entity type `label` can contain url which lead to settings entity.

## Description
Entity type label may contain link that lead to `settings://some/settings/path`. On click the path should be changed to the entity or category may change (e.g. from Project settings -> System settings). The first item in path must start with one of categories `system-settings`, `project_settings` or `project_anatomy`.

### Example of link
```
{
    "type": "label",
    "label": "Check your system settings <a href=\"settings://system_settings/modules/deadline/deadline_urls\">here</a>"
}
```

## How to test
1. Add any label to schemas
2. Click on the url in settings UI

### Style note
- url links can't be styled with Qt stylesheets so only way is to set style in the `<a style=\"color:red\">` tag (or using `<span>`)

Resolves: https://github.com/pypeclub/OpenPype/issues/2303