### PR TITLE
Fix create zip tool - path argument

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -762,7 +762,7 @@ class BootstrapRepos:
 
             destination = self._move_zip_to_data_dir(temp_zip)
 
-        return OpenPypeVersion(version=version, path=destination)
+        return OpenPypeVersion(version=version, path=Path(destination))
 
     def _move_zip_to_data_dir(self, zip_file) -> Union[None, Path]:
         """Move zip with OpenPype version to user data directory.

--- a/tools/create_zip.py
+++ b/tools/create_zip.py
@@ -31,7 +31,9 @@ def main(path):
     bs = bootstrap_repos.BootstrapRepos(progress_callback=progress)
     if path:
         out_path = Path(path)
-        bs.data_dir = out_path.parent
+        bs.data_dir = out_path
+        if out_path.is_file():
+            bs.data_dir = out_path.parent
 
     _print(f"Creating zip in {bs.data_dir} ...")
     repo_file = bs.create_version_from_live_code()


### PR DESCRIPTION
## Fix

this is fixing wrong type passed when using **create_zip** tool with `--path` argument.

Close #2451 