### PR TITLE
Fix "Set Frame Range" loaders to retrieve the correct data from the version

### DIFF
--- a/openpype/hosts/houdini/plugins/load/actions.py
+++ b/openpype/hosts/houdini/plugins/load/actions.py
@@ -29,8 +29,8 @@ class SetFrameRangeLoader(api.Loader):
         version = context["version"]
         version_data = version.get("data", {})
 
-        start = version_data.get("startFrame", None)
-        end = version_data.get("endFrame", None)
+        start = version_data.get("frameStart", None)
+        end = version_data.get("frameEnd", None)
 
         if start is None or end is None:
             print(
@@ -67,8 +67,8 @@ class SetFrameRangeWithHandlesLoader(api.Loader):
         version = context["version"]
         version_data = version.get("data", {})
 
-        start = version_data.get("startFrame", None)
-        end = version_data.get("endFrame", None)
+        start = version_data.get("frameStart", None)
+        end = version_data.get("frameEnd", None)
 
         if start is None or end is None:
             print(
@@ -78,9 +78,8 @@ class SetFrameRangeWithHandlesLoader(api.Loader):
             return
 
         # Include handles
-        handles = version_data.get("handles", 0)
-        start -= handles
-        end += handles
+        start -= version_data.get("handleStart", 0)
+        end += version_data.get("handleEnd", 0)
 
         hou.playbar.setFrameRange(start, end)
         hou.playbar.setPlaybackRange(start, end)

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -68,9 +68,8 @@ class SetFrameRangeWithHandlesLoader(api.Loader):
             return
 
         # Include handles
-        handles = version_data.get("handles", 0)
-        start -= handles
-        end += handles
+        start -= version_data.get("handleStart", 0)
+        end += version_data.get("handleEnd", 0)
 
         cmds.playbackOptions(minTime=start,
                              maxTime=end,


### PR DESCRIPTION
Over the development of OpenPype there has been some refactoring of some version data to new names. The Set Frame Range Loader Action to match the frame range of a specific publishes weren't refactored along.

- Maya was only missing the refactor for the handles.
- Houdini was missing the refactor for both the frame range and the handles.

These are now correctly refactored for the Maya and Houdini loaders:

- `startFrame` -> `frameStart`
- `endFrame` -> `frameEnd`
- `handles` -> `handleStart` and `handleEnd`