### PR TITLE
Expose toggle publish plug-in settings for Maya Look Shading Engine Naming

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -166,6 +166,11 @@
             "enabled": false,
             "regex": "(?P<asset>.*)_(.*)_SHD"
         },
+        "ValidateShadingEngine": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateAttributes": {
             "enabled": false,
             "attributes": {}

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -73,6 +73,17 @@
         },
 
         {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
+                    "key": "ValidateShadingEngine",
+                    "label": "Validate Look Shading Engine Naming"
+                }
+            ]
+        },
+
+        {
             "type": "dict",
             "collapsible": true,
             "key": "ValidateAttributes",


### PR DESCRIPTION
## Brief description

As [per request of Dillon Sindon (Lucan) on Discord](https://discord.com/channels/517362899170230292/563751989075378201/930864370756497469) here's a PR to expose the enabled status for the Maya Look Shading Engine Naming Validator.

## Description

The first step was to add it to the project settings definition in: `openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json`
By using the [validator's class name: `ValidateShadingEngine`](https://github.com/pypeclub/OpenPype/blob/f5c0c6453383c7a64e5ce3340c7227e11720c8e8/openpype/hosts/maya/plugins/publish/validate_look_shading_group.py#L8)

```json
        {
            "type": "schema_template",
            "name": "template_publish_plugin",
            "template_data": [
                {
                    "key": "ValidateShadingEngine",
                    "label": "Validate Look Shading Engine Naming"
                }
            ]
        },
```

After that we needed to generate the "default" settings for OpenPype. The easiest way to do so is to run the `tools/run_settings` tool provided with OpenPype code base. In there browse to the project settings and modify the defaults for this new entry. Save the settings.

This will update the relevant defaults `.json` - in this case: `openpype/settings/defaults/project_settings/maya.json`
That's all there is to it to expose settings for a publish plug-in.