### PR TITLE
Add zero padding to otio burnins for "current_frame"

### DIFF
--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -342,7 +342,8 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             if frame_start is None:
                 replacement_final = replacement_size = str(MISSING_KEY_VALUE)
             else:
-                replacement_final = "%{eif:n+" + str(frame_start) + ":d}"
+                replacement_final = "%{eif:n+" + str(frame_start) + ":d:" + \
+                                    str(len(str(frame_end))) + "}"
                 replacement_size = str(frame_end)
 
             final_text = final_text.replace(


### PR DESCRIPTION
Currently the option the "current_frame" option for burnins is not padded
This cause the text box to move with the current frame length increasing