### PR TITLE
Maya: Fix Extract Look with space in names

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -75,8 +75,12 @@ def maketx(source, destination, *args):
         "--filter lanczos3",
     ]
 
+    def _escape(path):
+        # Ensure path is enclosed by quotes to allow paths with spaces
+        return '"{}"'.format(path)
+
     cmd.extend(args)
-    cmd.extend(["-o", destination, source])
+    cmd.extend(["-o", _escape(destination), _escape(source)])
 
     cmd = " ".join(cmd)
 

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -62,7 +62,7 @@ def maketx(source, destination, *args):
     """
     from openpype.lib import get_oiio_tools_path
 
-    maketx_path = get_oiio_tools_path("maketx") + ".exe"
+    maketx_path = get_oiio_tools_path("maketx")
     if not os.path.exists(maketx_path):
         print(
             "OIIO tool not found in {}".format(maketx_path))

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -22,6 +22,11 @@ COPY = 1
 HARDLINK = 2
 
 
+def escape_space(path):
+    """Ensure path is enclosed by quotes to allow paths with spaces"""
+    return '"{}"'.format(path) if " " in path else path
+
+
 def find_paths_by_hash(texture_hash):
     """Find the texture hash key in the dictionary.
 
@@ -57,7 +62,7 @@ def maketx(source, destination, *args):
     """
     from openpype.lib import get_oiio_tools_path
 
-    maketx_path = get_oiio_tools_path("maketx")
+    maketx_path = get_oiio_tools_path("maketx") + ".exe"
     if not os.path.exists(maketx_path):
         print(
             "OIIO tool not found in {}".format(maketx_path))
@@ -75,12 +80,8 @@ def maketx(source, destination, *args):
         "--filter lanczos3",
     ]
 
-    def _escape(path):
-        # Ensure path is enclosed by quotes to allow paths with spaces
-        return '"{}"'.format(path)
-
     cmd.extend(args)
-    cmd.extend(["-o", _escape(destination), _escape(source)])
+    cmd.extend(["-o", escape_space(destination), escape_space(source)])
 
     cmd = " ".join(cmd)
 
@@ -318,7 +319,6 @@ class ExtractLook(openpype.api.Extractor):
         do_maketx = instance.data.get("maketx", False)
 
         # Collect all unique files used in the resources
-        files = set()
         files_metadata = {}
         for resource in resources:
             # Preserve color space values (force value after filepath change)
@@ -329,7 +329,6 @@ class ExtractLook(openpype.api.Extractor):
             for f in resource["files"]:
                 files_metadata[os.path.normpath(f)] = {
                     "color_space": color_space}
-                # files.update(os.path.normpath(f))
 
         # Process the resource files
         transfers = []
@@ -337,7 +336,6 @@ class ExtractLook(openpype.api.Extractor):
         hashes = {}
         force_copy = instance.data.get("forceCopy", False)
 
-        self.log.info(files)
         for filepath in files_metadata:
 
             linearize = False
@@ -496,7 +494,7 @@ class ExtractLook(openpype.api.Extractor):
                 # Include `source-hash` as string metadata
                 "-sattrib",
                 "sourceHash",
-                texture_hash,
+                escape_space(texture_hash),
                 colorconvert,
             )
 


### PR DESCRIPTION
## Brief description

This fixes #2055.

With this changed the source and destination filepath is now escaped with `"` quotes in the call to subprocess when a space is in the path. We're also doing this for the `sourceHash` argument since that uses the filename as part of the hash and had the same issue.

## Testing notes:

1. Publish a look that uses a texture with a space in filename.
2. Assign the look

### Tested

I've tested the publishing plus look assignment. It looks solid on my end. 👍 