### PR TITLE
General: Environment variables groups

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -138,7 +138,10 @@ def webpublisherwebserver(debug, executable, upload_dir, host=None, port=None):
 @click.option("--asset", help="Asset name", default=None)
 @click.option("--task", help="Task name", default=None)
 @click.option("--app", help="Application name", default=None)
-def extractenvironments(output_json_path, project, asset, task, app):
+@click.option(
+    "--envgroup", help="Environment group (e.g. \"farm\")", default=None
+)
+def extractenvironments(output_json_path, project, asset, task, app, envgroup):
     """Extract environment variables for entered context to a json file.
 
     Entered output filepath will be created if does not exists.
@@ -149,7 +152,7 @@ def extractenvironments(output_json_path, project, asset, task, app):
     Context options are "project", "asset", "task", "app"
     """
     PypeCommands.extractenvironments(
-        output_json_path, project, asset, task, app
+        output_json_path, project, asset, task, app, envgroup
     )
 
 

--- a/openpype/hooks/pre_global_host_data.py
+++ b/openpype/hooks/pre_global_host_data.py
@@ -48,7 +48,7 @@ class GlobalHostDataHook(PreLaunchHook):
             "log": self.log
         })
 
-        prepare_host_environments(temp_data)
+        prepare_host_environments(temp_data, self.launch_context.env_group)
         prepare_context_environments(temp_data)
 
         temp_data.pop("log")

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -95,9 +95,6 @@ def parse_environments(env_data, env_group=None, platform_name=None):
         }
     }
     ```
-
-    Args:
-
     """
     output = {}
     if not env_data:

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -305,13 +305,16 @@ class PypeCommands:
         log.info("Publish finished.")
 
     @staticmethod
-    def extractenvironments(output_json_path, project, asset, task, app):
-        env = os.environ.copy()
+    def extractenvironments(
+        output_json_path, project, asset, task, app, env_group
+    ):
         if all((project, asset, task, app)):
             from openpype.api import get_app_environments_for_context
             env = get_app_environments_for_context(
-                project, asset, task, app, env
+                project, asset, task, app, env_group
             )
+        else:
+            env = os.environ.copy()
 
         output_dir = os.path.dirname(output_json_path)
         if not os.path.exists(output_dir):

--- a/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
+++ b/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
@@ -48,6 +48,7 @@ def inject_openpype_environment(deadlinePlugin):
         add_args['asset'] = job.GetJobEnvironmentKeyValue('AVALON_ASSET')
         add_args['task'] = job.GetJobEnvironmentKeyValue('AVALON_TASK')
         add_args['app'] = job.GetJobEnvironmentKeyValue('AVALON_APP_NAME')
+        add_args["envgroup"] = "farm"
 
         if all(add_args.values()):
             for key, value in add_args.items():


### PR DESCRIPTION
## Brief description
Give ability to set different environment variables when are prepared on artist machine and on farm.

## Description
Added one more dictionary level to environment variables dictionary which is called environment group. Default group is "standard" but is not used until environment data values use it. This gives ability to not change current settings but just extend their usage.

The environment variable group level does **NOT** apply on general environment variables. General environments are set in `start.py` before openpype cli is used. 

The new dictionary level can be used before platform specific level. Example:
```
{
    "ENV_KEY": {
        "farm": {
            "windows": "WINDOWS",
            "linux": "LINUX",
            "darwin": "MACOS"
        }
    }
}
```
It won't work if the order is swapped. This will **NOT** work and the key will be skipped:
```
{
    "ENV_KEY": {
        "windows": {
            "farm": "WINDOWS"
        }
    }
}
```
It is also **NOT** possible to combine them at the same level. Only platform specific value will be used:
```
{
    # The key won't be set at all on Linux and MacOs
    "ENV_KEY": {
        "windows": "WINDOWS",
        "farm": "FARM"
}
```

New parsing function also keeps empty strings. Not sure if it's ok but there is no way how to "unset" environment variable value right now which should be possible, or?

## Changes
- implemented new function `parse_environments` which parse environmet variables data for passed context
    - context is defined by environemnt group (`"standard"` is default) and platform name
- the function is used when application and tool environments are used and when project specific environments are used
- command `extractenvironment` can have specified `envgroup` value
- deadline global job specify `envgroup` value to `"farm"`