### PR TITLE
Maya: namespaced context go back to original namespace when started from inside a namespace

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -733,7 +733,7 @@ def namespaced(namespace, new=True):
         str: The namespace that is used during the context
 
     """
-    original = cmds.namespaceInfo(cur=True)
+    original = cmds.namespaceInfo(cur=True, absoluteName=True)
     if new:
         namespace = avalon.maya.lib.unique_namespace(namespace)
         cmds.namespace(add=namespace)


### PR DESCRIPTION
## Brief description

Small fix for where `openpype.hosts.maya.api.lib.namespaced` context manager wouldn't go back to original state when started from inside a namespace.

### Test case

**To reproduce**

```python
cmds.file(new=True, force=True) # clear scene

# Create some namespaces
cmds.namespace(add=":aap")
cmds.namespace(add=":aap:foo")

# Start in a namespace :aap
cmds.namespace(set=":aap")
before = cmds.namespaceInfo(currentNamespace=True, absoluteName=True)
print("Before -> %s" % before)

# Go into namespace :aap:foo
with lib.namespaced(":aap:foo", new=False):
    during = cmds.namespaceInfo(currentNamespace=True, absoluteName=True)
    print("During -> %s" % during)

# Now should have reverted back to :aap
after = cmds.namespaceInfo(currentNamespace=True, absoluteName=True)
print("After  -> %s" % after)

assert before == after
```

That should work fine and print out:
```
Before -> :aap
During -> :aap:foo
After  -> :aap
```

But before this PR it would fail to go back to the namespace it had before and would error with:

```python
# Error: No namespace matches name: 'aap'.
# Traceback (most recent call last):
#   File "<maya console>", line 14, in <module>
#   File "C:\Program Files\Autodesk\Maya2022\Python37\lib\contextlib.py", line 119, in __exit__
#     next(self.gen)
#   File "S:\openpype\OpenPype\openpype\hosts\maya\api\lib.py", line 745, in namespaced
#     cmds.namespace(set=original)
# RuntimeError: No namespace matches name: 'aap'. # 
```