### PR TITLE
Houdini: vdbcache family preserve frame numbers on publish integration + enable validate version for Houdini

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_instances.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_instances.py
@@ -74,6 +74,9 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             instance = context.create_instance(label)
 
+            # Include `families` using `family` data
+            instance.data["families"] = [instance.data["family"]]
+
             instance[:] = [node]
             instance.data.update(data)
 

--- a/openpype/hosts/houdini/plugins/publish/extract_vdb_cache.py
+++ b/openpype/hosts/houdini/plugins/publish/extract_vdb_cache.py
@@ -37,5 +37,7 @@ class ExtractVDBCache(openpype.api.Extractor):
             "ext": "vdb",
             "files": output,
             "stagingDir": staging_dir,
+            "frameStart": instance.data["frameStart"],
+            "frameEnd": instance.data["frameEnd"],
         }
         instance.data["representations"].append(representation)

--- a/openpype/plugins/publish/validate_version.py
+++ b/openpype/plugins/publish/validate_version.py
@@ -10,7 +10,7 @@ class ValidateVersion(pyblish.api.InstancePlugin):
     order = pyblish.api.ValidatorOrder
 
     label = "Validate Version"
-    hosts = ["nuke", "maya", "blender", "standalonepublisher"]
+    hosts = ["nuke", "maya", "houdini", "blender", "standalonepublisher"]
 
     optional = False
     active = True


### PR DESCRIPTION
## Brief description

This PR fixes a bug with VDB publishes from Houdini so that it actually preserves its original frame numbers (otherwise would always get remapped to start at frame 0 by the integrator - even though the loader would still show frameStart and frameEnd as the non-remapped range.)

- The [Integrator requires `frameStart` data to be present on the `representations` to preserve the frame numbers upon integrating](https://github.com/pypeclub/OpenPype/blob/7d016ab82ca7d68695926b7ff49d6ef500218603/openpype/plugins/publish/integrate_new.py#L455) - I've added `frameEnd` too just to be consistent.
- [We had to include `families` data otherwise the integrator would error here](https://discord.com/channels/517362899170230292/563751989075378201/931579623593087027)

Publishing frame range 1000-1015

**Before**: `publish.0000.vdb - publish.0015.vdb`
**After:** `publish.1000.vdb - publish.1015.vdb`

---

This PR also enabled **Validate Version** for Houdini since that was disabled - which without it accidentally allowed me to publish into an already published version because I had Match Work File Version enabled in the test project. Which seemed like a required fix for Houdini too - since it's a small PR. :)
