### PR TITLE
Improve FusionPreLaunch hook errors

### DIFF
--- a/openpype/hosts/fusion/hooks/pre_fusion_setup.py
+++ b/openpype/hosts/fusion/hooks/pre_fusion_setup.py
@@ -16,11 +16,11 @@ class FusionPrelaunch(PreLaunchHook):
         py36_dir = os.path.normpath(self.launch_context.env.get("PYTHON36", ""))
         if not os.path.isdir(py36_dir):
             raise ApplicationLaunchFailed(
-            "Python 3.6 is not installed at the provided path.\n"
-            "Either make sure the 'environments/fusion.json' has "
-            "'PYTHON36' set corectly or make sure Python 3.6 is installed "
-            f"in the given path.\n\nPYTHON36: {py36_dir}"
-        )
+                "Python 3.6 is not installed at the provided path.\n"
+                "Either make sure the 'environments/fusion.json' has "
+                "'PYTHON36' set corectly or make sure Python 3.6 is installed "
+                f"in the given path.\n\nPYTHON36: {py36_dir}"
+            )
         self.log.info(f"Path to Fusion Python folder: '{py36_dir}'...")
         self.launch_context.env["PYTHON36"] = py36_dir
 
@@ -30,11 +30,12 @@ class FusionPrelaunch(PreLaunchHook):
         )
         if not os.path.isdir(us_dir):
             raise ApplicationLaunchFailed(
-            "Fusion utility script dir does not exist. Either make sure "
-            "the 'environments/fusion.json' has 'FUSION_UTILITY_SCRIPTS_DIR' "
-            "set correctly or reinstall DaVinci Resolve.\n\n"
-            f"FUSION_UTILITY_SCRIPTS_DIR: '{us_dir}'"
-        )
+                "Fusion utility script dir does not exist. Either make sure "
+                "the 'environments/fusion.json' has "
+                "'FUSION_UTILITY_SCRIPTS_DIR' set correctly or reinstall "
+                "DaVinci Resolve.\n\n"
+                f"FUSION_UTILITY_SCRIPTS_DIR: '{us_dir}'"
+            )
 
         try:
             __import__("avalon.fusion")

--- a/openpype/hosts/fusion/hooks/pre_fusion_setup.py
+++ b/openpype/hosts/fusion/hooks/pre_fusion_setup.py
@@ -1,6 +1,6 @@
 import os
 import importlib
-from openpype.lib import PreLaunchHook
+from openpype.lib import PreLaunchHook, ApplicationLaunchFailed
 from openpype.hosts.fusion.api import utils
 
 
@@ -14,24 +14,26 @@ class FusionPrelaunch(PreLaunchHook):
     def execute(self):
         # making sure pyton 3.6 is installed at provided path
         py36_dir = os.path.normpath(self.launch_context.env.get("PYTHON36", ""))
-        assert os.path.isdir(py36_dir), (
-            "Python 3.6 is not installed at the provided folder path. Either "
-            "make sure the `environments\resolve.json` is having correctly "
-            "set `PYTHON36` or make sure Python 3.6 is installed "
-            f"in given path. \nPYTHON36E: `{py36_dir}`"
+        if not os.path.isdir(py36_dir):
+            raise ApplicationLaunchFailed(
+            "Python 3.6 is not installed at the provided path.\n"
+            "Either make sure the 'environments/fusion.json' has "
+            "'PYTHON36' set corectly or make sure Python 3.6 is installed "
+            f"in the given path.\n\nPYTHON36: {py36_dir}"
         )
-        self.log.info(f"Path to Fusion Python folder: `{py36_dir}`...")
+        self.log.info(f"Path to Fusion Python folder: '{py36_dir}'...")
         self.launch_context.env["PYTHON36"] = py36_dir
 
         # setting utility scripts dir for scripts syncing
         us_dir = os.path.normpath(
             self.launch_context.env.get("FUSION_UTILITY_SCRIPTS_DIR", "")
         )
-        assert os.path.isdir(us_dir), (
-            "Fusion utility script dir does not exists. Either make sure "
-            "the `environments\fusion.json` is having correctly set "
-            "`FUSION_UTILITY_SCRIPTS_DIR` or reinstall DaVinci Resolve. \n"
-            f"FUSION_UTILITY_SCRIPTS_DIR: `{us_dir}`"
+        if not os.path.isdir(us_dir):
+            raise ApplicationLaunchFailed(
+            "Fusion utility script dir does not exist. Either make sure "
+            "the 'environments/fusion.json' has 'FUSION_UTILITY_SCRIPTS_DIR' "
+            "set correctly or reinstall DaVinci Resolve.\n\n"
+            f"FUSION_UTILITY_SCRIPTS_DIR: '{us_dir}'"
         )
 
         try:

--- a/openpype/hosts/fusion/hooks/pre_fusion_setup.py
+++ b/openpype/hosts/fusion/hooks/pre_fusion_setup.py
@@ -33,8 +33,7 @@ class FusionPrelaunch(PreLaunchHook):
                 "Fusion utility script dir does not exist. Either make sure "
                 "the 'environments/fusion.json' has "
                 "'FUSION_UTILITY_SCRIPTS_DIR' set correctly or reinstall "
-                "DaVinci Resolve.\n\n"
-                f"FUSION_UTILITY_SCRIPTS_DIR: '{us_dir}'"
+                f"Fusion.\n\nFUSION_UTILITY_SCRIPTS_DIR: '{us_dir}'"
             )
 
         try:


### PR DESCRIPTION
This is related to #2500 

Improve FusionPreLaunch hook error readability + make it a pop-up from the launcher.

- I've removed the usage of ` in the string as they would convert into special characters in the pop-up. So those are changed to '.
- Also fixed mention of `environments/resolve.json` to `environments/fusion.json`.

## Screenshot
![fusion_prelaunchhook_popup](https://user-images.githubusercontent.com/2439881/148698099-e9444adf-117f-4af2-b91d-bb3c3c7da13e.png)

