### PR TITLE
General: Settings work if OpenPypeVersion is available

### DIFF
--- a/openpype/settings/entities/op_version_entity.py
+++ b/openpype/settings/entities/op_version_entity.py
@@ -72,6 +72,8 @@ class ProductionVersionsInputEntity(OpenPypeVersionInput):
 
     def _get_openpype_versions(self):
         versions = get_remote_versions(staging=False, production=True)
+        if versions is None:
+            return []
         versions.append(get_installed_version())
         return sorted(versions)
 
@@ -82,4 +84,6 @@ class StagingVersionsInputEntity(OpenPypeVersionInput):
 
     def _get_openpype_versions(self):
         versions = get_remote_versions(staging=True, production=False)
+        if versions is None:
+            return []
         return sorted(versions)


### PR DESCRIPTION
## Brief description
Settings crash if OpenPypeVersion from igniter is not available.

## Description
Missing OpenPypeVersion can happen when build is older than 3.8.0 or when settings entities are loaded in non-OpenPype process.

## Changes
- validate if `get_remote_versions` returns `None` when getting hints for versions