### PR TITLE
Short Pyblish plugin path

### DIFF
--- a/openpype/lib/plugin_tools.py
+++ b/openpype/lib/plugin_tools.py
@@ -227,20 +227,27 @@ def filter_pyblish_plugins(plugins):
     # iterate over plugins
     for plugin in plugins[:]:
 
-        file = os.path.normpath(inspect.getsourcefile(plugin))
-        file = os.path.normpath(file)
-
-        # host determined from path
-        host_from_file = file.split(os.path.sep)[-4:-3][0]
-        plugin_kind = file.split(os.path.sep)[-2:-1][0]
-
-        # TODO: change after all plugins are moved one level up
-        if host_from_file == "openpype":
-            host_from_file = "global"
-
         try:
             config_data = presets[host]["publish"][plugin.__name__]
         except KeyError:
+            # host determined from path
+            file = os.path.normpath(inspect.getsourcefile(plugin))
+            file = os.path.normpath(file)
+
+            split_path = file.split(os.path.sep)
+            if len(split_path) < 4:
+                log.warning(
+                    'plugin path too short to extract host {}'.format(file)
+                )
+                continue
+
+            host_from_file = split_path[-4:-3][0]
+            plugin_kind = split_path[-2:-1][0]
+
+            # TODO: change after all plugins are moved one level up
+            if host_from_file == "openpype":
+                host_from_file = "global"
+
             try:
                 config_data = presets[host_from_file][plugin_kind][plugin.__name__]  # noqa: E501
             except KeyError:

--- a/openpype/lib/plugin_tools.py
+++ b/openpype/lib/plugin_tools.py
@@ -241,8 +241,8 @@ def filter_pyblish_plugins(plugins):
                 )
                 continue
 
-            host_from_file = split_path[-4:-3][0]
-            plugin_kind = split_path[-2:-1][0]
+            host_from_file = split_path[-4]
+            plugin_kind = split_path[-2]
 
             # TODO: change after all plugins are moved one level up
             if host_from_file == "openpype":


### PR DESCRIPTION
## Brief description
Bug fix when using a short path for Pyblish plugins.

## Description
When filtering the Pyblish plugins, if the config data for the current host is not found, the host will be extracted from the plugin's path.
If the path is composed of less than 4 elements (including the file name), it will crash.
Even more, the crash also occurs when the config data is found, as the code extracting the host name from the path is executed regardless its need.

## Additional info
The error occurs in the 'filter_pyblish_plugins' function, when trying to access the components of the path up to index -4.
Additionally, the code is executed even when not needed, as it is located before testing for the defined host.
The produced exception message:
```
# Traceback (most recent call last):
#   File "c:\Program Files (x86)\OpenPype\openpype\tools\pyblish_pype\control.py", line 180, in reset
#     self.load_plugins()
#   File "c:\Program Files (x86)\OpenPype\openpype\tools\pyblish_pype\control.py", line 192, in load_plugins
#     plugins = pyblish.api.discover()
#   File "c:\Program Files (x86)\OpenPype\dependencies\pyblish\plugin.py", line 1384, in discover
#     filter_(plugins)
#   File "c:\Program Files (x86)\OpenPype\openpype\lib\plugin_tools.py", line 187, in filter_pyblish_plugins
#     host_from_file = file.split(os.path.sep)[-4:-3][0]
# IndexError: list index out of range
```

## Testing notes:
1. Define a plugin path in the settings UI ('Additional Project Plugin Paths' in the project 'Global' settings) with a single directory. For example (in Windows) "C:\pype_plugins".
2. In this directory, add a plugin file (to have the plugin filtered and the path parsed).
3. Open a host via OpenPype launcher (e.g.: Maya) and start Pyblish.
4. The exception should occur.