### PR TITLE
Loader: Remove always on top flag in tray

### DIFF
--- a/openpype/modules/avalon_apps/avalon_app.py
+++ b/openpype/modules/avalon_apps/avalon_app.py
@@ -42,12 +42,20 @@ class AvalonModule(OpenPypeModule, ITrayModule):
     def tray_init(self):
         # Add library tool
         try:
+            from Qt import QtCore
             from openpype.tools.libraryloader import LibraryLoaderWindow
 
-            self.libraryloader = LibraryLoaderWindow(
+            libraryloader = LibraryLoaderWindow(
                 show_projects=True,
                 show_libraries=True
             )
+            # Remove always on top flag for tray
+            window_flags = libraryloader.windowFlags()
+            if window_flags | QtCore.Qt.WindowStaysOnTopHint:
+                window_flags ^= QtCore.Qt.WindowStaysOnTopHint
+                libraryloader.setWindowFlags(window_flags)
+            self.libraryloader = libraryloader
+
         except Exception:
             self.log.warning(
                 "Couldn't load Library loader tool for tray.",

--- a/openpype/modules/avalon_apps/avalon_app.py
+++ b/openpype/modules/avalon_apps/avalon_app.py
@@ -13,14 +13,6 @@ class AvalonModule(OpenPypeModule, ITrayModule):
 
         avalon_settings = modules_settings[self.name]
 
-        # Check if environment is already set
-        avalon_mongo_url = os.environ.get("AVALON_MONGO")
-        if not avalon_mongo_url:
-            avalon_mongo_url = avalon_settings["AVALON_MONGO"]
-        # Use pype mongo if Avalon's mongo not defined
-        if not avalon_mongo_url:
-            avalon_mongo_url = os.environ["OPENPYPE_MONGO"]
-
         thumbnail_root = os.environ.get("AVALON_THUMBNAIL_ROOT")
         if not thumbnail_root:
             thumbnail_root = avalon_settings["AVALON_THUMBNAIL_ROOT"]
@@ -31,7 +23,6 @@ class AvalonModule(OpenPypeModule, ITrayModule):
             avalon_mongo_timeout = avalon_settings["AVALON_TIMEOUT"]
 
         self.thumbnail_root = thumbnail_root
-        self.avalon_mongo_url = avalon_mongo_url
         self.avalon_mongo_timeout = avalon_mongo_timeout
 
         # Tray attributes

--- a/openpype/plugins/load/delivery.py
+++ b/openpype/plugins/load/delivery.py
@@ -3,11 +3,11 @@ import copy
 
 from Qt import QtWidgets, QtCore, QtGui
 
-from avalon import api, style
+from avalon import api
 from avalon.api import AvalonMongoDB
 
 from openpype.api import Anatomy, config
-from openpype import resources
+from openpype import resources, style
 
 from openpype.lib.delivery import (
     sizeof_fmt,

--- a/openpype/plugins/load/delivery.py
+++ b/openpype/plugins/load/delivery.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import copy
+from collections import defaultdict
 
 from Qt import QtWidgets, QtCore, QtGui
 
@@ -58,6 +58,18 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
     def __init__(self, contexts, log=None, parent=None):
         super(DeliveryOptionsDialog, self).__init__(parent=parent)
 
+        self.setWindowTitle("OpenPype - Deliver versions")
+        icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
+        self.setWindowIcon(icon)
+
+        self.setWindowFlags(
+            QtCore.Qt.WindowStaysOnTopHint
+            | QtCore.Qt.WindowCloseButtonHint
+            | QtCore.Qt.WindowMinimizeButtonHint
+        )
+
+        self.setStyleSheet(style.load_stylesheet())
+
         project = contexts[0]["project"]["name"]
         self.anatomy = Anatomy(project)
         self._representations = None
@@ -69,16 +81,6 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self.dbcon.install()
 
         self._set_representations(contexts)
-
-        self.setWindowTitle("OpenPype - Deliver versions")
-        icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
-        self.setWindowIcon(icon)
-
-        self.setWindowFlags(
-            QtCore.Qt.WindowCloseButtonHint |
-            QtCore.Qt.WindowMinimizeButtonHint
-        )
-        self.setStyleSheet(style.load_stylesheet())
 
         dropdown = QtWidgets.QComboBox()
         self.templates = self._get_templates(self.anatomy)


### PR DESCRIPTION
## Brief description
Library loader used in host without parent widget should be always on top but that is not true for tray.

## Description
Remove always on top flag from loader window in tray so it is possible to move it to back and front.

## Changes
- removed unused attribute `avalon_mongo_url` from avalon module
- library loader in tray does not have always on top flag
- delivery loader will show dialog always on top and uses openpype style

Resolves https://github.com/pypeclub/OpenPype/issues/2479