### PR TITLE
Slack: Add review to notification message

### DIFF
--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -15,7 +15,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         If instance contains 'thumbnail' it uploads it. Bot must be present
         in the target channel.
         If instance contains 'review' it could upload (if configured) or place
-        link with {review_link} placeholder.
+        link with {review_filepath} placeholder.
         Message template can contain {} placeholders from anatomyData.
     """
     order = pyblish.api.IntegratorOrder + 0.499
@@ -73,7 +73,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                                               fill_data.get("version"))))
         ]
         if review_path:
-            fill_pairs.append(("review_link", review_path))
+            fill_pairs.append(("review_filepath", review_path))
 
         task_data = instance.data.get("task")
         if not task_data:

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -14,6 +14,8 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         Project settings > Slack > Publish plugins > Notification to Slack.
         If instance contains 'thumbnail' it uploads it. Bot must be present
         in the target channel.
+        If instance contains 'review' it could upload (if configured) or place
+        link with {review_link} placeholder.
         Message template can contain {} placeholders from anatomyData.
     """
     order = pyblish.api.IntegratorOrder + 0.499
@@ -23,44 +25,68 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
-        published_path = self._get_thumbnail_path(instance)
+        thumbnail_path = self._get_thumbnail_path(instance)
+        review_path = self._get_review_path(instance)
 
+        publish_files = set()
         for message_profile in instance.data["slack_channel_message_profiles"]:
             message = self._get_filled_message(message_profile["message"],
-                                               instance)
+                                               instance,
+                                               review_path)
             if not message:
                 return
+
+            if message_profile["upload_thumbnail"] and thumbnail_path:
+                publish_files.add(thumbnail_path)
+
+            if message_profile["upload_review"] and review_path:
+                publish_files.add(review_path)
 
             for channel in message_profile["channels"]:
                 if six.PY2:
                     self._python2_call(instance.data["slack_token"],
                                        channel,
                                        message,
-                                       published_path,
-                                       message_profile["upload_thumbnail"])
+                                       publish_files)
                 else:
                     self._python3_call(instance.data["slack_token"],
                                        channel,
                                        message,
-                                       published_path,
-                                       message_profile["upload_thumbnail"])
+                                       publish_files)
 
-    def _get_filled_message(self, message_templ, instance):
-        """Use message_templ and data from instance to get message content."""
+    def _get_filled_message(self, message_templ, instance, review_path=None):
+        """Use message_templ and data from instance to get message content.
+
+        Reviews might be large, so allow only adding link to message instead of
+        uploading only.
+        """
         fill_data = copy.deepcopy(instance.context.data["anatomyData"])
 
-        fill_pairs = (
+        fill_pairs = [
             ("asset", instance.data.get("asset", fill_data.get("asset"))),
             ("subset", instance.data.get("subset", fill_data.get("subset"))),
-            ("task", instance.data.get("task", fill_data.get("task"))),
             ("username", instance.data.get("username",
                                            fill_data.get("username"))),
             ("app", instance.data.get("app", fill_data.get("app"))),
             ("family", instance.data.get("family", fill_data.get("family"))),
             ("version", str(instance.data.get("version",
                                               fill_data.get("version"))))
-        )
+        ]
+        if review_path:
+            fill_pairs.append(("review_link", review_path))
 
+        task_on_instance = instance.data.get("task")
+        task_on_anatomy = fill_data.get("task")
+        if task_on_instance:
+            fill_pairs.append(("task[name]", task_on_instance.get("type")))
+            fill_pairs.append(("task[name]", task_on_instance.get("name")))
+            fill_pairs.append(("task[short]", task_on_instance.get("short")))
+        elif task_on_anatomy:
+            fill_pairs.append(("task[name]", task_on_anatomy.get("type")))
+            fill_pairs.append(("task[name]", task_on_anatomy.get("name")))
+            fill_pairs.append(("task[short]", task_on_anatomy.get("short")))
+
+        self.log.debug("fill_pairs ::{}".format(fill_pairs))
         multiple_case_variants = prepare_template_data(fill_pairs)
         fill_data.update(multiple_case_variants)
 
@@ -79,39 +105,51 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         published_path = None
         for repre in instance.data['representations']:
             if repre.get('thumbnail') or "thumbnail" in repre.get('tags', []):
-                repre_files = repre["files"]
-                if isinstance(repre_files, (tuple, list, set)):
-                    filename = repre_files[0]
-                else:
-                    filename = repre_files
-
-                published_path = os.path.join(
-                    repre['stagingDir'], filename
-                )
+                if os.path.exists(repre["published_path"]):
+                    published_path = repre["published_path"]
                 break
         return published_path
 
+    def _get_review_path(self, instance):
+        """Returns abs url for review if present in instance repres"""
+        published_path = None
+        for repre in instance.data['representations']:
+            tags = repre.get('tags', [])
+            if (repre.get("review")
+                    or "review" in tags
+                    or "burnin" in tags):
+                if os.path.exists(repre["published_path"]):
+                    published_path = repre["published_path"]
+                if "burnin" in tags:  # burnin has precedence if exists
+                    break
+        return published_path
+
     def _python2_call(self, token, channel, message,
-                      published_path, upload_thumbnail):
+                      publish_files):
         from slackclient import SlackClient
         try:
             client = SlackClient(token)
-            if upload_thumbnail and \
-                    published_path and os.path.exists(published_path):
-                with open(published_path, 'rb') as pf:
+            for p_file in publish_files:
+                attachment_str = "\n\n Attachment links: \n"
+                with open(p_file, 'rb') as pf:
                     response = client.api_call(
                         "files.upload",
                         channels=channel,
-                        initial_comment=message,
                         file=pf,
-                        title=os.path.basename(published_path)
+                        title=os.path.basename(p_file),
                     )
-            else:
-                response = client.api_call(
-                    "chat.postMessage",
-                    channel=channel,
-                    text=message
-                )
+                    attachment_str += "\n<{}|{}>".format(
+                        response["file"]["permalink"],
+                        os.path.basename(p_file))
+
+            if publish_files:
+                message += attachment_str
+
+            response = client.api_call(
+                "chat.postMessage",
+                channel=channel,
+                text=message
+            )
 
             if response.get("error"):
                 error_str = self._enrich_error(str(response.get("error")),
@@ -123,23 +161,27 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             self.log.warning("Error happened: {}".format(error_str))
 
     def _python3_call(self, token, channel, message,
-                      published_path, upload_thumbnail):
+                      publish_files):
         from slack_sdk import WebClient
         from slack_sdk.errors import SlackApiError
         try:
             client = WebClient(token=token)
-            if upload_thumbnail and \
-                    published_path and os.path.exists(published_path):
-                _ = client.files_upload(
-                    channels=channel,
-                    initial_comment=message,
-                    file=published_path,
-                )
-            else:
-                _ = client.chat_postMessage(
-                    channel=channel,
-                    text=message
-                )
+            attachment_str = "\n\n Attachment links: \n"
+            for published_file in publish_files:
+                response = client.files_upload(
+                    file=published_file,
+                    filename=os.path.basename(published_file))
+                attachment_str += "\n<{}|{}>".format(
+                    response["file"]["permalink"],
+                    os.path.basename(published_file))
+
+            if publish_files:
+                message += attachment_str
+
+            _ = client.chat_postMessage(
+                channel=channel,
+                text=message
+            )
         except SlackApiError as e:
             # You will get a SlackApiError if "ok" is False
             error_str = self._enrich_error(str(e.response["error"]), channel)

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
@@ -92,6 +92,11 @@
                                                     "label": "Upload thumbnail"
                                                 },
                                                 {
+                                                    "type": "boolean",
+                                                    "key": "upload_review",
+                                                    "label": "Upload review"
+                                                },
+                                                {
                                                     "type": "text",
                                                     "multiline": true,
                                                     "key": "message",

--- a/website/docs/module_slack.md
+++ b/website/docs/module_slack.md
@@ -61,6 +61,18 @@ Integration can upload 'thumbnail' file (if present in an instance), for that bo
 manually added to target channel by Slack admin!
 (In target channel write: ```/invite @OpenPypeNotifier``)
 
+#### Upload review
+Integration can upload 'review' file (if present in an instance), for that bot must be 
+manually added to target channel by Slack admin!
+(In target channel write: ```/invite @OpenPypeNotifier``)
+
+Burnin version (usually .mp4) is preferred if present.
+
+Please be sure that this configuration is viable for your use case. In case of uploading large reviews to Slack, 
+all publishes will be slowed down and you might hit a file limit on Slack pretty soon (it is 5GB for Free version of Slack, any file cannot be bigger than 1GB).
+You might try to add `{review_link}` to message content. This link might help users to find review easier on their machines.
+(It won't show a playable preview though!)
+
 #### Message
 Message content can use Templating (see [Available template keys](admin_settings_project_anatomy#available-template-keys)).
 
@@ -69,8 +81,22 @@ Few keys also have Capitalized and UPPERCASE format. Values will be modified acc
 **Available keys:**
 - asset
 - subset
-- task
+- task\[name\]
+- task\[type\]
+- task\[short\]
 - username
 - app
 - family
 - version
+- review_link
+
+##### Message example
+```
+{Subset} was published for {ASSET} in {task[name]} task.
+
+Here you can find review {review_link}
+```
+
+#### Message retention
+Currently no purging of old messages is implemented in Openpype. Admins of Slack should set their own retention of messages and files per channel.
+(see https://slack.com/help/articles/203457187-Customize-message-and-file-retention-policies)

--- a/website/docs/module_slack.md
+++ b/website/docs/module_slack.md
@@ -78,23 +78,14 @@ Message content can use Templating (see [Available template keys](admin_settings
 
 Few keys also have Capitalized and UPPERCASE format. Values will be modified accordingly ({Asset} >> "Asset", {FAMILY} >> "RENDER").
 
-**Available keys:**
-- asset
-- subset
-- task\[name\]
-- task\[type\]
-- task\[short\]
-- username
-- app
-- family
-- version
-- review_link
+**Additional implemented keys:**
+- review_filepath
 
 ##### Message example
 ```
 {Subset} was published for {ASSET} in {task[name]} task.
 
-Here you can find review {review_link}
+Here you can find review {review_filepath}
 ```
 
 #### Message retention


### PR DESCRIPTION
## Brief description
Currently only thumbnail is present, it was required to add link to review.

## Description
There are two options now how to add review to Slack notification message. 
- upload file - burnin version is preferred if present
- use {review_link} placeholder in content of message

## Additional info
Uploading of review must be though through as in case of large sizes of reviews publish might be too slow and one will be hitting on Slack limits pretty soon.

Contained in #2499, use #2499 to test both.

## Testing notes:
1. Use configuration like: ![Screenshot 2022-01-07 121535](https://user-images.githubusercontent.com/4457962/148536219-4c3bd988-28b0-48e5-8cff-9cd081a93438.png)  (full bot key in Keeper under 'Slack bot token')
2. Publish any `render` family
3. Check `test_integration` channel 