### PR TITLE
Maya: ReferenceLoader fix not unique group name error for attach to root

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -63,6 +63,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             if current_namespace != ":":
                 group_name = current_namespace + ":" + group_name
 
+            group_name = "|" + group_name
+
             self[:] = new_nodes
 
             if attach_to_root:


### PR DESCRIPTION
(cherry picked from commit f1b7aed767b76bced648b785dc3d40a68b36db7b)

## Brief description

Very simple fix which actually avoids the error. It's not necessarily a full cleanup as to the root of the problem and why it could fail in the first place. It's a hotfix for #2528 

Later we can look into more accurate ways to retrieve the root group of a reference without issue. (Hint: Maya actually creates a connection from the reference node to the root group, we can abuse that!)