### PR TITLE
Aftereffects: New style validations for New publisher

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/help/validate_instance_asset.xml
+++ b/openpype/hosts/aftereffects/plugins/publish/help/validate_instance_asset.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Subset context</title>
+<description>
+## Invalid subset context
+
+Context of the given subset doesn't match your current scene.
+
+### How to repair?
+
+You can fix this with "repair" button on the right.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This might happen if you are reuse old workfile and open it in different context.
+    (Eg. you created subset "renderCompositingDefault" from asset "Robot' in "your_project_Robot_compositing.aep", now you opened this workfile in a context "Sloth" but existing subset for "Robot" asset stayed in the workfile.)
+</detail>
+</error>
+</root>

--- a/openpype/hosts/aftereffects/plugins/publish/help/validate_instance_asset.xml
+++ b/openpype/hosts/aftereffects/plugins/publish/help/validate_instance_asset.xml
@@ -15,7 +15,7 @@ You can fix this with "repair" button on the right.
 ### __Detailed Info__ (optional)
 
 This might happen if you are reuse old workfile and open it in different context.
-    (Eg. you created subset "renderCompositingDefault" from asset "Robot' in "your_project_Robot_compositing.aep", now you opened this workfile in a context "Sloth" but existing subset for "Robot" asset stayed in the workfile.)
+(Eg. you created subset "renderCompositingDefault" from asset "Robot' in "your_project_Robot_compositing.aep", now you opened this workfile in a context "Sloth" but existing subset for "Robot" asset stayed in the workfile.)
 </detail>
 </error>
 </root>

--- a/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
+++ b/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
@@ -6,12 +6,12 @@
 ## Invalid scene setting found
 
 One of the settings in a scene doesn't match to asset settings in database.
-Invalid setting:
+
 {invalid_setting_str}
 
 ### How to repair?
 
-Change {invalid_keys_str} setting in the scene OR change them in asset database if they are wrong there.
+Change values for {invalid_keys_str} in the scene OR change them in the asset database if they are wrong there.
 </description>
 <detail>
 ### __Detailed Info__ (optional)

--- a/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
+++ b/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Scene setting</title>
+<description>
+## Invalid scene setting found
+
+One of the settings in a scene doesn't match to asset settings in database.
+
+    Invalid setting:
+    {invalid_setting_str}
+
+### How to repair?
+
+Change {invalid_keys_str} in the scene OR change them in asset database if they are wrong there.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This error is shown when for example resolution in the scene doesn't match to resolution set on the asset in the database.
+    Either value in the database or in the scene is wrong.
+</detail>
+</error>
+    <error id="secondary">
+<title>Scene file doesn't exist</title>
+<description>
+## Scene file doesn't exist
+
+Collected scene {scene_url} doesn't exist.
+
+### How to repair?
+
+Re-save file, start publish from the beginning again.
+</description>
+</error>
+</root>

--- a/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
+++ b/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
@@ -6,22 +6,21 @@
 ## Invalid scene setting found
 
 One of the settings in a scene doesn't match to asset settings in database.
-
-    Invalid setting:
-    {invalid_setting_str}
+Invalid setting:
+{invalid_setting_str}
 
 ### How to repair?
 
-Change {invalid_keys_str} in the scene OR change them in asset database if they are wrong there.
+Change {invalid_keys_str} setting in the scene OR change them in asset database if they are wrong there.
 </description>
 <detail>
 ### __Detailed Info__ (optional)
 
 This error is shown when for example resolution in the scene doesn't match to resolution set on the asset in the database.
-    Either value in the database or in the scene is wrong.
+Either value in the database or in the scene is wrong.
 </detail>
 </error>
-    <error id="secondary">
+<error id="secondary">
 <title>Scene file doesn't exist</title>
 <description>
 ## Scene file doesn't exist

--- a/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
+++ b/openpype/hosts/aftereffects/plugins/publish/help/validate_scene_settings.xml
@@ -20,7 +20,7 @@ This error is shown when for example resolution in the scene doesn't match to re
 Either value in the database or in the scene is wrong.
 </detail>
 </error>
-<error id="secondary">
+<error id="file_not_found">
 <title>Scene file doesn't exist</title>
 <description>
 ## Scene file doesn't exist

--- a/openpype/hosts/aftereffects/plugins/publish/validate_instance_asset.py
+++ b/openpype/hosts/aftereffects/plugins/publish/validate_instance_asset.py
@@ -2,7 +2,7 @@ from avalon import api
 import pyblish.api
 import openpype.api
 from avalon import aftereffects
-from openpype.pipeline import PublishValidationError
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateInstanceAssetRepair(pyblish.api.Action):
@@ -56,6 +56,5 @@ class ValidateInstanceAsset(pyblish.api.InstancePlugin):
             f"as current context {current_asset}."
         )
 
-        # assert instance_asset == current_asset, msg
         if instance_asset != current_asset:
-            raise PublishValidationError(msg, "Subset context", DESCRIPTION)
+            raise PublishXmlValidationError(self, msg)

--- a/openpype/hosts/aftereffects/plugins/publish/validate_instance_asset.py
+++ b/openpype/hosts/aftereffects/plugins/publish/validate_instance_asset.py
@@ -2,6 +2,7 @@ from avalon import api
 import pyblish.api
 import openpype.api
 from avalon import aftereffects
+from openpype.pipeline import PublishValidationError
 
 
 class ValidateInstanceAssetRepair(pyblish.api.Action):
@@ -29,7 +30,6 @@ class ValidateInstanceAssetRepair(pyblish.api.Action):
             data["asset"] = api.Session["AVALON_ASSET"]
             stub.imprint(instance[0], data)
 
-
 class ValidateInstanceAsset(pyblish.api.InstancePlugin):
     """Validate the instance asset is the current selected context asset.
 
@@ -53,9 +53,9 @@ class ValidateInstanceAsset(pyblish.api.InstancePlugin):
         current_asset = api.Session["AVALON_ASSET"]
         msg = (
             f"Instance asset {instance_asset} is not the same "
-            f"as current context {current_asset}. PLEASE DO:\n"
-            f"Repair with 'A' action to use '{current_asset}'.\n"
-            f"If that's not correct value, close workfile and "
-            f"reopen via Workfiles!"
+            f"as current context {current_asset}."
         )
-        assert instance_asset == current_asset, msg
+
+        # assert instance_asset == current_asset, msg
+        if instance_asset != current_asset:
+            raise PublishValidationError(msg, "Subset context", DESCRIPTION)

--- a/openpype/hosts/aftereffects/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/aftereffects/plugins/publish/validate_scene_settings.py
@@ -126,8 +126,12 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
 
         if invalid_settings:
             invalid_keys_str = ",".join(invalid_keys)
+            break_str = "<br/>"
+            invalid_setting_str = "<b>Found invalid settings:</b><br/>{}".\
+                format(break_str.join(invalid_settings))
+
             formatting_data = {
-                "invalid_setting_str": msg,
+                "invalid_setting_str": invalid_setting_str,
                 "invalid_keys_str": invalid_keys_str
             }
             raise PublishXmlValidationError(self, msg,
@@ -141,5 +145,5 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
             formatting_data = {
                 "scene_url": scene_url
             }
-            raise PublishXmlValidationError(self, msg,
+            raise PublishXmlValidationError(self, msg, key="file_not_found",
                                             formatting_data=formatting_data)

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -9,6 +9,7 @@ from .create import (
 
 from .publish import (
     PublishValidationError,
+    PublishXmlValidationError,
     KnownPublishError,
     OpenPypePyblishPluginMixin
 )
@@ -23,6 +24,7 @@ __all__ = (
     "CreatedInstance",
 
     "PublishValidationError",
+    "PublishXmlValidationError",
     "KnownPublishError",
     "OpenPypePyblishPluginMixin"
 )

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -1,5 +1,6 @@
 from .publish_plugins import (
     PublishValidationError,
+    PublishXmlValidationError,
     KnownPublishError,
     OpenPypePyblishPluginMixin
 )
@@ -14,6 +15,7 @@ from .lib import (
 
 __all__ = (
     "PublishValidationError",
+    "PublishXmlValidationError",
     "KnownPublishError",
     "OpenPypePyblishPluginMixin",
 

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -6,7 +6,9 @@ from .publish_plugins import (
 
 from .lib import (
     DiscoverResult,
-    publish_plugins_discover
+    publish_plugins_discover,
+    load_help_content_from_plugin,
+    load_help_content_from_filepath
 )
 
 
@@ -16,5 +18,7 @@ __all__ = (
     "OpenPypePyblishPluginMixin",
 
     "DiscoverResult",
-    "publish_plugins_discover"
+    "publish_plugins_discover",
+    "load_help_content_from_plugin",
+    "load_help_content_from_filepath"
 )

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -64,7 +64,7 @@ def load_help_content_from_filepath(filepath):
         description = child.find("description").text
         detail_node = child.find("detail")
         detail = None
-        if detail_node:
+        if detail_node is not None:
             detail = detail_node.text
         if child.tag == "error":
             errors[child_id] = HelpContent(title, description, detail)

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import types
+import inspect
+import xml.etree.ElementTree
 
 import six
 import pyblish.plugin
@@ -26,6 +28,61 @@ class DiscoverResult:
 
     def __setitem__(self, item, value):
         self.plugins[item] = value
+
+
+class HelpContent:
+    def __init__(self, title, description, detail=None):
+        self.title = title
+        self.description = description
+        self.detail = detail
+
+
+def load_help_content_from_filepath(filepath):
+    """Load help content from xml file.
+
+    Xml file may containt errors and warnings.
+    """
+    errors = {}
+    warnings = {}
+    output = {
+        "errors": errors,
+        "warnings": warnings
+    }
+    if not os.path.exists(filepath):
+        return output
+    tree = xml.etree.ElementTree.parse(filepath)
+    root = tree.getroot()
+    for child in root:
+        child_id = child.attrib.get("id")
+        if child_id is None:
+            continue
+
+        # Make sure ID is string
+        child_id = str(child_id)
+
+        title = child.find("title").text
+        description = child.find("description").text
+        detail_node = child.find("detail")
+        detail = None
+        if detail_node:
+            detail = detail_node.text
+        if child.tag == "error":
+            errors[child_id] = HelpContent(title, description, detail)
+        elif child.tag == "warning":
+            warnings[child_id] = HelpContent(title, description, detail)
+    return output
+
+
+def load_help_content_from_plugin(plugin):
+    cls = plugin
+    if not inspect.isclass(plugin):
+        cls = plugin.__class__
+    plugin_filepath = inspect.getfile(cls)
+    plugin_dir = os.path.dirname(plugin_filepath)
+    basename = os.path.splitext(os.path.basename(plugin_filepath))[0]
+    filename = basename + ".xml"
+    filepath = os.path.join(plugin_dir, "help", filename)
+    return load_help_content_from_filepath(filepath)
 
 
 def publish_plugins_discover(paths=None):

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -25,18 +25,17 @@ class PublishValidationError(Exception):
 
 class PublishXmlValidationError(PublishValidationError):
     def __init__(
-        self, message, plugin, key=None, *formattings_arg, **formatting_kwargs
+        self, message, plugin, key=None, formatting_data=None
     ):
         if key is None:
             key = "main"
+
+        if not formatting_data:
+            formatting_data = {}
         result = load_help_content_from_plugin(plugin)
         content_obj = result["errors"][key]
-        description = content_obj.description.format(
-            *formattings_arg, **formatting_kwargs
-        )
-        detail = content_obj.detail.format(
-            *formattings_arg, **formatting_kwargs
-        )
+        description = content_obj.description.format(**formatting_data)
+        detail = content_obj.detail.format(**formatting_data)
         super(PublishXmlValidationError, self).__init__(
             message, content_obj.title, description, detail
         )

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -1,3 +1,6 @@
+from .lib import load_help_content_from_plugin
+
+
 class PublishValidationError(Exception):
     """Validation error happened during publishing.
 
@@ -12,11 +15,31 @@ class PublishValidationError(Exception):
         description(str): Detailed description of an error. It is possible
             to use Markdown syntax.
     """
-    def __init__(self, message, title=None, description=None):
+    def __init__(self, message, title=None, description=None, detail=None):
         self.message = message
         self.title = title or "< Missing title >"
         self.description = description or message
+        self.detail = detail
         super(PublishValidationError, self).__init__(message)
+
+
+class PublishXmlValidationError(PublishValidationError):
+    def __init__(
+        self, message, plugin, key=None, *formattings_arg, **formatting_kwargs
+    ):
+        if key is None:
+            key = "main"
+        result = load_help_content_from_plugin(plugin)
+        content_obj = result["errors"][key]
+        description = content_obj.description.format(
+            *formattings_arg, **formatting_kwargs
+        )
+        detail = content_obj.detail.format(
+            *formattings_arg, **formatting_kwargs
+        )
+        super(PublishXmlValidationError, self).__init__(
+            message, content_obj.title, description, detail
+        )
 
 
 class KnownPublishError(Exception):

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -25,7 +25,7 @@ class PublishValidationError(Exception):
 
 class PublishXmlValidationError(PublishValidationError):
     def __init__(
-        self, message, plugin, key=None, formatting_data=None
+        self, plugin, message, key=None, formatting_data=None
     ):
         if key is None:
             key = "main"

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -35,7 +35,9 @@ class PublishXmlValidationError(PublishValidationError):
         result = load_help_content_from_plugin(plugin)
         content_obj = result["errors"][key]
         description = content_obj.description.format(**formatting_data)
-        detail = content_obj.detail.format(**formatting_data)
+        detail = content_obj.detail
+        if detail:
+            detail = detail.format(**formatting_data)
         super(PublishXmlValidationError, self).__init__(
             message, content_obj.title, description, detail
         )


### PR DESCRIPTION
## Brief description
`New Publisher` expects a bit different styles of validators. (Using our own validator exception instead of asserts.)

## Description
This PR modifies validators for Photoshop

## Testing notes:
1. Enable availability of `New Publisher` in your Local Settings
2. Try New Publisher in AfterEffects, try to mess with scene to trigger validations.