### PR TITLE
Harmony: Added new style validations for New Publisher

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/help/validate_audio.xml
+++ b/openpype/hosts/harmony/plugins/publish/help/validate_audio.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Missing audio file</title>
+<description>
+## Cannot locate linked audio file
+
+Audio file at {audio_url} cannot be found.
+
+### How to repair?
+
+Copy audio file to the highlighted location or remove audio link in the workfile.
+</description>
+</error>
+</root>

--- a/openpype/hosts/harmony/plugins/publish/help/validate_instances.xml
+++ b/openpype/hosts/harmony/plugins/publish/help/validate_instances.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Subset context</title>
+<description>
+## Invalid subset context
+
+Asset name found '{found}' in subsets, expected '{expected}'.
+
+### How to repair?
+
+You can fix this with `Repair` button on the right. This will use '{expected}' asset name and overwrite '{found}' asset name in scene metadata.
+
+After that restart `Publish` with a `Reload button`.
+
+If this is unwanted, close workfile and open again, that way different asset value would be used for context information.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This might happen if you are reuse old workfile and open it in different context.
+(Eg. you created subset "renderCompositingDefault" from asset "Robot' in "your_project_Robot_compositing.aep", now you opened this workfile in a context "Sloth" but existing subset for "Robot" asset stayed in the workfile.)
+</detail>
+</error>
+</root>

--- a/openpype/hosts/harmony/plugins/publish/help/validate_scene_settings.xml
+++ b/openpype/hosts/harmony/plugins/publish/help/validate_scene_settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Scene setting</title>
+<description>
+## Invalid scene setting found
+
+One of the settings in a scene doesn't match to asset settings in database.
+
+{invalid_setting_str}
+
+### How to repair?
+
+Change values for {invalid_keys_str} in the scene OR change them in the asset database if they are wrong there.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This error is shown when for example resolution in the scene doesn't match to resolution set on the asset in the database.
+Either value in the database or in the scene is wrong.
+</detail>
+</error>
+<error id="file_not_found">
+<title>Scene file doesn't exist</title>
+<description>
+## Scene file doesn't exist
+
+Collected scene {scene_url} doesn't exist.
+
+### How to repair?
+
+Re-save file, start publish from the beginning again.
+</description>
+</error>
+</root>

--- a/openpype/hosts/harmony/plugins/publish/validate_audio.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_audio.py
@@ -4,6 +4,8 @@ import pyblish.api
 
 from avalon import harmony
 
+from openpype.pipeline import PublishXmlValidationError
+
 
 class ValidateAudio(pyblish.api.InstancePlugin):
     """Ensures that there is an audio file in the scene.
@@ -42,4 +44,9 @@ class ValidateAudio(pyblish.api.InstancePlugin):
 
         msg = "You are missing audio file:\n{}".format(audio_path)
 
-        assert os.path.isfile(audio_path), msg
+        formatting_data = {
+            "audio_url": audio_path
+        }
+        if os.path.isfile(audio_path):
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/harmony/plugins/publish/validate_instances.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_instances.py
@@ -1,8 +1,10 @@
 import os
 
+from avalon import harmony
 import pyblish.api
 import openpype.api
-from avalon import harmony
+
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateInstanceRepair(pyblish.api.Action):
@@ -45,4 +47,12 @@ class ValidateInstance(pyblish.api.InstancePlugin):
             "Instance asset is not the same as current asset:"
             f"\nInstance: {instance_asset}\nCurrent: {current_asset}"
         )
-        assert instance_asset == current_asset, msg
+
+        formatting_data = {
+            "found": instance_asset,
+            "expected": current_asset
+        }
+        if instance_asset != current_asset:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)
+


### PR DESCRIPTION
## Brief description
`New Publisher` expects a bit different styles of validators. (Using our own validator exception instead of asserts.)

## Description
This PR modifies validators for Harmony

## Testing notes:
1. Enable availability of `New Publisher` in your Local Settings
2. Try New Publisher in Harmony, try to mess with scene to trigger validations.
