### PR TITLE
Maya: Improve speed of Collect History logic

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_history.py
+++ b/openpype/hosts/maya/plugins/publish/collect_history.py
@@ -22,15 +22,22 @@ class CollectMayaHistory(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        # Collect the history with long names
-        history = cmds.listHistory(instance, leaf=False) or []
-        history = cmds.ls(history, long=True)
+        kwargs = {}
+        if int(cmds.about(version=True)) >= 2020:
+            # New flag since Maya 2020 which makes cmds.listHistory faster
+            kwargs = {"fastIteration": True}
+        else:
+            self.log.debug("Ignoring `fastIteration` flag before Maya 2020..")
 
-        # Remove invalid node types (like renderlayers)
-        invalid = cmds.ls(history, type="renderLayer", long=True)
-        if invalid:
-            invalid = set(invalid)  # optimize lookup
-            history = [x for x in history if x not in invalid]
+        # Collect the history with long names
+        history = set(cmds.listHistory(instance, leaf=False, **kwargs) or [])
+        history = cmds.ls(list(history), long=True)
+
+        # Exclude invalid nodes (like renderlayers)
+        exclude = cmds.ls(type="renderLayer", long=True)
+        if exclude:
+            exclude = set(exclude)  # optimize lookup
+            history = [x for x in history if x not in exclude]
 
         # Combine members with history
         members = instance[:] + history


### PR DESCRIPTION
Also felt like this Collector was running a bit slower than I liked.

Optimizations:
- `maya.cmds.listHistory` returns duplicates if multiple nodes have the same node in history, thus making them unique with `set` reduces tons of items continuing through all the commands (biggest speed improvement here)
- `cmds.ls(type="renderLayer")` now without input nodes. History tends to be so big that calling the command with those nodes as arguments produces a big overhead, simultaneously amount of renderlayers usually tend to be relatively small. So we just get all renderlayers and filter ourselves.
- use `fastIteration` flag in Maya 2020+ (about 10-20% speed difference in my tests)
