### PR TITLE
Maya: Validate Rig Controllers - fix Error: in script editor

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rig_controllers.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_controllers.py
@@ -164,7 +164,8 @@ class ValidateRigControllers(pyblish.api.InstancePlugin):
                 continue
 
             # Ignore proxy connections.
-            if cmds.addAttr(plug, query=True, usedAsProxy=True):
+            if (cmds.addAttr(plug, query=True, exists=True) and
+                    cmds.addAttr(plug, query=True, usedAsProxy=True)):
                 continue
 
             # Check for incoming connections


### PR DESCRIPTION
The code implemented with [this commit](https://github.com/pypeclub/OpenPype/commit/127a167224c10dac532dccf805204db67f46e7e1) by @tokejepsen prints "error" messages in my script editor in both Maya 2020 and 2022.

For example:
```
# Error: 'visibility' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'translateX' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'translateY' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'translateZ' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'rotateX' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'rotateY' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'rotateZ' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'scaleX' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'scaleY' is not a dynamic attribute of node 'pCube1'. # 
# Error: 'scaleZ' is not a dynamic attribute of node 'pCube1'. # 
```
_For sake of example I just quickly added a cube as "controller"_

The script continues fine but it's a confusing/annoying side effect and because it prints so many in the Script Editor it also slows down the validation.

This code change avoids the error and still correctly skips the usedAsProxy attributes as intended originally.

Note that it's using [`maya.cmds.addAttr` flag `exists=True`](https://help.autodesk.com/cloudhelp/2017/ENU/Maya-Tech-Docs/CommandsPython/addAttr.html#flagexists) instead of checking whether the attribute itself exists with `attributeQuery`. According to the docs `exists` on `maya.cmds.addAttr` should:
> Returns true if the attribute queried is a user-added, dynamic attribute; false if not. 
