### PR TITLE
Tools: Be able to change models of tasks and assets widgets

### DIFF
--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -306,6 +306,8 @@ class AssetModel(QtGui.QStandardItemModel):
         self._items_with_color_by_id = {}
         self._items_by_asset_id = {}
 
+        self._last_project_name = None
+
     @property
     def refreshing(self):
         return self._refreshing
@@ -347,7 +349,7 @@ class AssetModel(QtGui.QStandardItemModel):
 
         return self.get_indexes_by_asset_ids(asset_ids)
 
-    def refresh(self, force=False, clear=False):
+    def refresh(self, force=False):
         """Refresh the data for the model.
 
         Args:
@@ -360,7 +362,13 @@ class AssetModel(QtGui.QStandardItemModel):
                 return
             self.stop_refresh()
 
-        if clear:
+        project_name = self.dbcon.Session.get("AVALON_PROJECT")
+        clear_model = False
+        if project_name != self._last_project_name:
+            clear_model = True
+            self._last_project_name = project_name
+
+        if clear_model:
             self._clear_items()
 
         # Fetch documents from mongo
@@ -401,11 +409,18 @@ class AssetModel(QtGui.QStandardItemModel):
             self._clear_items()
             return
 
+        self._fill_assets(self._doc_payload)
+
+        self.refreshed.emit(bool(self._items_by_asset_id))
+
+        self._stop_fetch_thread()
+
+    def _fill_assets(self, asset_docs):
         # Collect asset documents as needed
         asset_ids = set()
         asset_docs_by_id = {}
         asset_ids_by_parents = collections.defaultdict(set)
-        for asset_doc in self._doc_payload:
+        for asset_doc in asset_docs:
             asset_id = asset_doc["_id"]
             asset_data = asset_doc.get("data") or {}
             parent_id = asset_data.get("visualParent")
@@ -510,10 +525,6 @@ class AssetModel(QtGui.QStandardItemModel):
 
             except Exception:
                 pass
-
-        self.refreshed.emit(bool(self._items_by_asset_id))
-
-        self._stop_fetch_thread()
 
     def _threaded_fetch(self):
         asset_docs = self._fetch_asset_docs()
@@ -652,12 +663,7 @@ class AssetsWidget(QtWidgets.QWidget):
         return self._model.refreshing
 
     def refresh(self):
-        project_name = self.dbcon.Session.get("AVALON_PROJECT")
-        clear_model = False
-        if project_name != self._last_project_name:
-            clear_model = True
-            self._last_project_name = project_name
-        self._refresh_model(clear_model)
+        self._refresh_model()
 
     def stop_refresh(self):
         self._model.stop_refresh()
@@ -709,14 +715,14 @@ class AssetsWidget(QtWidgets.QWidget):
         self._set_loading_state(loading=False, empty=not has_item)
         self.refreshed.emit()
 
-    def _refresh_model(self, clear=False):
+    def _refresh_model(self):
         # Store selection
         self._set_loading_state(loading=True, empty=True)
 
         # Trigger signal before refresh is called
         self.refresh_triggered.emit()
         # Refresh model
-        self._model.refresh(clear=clear)
+        self._model.refresh()
 
     def _set_loading_state(self, loading, empty):
         self._view.set_loading_state(loading, empty)

--- a/openpype/tools/utils/tasks_widget.py
+++ b/openpype/tools/utils/tasks_widget.py
@@ -194,6 +194,8 @@ class TasksWidget(QtWidgets.QWidget):
     task_changed = QtCore.Signal()
 
     def __init__(self, dbcon, parent=None):
+        self._dbcon = dbcon
+
         super(TasksWidget, self).__init__(parent)
 
         tasks_view = DeselectableTreeView(self)
@@ -204,9 +206,8 @@ class TasksWidget(QtWidgets.QWidget):
         header_view = tasks_view.header()
         header_view.setSortIndicator(0, QtCore.Qt.AscendingOrder)
 
-        tasks_model = TasksModel(dbcon)
-        tasks_proxy = TasksProxyModel()
-        tasks_proxy.setSourceModel(tasks_model)
+        tasks_model = self._create_source_model()
+        tasks_proxy = self._create_proxy_model(tasks_model)
         tasks_view.setModel(tasks_proxy)
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -221,6 +222,19 @@ class TasksWidget(QtWidgets.QWidget):
         self._tasks_view = tasks_view
 
         self._last_selected_task_name = None
+
+    def _create_source_model(self):
+        """Create source model of tasks widget.
+
+        Model must have available 'refresh' method and 'set_asset_id' to change
+        context of asset.
+        """
+        return TasksModel(self._dbcon)
+
+    def _create_proxy_model(self, source_model):
+        proxy = TasksProxyModel()
+        proxy.setSourceModel(source_model)
+        return proxy
 
     def refresh(self):
         self._tasks_model.refresh()


### PR DESCRIPTION
## Brief description
Be able to create different source model for assets widget and tasks widget.

## Description
In some cases it is better to use different model for assets and tasks widget which is based on different source of data. For example when a tool is querying asset documents for it's purposes then triggers refresh of assets widget. In that case the same data are queried twice which makes loading of tool slower. At the same time a tool may require custom filtering of assets or tasks which is not possible right now. Both use cases would require to create whole new asset or task widget for the tool which is duplication of code.

## Changes
- tasks and asset widget have methods to create model and proxy model
    - this way it is easy to inherit from the class and override those methods to define different source of data
- clearing of model of refresh is handled in `_refresh_model` because if may not be possible for custom model to do so

## Note
- This change is needed for 2 or more other features that are long term so it would be hard to maintain those changes

## Testing notes:
1. Everything should work as before