### PR TITLE
Workfiles Tool can handle when workfile is not created directly in workdir path

### DIFF
--- a/openpype/hosts/maya/api/__init__.py
+++ b/openpype/hosts/maya/api/__init__.py
@@ -218,7 +218,8 @@ def on_task_changed(*args):
     )
 
 
-def before_workfile_save(workfile_path, workdir_path):
+def before_workfile_save(event):
+    workdir_path = event.workdir_path
     if workdir_path:
         copy_workspace_mel(workdir_path)
 

--- a/openpype/hosts/maya/api/__init__.py
+++ b/openpype/hosts/maya/api/__init__.py
@@ -218,12 +218,9 @@ def on_task_changed(*args):
     )
 
 
-def before_workfile_save(workfile_path):
-    if not workfile_path:
-        return
-
-    workdir = os.path.dirname(workfile_path)
-    copy_workspace_mel(workdir)
+def before_workfile_save(workfile_path, workdir_path):
+    if workdir_path:
+        copy_workspace_mel(workdir_path)
 
 
 class MayaDirmap(HostDirmap):

--- a/openpype/pipeline/lib/__init__.py
+++ b/openpype/pipeline/lib/__init__.py
@@ -1,3 +1,8 @@
+from .events import (
+    BaseEvent,
+    BeforeWorkfileSave
+)
+
 from .attribute_definitions import (
     AbtractAttrDef,
     UnknownDef,
@@ -9,6 +14,9 @@ from .attribute_definitions import (
 
 
 __all__ = (
+    "BaseEvent",
+    "BeforeWorkfileSave",
+
     "AbtractAttrDef",
     "UnknownDef",
     "NumberDef",

--- a/openpype/pipeline/lib/events.py
+++ b/openpype/pipeline/lib/events.py
@@ -31,10 +31,16 @@ class BaseEvent(object):
 
     @classmethod
     def emit(cls, *args, **kwargs):
+        """Create object of event and emit.
+
+        Args:
+            Same args as '__init__' expects which may be class specific.
+        """
         from avalon import pipeline
 
         obj = cls(*args, **kwargs)
         pipeline.emit(obj.topic, [obj])
+        return obj
 
 
 class BeforeWorkfileSave(BaseEvent):

--- a/openpype/pipeline/lib/events.py
+++ b/openpype/pipeline/lib/events.py
@@ -1,0 +1,38 @@
+"""Events holding data about specific event."""
+
+
+class BaseEvent:
+    """Base event object.
+
+    Can be used to anything because data are not much specific. Only required
+    argument is topic which defines why event is happening and may be used for
+    filtering.
+
+    Arg:
+        topic (str): Identifier of event.
+        data (Any): Data specific for event. Dictionary is recommended.
+    """
+    _data = {}
+
+    def __init__(self, topic, data=None):
+        self._topic = topic
+        if data is None:
+            data = {}
+        self._data = data
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def topic(self):
+        return self._topic
+
+
+class BeforeWorkfileSave(BaseEvent):
+    """Before workfile changes event data."""
+    def __init__(self, new_workfile, workdir):
+        super(BeforeWorkfileSave, self).__init__("before.workfile.save")
+
+        self.workfile_path = new_workfile
+        self.workdir_path = workdir

--- a/openpype/pipeline/lib/events.py
+++ b/openpype/pipeline/lib/events.py
@@ -1,7 +1,8 @@
 """Events holding data about specific event."""
 
 
-class BaseEvent:
+# Inherit from 'object' for Python 2 hosts
+class BaseEvent(object):
     """Base event object.
 
     Can be used to anything because data are not much specific. Only required
@@ -27,6 +28,13 @@ class BaseEvent:
     @property
     def topic(self):
         return self._topic
+
+    @classmethod
+    def emit(cls, *args, **kwargs):
+        from avalon import pipeline
+
+        obj = cls(*args, **kwargs)
+        pipeline.emit(obj.topic, [obj])
 
 
 class BeforeWorkfileSave(BaseEvent):

--- a/openpype/pipeline/lib/events.py
+++ b/openpype/pipeline/lib/events.py
@@ -45,12 +45,7 @@ class BaseEvent(object):
 
 class BeforeWorkfileSave(BaseEvent):
     """Before workfile changes event data."""
-    def __init__(self, new_workfile, workdir):
-        data = {
-            "workfile_path": new_workfile,
-            "workdir_path": workdir
-        }
-        super(BeforeWorkfileSave, self).__init__("before.workfile.save", data)
-
-        self.workfile_path = new_workfile
+    def __init__(self, filename, workdir):
+        super(BeforeWorkfileSave, self).__init__("before.workfile.save")
+        self.filename = filename
         self.workdir_path = workdir

--- a/openpype/pipeline/lib/events.py
+++ b/openpype/pipeline/lib/events.py
@@ -46,7 +46,11 @@ class BaseEvent(object):
 class BeforeWorkfileSave(BaseEvent):
     """Before workfile changes event data."""
     def __init__(self, new_workfile, workdir):
-        super(BeforeWorkfileSave, self).__init__("before.workfile.save")
+        data = {
+            "workfile_path": new_workfile,
+            "workdir_path": workdir
+        }
+        super(BeforeWorkfileSave, self).__init__("before.workfile.save", data)
 
         self.workfile_path = new_workfile
         self.workdir_path = workdir

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -368,6 +368,7 @@ class FilesWidget(QtWidgets.QWidget):
 
         # This is not root but workfile directory
         self._workfiles_root = None
+        self._workdir_path = None
         self.host = api.registered_host()
 
         # Whether to automatically select the latest modified
@@ -465,6 +466,7 @@ class FilesWidget(QtWidgets.QWidget):
         # This way we can browse it even before we enter it.
         if self._asset_id and self._task_name and self._task_type:
             session = self._get_session()
+            self._workdir_path = session["AVALON_WORKDIR"]
             self._workfiles_root = self.host.work_root(session)
             self.files_model.set_root(self._workfiles_root)
 
@@ -677,6 +679,7 @@ class FilesWidget(QtWidgets.QWidget):
             self._asset_id, self._task_name, self._task_type
         )
         create_workdir_extra_folders(
+            self._workdir_path,
             self._workfiles_root,
             api.Session["AVALON_APP"],
             self._task_type,

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -681,7 +681,6 @@ class FilesWidget(QtWidgets.QWidget):
         )
         create_workdir_extra_folders(
             self._workdir_path,
-            self._workfiles_root,
             api.Session["AVALON_APP"],
             self._task_type,
             self._task_name,

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -670,7 +670,7 @@ class FilesWidget(QtWidgets.QWidget):
             os.path.normpath(self._workfiles_root), work_file
         )
 
-        pipeline.emit("before.workfile.save", [file_path])
+        pipeline.emit("before.workfile.save", [file_path, self._workdir_path])
 
         self._enter_session()   # Make sure we are in the right session
         self.host.save_file(file_path)

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -654,6 +654,9 @@ class FilesWidget(QtWidgets.QWidget):
         if not work_file:
             return
 
+        # Trigger before save event
+        BeforeWorkfileSave.emit(work_file, self._workdir_path)
+
         # Initialize work directory if it has not been initialized before
         if not os.path.exists(self._workfiles_root):
             log.debug("Initializing Work Directory: %s", self._workfiles_root)
@@ -670,9 +673,6 @@ class FilesWidget(QtWidgets.QWidget):
         file_path = os.path.join(
             os.path.normpath(self._workfiles_root), work_file
         )
-
-        BeforeWorkfileSave.emit(file_path, self._workdir_path)
-
         self._enter_session()   # Make sure we are in the right session
         self.host.save_file(file_path)
 

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -11,6 +11,7 @@ from Qt import QtWidgets, QtCore
 from avalon import io, api, pipeline
 
 from openpype import style
+from openpype.pipeline.lib import BeforeWorkfileSave
 from openpype.tools.utils.lib import (
     qt_app_context
 )
@@ -670,7 +671,7 @@ class FilesWidget(QtWidgets.QWidget):
             os.path.normpath(self._workfiles_root), work_file
         )
 
-        pipeline.emit("before.workfile.save", [file_path, self._workdir_path])
+        BeforeWorkfileSave.emit(file_path, self._workdir_path)
 
         self._enter_session()   # Make sure we are in the right session
         self.host.save_file(file_path)


### PR DESCRIPTION
## Brief description
Workfiles tool does not know how to work when workfiles directory does not match workdir path which cause issues in maya where workspace.mel is created and when extra folders should be created.

## Changes
- in Workfiles tool renamed `root` to `_workfiles_root` and added attribute `_workdir_path` which may not be the same
- added base of objected events where only one argument (object of the event) is passed to callback
     - this approach gives more abilities for backwards compatibility when we need to tweak arguments for callbacks
- use objected events to pass workfile path with workdir path into callback
- maya callback is looking for workfile directory instead of directory where workfile is


## Testing notes:
Expected that we're testing in Maya
1. Set `AVALON_SCENEDIR` environment in maya and set it to `"scene"`
2. Add some extra folders in project settings `project_settings/global/tools/Workfiles/extra_folders` for Maya
3. Open Maya from launcher
4. Change context to task where is not yet created work directory
5. Hit Save As to create new workfile
6. Check if extra folders and workfile is in right strucutre
Resovles https://github.com/pypeclub/OpenPype/issues/2503