### PR TITLE
Fixed bug: Minor inaccuracy in multi-frame calculation

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_frames.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_frames.py
@@ -37,7 +37,7 @@ class CollectFrames(pyblish.api.InstancePlugin):
 
             # Check if frames are bigger than 1 (file collection)
             # override the result
-            if end_frame - start_frame > 1:
+            if end_frame - start_frame > 0:
                 result = self.create_file_list(
                     match, int(start_frame), int(end_frame)
                 )


### PR DESCRIPTION
## Brief description
Houdini's collect_frames plugin has a bug in frame range check.

## Description
It's fairly minor issue. 
We assume the 'endframe' is the last frame *to be included*. 
Thus, the current condition works for all cases, except a frame range of 2 frames, e.g. [1001-1002] , in this case it'll incorrectly consider it to be single frame publish. This isn't affecting almost all realistic use cases.. we simply spotted this during some testing. 

Technical artist spotted this, so I surfaced his commit from our internal git system. 
