### PR TITLE
TVPaint: Create render layer dialog is in front

### DIFF
--- a/openpype/hosts/tvpaint/plugins/create/create_render_layer.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render_layer.py
@@ -197,6 +197,7 @@ class CreateRenderlayer(plugin.Creator):
         )
 
     def _ask_user_subset_override(self, instance):
+        from Qt import QtCore
         from Qt.QtWidgets import QMessageBox
 
         title = "Subset \"{}\" already exist".format(instance["subset"])
@@ -206,6 +207,10 @@ class CreateRenderlayer(plugin.Creator):
         ).format(instance["subset"])
 
         dialog = QMessageBox()
+        dialog.setWindowFlags(
+            dialog.windowFlags()
+            | QtCore.Qt.WindowStaysOnTopHint
+        )
         dialog.setWindowTitle(title)
         dialog.setText(text)
         dialog.setStandardButtons(QMessageBox.Yes | QMessageBox.No)


### PR DESCRIPTION
## Brief description
First sentence is brief description.

## Changes
- make dialog shown in create render layer always on top

## How to test
- run TVPaint
- select layer with group (e.g. Red color) and create Render Layer with name 'Test'
- select layer with a different group (e.g. Blue color) and create Render Layer with name 'Test'
- a dialog should show up with message which should be visible on top of Creator tool