### PR TITLE
AE: fix hiding of alert window below Publish

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/create_render.py
+++ b/openpype/hosts/aftereffects/plugins/create/create_render.py
@@ -1,6 +1,7 @@
-import openpype.api
-from Qt import QtWidgets
 from avalon import aftereffects
+from avalon.api import CreatorError
+
+import openpype.api
 
 import logging
 
@@ -27,14 +28,13 @@ class CreateRender(openpype.api.Creator):
                                             folders=False,
                                             footages=False)
         if len(items) > 1:
-            self._show_msg("Please select only single composition at time.")
-            return False
+            raise CreatorError("Please select only single "
+                               "composition at time.")
 
         if not items:
-            self._show_msg("Nothing to create. Select composition " +
-                           "if 'useSelection' or create at least " +
-                           "one composition.")
-            return False
+            raise CreatorError("Nothing to create. Select composition " +
+                               "if 'useSelection' or create at least " +
+                               "one composition.")
 
         existing_subsets = [instance['subset'].lower()
                             for instance in aftereffects.list_instances()]
@@ -42,8 +42,7 @@ class CreateRender(openpype.api.Creator):
         item = items.pop()
         if self.name.lower() in existing_subsets:
             txt = "Instance with name \"{}\" already exists.".format(self.name)
-            self._show_msg(txt)
-            return False
+            raise CreatorError(txt)
 
         self.data["members"] = [item.id]
         self.data["uuid"] = item.id  # for SubsetManager
@@ -54,9 +53,3 @@ class CreateRender(openpype.api.Creator):
         stub.imprint(item, self.data)
         stub.set_label_color(item.id, 14)  # Cyan options 0 - 16
         stub.rename_item(item.id, stub.PUBLISH_ICON + self.data["subset"])
-
-    def _show_msg(self, txt):
-        msg = QtWidgets.QMessageBox()
-        msg.setIcon(QtWidgets.QMessageBox.Warning)
-        msg.setText(txt)
-        msg.exec_()

--- a/openpype/hosts/aftereffects/plugins/load/load_background.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_background.py
@@ -22,21 +22,23 @@ class BackgroundLoader(api.Loader):
 
     def load(self, context, name=None, namespace=None, data=None):
         items = stub.get_items(comps=True)
-        existing_items = [layer.name for layer in items]
+        existing_items = [layer.name.replace(stub.LOADED_ICON, '')
+                          for layer in items]
 
         comp_name = get_unique_layer_name(
             existing_items,
             "{}_{}".format(context["asset"]["name"], name))
 
         layers = get_background_layers(self.fname)
+        if not layers:
+            raise ValueError("No layers found in {}".format(self.fname))
+
         comp = stub.import_background(None, stub.LOADED_ICON + comp_name,
                                       layers)
 
         if not comp:
-            self.log.warning(
-                "Import background failed.")
-            self.log.warning("Check host app for alert error.")
-            return
+            raise ValueError("Import background failed. "
+                             "Please contact support")
 
         self[:] = [comp]
         namespace = namespace or comp_name


### PR DESCRIPTION
## Brief description
Creator error was handled but non standard custom widget. This replaces it.

## Description
The error window should be always put on top, it contains collapsible 

## Testing notes:
1. Create subset with Creator
2. Try to create it again, it should throw error 