### PR TITLE
Maya: Collect 'fps' animation data only for "review" instances

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -280,7 +280,7 @@ def shape_from_element(element):
         return node
 
 
-def collect_animation_data():
+def collect_animation_data(fps=False):
     """Get the basic animation data
 
     Returns:
@@ -291,7 +291,6 @@ def collect_animation_data():
     # get scene values as defaults
     start = cmds.playbackOptions(query=True, animationStartTime=True)
     end = cmds.playbackOptions(query=True, animationEndTime=True)
-    fps = mel.eval('currentTimeUnitToFPS()')
 
     # build attributes
     data = OrderedDict()
@@ -299,7 +298,9 @@ def collect_animation_data():
     data["frameEnd"] = end
     data["handles"] = 0
     data["step"] = 1.0
-    data["fps"] = fps
+
+    if fps:
+        data["fps"] = mel.eval('currentTimeUnitToFPS()')
 
     return data
 

--- a/openpype/hosts/maya/plugins/create/create_review.py
+++ b/openpype/hosts/maya/plugins/create/create_review.py
@@ -22,7 +22,7 @@ class CreateReview(plugin.Creator):
 
         # get basic animation data : start / end / handles / steps
         data = OrderedDict(**self.data)
-        animation_data = lib.collect_animation_data()
+        animation_data = lib.collect_animation_data(fps=True)
         for key, value in animation_data.items():
             data[key] = value
 


### PR DESCRIPTION
## Brief description

Here's a draft implementation for #2443 where it remains exposed on the Review family but is removed from the others. It's still up for discussion whether it's even relevant for the Review family too. I'm not entirely sure that attribute actually influences the output of the created review since I couldn't easily trace that in the code.