### PR TITLE
General: Anatomy does not return root envs as unicode

### DIFF
--- a/openpype/lib/anatomy.py
+++ b/openpype/lib/anatomy.py
@@ -1568,8 +1568,11 @@ class Roots:
             key_items = [self.env_prefix]
             for _key in keys:
                 key_items.append(_key.upper())
+
             key = "_".join(key_items)
-            return {key: roots.value}
+            # Make sure key and value does not contain unicode
+            #   - can happen in Python 2 hosts
+            return {str(key): str(roots.value)}
 
         output = {}
         for _key, _value in roots.items():


### PR DESCRIPTION
## Brief description
It seems that anatomy sets environments in `os.environ` as unicode type in Python 2 host which cause issues in subprocess.Popen.

## Changes
- make sure anatomy does not return unicode strings