### PR TITLE
Houdini: Remove broken unique name counter

### DIFF
--- a/openpype/hosts/houdini/plugins/load/load_alembic.py
+++ b/openpype/hosts/houdini/plugins/load/load_alembic.py
@@ -1,6 +1,6 @@
 from avalon import api
 
-from avalon.houdini import pipeline, lib
+from avalon.houdini import pipeline
 
 
 class AbcLoader(api.Loader):
@@ -25,16 +25,9 @@ class AbcLoader(api.Loader):
         # Get the root node
         obj = hou.node("/obj")
 
-        # Create a unique name
-        counter = 1
+        # Define node name
         namespace = namespace if namespace else context["asset"]["name"]
-        formatted = "{}_{}".format(namespace, name) if namespace else name
-        node_name = "{0}_{1:03d}".format(formatted, counter)
-
-        children = lib.children_as_string(hou.node("/obj"))
-        while node_name in children:
-            counter += 1
-            node_name = "{0}_{1:03d}".format(formatted, counter)
+        node_name = "{}_{}".format(namespace, name) if namespace else name
 
         # Create a new geo node
         container = obj.createNode("geo", node_name=node_name)

--- a/openpype/hosts/houdini/plugins/load/load_camera.py
+++ b/openpype/hosts/houdini/plugins/load/load_camera.py
@@ -1,5 +1,5 @@
 from avalon import api
-from avalon.houdini import pipeline, lib
+from avalon.houdini import pipeline
 
 
 ARCHIVE_EXPRESSION = ('__import__("_alembic_hom_extensions")'
@@ -97,18 +97,9 @@ class CameraLoader(api.Loader):
         # Get the root node
         obj = hou.node("/obj")
 
-        # Create a unique name
-        counter = 1
-        asset_name = context["asset"]["name"]
-
-        namespace = namespace or asset_name
-        formatted = "{}_{}".format(namespace, name) if namespace else name
-        node_name = "{0}_{1:03d}".format(formatted, counter)
-
-        children = lib.children_as_string(hou.node("/obj"))
-        while node_name in children:
-            counter += 1
-            node_name = "{0}_{1:03d}".format(formatted, counter)
+        # Define node name
+        namespace = namespace if namespace else context["asset"]["name"]
+        node_name = "{}_{}".format(namespace, name) if namespace else name
 
         # Create a archive node
         container = self.create_and_connect(obj, "alembicarchive", node_name)


### PR DESCRIPTION
## Brief description

This removes the unique name counter in some Houdini loaders and resolves #2449.

However, it requires a change in `avalon.houdini.pipeline` as well.

In particular [this line](https://github.com/pypeclub/avalon-core/blob/ffe9e910f1f382e222d457d8e4a8426c41ed43ae/avalon/houdini/pipeline.py#L148) should be changed to:
```python
    container.setName(container_name, unique_name=True)
```

With this change the [`children_as_string` method can also be removed from `avalon.houdini.lib`](https://github.com/pypeclub/avalon-core/blob/ffe9e910f1f382e222d457d8e4a8426c41ed43ae/avalon/houdini/lib.py#L7-L8) since it's only used throughout the code base for these two loaders.