### PR TITLE
Make launcher and workfiles interfaces use main_task info

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -90,6 +90,7 @@ from .avalon_context import (
     get_workdir_data,
     get_workdir,
     get_workdir_with_workdir_data,
+    get_master_task,
 
     create_workfile_doc,
     save_workfile_data_to_doc,
@@ -228,6 +229,7 @@ __all__ = [
     "get_workdir_data",
     "get_workdir",
     "get_workdir_with_workdir_data",
+    "get_master_task",
 
     "create_workfile_doc",
     "save_workfile_data_to_doc",

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -90,7 +90,7 @@ from .avalon_context import (
     get_workdir_data,
     get_workdir,
     get_workdir_with_workdir_data,
-    get_master_task,
+    get_main_task,
 
     create_workfile_doc,
     save_workfile_data_to_doc,
@@ -229,7 +229,7 @@ __all__ = [
     "get_workdir_data",
     "get_workdir",
     "get_workdir_with_workdir_data",
-    "get_master_task",
+    "get_main_task",
 
     "create_workfile_doc",
     "save_workfile_data_to_doc",

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -375,27 +375,27 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     return version_doc
 
 
-def get_master_task(asset_doc, task_name):
-    """Retrieve master_task from avalon asset requested task
+def get_main_task(asset_doc, task_name):
+    """Retrieve main_task from avalon asset requested task
 
-    Return the master task if there is one, return the task otherwise.
+    Return the main task if there is one, return the task otherwise.
 
     Args:
         asset_id (int): Id of asset under which the task belongs.
-        task_name (str): Name of task to retrieve master_task from.
+        task_name (str): Name of task to retrieve main_task from.
     Returns:
-        str: master task name if there is one, task name otherwise.
+        str: main task name if there is one, task name otherwise.
     """
 
     if asset_doc:
-        master_task = (
+        main_task = (
             asset_doc.get("data", {})
             .get("tasks", {})
             .get(task_name, {})
-            .get("master_task", None)
+            .get("main_task", None)
         )
-        if master_task:
-            return master_task
+        if main_task:
+            return main_task
     return task_name
 
 
@@ -544,9 +544,9 @@ def get_workdir_data(project_doc, asset_doc, task_name, host_name):
     if asset_parents:
         parent_name = asset_parents[-1]
 
-    master_task = get_master_task(asset_doc, task_name)
-    if master_task:
-        task_name = master_task
+    main_task = get_main_task(asset_doc, task_name)
+    if main_task:
+        task_name = main_task
 
     data = {
         "project": {

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -375,8 +375,7 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     return version_doc
 
 
-# @with_avalon
-def get_master_task(asset_doc, task_name, dbcon=None):
+def get_master_task(asset_doc, task_name):
     """Retrieve master_task from avalon asset requested task
 
     Return the master task if there is one, return the task otherwise.
@@ -384,22 +383,9 @@ def get_master_task(asset_doc, task_name, dbcon=None):
     Args:
         asset_id (int): Id of asset under which the task belongs.
         task_name (str): Name of task to retrieve master_task from.
-        dbcon (avalon.mongodb.AvalonMongoDB, optional): Avalon Mongo connection
-            with Session.
     Returns:
         str: master task name if there is one, task name otherwise.
     """
-
-    # if not dbcon:
-    #     log.debug("Using `avalon.io` for query.")
-    #     dbcon = avalon.io
-    #     # Make sure is installed
-    #     dbcon.install()
-    #
-    # asset_doc = avalon.io.find_one(
-    #     {"type": "asset", "_id": asset_id},
-    #     {"data": True}
-    # )
 
     if asset_doc:
         master_task = (

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -375,6 +375,44 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     return version_doc
 
 
+# @with_avalon
+def get_master_task(asset_doc, task_name, dbcon=None):
+    """Retrieve master_task from avalon asset requested task
+
+    Return the master task if there is one, return the task otherwise.
+
+    Args:
+        asset_id (int): Id of asset under which the task belongs.
+        task_name (str): Name of task to retrieve master_task from.
+        dbcon (avalon.mongodb.AvalonMongoDB, optional): Avalon Mongo connection
+            with Session.
+    Returns:
+        str: master task name if there is one, task name otherwise.
+    """
+
+    # if not dbcon:
+    #     log.debug("Using `avalon.io` for query.")
+    #     dbcon = avalon.io
+    #     # Make sure is installed
+    #     dbcon.install()
+    #
+    # asset_doc = avalon.io.find_one(
+    #     {"type": "asset", "_id": asset_id},
+    #     {"data": True}
+    # )
+
+    if asset_doc:
+        master_task = (
+            asset_doc.get("data", {})
+            .get("tasks", {})
+            .get(task_name, {})
+            .get("master_task", None)
+        )
+        if master_task:
+            return master_task
+    return task_name
+
+
 def get_workfile_template_key_from_context(
     asset_name, task_name, host_name, project_name=None,
     dbcon=None, project_settings=None
@@ -519,6 +557,10 @@ def get_workdir_data(project_doc, asset_doc, task_name, host_name):
     parent_name = project_doc["name"]
     if asset_parents:
         parent_name = asset_parents[-1]
+
+    master_task = get_master_task(asset_doc, task_name)
+    if master_task:
+        task_name = master_task
 
     data = {
         "project": {

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -21,7 +21,7 @@ from openpype.tools.utils.tasks_widget import TasksWidget
 from openpype.tools.utils.delegates import PrettyTimeDelegate
 from openpype.lib import (
     Anatomy,
-    get_master_task,
+    get_main_task,
     get_workdir,
     get_workfile_doc,
     create_workfile_doc,
@@ -464,7 +464,7 @@ class FilesWidget(QtWidgets.QWidget):
             {"type": "asset", "_id": asset_id},
             {"data": True}
         )
-        self._task_name = get_master_task(asset_doc, task_name)
+        self._task_name = get_main_task(asset_doc, task_name)
         self._task_type = task_type
 
         # Define a custom session so we can query the work root

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -21,6 +21,7 @@ from openpype.tools.utils.tasks_widget import TasksWidget
 from openpype.tools.utils.delegates import PrettyTimeDelegate
 from openpype.lib import (
     Anatomy,
+    get_master_task,
     get_workdir,
     get_workfile_doc,
     create_workfile_doc,
@@ -459,7 +460,11 @@ class FilesWidget(QtWidgets.QWidget):
         if asset_id != self._asset_id:
             self._asset_doc = None
         self._asset_id = asset_id
-        self._task_name = task_name
+        asset_doc = io.find_one(
+            {"type": "asset", "_id": asset_id},
+            {"data": True}
+        )
+        self._task_name = get_master_task(asset_doc, task_name)
         self._task_type = task_type
 
         # Define a custom session so we can query the work root
@@ -481,6 +486,8 @@ class FilesWidget(QtWidgets.QWidget):
         if not has_filenames:
             # Manually trigger file selection
             self.on_file_select()
+
+        self._task_name = task_name
 
     def _get_asset_doc(self):
         if self._asset_id is None:


### PR DESCRIPTION
Here is a simple implementation for the feature proposed in the issue #2201

This feature rely on a new field named `main_task` within the task object of an asset.
This field accept an other task name as value.

If you mark a task as a slave of another task like so, this will inform the launcher and the workfiles interface to use the workfile of the master task while keeping the information of the slave task within the Session an the environment to keep publishing normaly within this task.