### PR TITLE
Forced cx_freeze to include sqlite3 into build 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ install_requires = [
     "filecmp",
     "dns",
     # Python defaults (cx_Freeze skip them by default)
-    "dbm"
+    "dbm",
+    "sqlite3"
 ]
 
 includes = []


### PR DESCRIPTION
## Brief description
Pytest run as a module requires `sqlite3`. `cx_freeze` didn't copy it into build.

## Description
Added `sqlite3` into setup to force `cx_freeze` to copy it.
`openpype_console runtests` before would fail because missing module `sqlite3`.

## Testing notes:
1. create new build
2. run `openpype_console runtests ABS_PATH/tests/integration/hosts/nuke`