### PR TITLE
Photoshop: New style validations for New publisher

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/help/validate_instance_asset.xml
+++ b/openpype/hosts/photoshop/plugins/publish/help/validate_instance_asset.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Subset context</title>
+<description>
+## Invalid subset context
+
+Asset name found '{found}' in subsets, expected '{expected}'.
+
+### How to repair?
+
+You can fix this with `Repair` button on the right. This will use '{expected}' asset name and overwrite '{found}' asset name in scene metadata.
+
+After that restart `Publish` with a `Reload button`.
+
+If this is unwanted, close workfile and open again, that way different asset value would be used for context information.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This might happen if you are reuse old workfile and open it in different context.
+(Eg. you created subset "renderCompositingDefault" from asset "Robot' in "your_project_Robot_compositing.aep", now you opened this workfile in a context "Sloth" but existing subset for "Robot" asset stayed in the workfile.)
+</detail>
+</error>
+</root>

--- a/openpype/hosts/photoshop/plugins/publish/help/validate_naming.xml
+++ b/openpype/hosts/photoshop/plugins/publish/help/validate_naming.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Invalid name</title>
+<description>
+## Invalid name of subset
+
+Name of subset is created from a layer name. Some characters (whitespace, '/' etc.) are not allowed because of publishing (files couldn't be saved on some OSes).
+
+### How to repair?
+
+You can fix this with `Repair` button on the right. This will remove invalid characters with safe character ('_' by default) in both subset names and matching group names.
+
+After that restart `Publish` with a `Reload button`.
+
+Or you use `Subset Manager` to delete existing subsets, remove created groups, rename layers that are used for their creation and use `Create` option in the Openpype menu to create them again.
+
+Invalid characters and 'safe character' could be configured in Settings. Ask your OpenPype admin to modify them if necessary.
+</description>
+</error>
+</root>

--- a/openpype/hosts/photoshop/plugins/publish/help/validate_unique_subsets.xml
+++ b/openpype/hosts/photoshop/plugins/publish/help/validate_unique_subsets.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Subsets duplicated</title>
+<description>
+## Some subsets are duplicated
+
+Created subsets must be unique.
+
+Subsets '{duplicates_str}' are duplicated.
+
+### How to repair?
+
+Use `Subset Manager` to delete duplicated subset to have only unique subset names and restart `Publish` with a `Reload button`.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+Subset names are created from layer names. Layer names are filtered for characters that would break publishing process when files are created.
+This replacement process might result in duplicate names of subsets.
+</detail>
+</error>
+</root>

--- a/openpype/hosts/photoshop/plugins/publish/validate_instance_asset.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_instance_asset.py
@@ -1,7 +1,9 @@
 from avalon import api
 import pyblish.api
-import openpype.api
 from avalon import photoshop
+
+import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateInstanceAssetRepair(pyblish.api.Action):
@@ -56,4 +58,10 @@ class ValidateInstanceAsset(pyblish.api.InstancePlugin):
             f"If that's not correct value, close workfile and "
             f"reopen via Workfiles!"
         )
-        assert instance_asset == current_asset, msg
+        formatting_data = {
+            "found": instance_asset,
+            "expected": current_asset
+        }
+        if instance_asset != current_asset:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -1,8 +1,10 @@
 import re
 
 import pyblish.api
-import openpype.api
 from avalon import photoshop
+
+import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateNamingRepair(pyblish.api.Action):
@@ -69,14 +71,18 @@ class ValidateNaming(pyblish.api.InstancePlugin):
     replace_char = ''
 
     def process(self, instance):
-        help_msg = ' Use Repair action (A) in Pyblish to fix it.'
-        msg = "Name \"{}\" is not allowed.{}".format(instance.data["name"],
-                                                     help_msg)
-        assert not re.search(self.invalid_chars, instance.data["name"]), msg
+        msg = "Name \"{}\" is not allowed.".format(instance.data["name"])
 
-        msg = "Subset \"{}\" is not allowed.{}".format(instance.data["subset"],
-                                                       help_msg)
-        assert not re.search(self.invalid_chars, instance.data["subset"]), msg
+        formatting_data = {"error_msg": msg}
+        if re.search(self.invalid_chars, instance.data["name"]):
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)
+
+        msg = "Subset \"{}\" is not allowed.".format(instance.data["subset"])
+        formatting_data = {"error_msg": msg}
+        if re.search(self.invalid_chars, instance.data["subset"]):
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)
 
     @classmethod
     def get_replace_chars(cls):

--- a/openpype/hosts/photoshop/plugins/publish/validate_unique_subsets.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_unique_subsets.py
@@ -1,5 +1,8 @@
+import collections
+
 import pyblish.api
 import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateSubsetUniqueness(pyblish.api.ContextPlugin):
@@ -19,8 +22,18 @@ class ValidateSubsetUniqueness(pyblish.api.ContextPlugin):
             if instance.data.get('publish'):
                 subset_names.append(instance.data.get('subset'))
 
-        msg = (
-            "Instance subset names are not unique. " +
-            "Remove duplicates via SubsetManager."
-        )
-        assert len(subset_names) == len(set(subset_names)), msg
+        duplicates = [item
+                      for item, count in
+                      collections.Counter(subset_names).items()
+                      if count > 1]
+
+        if duplicates:
+            duplicates_str = ",".join(duplicates)
+            formatting_data = {"duplicates_str": duplicates_str}
+            msg = (
+                    "Instance subset names {} are not unique.".format(
+                        duplicates_str) +
+                    " Remove duplicates via SubsetManager."
+            )
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)


### PR DESCRIPTION
## Brief description
`New Publisher` expects a bit different styles of validators. (Using our own validator exception instead of asserts.)

## Description
This PR modifies validators for Photoshop

## Testing notes:
1. Enable availability of `New Publisher` in your Local Settings
2. Try New Publisher in Photoshop, try to mess with scene to trigger validations.