### PR TITLE
Workfiles tool: Files widget show files on first show

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -1074,6 +1074,7 @@ class Window(QtWidgets.QMainWindow):
 
         if "task" in context:
             self.tasks_widget.select_task_name(context["task"])
+        self._on_task_changed()
 
     def _on_asset_changed(self):
         asset_id = self.assets_widget.get_selected_asset_id()


### PR DESCRIPTION
## Brief description
Files view in Workfiles tool is disabled and without files on first show.

## Changes
- trigger on task changed in set context method to trigger update of files view