### PR TITLE
Ftrack: Event handlers settings

### DIFF
--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -45,35 +45,23 @@ class FtrackModule(
         current_dir = os.path.dirname(os.path.abspath(__file__))
         low_platform = platform.system().lower()
 
+        # Server event handler paths
         server_event_handlers_paths = [
             os.path.join(current_dir, "event_handlers_server")
         ]
         settings_server_paths = ftrack_settings["ftrack_events_path"]
         if isinstance(settings_server_paths, dict):
             settings_server_paths = settings_server_paths[low_platform]
+        server_event_handlers_paths.extend(settings_server_paths)
 
-        for path in settings_server_paths:
-            # Try to format path with environments
-            try:
-                path = path.format(**os.environ)
-            except BaseException:
-                pass
-            server_event_handlers_paths.append(path)
-
+        # User event handler paths
         user_event_handlers_paths = [
             os.path.join(current_dir, "event_handlers_user")
         ]
         settings_action_paths = ftrack_settings["ftrack_actions_path"]
         if isinstance(settings_action_paths, dict):
             settings_action_paths = settings_action_paths[low_platform]
-
-        for path in settings_action_paths:
-            # Try to format path with environments
-            try:
-                path = path.format(**os.environ)
-            except BaseException:
-                pass
-            user_event_handlers_paths.append(path)
+        user_event_handlers_paths.extend(settings_action_paths)
 
         # Prepare attribute
         self.server_event_handlers_paths = server_event_handlers_paths

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -53,6 +53,11 @@ class FtrackModule(
             settings_server_paths = settings_server_paths[low_platform]
 
         for path in settings_server_paths:
+            # Try to format path with environments
+            try:
+                path = path.format(**os.environ)
+            except BaseException:
+                pass
             server_event_handlers_paths.append(path)
 
         user_event_handlers_paths = [
@@ -63,6 +68,11 @@ class FtrackModule(
             settings_action_paths = settings_action_paths[low_platform]
 
         for path in settings_action_paths:
+            # Try to format path with environments
+            try:
+                path = path.format(**os.environ)
+            except BaseException:
+                pass
             user_event_handlers_paths.append(path)
 
         # Prepare attribute

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -1,6 +1,7 @@
 import os
 import json
 import collections
+import platform
 
 import click
 
@@ -42,18 +43,28 @@ class FtrackModule(
         self.ftrack_url = ftrack_url
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
+        low_platform = platform.system().lower()
+
         server_event_handlers_paths = [
             os.path.join(current_dir, "event_handlers_server")
         ]
-        server_event_handlers_paths.extend(
-            ftrack_settings["ftrack_events_path"]
-        )
+        settings_server_paths = ftrack_settings["ftrack_events_path"]
+        if isinstance(settings_server_paths, dict):
+            settings_server_paths = settings_server_paths[low_platform]
+
+        for path in settings_server_paths:
+            server_event_handlers_paths.append(path)
+
         user_event_handlers_paths = [
             os.path.join(current_dir, "event_handlers_user")
         ]
-        user_event_handlers_paths.extend(
-            ftrack_settings["ftrack_actions_path"]
-        )
+        settings_action_paths = ftrack_settings["ftrack_actions_path"]
+        if isinstance(settings_action_paths, dict):
+            settings_action_paths = settings_action_paths[low_platform]
+
+        for path in settings_action_paths:
+            user_event_handlers_paths.append(path)
+
         # Prepare attribute
         self.server_event_handlers_paths = server_event_handlers_paths
         self.user_event_handlers_paths = user_event_handlers_paths

--- a/openpype/modules/default_modules/ftrack/ftrack_server/ftrack_server.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_server/ftrack_server.py
@@ -63,6 +63,12 @@ class FtrackServer:
         # Iterate all paths
         register_functions = []
         for path in paths:
+            # Try to format path with environments
+            try:
+                path = path.format(**os.environ)
+            except BaseException:
+                pass
+
             # Get all modules with functions
             modules, crashed = modules_from_path(path)
             for filepath, exc_info in crashed:

--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -15,8 +15,16 @@
     "ftrack": {
         "enabled": true,
         "ftrack_server": "",
-        "ftrack_actions_path": [],
-        "ftrack_events_path": [],
+        "ftrack_actions_path": {
+            "windows": [],
+            "darwin": [],
+            "linux": []
+        },
+        "ftrack_events_path": {
+            "windows": [],
+            "darwin": [],
+            "linux": []
+        },
         "intent": {
             "items": {
                 "-": "-",

--- a/openpype/settings/entities/schemas/system_schema/module_settings/schema_ftrack.json
+++ b/openpype/settings/entities/schemas/system_schema/module_settings/schema_ftrack.json
@@ -21,19 +21,23 @@
         },
         {
             "type": "label",
-            "label": "Additional Ftrack paths"
+            "label": "Additional Ftrack event handlers paths"
         },
         {
-            "type": "list",
+            "type": "path",
             "key": "ftrack_actions_path",
-            "label": "Action paths",
-            "object_type": "text"
+            "label": "User paths",
+            "use_label_wrap": true,
+            "multipath": true,
+            "multiplatform": true
         },
         {
-            "type": "list",
+            "type": "path",
             "key": "ftrack_events_path",
-            "label": "Event paths",
-            "object_type": "text"
+            "label": "Server paths",
+            "use_label_wrap": true,
+            "multipath": true,
+            "multiplatform": true
         },
         {
             "type": "separator"


### PR DESCRIPTION
## Brief description
Ftrack event handler settings can't define multiplatform paths.

## Changes
- added option to define platform specific paths to ftrack event handlers
- changed labels in settings
- ftrack event server will try format paths with environments so it is possible enter environmets into user/server paths in settings