### PR TITLE
Fix error when clicking on empty Subset area in Loader after having a Subset active

### DIFF
--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -363,7 +363,6 @@ class LoaderWindow(QtWidgets.QDialog):
 
         # Active must be in the selected rows otherwise we
         # assume it's not actually an "active" current index.
-        version_docs = None
         version_doc = None
         active = selection.currentIndex()
         rows = selection.selectedRows(column=active.column())
@@ -375,9 +374,10 @@ class LoaderWindow(QtWidgets.QDialog):
                     not (item.get("isGroup") or item.get("isMerged"))
                 ):
                     version_doc = item["version_document"]
+        self._version_info_widget.set_version(version_doc)
 
+        version_docs = []
         if rows:
-            version_docs = []
             for index in rows:
                 if not index or not index.isValid():
                     continue
@@ -390,8 +390,6 @@ class LoaderWindow(QtWidgets.QDialog):
                 else:
                     version_docs.append(item["version_document"])
 
-        self._version_info_widget.set_version(version_doc)
-
         thumbnail_src_ids = [
             version_doc["_id"]
             for version_doc in version_docs
@@ -402,7 +400,7 @@ class LoaderWindow(QtWidgets.QDialog):
         self._thumbnail_widget.set_thumbnail(thumbnail_src_ids)
 
         if self._repres_widget is not None:
-            version_ids = [doc["_id"] for doc in version_docs or []]
+            version_ids = [doc["_id"] for doc in version_docs]
             self._repres_widget.set_version_ids(version_ids)
 
             # self._repres_widget.change_visibility("subset", len(rows) > 1)


### PR DESCRIPTION

- Fixes an error that is produced when in the Loader selecting a Subset and then clicking in the empty area below subsets (basically deselecting a subset). Previously it would error:
```python
# Traceback (most recent call last):
#   File "S:\openpype\OpenPype\openpype\tools\loader\app.py", line 331, in _subsetschanged
#     self._versionschanged()
#   File "S:\openpype\OpenPype\openpype\tools\loader\app.py", line 397, in _versionschanged
#     if not thumbnail_src_ids:
# TypeError: 'NoneType' object is not iterable
```

- This also reorders some of the code so variables are closer to where they are used to avoid confusion. Now it's clearer `version_docs` isn't actually used up to where it's now defined.
