### PR TITLE
Fix published frame content for sequence starting with 0

### DIFF
--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -580,7 +580,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             if repre.get("outputName"):
                 representation["context"]["output"] = repre['outputName']
 
-            if sequence_repre and repre.get("frameStart"):
+            if sequence_repre and repre.get("frameStart") is not None:
                 representation['context']['frame'] = (
                     dst_padding_exp % int(repre.get("frameStart"))
                 )


### PR DESCRIPTION
## Brief description
Previously expression didn't trigger as `repre.get("frameStart")` returned 0 which translated into False

## Description
This resulted in using frame value in source padding which might had been different from final, correct value.

## Additional info
In AE it manifested when artist manually updated frame pattern in Render Queue, used more `#` than is in final pattern from Anatomy (which is `####`).  AE rendered locally files with `00000` temporarily, `integrate_new` used correct padding for publishing, but `representation.context.frame` stayed with wrong value (`00000` instead of `0000`).
This might have happened in another hosts too.


## Testing notes:
1. add new Render Queue in AE, choose "PNG" as destination format
2. modify name there to contain more or less # than 4
3. render locally
4. check published files, they will be correct
5. check representation in DB (`db.getCollection('petr_test').find({type:"representation", name:"png"}).sort({"_id": -1})`) , its `context.frame` will match source pattern
6. Try to load this published representation (you can load it in AE directly) - it should fail 