### PR TITLE
StandalonePublisher: New style validations for New publisher 

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_frame_ranges.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_frame_ranges.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Invalid frame range</title>
+<description>
+## Invalid frame range
+
+Expected duration or '{duration}' frames set in database, workfile contains only '{found}' frames.
+
+### How to repair?
+
+Modify configuration in the database or tweak frame range in the workfile.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_shot_duplicates.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_shot_duplicates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Duplicate shots</title>
+<description>
+## Duplicate shot names
+
+Process contains duplicated shot names '{duplicates_str}'.
+
+### How to repair?
+
+Remove shot duplicates.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_sources.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_sources.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Files not found</title>
+<description>
+## Source files not found
+
+Process contains duplicated shot names:
+'{files_not_found}'
+
+### How to repair?
+
+Add missing files or run Publish again to collect new publishable files.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_task_existence.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_task_existence.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Task not found</title>
+<description>
+## Task not found in database
+
+Process contains tasks that don't exist in database:
+'{task_not_found}'
+
+### How to repair?
+
+Remove set task or add task into database into proper place.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_batch.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_batch.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>No texture files found</title>
+<description>
+## Batch doesn't contain texture files
+
+Batch must contain at least one texture file.
+
+### How to repair?
+
+Add texture file to the batch or check name if it follows naming convention to match texture files to the batch.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_has_workfile.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_has_workfile.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>No workfile found</title>
+<description>
+## Batch should contain workfile
+
+It is expected that published contains workfile that served as a source for textures.
+
+### How to repair?
+
+Add workfile to the batch, or disable this validator if you do not want workfile published.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_name.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_name.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Asset name not found</title>
+<description>
+## Couldn't parse asset name from a file
+
+Unable to parse asset name from '{file_name}'. File name doesn't match configured naming convention.
+
+### How to repair?
+
+Check Settings: project_settings/standalonepublisher/publish/CollectTextures for naming convention.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This error happens when parsing cannot figure out name of asset texture files belong under.
+</detail>
+</error>
+<error id="missing_values">
+<title>Missing keys</title>
+<description>
+## Texture file name is missing some required keys
+
+Texture '{file_name}' is missing values for {missing_str} keys.
+
+### How to repair?
+
+Fix name of texture file and Publish again.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_versions.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_versions.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Texture version</title>
+<description>
+## Texture version mismatch with workfile
+
+Workfile '{file_name}' version doesn't match with '{version}' of a texture.
+
+### How to repair?
+
+Rename either workfile or texture to contain matching versions
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This might happen if you are trying to publish textures for older version of workfile (or the other way).
+(Eg. publishing 'workfile_v001' and 'texture_file_v002')
+</detail>
+</error>
+<error id="too_many">
+<title>Too many versions</title>
+<description>
+## Too many versions published at same time
+
+It is currently expected to publish only batch with single version.
+
+Found {found} versions.
+
+### How to repair?
+
+Please remove files with different version and split publishing into multiple steps.
+</description>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_workfiles.xml
+++ b/openpype/hosts/standalonepublisher/plugins/publish/help/validate_texture_workfiles.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>No secondary workfile</title>
+<description>
+## No secondary workfile found
+
+Current process expects that primary workfile (for example with a extension '{extension}') will contain also 'secondary' workfile.
+
+Secondary workfile for '{file_name}' wasn't found.
+
+### How to repair?
+
+Attach secondary workfile or disable this validator and Publish again.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This process was implemented for a possible use case of first workfile coming from Mari, secondary workfile for textures from Substance.
+Publish should contain both if primary workfile is present.
+</detail>
+</error>
+</root>

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py
@@ -1,8 +1,10 @@
 import re
 
 import pyblish.api
+
 import openpype.api
 from openpype import lib
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateFrameRange(pyblish.api.InstancePlugin):
@@ -48,9 +50,15 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
             files = [files]
         frames = len(files)
 
-        err_msg = "Frame duration from DB:'{}' ". format(int(duration)) +\
-                  " doesn't match number of files:'{}'".format(frames) +\
-                  " Please change frame range for Asset or limit no. of files"
-        assert frames == duration, err_msg
+        msg = "Frame duration from DB:'{}' ". format(int(duration)) +\
+              " doesn't match number of files:'{}'".format(frames) +\
+              " Please change frame range for Asset or limit no. of files"
 
-        self.log.debug("Valid ranges {} - {}".format(int(duration), frames))
+        formatting_data = {"duration": duration,
+                           "found": frames}
+        if frames == duration:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)
+
+        self.log.debug("Valid ranges expected '{}' - found '{}'".
+                       format(int(duration), frames))

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_shot_duplicates.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_shot_duplicates.py
@@ -1,6 +1,7 @@
 import pyblish.api
-import openpype.api
 
+import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 class ValidateShotDuplicates(pyblish.api.ContextPlugin):
     """Validating no duplicate names are in context."""
@@ -20,4 +21,8 @@ class ValidateShotDuplicates(pyblish.api.ContextPlugin):
                 shot_names.append(name)
 
         msg = "There are duplicate shot names:\n{}".format(duplicate_names)
-        assert not duplicate_names, msg
+
+        formatting_data = {"duplicate_str": ','.join(duplicate_names)}
+        if duplicate_names:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_sources.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_sources.py
@@ -1,7 +1,9 @@
-import pyblish.api
-import openpype.api
-
 import os
+
+import pyblish.api
+
+import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateSources(pyblish.api.InstancePlugin):
@@ -11,7 +13,6 @@ class ValidateSources(pyblish.api.InstancePlugin):
         got deleted between starting of SP and now.
 
     """
-
     order = openpype.api.ValidateContentsOrder
     label = "Check source files"
 
@@ -22,6 +23,7 @@ class ValidateSources(pyblish.api.InstancePlugin):
     def process(self, instance):
         self.log.info("instance {}".format(instance.data))
 
+        missing_files = set()
         for repre in instance.data.get("representations") or []:
             files = []
             if isinstance(repre["files"], str):
@@ -34,4 +36,10 @@ class ValidateSources(pyblish.api.InstancePlugin):
                                            file_name)
 
                 if not os.path.exists(source_file):
-                    raise ValueError("File {} not found".format(source_file))
+                    missing_files.add(source_file)
+
+        msg = "Files '{}' not found".format(','.join(missing_files))
+        formatting_data = {"files_not_found": '    - {}'.join(missing_files)}
+        if missing_files:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
@@ -1,6 +1,8 @@
 import pyblish.api
 from avalon import io
 
+from openpype.pipeline import PublishXmlValidationError
+
 
 class ValidateTaskExistence(pyblish.api.ContextPlugin):
     """Validating tasks on instances are filled and existing."""
@@ -53,4 +55,9 @@ class ValidateTaskExistence(pyblish.api.ContextPlugin):
                 "Asset: \"{}\" Task: \"{}\"".format(*missing_pair)
             )
 
-        raise AssertionError(msg.format("\n".join(pair_msgs)))
+        msg = msg.format("\n".join(pair_msgs))
+
+        formatting_data = {"task_not_found": '    - {}'.join(pair_msgs)}
+        if pair_msgs:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_batch.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_batch.py
@@ -1,6 +1,8 @@
 import pyblish.api
 import openpype.api
 
+from openpype.pipeline import PublishXmlValidationError
+
 
 class ValidateTextureBatch(pyblish.api.InstancePlugin):
     """Validates that some texture files are present."""
@@ -15,8 +17,10 @@ class ValidateTextureBatch(pyblish.api.InstancePlugin):
         present = False
         for instance in instance.context:
             if instance.data["family"] == "textures":
-                self.log.info("Some textures present.")
+                self.log.info("At least some textures present.")
 
                 return
 
-        assert present, "No textures found in published batch!"
+        msg = "No textures found in published batch!"
+        if not present:
+            raise PublishXmlValidationError(self, msg)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_has_workfile.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_has_workfile.py
@@ -1,5 +1,7 @@
 import pyblish.api
+
 import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateTextureHasWorkfile(pyblish.api.InstancePlugin):
@@ -17,4 +19,6 @@ class ValidateTextureHasWorkfile(pyblish.api.InstancePlugin):
     def process(self, instance):
         wfile = instance.data["versionData"].get("workfile")
 
-        assert wfile, "Textures are missing attached workfile"
+        msg = "Textures are missing attached workfile"
+        if not wfile:
+            raise PublishXmlValidationError(self, msg)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_name.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_name.py
@@ -1,6 +1,7 @@
 import pyblish.api
-import openpype.api
 
+import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 class ValidateTextureBatchNaming(pyblish.api.InstancePlugin):
     """Validates that all instances had properly formatted name."""
@@ -16,12 +17,16 @@ class ValidateTextureBatchNaming(pyblish.api.InstancePlugin):
         if isinstance(file_name, list):
             file_name = file_name[0]
 
-        msg = "Couldnt find asset name in '{}'\n".format(file_name) + \
+        msg = "Couldn't find asset name in '{}'\n".format(file_name) + \
               "File name doesn't follow configured pattern.\n" + \
               "Please rename the file."
-        assert "NOT_AVAIL" not in instance.data["asset_build"], msg
 
-        instance.data.pop("asset_build")
+        formatting_data = {"file_name": file_name}
+        if "NOT_AVAIL" in instance.data["asset_build"]:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)
+
+        instance.data.pop("asset_build")  # not needed anymore
 
         if instance.data["family"] == "textures":
             file_name = instance.data["representations"][0]["files"][0]
@@ -47,4 +52,10 @@ class ValidateTextureBatchNaming(pyblish.api.InstancePlugin):
             "Name of the texture file doesn't match expected pattern.\n" + \
             "Please rename file(s) {}".format(file_name)
 
-        assert not missing_key_values, msg
+        missing_str = ','.join(["'{}'".format(key)
+                                for key in missing_key_values])
+        formatting_data = {"file_name": file_name,
+                           "missing_str": missing_str}
+        if missing_key_values:
+            raise PublishXmlValidationError(self, msg, key="missing_values",
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_versions.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_versions.py
@@ -1,5 +1,7 @@
 import pyblish.api
+
 import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateTextureBatchVersions(pyblish.api.InstancePlugin):
@@ -25,14 +27,21 @@ class ValidateTextureBatchVersions(pyblish.api.InstancePlugin):
             self.log.info("No workfile present for textures")
             return
 
-        msg = "Not matching version: texture v{:03d} - workfile {}"
-        assert version_str in wfile, \
+        if version_str not in wfile:
+            msg = "Not matching version: texture v{:03d} - workfile {}"
             msg.format(
                 instance.data["version"], wfile
             )
+            raise PublishXmlValidationError(self, msg)
 
         present_versions = set()
         for instance in instance.context:
             present_versions.add(instance.data["version"])
 
-        assert len(present_versions) == 1, "Too many versions in a batch!"
+        if len(present_versions) != 1:
+            msg = "Too many versions in a batch!"
+            found = ','.join(["'{}'".format(val) for val in present_versions])
+            formatting_data = {"found": found}
+
+            raise PublishXmlValidationError(self, msg, key="too_many",
+                                            formatting_data=formatting_data)

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_workfiles.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_texture_workfiles.py
@@ -1,11 +1,13 @@
 import pyblish.api
+
 import openpype.api
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateTextureBatchWorkfiles(pyblish.api.InstancePlugin):
     """Validates that textures workfile has collected resources (optional).
 
-        Collected recourses means secondary workfiles (in most cases).
+        Collected resources means secondary workfiles (in most cases).
     """
 
     label = "Validate Texture Workfile Has Resources"
@@ -24,6 +26,13 @@ class ValidateTextureBatchWorkfiles(pyblish.api.InstancePlugin):
                 self.log.warning("Only secondary workfile present!")
                 return
 
-            msg = "No secondary workfiles present for workfile {}".\
-                format(instance.data["name"])
-            assert instance.data.get("resources"), msg
+            if not instance.data.get("resources"):
+                msg = "No secondary workfile present for workfile '{}'". \
+                    format(instance.data["name"])
+                ext = self.main_workfile_extensions[0]
+                formatting_data = {"file_name": instance.data["name"],
+                                   "extension": ext}
+
+                raise PublishXmlValidationError(self, msg,
+                                                formatting_data=formatting_data
+                                                )

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -9,6 +9,7 @@ from .create import (
 
 from .publish import (
     PublishValidationError,
+    PublishXmlValidationError,
     KnownPublishError,
     OpenPypePyblishPluginMixin
 )
@@ -23,6 +24,7 @@ __all__ = (
     "CreatedInstance",
 
     "PublishValidationError",
+    "PublishXmlValidationError",
     "KnownPublishError",
     "OpenPypePyblishPluginMixin"
 )

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -306,8 +306,6 @@ class PublishAttributes:
         self._plugin_names_order = []
         self._missing_plugins = []
         self.attr_plugins = attr_plugins or []
-        if not attr_plugins:
-            return
 
         origin_data = self._origin_data
         data = self._data

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -64,7 +64,7 @@ def load_help_content_from_filepath(filepath):
         description = child.find("description").text
         detail_node = child.find("detail")
         detail = None
-        if detail_node:
+        if detail_node is not None:
             detail = detail_node.text
         if child.tag == "error":
             errors[child_id] = HelpContent(title, description, detail)

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -25,7 +25,7 @@ class PublishValidationError(Exception):
 
 class PublishXmlValidationError(PublishValidationError):
     def __init__(
-        self, message, plugin, key=None, formatting_data=None
+        self, plugin, message, key=None, formatting_data=None
     ):
         if key is None:
             key = "main"

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -35,7 +35,9 @@ class PublishXmlValidationError(PublishValidationError):
         result = load_help_content_from_plugin(plugin)
         content_obj = result["errors"][key]
         description = content_obj.description.format(**formatting_data)
-        detail = content_obj.detail.format(**formatting_data)
+        detail = content_obj.detail
+        if detail:
+            detail = detail.format(**formatting_data)
         super(PublishXmlValidationError, self).__init__(
             message, content_obj.title, description, detail
         )

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -414,8 +414,8 @@ class ValidationsWidget(QtWidgets.QWidget):
 
         errors_scroll.setWidget(errors_widget)
 
-        error_details_widget = QtWidgets.QWidget(self)
-        error_details_input = QtWidgets.QTextEdit(error_details_widget)
+        error_details_frame = QtWidgets.QFrame(self)
+        error_details_input = QtWidgets.QTextEdit(error_details_frame)
         error_details_input.setObjectName("InfoText")
         error_details_input.setTextInteractionFlags(
             QtCore.Qt.TextBrowserInteraction
@@ -424,7 +424,7 @@ class ValidationsWidget(QtWidgets.QWidget):
         actions_widget = ValidateActionsWidget(controller, self)
         actions_widget.setFixedWidth(140)
 
-        error_details_layout = QtWidgets.QHBoxLayout(error_details_widget)
+        error_details_layout = QtWidgets.QHBoxLayout(error_details_frame)
         error_details_layout.addWidget(error_details_input, 1)
         error_details_layout.addWidget(actions_widget, 0)
 
@@ -433,7 +433,7 @@ class ValidationsWidget(QtWidgets.QWidget):
         content_layout.setContentsMargins(0, 0, 0, 0)
 
         content_layout.addWidget(errors_scroll, 0)
-        content_layout.addWidget(error_details_widget, 1)
+        content_layout.addWidget(error_details_frame, 1)
 
         top_label = QtWidgets.QLabel("Publish validation report", self)
         top_label.setObjectName("PublishInfoMainLabel")
@@ -447,7 +447,7 @@ class ValidationsWidget(QtWidgets.QWidget):
         self._top_label = top_label
         self._errors_widget = errors_widget
         self._errors_layout = errors_layout
-        self._error_details_widget = error_details_widget
+        self._error_details_frame = error_details_frame
         self._error_details_input = error_details_input
         self._actions_widget = actions_widget
 
@@ -467,7 +467,7 @@ class ValidationsWidget(QtWidgets.QWidget):
                 widget.deleteLater()
 
         self._top_label.setVisible(False)
-        self._error_details_widget.setVisible(False)
+        self._error_details_frame.setVisible(False)
         self._errors_widget.setVisible(False)
         self._actions_widget.setVisible(False)
 
@@ -478,7 +478,7 @@ class ValidationsWidget(QtWidgets.QWidget):
             return
 
         self._top_label.setVisible(True)
-        self._error_details_widget.setVisible(True)
+        self._error_details_frame.setVisible(True)
         self._errors_widget.setVisible(True)
 
         errors_by_title = []

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -226,13 +226,15 @@ class ActionButton(ClickableFrame):
         action_label = action.label or action.__name__
         action_icon = getattr(action, "icon", None)
         label_widget = QtWidgets.QLabel(action_label, self)
+        icon_label = None
         if action_icon:
             icon_label = IconValuePixmapLabel(action_icon, self)
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(5, 0, 5, 0)
         layout.addWidget(label_widget, 1)
-        layout.addWidget(icon_label, 0)
+        if icon_label is not None:
+            layout.addWidget(icon_label, 0)
 
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum,

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -10,6 +10,9 @@ from .widgets import (
     ClickableFrame,
     IconValuePixmapLabel
 )
+from ..constants import (
+    INSTANCE_ID_ROLE
+)
 
 
 class ValidationErrorInstanceList(QtWidgets.QListView):
@@ -47,6 +50,7 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
     if there is a list (Valdation error may happen on context).
     """
     selected = QtCore.Signal(int)
+    instance_changed = QtCore.Signal(int)
 
     def __init__(self, index, error_info, parent):
         super(ValidationErrorTitleWidget, self).__init__(parent)
@@ -72,24 +76,37 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
         title_frame_layout.addWidget(label_widget)
 
         instances_model = QtGui.QStandardItemModel()
-        instances = error_info["instances"]
+        error_info = error_info["error_info"]
+
+        help_text_by_instance_id = {}
         context_validation = False
         if (
-            not instances
-            or (len(instances) == 1 and instances[0] is None)
+            not error_info
+            or (len(error_info) == 1 and error_info[0][0] is None)
         ):
             context_validation = True
             toggle_instance_btn.setArrowType(QtCore.Qt.NoArrow)
+            help_text_by_instance_id[None] = error_info[0][1]
         else:
             items = []
-            for instance in instances:
+            for instance, exception in error_info:
                 label = instance.data.get("label") or instance.data.get("name")
                 item = QtGui.QStandardItem(label)
                 item.setFlags(
                     QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
                 )
-                item.setData(instance.id)
+                item.setData(instance.id, INSTANCE_ID_ROLE)
                 items.append(item)
+                dsc = exception.description
+                detail = exception.detail
+                if detail:
+                    dsc += "<br/><br/>{}".format(detail)
+
+                help_text = dsc
+                if commonmark:
+                    help_text = commonmark.commonmark(dsc)
+
+                help_text_by_instance_id[instance.id] = help_text
 
             instances_model.invisibleRootItem().appendRows(items)
 
@@ -114,12 +131,19 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
         if not context_validation:
             toggle_instance_btn.clicked.connect(self._on_toggle_btn_click)
 
+        instances_view.selectionModel().selectionChanged.connect(
+            self._on_seleciton_change
+        )
+
         self._title_frame = title_frame
 
         self._toggle_instance_btn = toggle_instance_btn
 
         self._instances_model = instances_model
         self._instances_view = instances_view
+
+        self._context_validation = context_validation
+        self._help_text_by_instance_id = help_text_by_instance_id
 
     def _mouse_release_callback(self):
         """Mark this widget as selected on click."""
@@ -145,6 +169,17 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
         self._title_frame.setProperty("selected", value)
         self._title_frame.style().polish(self._title_frame)
 
+    def current_desctiption_text(self):
+        if self._context_validation:
+            return self._help_text_by_instance_id[None]
+        index = self._instances_view.currentIndex()
+        # TODO make sure instance is selected
+        if not index.isValid():
+            index = self._instances_model.index(0, 0)
+
+        indence_id = index.data(INSTANCE_ID_ROLE)
+        return self._help_text_by_instance_id[indence_id]
+
     def set_selected(self, selected=None):
         """Change selected state of widget."""
         if selected is None:
@@ -166,6 +201,9 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
             self._toggle_instance_btn.setArrowType(QtCore.Qt.DownArrow)
         else:
             self._toggle_instance_btn.setArrowType(QtCore.Qt.RightArrow)
+
+    def _on_seleciton_change(self):
+        self.instance_changed.emit(self._index)
 
 
 class ActionButton(ClickableFrame):
@@ -440,28 +478,28 @@ class ValidationsWidget(QtWidgets.QWidget):
         errors_by_title = []
         for plugin_info in errors:
             titles = []
-            exception_by_title = {}
-            instances_by_title = {}
+            error_info_by_title = {}
 
             for error_info in plugin_info["errors"]:
                 exception = error_info["exception"]
                 title = exception.title
                 if title not in titles:
                     titles.append(title)
-                    instances_by_title[title] = []
-                    exception_by_title[title] = exception
-                instances_by_title[title].append(error_info["instance"])
+                    error_info_by_title[title] = []
+                error_info_by_title[title].append(
+                    (error_info["instance"], exception)
+                )
 
             for title in titles:
                 errors_by_title.append({
                     "plugin": plugin_info["plugin"],
-                    "exception": exception_by_title[title],
-                    "instances": instances_by_title[title]
+                    "error_info": error_info_by_title[title]
                 })
 
         for idx, item in enumerate(errors_by_title):
             widget = ValidationErrorTitleWidget(idx, item, self)
             widget.selected.connect(self._on_select)
+            widget.instance_changed.connect(self._on_instance_change)
             self._errors_layout.addWidget(widget)
             self._title_widgets[idx] = widget
             self._error_info[idx] = item
@@ -480,11 +518,18 @@ class ValidationsWidget(QtWidgets.QWidget):
         self._previous_select = self._title_widgets[index]
 
         error_item = self._error_info[index]
-
-        dsc = error_item["exception"].description
-        if commonmark:
-            html = commonmark.commonmark(dsc)
-            self._error_details_input.setHtml(html)
-        else:
-            self._error_details_input.setMarkdown(dsc)
         self._actions_widget.set_plugin(error_item["plugin"])
+
+        self._update_description()
+
+    def _on_instance_change(self, index):
+        if self._previous_select and self._previous_select.index != index:
+            return
+        self._update_description()
+
+    def _update_description(self):
+        description = self._previous_select.current_desctiption_text()
+        if commonmark:
+            self._error_details_input.setHtml(description)
+        else:
+            self._error_details_input.setMarkdown(description)

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -272,6 +272,7 @@ class ValidateActionsWidget(QtWidgets.QFrame):
             item = self._content_layout.takeAt(0)
             widget = item.widget()
             if widget:
+                widget.setVisible(False)
                 widget.deleteLater()
         self._actions_mapping = {}
 

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -68,8 +68,7 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
         toggle_instance_btn.setArrowType(QtCore.Qt.RightArrow)
         toggle_instance_btn.setMaximumWidth(14)
 
-        exception = error_info["exception"]
-        label_widget = QtWidgets.QLabel(exception.title, title_frame)
+        label_widget = QtWidgets.QLabel(error_info["title"], title_frame)
 
         title_frame_layout = QtWidgets.QHBoxLayout(title_frame)
         title_frame_layout.addWidget(toggle_instance_btn)
@@ -86,7 +85,8 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
         ):
             context_validation = True
             toggle_instance_btn.setArrowType(QtCore.Qt.NoArrow)
-            help_text_by_instance_id[None] = error_info[0][1]
+            description = self._prepare_description(error_info[0][1])
+            help_text_by_instance_id[None] = description
         else:
             items = []
             for instance, exception in error_info:
@@ -97,16 +97,8 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
                 )
                 item.setData(instance.id, INSTANCE_ID_ROLE)
                 items.append(item)
-                dsc = exception.description
-                detail = exception.detail
-                if detail:
-                    dsc += "<br/><br/>{}".format(detail)
-
-                help_text = dsc
-                if commonmark:
-                    help_text = commonmark.commonmark(dsc)
-
-                help_text_by_instance_id[instance.id] = help_text
+                description = self._prepare_description(exception)
+                help_text_by_instance_id[instance.id] = description
 
             instances_model.invisibleRootItem().appendRows(items)
 
@@ -144,6 +136,17 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
 
         self._context_validation = context_validation
         self._help_text_by_instance_id = help_text_by_instance_id
+
+    def _prepare_description(self, exception):
+        dsc = exception.description
+        detail = exception.detail
+        if detail:
+            dsc += "<br/><br/>{}".format(detail)
+
+        description = dsc
+        if commonmark:
+            description = commonmark.commonmark(dsc)
+        return description
 
     def _mouse_release_callback(self):
         """Mark this widget as selected on click."""
@@ -493,7 +496,8 @@ class ValidationsWidget(QtWidgets.QWidget):
             for title in titles:
                 errors_by_title.append({
                     "plugin": plugin_info["plugin"],
-                    "error_info": error_info_by_title[title]
+                    "error_info": error_info_by_title[title],
+                    "title": title
                 })
 
         for idx, item in enumerate(errors_by_title):

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -79,7 +79,7 @@ class PublisherWindow(QtWidgets.QDialog):
 
         # Content
         # Subset widget
-        subset_frame = QtWidgets.QWidget(self)
+        subset_frame = QtWidgets.QFrame(self)
 
         subset_views_widget = BorderedLabelWidget(
             "Subsets to publish", subset_frame


### PR DESCRIPTION
Actually not sure if new validation styles are applicable for Standalone Publisher, but they were in Clickup so I took a stab at them.

`validate_editorial_resources` is missing as it doesn't make much sense (or at least error message doesn't.)