### PR TITLE
General: Custom template paths filter fix

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1560,7 +1560,7 @@ def get_custom_workfile_template_by_context(
     # get path from matching profile
     matching_item = filter_profiles(
         template_profiles,
-        {"task_type": current_task_type}
+        {"task_types": current_task_type}
     )
     # when path is available try to format it in case
     # there are some anatomy template strings


### PR DESCRIPTION
## Brief description
Custom template filter key `task_type` does not match data in profiles where is `task_types`.

## Changes
- fix filter key from `task_type` to `task_types`