### PR TITLE
Publish pype: Reduce publish process defering

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -42,7 +42,7 @@ class MainThreadProcess(QtCore.QObject):
     This approach gives ability to update UI meanwhile plugin is in progress.
     """
 
-    timer_interval = 10
+    timer_interval = 3
 
     def __init__(self):
         super(MainThreadProcess, self).__init__()

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -41,12 +41,15 @@ class MainThreadProcess(QtCore.QObject):
 
     This approach gives ability to update UI meanwhile plugin is in progress.
     """
+
+    timer_interval = 10
+
     def __init__(self):
         super(MainThreadProcess, self).__init__()
         self._items_to_process = collections.deque()
 
         timer = QtCore.QTimer()
-        timer.setInterval(50)
+        timer.setInterval(self.timer_interval)
 
         timer.timeout.connect(self._execute)
 

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -47,12 +47,14 @@ class MainThreadProcess(QtCore.QObject):
 
     This approach gives ability to update UI meanwhile plugin is in progress.
     """
+    timer_interval = 3
+
     def __init__(self):
         super(MainThreadProcess, self).__init__()
         self._items_to_process = collections.deque()
 
         timer = QtCore.QTimer()
-        timer.setInterval(10)
+        timer.setInterval(self.timer_interval)
 
         timer.timeout.connect(self._execute)
 

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -9,6 +9,7 @@ import os
 import sys
 import inspect
 import logging
+import collections
 
 from Qt import QtCore
 
@@ -137,6 +138,7 @@ class Controller(QtCore.QObject):
         self.plugins = {}
         self.optional_default = {}
         self.instance_toggled.connect(self._on_instance_toggled)
+        self._main_thread_processor = MainThreadProcess()
 
     def reset_variables(self):
         self.log.debug("Resetting pyblish context variables")
@@ -235,7 +237,11 @@ class Controller(QtCore.QObject):
 
     def reset(self):
         """Discover plug-ins and run collection."""
+        self._main_thread_processor.clear()
+        self._main_thread_processor.process(self._reset)
+        self._main_thread_processor.start()
 
+    def _reset(self):
         self.reset_context()
         self.reset_variables()
 
@@ -276,21 +282,25 @@ class Controller(QtCore.QObject):
         if self.is_running:
             self.is_running = False
         self.was_finished.emit()
+        self._main_thread_processor.stop()
 
     def stop(self):
         self.log.debug("Stopping")
         self.stopped = True
 
     def act(self, plugin, action):
-        def on_next():
-            result = pyblish.plugin.process(
-                plugin, self.context, None, action.id
-            )
-            self.is_running = False
-            self.was_acted.emit(result)
-
         self.is_running = True
-        util.defer(100, on_next)
+        item = MainThreadItem(self._process_action, plugin, action)
+        self._main_thread_processor.add_item(item)
+        self._main_thread_processor.start()
+        self._main_thread_processor.stop_if_empty()
+
+    def _process_action(self, plugin, action):
+        result = pyblish.plugin.process(
+            plugin, self.context, None, action.id
+        )
+        self.is_running = False
+        self.was_acted.emit(result)
 
     def emit_(self, signal, kwargs):
         pyblish.api.emit(signal, **kwargs)
@@ -421,11 +431,13 @@ class Controller(QtCore.QObject):
 
         self.passed_group.emit(self.processing["next_group_order"])
 
-    def iterate_and_process(self, on_finished=lambda: None):
+    def iterate_and_process(self, on_finished=None):
         """ Iterating inserted plugins with current context.
         Collectors do not contain instances, they are None when collecting!
         This process don't stop on one
         """
+        self._main_thread_processor.start()
+
         def on_next():
             self.log.debug("Looking for next pair to process")
             try:
@@ -437,13 +449,19 @@ class Controller(QtCore.QObject):
                 self.log.debug("Iteration break was raised")
                 self.is_running = False
                 self.was_stopped.emit()
+                self._main_thread_processor.stop()
                 return
 
             except StopIteration:
                 self.log.debug("Iteration stop was raised")
                 self.is_running = False
                 # All pairs were processed successfully!
-                return util.defer(500, on_finished)
+                if on_finished is not None:
+                    self._main_thread_processor.add_item(
+                        MainThreadItem(on_finished)
+                    )
+                self._main_thread_processor.stop_if_empty()
+                return
 
             except Exception as exc:
                 self.log.warning(
@@ -451,12 +469,15 @@ class Controller(QtCore.QObject):
                     exc_info=True
                 )
                 exc_msg = str(exc)
-                return util.defer(
-                    500, lambda: on_unexpected_error(error=exc_msg)
+                self._main_thread_processor.add_item(
+                    MainThreadItem(on_unexpected_error, error=exc_msg)
                 )
+                return
 
             self.about_to_process.emit(*self.current_pair)
-            util.defer(100, on_process)
+            self._main_thread_processor.add_item(
+                MainThreadItem(on_process)
+            )
 
         def on_process():
             try:
@@ -477,11 +498,14 @@ class Controller(QtCore.QObject):
                     exc_info=True
                 )
                 exc_msg = str(exc)
-                return util.defer(
-                    500, lambda: on_unexpected_error(error=exc_msg)
+                self._main_thread_processor.add_item(
+                    MainThreadItem(on_unexpected_error, error=exc_msg)
                 )
+                return
 
-            util.defer(10, on_next)
+            self._main_thread_processor.add_item(
+                MainThreadItem(on_next)
+            )
 
         def on_unexpected_error(error):
             # TODO this should be handled much differently
@@ -489,24 +513,42 @@ class Controller(QtCore.QObject):
             self.is_running = False
             self.was_stopped.emit()
             util.u_print(u"An unexpected error occurred:\n %s" % error)
-            return util.defer(500, on_finished)
+            if on_finished is not None:
+                self._main_thread_processor.add_item(
+                    MainThreadItem(on_finished)
+                )
+            self._main_thread_processor.stop_if_empty()
 
         self.is_running = True
-        util.defer(10, on_next)
+        self._main_thread_processor.add_item(
+            MainThreadItem(on_next)
+        )
 
     def collect(self):
         """ Iterate and process Collect plugins
         - load_plugins method is launched again when finished
         """
-        self.iterate_and_process()
+        self._main_thread_processor.process(self._start_collect)
+        self._main_thread_processor.start()
 
     def validate(self):
         """ Process plugins to validations_order value."""
-        self.processing["stop_on_validation"] = True
-        self.iterate_and_process()
+        self._main_thread_processor.process(self._start_validate)
+        self._main_thread_processor.start()
 
     def publish(self):
         """ Iterate and process all remaining plugins."""
+        self._main_thread_processor.process(self._start_publish)
+        self._main_thread_processor.start()
+
+    def _start_collect(self):
+        self.iterate_and_process()
+
+    def _start_validate(self):
+        self.processing["stop_on_validation"] = True
+        self.iterate_and_process()
+
+    def _start_publish(self):
         self.processing["stop_on_validation"] = False
         self.iterate_and_process(self.on_published)
 

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -1148,7 +1148,7 @@ class Window(QtWidgets.QDialog):
         self.comment_box.placeholder.setVisible(False)
         self.comment_box.placeholder.setVisible(True)
         # Launch controller reset
-        util.defer(500, self.controller.reset)
+        self.controller.reset()
 
     def validate(self):
         self.info(self.tr("Preparing validate.."))
@@ -1159,7 +1159,7 @@ class Window(QtWidgets.QDialog):
 
         self.button_suspend_logs.setEnabled(False)
 
-        util.defer(5, self.controller.validate)
+        self.controller.validate()
 
     def publish(self):
         self.info(self.tr("Preparing publish.."))
@@ -1170,7 +1170,7 @@ class Window(QtWidgets.QDialog):
 
         self.button_suspend_logs.setEnabled(False)
 
-        util.defer(5, self.controller.publish)
+        self.controller.publish()
 
     def act(self, plugin_item, action):
         self.info("%s %s.." % (self.tr("Preparing"), action))
@@ -1187,9 +1187,7 @@ class Window(QtWidgets.QDialog):
         )
 
         # Give Qt time to draw
-        util.defer(100, lambda: self.controller.act(
-            plugin_item.plugin, action
-        ))
+        self.controller.act(plugin_item.plugin, action)
 
         self.info(self.tr("Action prepared."))
 
@@ -1267,7 +1265,7 @@ class Window(QtWidgets.QDialog):
             self.info(self.tr("..as soon as processing is finished.."))
             self.controller.stop()
             self.finished.connect(self.close)
-            util.defer(2000, on_problem)
+            util.defer(200, on_problem)
             return event.ignore()
 
         self.state["is_closing"] = True


### PR DESCRIPTION
## Brief description
Defered execution in publish pype makes processing much slower because of deffering.

## Description
Reduced defering of execution to minimum using main thread process helper. Which tries to execute methods each 10 ms (if there are any). This approach makes publishing faster and should also allow repaint of UI.

## Changes
- copied main thread processor from new publisher (and slightly modified) to publish pype
- converted current methods to use new processor to reduce waiting time

### Notes
- didn't test actions
- didn't test long time plugins properly but collect ftrack api (takes 1s +/-) stopped and UI was painted

## Testing notes:
1. Run publish
2. Check speed
*3. Try to run any action (repair etc.)