### PR TITLE
TVPaint: Use new publisher exceptions in validators

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_asset_name.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_asset_name.xml
@@ -8,7 +8,7 @@ Context of the given subset doesn't match your current scene.
 
 ### How to repair?
 
-Yout can fix with "Repair" button on the right. This will use '{expected_asset}' asset name and overwrite '{found_asset}' asset name in scene metadata.
+Yout can fix this with "Repair" button on the right. This will use '{expected_asset}' asset name and overwrite '{found_asset}' asset name in scene metadata.
 
 After that restart publishing with Reload button.
 </description>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_asset_name.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_asset_name.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Subset context</title>
+<description>## Invalid subset context
+
+Context of the given subset doesn't match your current scene.
+
+### How to repair?
+
+Yout can fix with "Repair" button on the right. This will use '{expected_asset}' asset name and overwrite '{found_asset}' asset name in scene metadata.
+
+After that restart publishing with Reload button.
+</description>
+<detail>
+### How could this happen?
+
+The subset was created in different scene with different context
+or the scene file was copy pasted from different context.
+</detail>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_duplicated_layer_names.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_duplicated_layer_names.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Layer names</title>
+<description>## Duplicated layer names
+
+Can't determine which layers should be published because there are duplicated layer names in the scene.
+
+### Duplicated layer names
+
+{layer_names}
+
+*Check layer names for all subsets in list on left side.*
+
+### How to repair?
+
+Hide/rename/remove layers that should not be published.
+
+If all of them should be published then you have duplicated subset names in the scene. In that case you have to recrete them and use different variant name.
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_layers_visibility.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_layers_visibility.xml
@@ -4,7 +4,7 @@
 <title>Layers visiblity</title>
 <description>## All layers are not visible
 
-All layers for subset "{instance_name}" are hidden.
+Layers visibility was changed during publishing which caused that all layers for subset "{instance_name}" are hidden.
 
 ### Layer names for **{instance_name}**
 
@@ -14,7 +14,7 @@ All layers for subset "{instance_name}" are hidden.
 
 ### How to repair?
 
-Make sure that at least one layer in the scene is visible or disable the subset before hitting publish button after refresh.
+Reset publishing and do not change visibility of layers after hitting publish button.
 </description>
 </error>
 </root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_layers_visibility.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_layers_visibility.xml
@@ -10,7 +10,7 @@ All layers for subset "{instance_name}" are hidden.
 
 {layer_names}
 
-*Check layer names for all subsets in list on left side.*
+*Check layer names for all subsets in the list on the left side.*
 
 ### How to repair?
 

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_layers_visibility.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_layers_visibility.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Layers visiblity</title>
+<description>## All layers are not visible
+
+All layers for subset "{instance_name}" are hidden.
+
+### Layer names for **{instance_name}**
+
+{layer_names}
+
+*Check layer names for all subsets in list on left side.*
+
+### How to repair?
+
+Make sure that at least one layer in the scene is visible or disable the subset before hitting publish button after refresh.
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_marks.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_marks.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Frame range</title>
+<description>## Invalid render frame range
+
+Scene frame range which will be rendered is defined by MarkIn and MarkOut. Expected frame range is {expected_frame_range} and current frame range is {current_frame_range}.
+
+It is also required that MarkIn and MarkOut are enabled in the scene. Their color is highlighted on timeline when are enabled.
+
+- MarkIn is {mark_in_enable_state}
+- MarkOut is {mark_out_enable_state}
+
+### How to repair?
+
+Yout can fix this with "Repair" button on the right. That will change MarkOut to {expected_mark_out}.
+
+Or you can manually modify MarkIn and MarkOut in the scene timeline.
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_missing_layer_names.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_missing_layer_names.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Missing layers</title>
+<description>## Missing layers for render pass
+
+Render pass subset "{instance_name}" has stored layer names that belong to it's rendering scope but layers were not found in scene.
+
+### Missing layer names
+
+{layer_names}
+
+### How to repair?
+
+Find layers that belong to subset {instance_name} and rename them back to expected layer names or remove the subset and create new with right layers.
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_render_pass_group.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_render_pass_group.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Render pass group</title>
+<description>## Invalid group of Render Pass layers
+
+Layers of Render Pass {instance_name} belong to Render Group which is defined by TVPaint color group {expected_group}. But the layers are not in the group.
+
+### How to repair?
+
+Change the color group to {expected_group} on layers {layer_names}.
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_scene_settings.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_scene_settings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Scene settings</title>
+<description>## Invalid scene settings
+
+Scene settings do not match to expected values.
+
+**FPS**
+- Expected value: {expected_fps}
+- Current value: {current_fps}
+
+**Resolution**
+- Expected value: {expected_width}x{expected_height}
+- Current value: {current_width}x{current_height}
+
+**Pixel ratio**
+- Expected value: {expected_pixel_ratio}
+- Current value: {current_pixel_ratio}
+
+### How to repair?
+
+FPS and Pixel ratio can be modified in scene setting. Wrong resolution can be fixed with changing resolution of scene but due to TVPaint limitations it is possible that you will need to create new scene.
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_start_frame.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_start_frame.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>First frame</title>
+<description>## MarkIn is not set to 0
+
+MarkIn in your scene must start from 0 fram index but MarkIn is set to {current_start_frame}.
+
+### How to repair?
+
+You can modify MarkIn manually or hit the "Repair" button on the right which will change MarkIn to 0 (does not change MarkOut).
+</description>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_workfile_metadata.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_workfile_metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Missing metadata</title>
+<description>## Your scene miss context metadata
+
+Your scene does not contain metadata about {missing_metadata}.
+
+### How to repair?
+
+Resave the scene using Workfiles tool or hit the "Repair" button on the right.
+</description>
+<detail>
+### How this could happend?
+
+You're using scene file that was not created using Workfiles tool.
+</detail>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_workfile_project_name.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_workfile_project_name.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Project name</title>
+<description>## Your scene is from different project
+
+It is not possible to publish into project "{workfile_project_name}" when TVPaint was opened with project "{env_project_name}" in context.
+
+### How to repair?
+
+If the workfile belongs to project "{env_project_name}" then use Workfiles tool to resave it.
+
+Otherwise close TVPaint and launch it again from project you want to publish in.
+</description>
+<detail>
+### How this could happend?
+
+You've opened workfile from different project. You've opened TVPaint on a task from "{env_project_name}" then you've opened TVPaint again on task from "{workfile_project_name}" without closing the TVPaint. Because TVPaint can run only once the project didn't change.
+
+### Why it is important?
+Because project may affect how TVPaint works or change publishing behavior it is dangerous to allow change project context in many ways. For example publishing will not run as expected.
+</detail>
+</error>
+</root>

--- a/openpype/hosts/tvpaint/plugins/publish/validate_asset_name.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_asset_name.py
@@ -1,5 +1,6 @@
 import pyblish.api
 from avalon.tvpaint import pipeline
+from openpype.pipeline import PublishXmlValidationError
 
 
 class FixAssetNames(pyblish.api.Action):
@@ -27,7 +28,7 @@ class FixAssetNames(pyblish.api.Action):
         pipeline._write_instances(new_instance_items)
 
 
-class ValidateMissingLayers(pyblish.api.ContextPlugin):
+class ValidateAssetNames(pyblish.api.ContextPlugin):
     """Validate assset name present on instance.
 
     Asset name on instance should be the same as context's.
@@ -48,8 +49,18 @@ class ValidateMissingLayers(pyblish.api.ContextPlugin):
             instance_label = (
                 instance.data.get("label") or instance.data["name"]
             )
-            raise AssertionError((
-                "Different asset name on instance then context's."
-                " Instance \"{}\" has asset name: \"{}\""
-                " Context asset name is: \"{}\""
-            ).format(instance_label, asset_name, context_asset_name))
+
+            raise PublishXmlValidationError(
+                self,
+                (
+                    "Different asset name on instance then context's."
+                    " Instance \"{}\" has asset name: \"{}\""
+                    " Context asset name is: \"{}\""
+                ).format(
+                    instance_label, asset_name, context_asset_name
+                ),
+                formatting_data={
+                    "expected_asset": context_asset_name,
+                    "found_asset": asset_name
+                }
+            )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_duplicated_layer_names.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_duplicated_layer_names.py
@@ -1,4 +1,5 @@
 import pyblish.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateLayersGroup(pyblish.api.InstancePlugin):
@@ -30,14 +31,20 @@ class ValidateLayersGroup(pyblish.api.InstancePlugin):
             "\"{}\"".format(layer_name)
             for layer_name in duplicated_layer_names
         ])
-
-        # Raise an error
-        raise AssertionError(
+        detail_lines = [
+            "- {}".format(layer_name)
+            for layer_name in set(duplicated_layer_names)
+        ]
+        raise PublishXmlValidationError(
+            self,
             (
                 "Layers have duplicated names for instance {}."
                 # Description what's wrong
                 " There are layers with same name and one of them is marked"
                 " for publishing so it is not possible to know which should"
                 " be published. Please look for layers with names: {}"
-            ).format(instance.data["label"], layers_msg)
+            ).format(instance.data["label"], layers_msg),
+            formatting_data={
+                "layer_names": "<br/>".join(detail_lines)
+            }
         )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
@@ -2,6 +2,7 @@ import json
 
 import pyblish.api
 from avalon.tvpaint import lib
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateMarksRepair(pyblish.api.Action):
@@ -73,9 +74,34 @@ class ValidateMarks(pyblish.api.ContextPlugin):
                     "expected": expected_data[k]
                 }
 
-        if invalid:
-            raise AssertionError(
-                "Marks does not match database:\n{}".format(
-                    json.dumps(invalid, sort_keys=True, indent=4)
-                )
-            )
+        # Validation ends
+        if not invalid:
+            return
+
+        current_frame_range = (
+            (current_data["markOut"] - current_data["markIn"]) + 1
+        )
+        expected_frame_range = (
+            (expected_data["markOut"] - expected_data["markIn"]) + 1
+        )
+        mark_in_enable_state = "disabled"
+        if current_data["markInState"]:
+            mark_in_enable_state = "enabled"
+
+        mark_out_enable_state = "disabled"
+        if current_data["markOutState"]:
+            mark_out_enable_state = "enabled"
+
+        raise PublishXmlValidationError(
+            self,
+            "Marks does not match database:\n{}".format(
+                json.dumps(invalid, sort_keys=True, indent=4)
+            ),
+            formatting_data={
+                "current_frame_range": str(current_frame_range),
+                "expected_frame_range": str(expected_frame_range),
+                "mark_in_enable_state": mark_in_enable_state,
+                "mark_out_enable_state": mark_out_enable_state,
+                "expected_mark_out": expected_data["markOut"]
+            }
+        )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_missing_layer_names.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_missing_layer_names.py
@@ -1,4 +1,5 @@
 import pyblish.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateMissingLayers(pyblish.api.InstancePlugin):
@@ -30,13 +31,25 @@ class ValidateMissingLayers(pyblish.api.InstancePlugin):
             "\"{}\"".format(layer_name)
             for layer_name in missing_layer_names
         ])
+        instance_label = (
+            instance.data.get("label") or instance.data["name"]
+        )
+        description_layer_names = "<br/>".join([
+            "- {}".format(layer_name)
+            for layer_name in missing_layer_names
+        ])
 
         # Raise an error
-        raise AssertionError(
+        raise PublishXmlValidationError(
+            self,
             (
                 "Layers were not found by name for instance \"{}\"."
                 # Description what's wrong
                 " Layer names marked for publishing are not available"
                 " in layers list. Missing layer names: {}"
-            ).format(instance.data["label"], layers_msg)
+            ).format(instance.data["label"], layers_msg),
+            formatting_data={
+                "instance_name": instance_label,
+                "layer_names": description_layer_names
+            }
         )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_scene_settings.py
@@ -1,9 +1,11 @@
 import json
 
 import pyblish.api
+from openpype.pipeline import PublishXmlValidationError
 
 
-class ValidateSceneSettings(pyblish.api.ContextPlugin):
+# TODO @iLliCiTiT add fix action for fps
+class ValidateProjectSettings(pyblish.api.ContextPlugin):
     """Validate scene settings against database."""
 
     label = "Validate Scene Settings"
@@ -11,6 +13,7 @@ class ValidateSceneSettings(pyblish.api.ContextPlugin):
     optional = True
 
     def process(self, context):
+        expected_data = context.data["assetEntity"]["data"]
         scene_data = {
             "fps": context.data.get("sceneFps"),
             "resolutionWidth": context.data.get("sceneWidth"),
@@ -19,15 +22,28 @@ class ValidateSceneSettings(pyblish.api.ContextPlugin):
         }
         invalid = {}
         for k in scene_data.keys():
-            expected_value = context.data["assetEntity"]["data"][k]
+            expected_value = expected_data[k]
             if scene_data[k] != expected_value:
                 invalid[k] = {
                     "current": scene_data[k], "expected": expected_value
                 }
 
-        if invalid:
-            raise AssertionError(
-                "Scene settings does not match database:\n{}".format(
-                    json.dumps(invalid, sort_keys=True, indent=4)
-                )
-            )
+        if not invalid:
+            return
+
+        raise PublishXmlValidationError(
+            self,
+            "Scene settings does not match database:\n{}".format(
+                json.dumps(invalid, sort_keys=True, indent=4)
+            ),
+            formatting_data={
+                "expected_fps": expected_data["fps"],
+                "current_fps": scene_data["fps"],
+                "expected_width": expected_data["resolutionWidth"],
+                "expected_height": expected_data["resolutionHeight"],
+                "current_width": scene_data["resolutionWidth"],
+                "current_height": scene_data["resolutionWidth"],
+                "expected_pixel_ratio": expected_data["pixelAspect"],
+                "current_pixel_ratio": scene_data["pixelAspect"]
+            }
+        )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_scene_settings.py
@@ -3,11 +3,10 @@ import json
 import pyblish.api
 
 
-class ValidateProjectSettings(pyblish.api.ContextPlugin):
-    """Validate project settings against database.
-    """
+class ValidateSceneSettings(pyblish.api.ContextPlugin):
+    """Validate scene settings against database."""
 
-    label = "Validate Project Settings"
+    label = "Validate Scene Settings"
     order = pyblish.api.ValidatorOrder
     optional = True
 
@@ -28,7 +27,7 @@ class ValidateProjectSettings(pyblish.api.ContextPlugin):
 
         if invalid:
             raise AssertionError(
-                "Project settings does not match database:\n{}".format(
+                "Scene settings does not match database:\n{}".format(
                     json.dumps(invalid, sort_keys=True, indent=4)
                 )
             )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_start_frame.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_start_frame.py
@@ -1,5 +1,6 @@
 import pyblish.api
 from avalon.tvpaint import lib
+from openpype.pipeline import PublishXmlValidationError
 
 
 class RepairStartFrame(pyblish.api.Action):
@@ -24,4 +25,13 @@ class ValidateStartFrame(pyblish.api.ContextPlugin):
 
     def process(self, context):
         start_frame = lib.execute_george("tv_startframe")
-        assert int(start_frame) == 0, "Start frame has to be frame 0."
+        if start_frame == 0:
+            return
+
+        raise PublishXmlValidationError(
+            self,
+            "Start frame has to be frame 0.",
+            formatting_data={
+                "current_start_frame": start_frame
+            }
+        )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_workfile_metadata.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_workfile_metadata.py
@@ -1,5 +1,6 @@
 import pyblish.api
 from avalon.tvpaint import save_file
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateWorkfileMetadataRepair(pyblish.api.Action):
@@ -42,8 +43,12 @@ class ValidateWorkfileMetadata(pyblish.api.ContextPlugin):
                 missing_keys.append(key)
 
         if missing_keys:
-            raise AssertionError(
+            raise PublishXmlValidationError(
+                self,
                 "Current workfile is missing metadata about {}.".format(
                     ", ".join(missing_keys)
-                )
+                ),
+                formatting_data={
+                    "missing_metadata": ", ".join(missing_keys)
+                }
             )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_workfile_project_name.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_workfile_project_name.py
@@ -1,5 +1,6 @@
 import os
 import pyblish.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateWorkfileProjectName(pyblish.api.ContextPlugin):
@@ -31,15 +32,23 @@ class ValidateWorkfileProjectName(pyblish.api.ContextPlugin):
             return
 
         # Raise an error
-        raise AssertionError((
-            # Short message
-            "Workfile from different Project ({})."
-            # Description what's wrong
-            " It is not possible to publish when TVPaint was launched in"
-            "context of different project. Current context project is \"{}\"."
-            " Launch TVPaint in context of project \"{}\" and then publish."
-        ).format(
-            workfile_project_name,
-            env_project_name,
-            workfile_project_name,
-        ))
+        raise AssertionError(
+            self,
+            (
+                # Short message
+                "Workfile from different Project ({})."
+                # Description what's wrong
+                " It is not possible to publish when TVPaint was launched in"
+                "context of different project. Current context project is"
+                " \"{}\". Launch TVPaint in context of project \"{}\""
+                " and then publish."
+            ).format(
+                workfile_project_name,
+                env_project_name,
+                workfile_project_name,
+            ),
+            formatting_data={
+                "workfile_project_name": workfile_project_name,
+                "expected_project_name": env_project_name
+            }
+        )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_workfile_project_name.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_workfile_project_name.py
@@ -32,7 +32,7 @@ class ValidateWorkfileProjectName(pyblish.api.ContextPlugin):
             return
 
         # Raise an error
-        raise AssertionError(
+        raise PublishXmlValidationError(
             self,
             (
                 # Short message


### PR DESCRIPTION
## Brief description
Use new Exception for validation errors inside TVPaint validators.

## Testing notes:
1. Check the xml and their texts
2. OPTIONAL: Enable new publisher
3. OPTIONAL: Start publishing of TVPaint file and go through each validator