### PR TITLE
Tools: Fix style and modality of errors in loader and creator

### DIFF
--- a/openpype/style/__init__.py
+++ b/openpype/style/__init__.py
@@ -1,8 +1,10 @@
 import os
 import json
 import collections
-from openpype import resources
 import six
+
+from openpype import resources
+
 from .color_defs import parse_color
 
 
@@ -10,6 +12,18 @@ _STYLESHEET_CACHE = None
 _FONT_IDS = None
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_style_image_path(image_name):
+    # All filenames are lowered
+    image_name = image_name.lower()
+    # Male sure filename has png extension
+    if not image_name.endswith(".png"):
+        image_name += ".png"
+    filepath = os.path.join(current_dir, "images", image_name)
+    if os.path.exists(filepath):
+        return filepath
+    return None
 
 
 def _get_colors_raw_data():
@@ -160,6 +174,11 @@ def load_stylesheet():
     return _STYLESHEET_CACHE
 
 
-def app_icon_path():
+def get_app_icon_path():
     """Path to OpenPype icon."""
     return resources.get_openpype_icon_filepath()
+
+
+def app_icon_path():
+    # Backwards compatibility
+    return get_app_icon_path()

--- a/openpype/tools/creator/widgets.py
+++ b/openpype/tools/creator/widgets.py
@@ -42,7 +42,7 @@ class CreateErrorMessageBox(ErrorMessageBox):
         ).format(
             subset=self._subset_name,
             family=self._family,
-            asset=self._asset,
+            asset=self._asset_name,
             message=self._exc_msg
         )
         if self._formatted_traceback:
@@ -62,10 +62,8 @@ class CreateErrorMessageBox(ErrorMessageBox):
 
         item_name_widget = QtWidgets.QLabel(self)
         item_name_widget.setText(
-            self.convert_text_for_html(
-                item_name_template.format(
-                    self._family, self._subset_name, self._asset_name
-                )
+            item_name_template.format(
+                self._family, self._subset_name, self._asset_name
             )
         )
         content_layout.addWidget(item_name_widget)
@@ -77,9 +75,11 @@ class CreateErrorMessageBox(ErrorMessageBox):
         content_layout.addWidget(message_label_widget)
 
         if self._formatted_traceback:
+            line_widget = self._create_line()
             tb_widget = self._create_traceback_widget(
                 self._formatted_traceback
             )
+            content_layout.addWidget(line_widget)
             content_layout.addWidget(tb_widget)
 
 

--- a/openpype/tools/creator/widgets.py
+++ b/openpype/tools/creator/widgets.py
@@ -7,9 +7,10 @@ from avalon.vendor import qtawesome
 
 from openpype import style
 from openpype.pipeline.create import SUBSET_NAME_ALLOWED_SYMBOLS
+from openpype.tools.utils import ErrorMessageBox
 
 
-class CreateErrorMessageBox(QtWidgets.QDialog):
+class CreateErrorMessageBox(ErrorMessageBox):
     def __init__(
         self,
         family,
@@ -17,23 +18,38 @@ class CreateErrorMessageBox(QtWidgets.QDialog):
         asset_name,
         exc_msg,
         formatted_traceback,
-        parent=None
+        parent
     ):
-        super(CreateErrorMessageBox, self).__init__(parent)
-        self.setWindowTitle("Creation failed")
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
-        self.setWindowFlags(
-            self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint
-        )
+        self._family = family
+        self._subset_name = subset_name
+        self._asset_name = asset_name
+        self._exc_msg = exc_msg
+        self._formatted_traceback = formatted_traceback
+        super(CreateErrorMessageBox, self).__init__("Creation failed", parent)
 
-        body_layout = QtWidgets.QVBoxLayout(self)
-
-        main_label = (
+    def _create_top_widget(self, parent_widget):
+        label_widget = QtWidgets.QLabel(parent_widget)
+        label_widget.setText(
             "<span style='font-size:18pt;'>Failed to create</span>"
         )
-        main_label_widget = QtWidgets.QLabel(main_label, self)
-        body_layout.addWidget(main_label_widget)
+        return label_widget
 
+    def _get_report_data(self):
+        report_message = (
+            "Failed to create Subset: \"{subset}\" Family: \"{family}\""
+            " in Asset: \"{asset}\""
+            "\n\nError: {message}"
+        ).format(
+            subset=self._subset_name,
+            family=self._family,
+            asset=self._asset,
+            message=self._exc_msg
+        )
+        if self._formatted_traceback:
+            report_message += "\n\n{}".format(self._formatted_traceback)
+        return [report_message]
+
+    def _create_content(self, content_layout):
         item_name_template = (
             "<span style='font-weight:bold;'>Family:</span> {}<br>"
             "<span style='font-weight:bold;'>Subset:</span> {}<br>"
@@ -42,50 +58,29 @@ class CreateErrorMessageBox(QtWidgets.QDialog):
         exc_msg_template = "<span style='font-weight:bold'>{}</span>"
 
         line = self._create_line()
-        body_layout.addWidget(line)
+        content_layout.addWidget(line)
 
-        item_name = item_name_template.format(family, subset_name, asset_name)
-        item_name_widget = QtWidgets.QLabel(
-            item_name.replace("\n", "<br>"), self
-        )
-        body_layout.addWidget(item_name_widget)
-
-        exc_msg = exc_msg_template.format(exc_msg.replace("\n", "<br>"))
-        message_label_widget = QtWidgets.QLabel(exc_msg, self)
-        body_layout.addWidget(message_label_widget)
-
-        if formatted_traceback:
-            tb_widget = QtWidgets.QLabel(
-                formatted_traceback.replace("\n", "<br>"), self
+        item_name_widget = QtWidgets.QLabel(self)
+        item_name_widget.setText(
+            self.convert_text_for_html(
+                item_name_template.format(
+                    self._family, self._subset_name, self._asset_name
+                )
             )
-            tb_widget.setTextInteractionFlags(
-                QtCore.Qt.TextBrowserInteraction
-            )
-            body_layout.addWidget(tb_widget)
-
-        footer_widget = QtWidgets.QWidget(self)
-        footer_layout = QtWidgets.QHBoxLayout(footer_widget)
-        button_box = QtWidgets.QDialogButtonBox(QtCore.Qt.Vertical)
-        button_box.setStandardButtons(
-            QtWidgets.QDialogButtonBox.StandardButton.Ok
         )
-        button_box.accepted.connect(self._on_accept)
-        footer_layout.addWidget(button_box, alignment=QtCore.Qt.AlignRight)
-        body_layout.addWidget(footer_widget)
+        content_layout.addWidget(item_name_widget)
 
-    def showEvent(self, event):
-        self.setStyleSheet(style.load_stylesheet())
-        super(CreateErrorMessageBox, self).showEvent(event)
+        message_label_widget = QtWidgets.QLabel(self)
+        message_label_widget.setText(
+            exc_msg_template.format(self.convert_text_for_html(self._exc_msg))
+        )
+        content_layout.addWidget(message_label_widget)
 
-    def _on_accept(self):
-        self.close()
-
-    def _create_line(self):
-        line = QtWidgets.QFrame(self)
-        line.setFixedHeight(2)
-        line.setFrameShape(QtWidgets.QFrame.HLine)
-        line.setFrameShadow(QtWidgets.QFrame.Sunken)
-        return line
+        if self._formatted_traceback:
+            tb_widget = self._create_traceback_widget(
+                self._formatted_traceback
+            )
+            content_layout.addWidget(tb_widget)
 
 
 class SubsetNameValidator(QtGui.QRegExpValidator):

--- a/openpype/tools/creator/window.py
+++ b/openpype/tools/creator/window.py
@@ -445,7 +445,11 @@ class CreatorWindow(QtWidgets.QDialog):
 
         if error_info:
             box = CreateErrorMessageBox(
-                creator_plugin.family, subset_name, asset_name, *error_info
+                creator_plugin.family,
+                subset_name,
+                asset_name,
+                *error_info,
+                parent=self
             )
             box.show()
             # Store dialog so is not garbage collected before is shown

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -18,6 +18,8 @@ from openpype.tools.utils.delegates import (
 )
 from openpype.tools.utils.widgets import (
     OptionalMenu,
+    ClickableFrame,
+    ExpandBtn,
     PlaceholderLineEdit
 )
 from openpype.tools.utils.views import (
@@ -62,6 +64,55 @@ class OverlayFrame(QtWidgets.QFrame):
 
     def set_label(self, label):
         self.label_widget.setText(label)
+
+
+class TracebackWidget(QtWidgets.QWidget):
+    def __init__(self, tb_text, parent):
+        super(TracebackWidget, self).__init__(parent)
+
+        # Modify text to match html
+        # - add more replacements when needed
+        tb_text = (
+            tb_text
+            .replace("<", "&#60;")
+            .replace(">", "&#62;")
+            .replace("\n", "<br>")
+            .replace(" ", "&nbsp;")
+        )
+
+        expand_btn = ExpandBtn(self)
+
+        clickable_frame = ClickableFrame(self)
+        clickable_layout = QtWidgets.QHBoxLayout(clickable_frame)
+        clickable_layout.setContentsMargins(0, 0, 0, 0)
+
+        expand_label = QtWidgets.QLabel("Details", clickable_frame)
+        clickable_layout.addWidget(expand_label, 0)
+        clickable_layout.addStretch(1)
+
+        show_details_layout = QtWidgets.QHBoxLayout()
+        show_details_layout.addWidget(expand_btn, 0)
+        show_details_layout.addWidget(clickable_frame, 1)
+
+        text_widget = QtWidgets.QLabel(self)
+        text_widget.setText(tb_text)
+        text_widget.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+        text_widget.setVisible(False)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(show_details_layout, 0)
+        layout.addWidget(text_widget, 1)
+
+        clickable_frame.clicked.connect(self._on_show_details_click)
+        expand_btn.clicked.connect(self._on_show_details_click)
+
+        self._expand_btn = expand_btn
+        self._text_widget = text_widget
+
+    def _on_show_details_click(self):
+        self._text_widget.setVisible(not self._text_widget.isVisible())
+        self._expand_btn.set_collapsed(not self._text_widget.isVisible())
 
 
 class LoadErrorMessageBox(QtWidgets.QDialog):

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -188,9 +188,9 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
 
     def _create_line(self):
         line = QtWidgets.QFrame(self)
-        line.setFixedHeight(2)
-        line.setFrameShape(QtWidgets.QFrame.HLine)
-        line.setFrameShadow(QtWidgets.QFrame.Sunken)
+        line.setObjectName("Separator")
+        line.setMinimumHeight(2)
+        line.setMaximumHeight(2)
         return line
 
 

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -535,7 +535,7 @@ class SubsetWidget(QtWidgets.QWidget):
         self.load_ended.emit()
 
         if error_info:
-            box = LoadErrorMessageBox(error_info)
+            box = LoadErrorMessageBox(error_info, self)
             box.show()
 
     def selected_subsets(self, _groups=False, _merged=False, _other=True):
@@ -1431,7 +1431,7 @@ class RepresentationWidget(QtWidgets.QWidget):
         self.load_ended.emit()
 
         if errors:
-            box = LoadErrorMessageBox(errors)
+            box = LoadErrorMessageBox(errors, self)
             box.show()
 
     def _get_optional_labels(self, loaders, selected_side):

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -72,6 +72,31 @@ class LoadErrorMessageBox(ErrorMessageBox):
         self._messages = messages
         super(LoadErrorMessageBox, self).__init__("Loading failed", parent)
 
+    def _create_top_widget(self, parent_widget):
+        label_widget = QtWidgets.QLabel(parent_widget)
+        label_widget.setText(
+            "<span style='font-size:18pt;'>Failed to load items</span>"
+        )
+        return label_widget
+
+    def _get_report_data(self):
+        report_data = []
+        for exc_msg, tb_text, repre, subset, version in self._messages:
+            report_message = (
+                "During load error happened on Subset: \"{subset}\""
+                " Representation: \"{repre}\" Version: {version}"
+                "\n\nError message: {message}"
+            ).format(
+                subset=subset,
+                repre=repre,
+                version=version,
+                message=exc_msg
+            )
+            if tb_text:
+                report_message += "\n\n{}".format(tb_text)
+            report_data.append(report_message)
+        return report_data
+
     def _create_content(self, content_layout):
         item_name_template = (
             "<span style='font-weight:bold;'>Subset:</span> {}<br>"
@@ -101,31 +126,6 @@ class LoadErrorMessageBox(ErrorMessageBox):
                 tb_widget = self._create_traceback_widget(tb_text, self)
                 content_layout.addWidget(line)
                 content_layout.addWidget(tb_widget)
-
-    def _get_report_data(self):
-        report_data = []
-        for exc_msg, tb_text, repre, subset, version in self._messages:
-            report_message = (
-                "During load error happened on Subset: \"{subset}\""
-                " Representation: \"{repre}\" Version: {version}"
-                "\n\nError message: {message}"
-            ).format(
-                subset=subset,
-                repre=repre,
-                version=version,
-                message=exc_msg
-            )
-            if tb_text:
-                report_message += "\n\n{}".format(tb_text)
-            report_data.append(report_message)
-        return report_data
-
-    def _create_top_widget(self, parent_widget):
-        label_widget = QtWidgets.QLabel(parent_widget)
-        label_widget.setText(
-            "<span style='font-size:18pt;'>Failed to load items</span>"
-        )
-        return label_widget
 
 
 class SubsetWidget(QtWidgets.QWidget):

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -11,15 +11,16 @@ from Qt import QtWidgets, QtCore, QtGui
 from avalon import api, pipeline
 from avalon.lib import HeroVersionType
 
-from openpype.tools.utils import lib as tools_lib
+from openpype.tools.utils import (
+    ErrorMessageBox,
+    lib as tools_lib
+)
 from openpype.tools.utils.delegates import (
     VersionDelegate,
     PrettyTimeDelegate
 )
 from openpype.tools.utils.widgets import (
     OptionalMenu,
-    ClickableFrame,
-    ExpandBtn,
     PlaceholderLineEdit
 )
 from openpype.tools.utils.views import (
@@ -66,66 +67,12 @@ class OverlayFrame(QtWidgets.QFrame):
         self.label_widget.setText(label)
 
 
-class TracebackWidget(QtWidgets.QWidget):
-    def __init__(self, tb_text, parent):
-        super(TracebackWidget, self).__init__(parent)
-
-        # Modify text to match html
-        # - add more replacements when needed
-        tb_text = (
-            tb_text
-            .replace("<", "&#60;")
-            .replace(">", "&#62;")
-            .replace("\n", "<br>")
-            .replace(" ", "&nbsp;")
-        )
-
-        expand_btn = ExpandBtn(self)
-
-        clickable_frame = ClickableFrame(self)
-        clickable_layout = QtWidgets.QHBoxLayout(clickable_frame)
-        clickable_layout.setContentsMargins(0, 0, 0, 0)
-
-        expand_label = QtWidgets.QLabel("Details", clickable_frame)
-        clickable_layout.addWidget(expand_label, 0)
-        clickable_layout.addStretch(1)
-
-        show_details_layout = QtWidgets.QHBoxLayout()
-        show_details_layout.addWidget(expand_btn, 0)
-        show_details_layout.addWidget(clickable_frame, 1)
-
-        text_widget = QtWidgets.QLabel(self)
-        text_widget.setText(tb_text)
-        text_widget.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
-        text_widget.setVisible(False)
-
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(show_details_layout, 0)
-        layout.addWidget(text_widget, 1)
-
-        clickable_frame.clicked.connect(self._on_show_details_click)
-        expand_btn.clicked.connect(self._on_show_details_click)
-
-        self._expand_btn = expand_btn
-        self._text_widget = text_widget
-
-    def _on_show_details_click(self):
-        self._text_widget.setVisible(not self._text_widget.isVisible())
-        self._expand_btn.set_collapsed(not self._text_widget.isVisible())
-
-
-class LoadErrorMessageBox(QtWidgets.QDialog):
+class LoadErrorMessageBox(ErrorMessageBox):
     def __init__(self, messages, parent=None):
-        super(LoadErrorMessageBox, self).__init__(parent)
-        self.setWindowTitle("Loading failed")
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self._messages = messages
+        super(LoadErrorMessageBox, self).__init__("Loading failed", parent)
 
-        main_label = (
-            "<span style='font-size:18pt;'>Failed to load items</span>"
-        )
-        main_label_widget = QtWidgets.QLabel(main_label, self)
-
+    def _create_content(self, content_layout):
         item_name_template = (
             "<span style='font-weight:bold;'>Subset:</span> {}<br>"
             "<span style='font-weight:bold;'>Version:</span> {}<br>"
@@ -133,31 +80,7 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
         )
         exc_msg_template = "<span style='font-weight:bold'>{}</span>"
 
-        content_scroll = QtWidgets.QScrollArea(self)
-        content_scroll.setWidgetResizable(True)
-
-        content_widget = QtWidgets.QWidget(content_scroll)
-        content_scroll.setWidget(content_widget)
-
-        content_layout = QtWidgets.QVBoxLayout(content_widget)
-        content_layout.setContentsMargins(0, 0, 0, 0)
-
-        report_data = []
-        for exc_msg, tb_text, repre, subset, version in messages:
-            report_message = (
-                "During load error happened on Subset: \"{subset}\""
-                " Representation: \"{repre}\" Version: {version}"
-                "\n\nError message: {message}"
-            ).format(
-                subset=subset,
-                repre=repre,
-                version=version,
-                message=exc_msg
-            )
-            if tb_text:
-                report_message += "\n\n{}".format(tb_text)
-            report_data.append(report_message)
-
+        for exc_msg, tb_text, repre, subset, version in self._messages:
             line = self._create_line()
             content_layout.addWidget(line)
 
@@ -175,52 +98,34 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
 
             if tb_text:
                 line = self._create_line()
-                tb_widget = TracebackWidget(tb_text, self)
+                tb_widget = self._create_traceback_widget(tb_text, self)
                 content_layout.addWidget(line)
                 content_layout.addWidget(tb_widget)
 
-        content_layout.addStretch(1)
+    def _get_report_data(self):
+        report_data = []
+        for exc_msg, tb_text, repre, subset, version in self._messages:
+            report_message = (
+                "During load error happened on Subset: \"{subset}\""
+                " Representation: \"{repre}\" Version: {version}"
+                "\n\nError message: {message}"
+            ).format(
+                subset=subset,
+                repre=repre,
+                version=version,
+                message=exc_msg
+            )
+            if tb_text:
+                report_message += "\n\n{}".format(tb_text)
+            report_data.append(report_message)
+        return report_data
 
-        copy_report_btn = QtWidgets.QPushButton("Copy report", self)
-        ok_btn = QtWidgets.QPushButton("OK", self)
-
-        footer_layout = QtWidgets.QHBoxLayout()
-        footer_layout.addWidget(copy_report_btn, 0)
-        footer_layout.addStretch(1)
-        footer_layout.addWidget(ok_btn, 0)
-
-        bottom_line = self._create_line()
-        body_layout = QtWidgets.QVBoxLayout(self)
-        body_layout.addWidget(main_label_widget, 0)
-        body_layout.addWidget(content_scroll, 1)
-        body_layout.addWidget(bottom_line, 0)
-        body_layout.addLayout(footer_layout, 0)
-
-        copy_report_btn.clicked.connect(self._on_copy_report)
-        ok_btn.clicked.connect(self._on_ok_clicked)
-
-        self.resize(660, 350)
-
-        self._report_data = report_data
-
-    def _on_ok_clicked(self):
-        self.close()
-
-    def _on_copy_report(self):
-        report_text = (10 * "*").join(self._report_data)
-
-        mime_data = QtCore.QMimeData()
-        mime_data.setText(report_text)
-        QtWidgets.QApplication.instance().clipboard().setMimeData(
-            mime_data
+    def _create_top_widget(self, parent_widget):
+        label_widget = QtWidgets.QLabel(parent_widget)
+        label_widget.setText(
+            "<span style='font-size:18pt;'>Failed to load items</span>"
         )
-
-    def _create_line(self):
-        line = QtWidgets.QFrame(self)
-        line.setObjectName("Separator")
-        line.setMinimumHeight(2)
-        line.setMaximumHeight(2)
-        return line
+        return label_widget
 
 
 class SubsetWidget(QtWidgets.QWidget):

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -142,7 +142,22 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.setContentsMargins(0, 0, 0, 0)
 
+        report_data = []
         for exc_msg, tb_text, repre, subset, version in messages:
+            report_message = (
+                "During load error happened on Subset: \"{subset}\""
+                " Representation: \"{repre}\" Version: {version}"
+                "\n\nError message: {message}"
+            ).format(
+                subset=subset,
+                repre=repre,
+                version=version,
+                message=exc_msg
+            )
+            if tb_text:
+                report_message += "\n\n{}".format(tb_text)
+            report_data.append(report_message)
+
             line = self._create_line()
             content_layout.addWidget(line)
 
@@ -166,9 +181,11 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
 
         content_layout.addStretch(1)
 
+        copy_report_btn = QtWidgets.QPushButton("Copy report", self)
         ok_btn = QtWidgets.QPushButton("OK", self)
 
         footer_layout = QtWidgets.QHBoxLayout()
+        footer_layout.addWidget(copy_report_btn, 0)
         footer_layout.addStretch(1)
         footer_layout.addWidget(ok_btn, 0)
 
@@ -179,12 +196,24 @@ class LoadErrorMessageBox(QtWidgets.QDialog):
         body_layout.addWidget(bottom_line, 0)
         body_layout.addLayout(footer_layout, 0)
 
+        copy_report_btn.clicked.connect(self._on_copy_report)
         ok_btn.clicked.connect(self._on_ok_clicked)
 
         self.resize(660, 350)
 
+        self._report_data = report_data
+
     def _on_ok_clicked(self):
         self.close()
+
+    def _on_copy_report(self):
+        report_text = (10 * "*").join(self._report_data)
+
+        mime_data = QtCore.QMimeData()
+        mime_data.setText(report_text)
+        QtWidgets.QApplication.instance().clipboard().setMimeData(
+            mime_data
+        )
 
     def _create_line(self):
         line = QtWidgets.QFrame(self)

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -5,10 +5,14 @@ from .widgets import (
     ExpandBtn,
 )
 
+from .error_dialog import ErrorMessageBox
+
 
 __all__ = (
     "PlaceholderLineEdit",
     "BaseClickableFrame",
     "ClickableFrame",
-    "ExpandBtn"
+    "ExpandBtn",
+
+    "ErrorMessageBox"
 )

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -2,6 +2,7 @@ from .widgets import (
     PlaceholderLineEdit,
     BaseClickableFrame,
     ClickableFrame,
+    ExpandBtn,
 )
 
 
@@ -9,4 +10,5 @@ __all__ = (
     "PlaceholderLineEdit",
     "BaseClickableFrame",
     "ClickableFrame",
+    "ExpandBtn"
 )

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -1,8 +1,12 @@
 from .widgets import (
     PlaceholderLineEdit,
+    BaseClickableFrame,
+    ClickableFrame,
 )
 
 
 __all__ = (
     "PlaceholderLineEdit",
+    "BaseClickableFrame",
+    "ClickableFrame",
 )

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -75,6 +75,9 @@ class ErrorMessageBox(QtWidgets.QDialog):
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.setContentsMargins(0, 0, 0, 0)
 
+        # Store content widget before creation of content
+        self._content_widget = content_widget
+
         self._create_content(content_layout)
 
         content_layout.addStretch(1)
@@ -104,7 +107,6 @@ class ErrorMessageBox(QtWidgets.QDialog):
             copy_report_btn.setVisible(False)
 
         self._report_data = report_data
-        self._content_widget = content_widget
 
     @staticmethod
     def convert_text_for_html(text):

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -1,0 +1,143 @@
+from Qt import QtWidgets, QtCore
+
+from .widgets import ClickableFrame, ExpandBtn
+
+
+class TracebackWidget(QtWidgets.QWidget):
+    def __init__(self, tb_text, parent):
+        super(TracebackWidget, self).__init__(parent)
+
+        # Modify text to match html
+        # - add more replacements when needed
+        tb_text = (
+            tb_text
+            .replace("<", "&#60;")
+            .replace(">", "&#62;")
+            .replace("\n", "<br>")
+            .replace(" ", "&nbsp;")
+        )
+
+        expand_btn = ExpandBtn(self)
+
+        clickable_frame = ClickableFrame(self)
+        clickable_layout = QtWidgets.QHBoxLayout(clickable_frame)
+        clickable_layout.setContentsMargins(0, 0, 0, 0)
+
+        expand_label = QtWidgets.QLabel("Details", clickable_frame)
+        clickable_layout.addWidget(expand_label, 0)
+        clickable_layout.addStretch(1)
+
+        show_details_layout = QtWidgets.QHBoxLayout()
+        show_details_layout.addWidget(expand_btn, 0)
+        show_details_layout.addWidget(clickable_frame, 1)
+
+        text_widget = QtWidgets.QLabel(self)
+        text_widget.setText(tb_text)
+        text_widget.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+        text_widget.setVisible(False)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(show_details_layout, 0)
+        layout.addWidget(text_widget, 1)
+
+        clickable_frame.clicked.connect(self._on_show_details_click)
+        expand_btn.clicked.connect(self._on_show_details_click)
+
+        self._expand_btn = expand_btn
+        self._text_widget = text_widget
+
+    def _on_show_details_click(self):
+        self._text_widget.setVisible(not self._text_widget.isVisible())
+        self._expand_btn.set_collapsed(not self._text_widget.isVisible())
+
+
+class ErrorMessageBox(QtWidgets.QDialog):
+    _default_width = 660
+    _default_height = 350
+
+    def __init__(self, title, parent):
+        super(ErrorMessageBox, self).__init__(parent)
+        self.setWindowTitle(title)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+        top_widget = self._create_top_widget(self)
+
+        content_scroll = QtWidgets.QScrollArea(self)
+        content_scroll.setWidgetResizable(True)
+
+        content_widget = QtWidgets.QWidget(content_scroll)
+        content_scroll.setWidget(content_widget)
+
+        content_layout = QtWidgets.QVBoxLayout(content_widget)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._create_content(content_layout)
+
+        content_layout.addStretch(1)
+
+        copy_report_btn = QtWidgets.QPushButton("Copy report", self)
+        ok_btn = QtWidgets.QPushButton("OK", self)
+
+        footer_layout = QtWidgets.QHBoxLayout()
+        footer_layout.addWidget(copy_report_btn, 0)
+        footer_layout.addStretch(1)
+        footer_layout.addWidget(ok_btn, 0)
+
+        bottom_line = self._create_line()
+        body_layout = QtWidgets.QVBoxLayout(self)
+        body_layout.addWidget(top_widget, 0)
+        body_layout.addWidget(content_scroll, 1)
+        body_layout.addWidget(bottom_line, 0)
+        body_layout.addLayout(footer_layout, 0)
+
+        copy_report_btn.clicked.connect(self._on_copy_report)
+        ok_btn.clicked.connect(self._on_ok_clicked)
+
+        self.resize(self._default_width, self._default_height)
+
+        report_data = self._get_report_data()
+        if not report_data:
+            copy_report_btn.setVisible(False)
+
+        self._report_data = report_data
+        self._content_widget = content_widget
+
+    def _create_top_widget(self, parent_widget):
+        label_widget = QtWidgets.QLabel(parent_widget)
+        label_widget.setText(
+            "<span style='font-size:18pt;'>Something went wrong</span>"
+        )
+        return label_widget
+
+    def _create_content(self, content_layout):
+        raise NotImplementedError(
+            "Method '_fill_content_layout' is not implemented!"
+        )
+
+    def _get_report_data(self):
+        return []
+
+    def _on_ok_clicked(self):
+        self.close()
+
+    def _on_copy_report(self):
+        report_text = (10 * "*").join(self._report_data)
+
+        mime_data = QtCore.QMimeData()
+        mime_data.setText(report_text)
+        QtWidgets.QApplication.instance().clipboard().setMimeData(
+            mime_data
+        )
+
+    def _create_line(self):
+        line = QtWidgets.QFrame(self)
+        line.setObjectName("Separator")
+        line.setMinimumHeight(2)
+        line.setMaximumHeight(2)
+        return line
+
+    def _create_traceback_widget(self, traceback_text, parent=None):
+        if parent is None:
+            parent = self._content_widget
+        return TracebackWidget(traceback_text, parent)

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -3,20 +3,23 @@ from Qt import QtWidgets, QtCore
 from .widgets import ClickableFrame, ExpandBtn
 
 
+def convert_text_for_html(text):
+    return (
+        text
+        .replace("<", "&#60;")
+        .replace(">", "&#62;")
+        .replace("\n", "<br>")
+        .replace(" ", "&nbsp;")
+    )
+
+
 class TracebackWidget(QtWidgets.QWidget):
     def __init__(self, tb_text, parent):
         super(TracebackWidget, self).__init__(parent)
 
         # Modify text to match html
         # - add more replacements when needed
-        tb_text = (
-            tb_text
-            .replace("<", "&#60;")
-            .replace(">", "&#62;")
-            .replace("\n", "<br>")
-            .replace(" ", "&nbsp;")
-        )
-
+        tb_text = convert_text_for_html(tb_text)
         expand_btn = ExpandBtn(self)
 
         clickable_frame = ClickableFrame(self)
@@ -102,6 +105,10 @@ class ErrorMessageBox(QtWidgets.QDialog):
 
         self._report_data = report_data
         self._content_widget = content_widget
+
+    @staticmethod
+    def convert_text_for_html(text):
+        return convert_text_for_html(text)
 
     def _create_top_widget(self, parent_widget):
         label_widget = QtWidgets.QLabel(parent_widget)

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -25,6 +25,41 @@ class PlaceholderLineEdit(QtWidgets.QLineEdit):
             self.setPalette(filter_palette)
 
 
+class BaseClickableFrame(QtWidgets.QFrame):
+    """Widget that catch left mouse click and can trigger a callback.
+
+    Callback is defined by overriding `_mouse_release_callback`.
+    """
+    def __init__(self, parent):
+        super(BaseClickableFrame, self).__init__(parent)
+
+        self._mouse_pressed = False
+
+    def _mouse_release_callback(self):
+        pass
+
+    def mousePressEvent(self, event):
+        if event.button() == QtCore.Qt.LeftButton:
+            self._mouse_pressed = True
+        super(BaseClickableFrame, self).mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if self._mouse_pressed:
+            self._mouse_pressed = False
+            if self.rect().contains(event.pos()):
+                self._mouse_release_callback()
+
+        super(BaseClickableFrame, self).mouseReleaseEvent(event)
+
+
+class ClickableFrame(BaseClickableFrame):
+    """Extended clickable frame which triggers 'clicked' signal."""
+    clicked = QtCore.Signal()
+
+    def _mouse_release_callback(self):
+        self.clicked.emit()
+
+
 class ImageButton(QtWidgets.QPushButton):
     """PushButton with icon and size of font.
 

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -3,7 +3,10 @@ import logging
 from Qt import QtWidgets, QtCore, QtGui
 
 from avalon.vendor import qtawesome, qargparse
-from openpype.style import get_objected_colors
+from openpype.style import (
+    get_objected_colors,
+    get_style_image_path
+)
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +61,65 @@ class ClickableFrame(BaseClickableFrame):
 
     def _mouse_release_callback(self):
         self.clicked.emit()
+
+
+class ExpandBtnLabel(QtWidgets.QLabel):
+    """Label showing expand icon meant for ExpandBtn."""
+    def __init__(self, parent):
+        super(ExpandBtnLabel, self).__init__(parent)
+        self._source_collapsed_pix = QtGui.QPixmap(
+            get_style_image_path("branch_closed")
+        )
+        self._source_expanded_pix = QtGui.QPixmap(
+            get_style_image_path("branch_open")
+        )
+
+        self._current_image = self._source_collapsed_pix
+        self._collapsed = True
+
+    def set_collapsed(self, collapsed):
+        if self._collapsed == collapsed:
+            return
+        self._collapsed = collapsed
+        if collapsed:
+            self._current_image = self._source_collapsed_pix
+        else:
+            self._current_image = self._source_expanded_pix
+        self._set_resized_pix()
+
+    def resizeEvent(self, event):
+        self._set_resized_pix()
+        super(ExpandBtnLabel, self).resizeEvent(event)
+
+    def _set_resized_pix(self):
+        size = int(self.fontMetrics().height() / 2)
+        if size < 1:
+            size = 1
+        size += size % 2
+        self.setPixmap(
+            self._current_image.scaled(
+                size,
+                size,
+                QtCore.Qt.KeepAspectRatio,
+                QtCore.Qt.SmoothTransformation
+            )
+        )
+
+
+class ExpandBtn(ClickableFrame):
+    def __init__(self, parent=None):
+        super(ExpandBtn, self).__init__(parent)
+
+        pixmap_label = ExpandBtnLabel(self)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(pixmap_label)
+
+        self._pixmap_label = pixmap_label
+
+    def set_collapsed(self, collapsed):
+        self._pixmap_label.set_collapsed(collapsed)
 
 
 class ImageButton(QtWidgets.QPushButton):


### PR DESCRIPTION
## Brief description
Error dialog in loader miss styles and is under Loader window if Loader tool has flag `AlwaysOnTop`. Also traceback could be collapsible.

## Description
The error dialog does not have parent which would fix the modality and style issue. The traceback can extend the dialog to infinite size so it would be nice to have it collapsible and if the contet would be in `QTextEdit` which has scrollbars so the text size of traceback won't matter.

## Changes
- crated base for error dialogs for both creating and loading
    - added them to utils, they are not much generic but it can be easily changed now
    - have ability to copy report data with button if the method for returning the report data returns any data
- `LoadErrorMessageBox` and `CreateErrorMessageBox` inherit from base `ErrorMessageBox`
- parent is passed to `LoadErrorMessageBox` and `CreateErrorMessageBox`
    - this fixes style and modality of dialogs
- `openpype.style` has new function `get_style_image_path` which returns path to image resources in style folder
- copied `ClickableFrame` from new publisher to utils and extended it to 2 versions
- implemented expanding button in utils

Resolves https://github.com/pypeclub/OpenPype/issues/2487