### PR TITLE
Maya: Validate Shape Zero do not keep fixed geometry vertices selected/active after repair

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -4,6 +4,8 @@ import pyblish.api
 import openpype.api
 import openpype.hosts.maya.api.action
 
+from avalon.maya import maintained_selection
+
 
 class ValidateShapeZero(pyblish.api.Validator):
     """shape can't have any values
@@ -47,8 +49,12 @@ class ValidateShapeZero(pyblish.api.Validator):
     @classmethod
     def repair(cls, instance):
         invalid_shapes = cls.get_invalid(instance)
-        for shape in invalid_shapes:
-            cmds.polyCollapseTweaks(shape)
+        if not invalid_shapes:
+            return
+
+        with maintained_selection():
+            for shape in invalid_shapes:
+                cmds.polyCollapseTweaks(shape)
 
     def process(self, instance):
         """Process all the nodes in the instance "objectSet"""

--- a/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -9,11 +9,9 @@ from avalon.maya import maintained_selection
 
 
 class ValidateShapeZero(pyblish.api.Validator):
-    """shape can't have any values
+    """Shape components may not have any "tweak" values
 
-    To solve this issue, try freezing the shapes. So long
-    as the translation, rotation and scaling values are zero,
-    you're all good.
+    To solve this issue, try freezing the shapes.
 
     """
 
@@ -67,5 +65,5 @@ class ValidateShapeZero(pyblish.api.Validator):
 
         invalid = self.get_invalid(instance)
         if invalid:
-            raise ValueError("Nodes found with shape or vertices not freezed"
-                             "values: {0}".format(invalid))
+            raise ValueError("Shapes found with non-zero component tweaks: "
+                             "{0}".format(invalid))

--- a/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -3,6 +3,7 @@ from maya import cmds
 import pyblish.api
 import openpype.api
 import openpype.hosts.maya.api.action
+from openpype.hosts.maya.api import lib
 
 from avalon.maya import maintained_selection
 
@@ -53,8 +54,13 @@ class ValidateShapeZero(pyblish.api.Validator):
             return
 
         with maintained_selection():
-            for shape in invalid_shapes:
-                cmds.polyCollapseTweaks(shape)
+            with lib.tool("selectSuperContext"):
+                for shape in invalid_shapes:
+                    cmds.polyCollapseTweaks(shape)
+                    # cmds.polyCollapseTweaks keeps selecting the geometry
+                    # after each command. When running on many meshes
+                    # after one another this tends to get really heavy
+                    cmds.select(clear=True)
 
     def process(self, instance):
         """Process all the nodes in the instance "objectSet"""


### PR DESCRIPTION
## Brief description

Previously when performing repair on the Validate Shape Zero plug-in the last processed mesh would remain highlighted for all its individual vertices. This fixes that issue.