### PR TITLE
Maya: Remove Maya Look Assigner check on startup

### DIFF
--- a/openpype/hosts/maya/api/customize.py
+++ b/openpype/hosts/maya/api/customize.py
@@ -95,29 +95,20 @@ def override_toolbox_ui():
     # Create our controls
     background_color = (0.267, 0.267, 0.267)
     controls = []
-    look_assigner = None
-    try:
-        look_assigner = host_tools.get_tool_by_name(
-            "lookassigner",
-            parent=pipeline._parent
-        )
-    except Exception:
-        log.warning("Couldn't create Look assigner window.", exc_info=True)
 
-    if look_assigner is not None:
-        controls.append(
-            mc.iconTextButton(
-                "pype_toolbox_lookmanager",
-                annotation="Look Manager",
-                label="Look Manager",
-                image=os.path.join(icons, "lookmanager.png"),
-                command=host_tools.show_look_assigner,
-                bgc=background_color,
-                width=icon_size,
-                height=icon_size,
-                parent=parent
-            )
+    controls.append(
+        mc.iconTextButton(
+            "pype_toolbox_lookmanager",
+            annotation="Look Manager",
+            label="Look Manager",
+            image=os.path.join(icons, "lookmanager.png"),
+            command=host_tools.show_look_assigner,
+            bgc=background_color,
+            width=icon_size,
+            height=icon_size,
+            parent=parent
         )
+    )
 
     controls.append(
         mc.iconTextButton(

--- a/openpype/hosts/maya/api/customize.py
+++ b/openpype/hosts/maya/api/customize.py
@@ -93,7 +93,6 @@ def override_toolbox_ui():
         return
 
     # Create our controls
-    background_color = (0.267, 0.267, 0.267)
     controls = []
 
     controls.append(
@@ -103,7 +102,6 @@ def override_toolbox_ui():
             label="Look Manager",
             image=os.path.join(icons, "lookmanager.png"),
             command=host_tools.show_look_assigner,
-            bgc=background_color,
             width=icon_size,
             height=icon_size,
             parent=parent
@@ -119,7 +117,6 @@ def override_toolbox_ui():
             command=lambda: host_tools.show_workfiles(
                 parent=pipeline._parent
             ),
-            bgc=background_color,
             width=icon_size,
             height=icon_size,
             parent=parent
@@ -135,7 +132,6 @@ def override_toolbox_ui():
             command=lambda: host_tools.show_loader(
                 parent=pipeline._parent, use_context=True
             ),
-            bgc=background_color,
             width=icon_size,
             height=icon_size,
             parent=parent
@@ -151,7 +147,6 @@ def override_toolbox_ui():
             command=lambda: host_tools.show_scene_inventory(
                 parent=pipeline._parent
             ),
-            bgc=background_color,
             width=icon_size,
             height=icon_size,
             parent=parent


### PR DESCRIPTION
## Brief description

This PR relates to #2539 and avoids Maya Look Assigner getting initialized on Maya launch. The code change is basically a full removal of checking whether Maya Look Assigner exists on startup since the code for it is embedded directly within OpenPype and [always gets added to `sys.path`](https://github.com/pypeclub/OpenPype/blob/7a2164cf4f941ed0ac313ea9add5aa6436c1bff8/openpype/hosts/maya/__init__.py#L10). **_It would be good to know if there are any expected issues with this check being fully removed._**

This PR also removes the background color flag on the icons - because it didn't seem to make any difference when I removed it.

---

Note: Changes to this code will conflict on merge with changes in #2445 but merging them should be trivial since they don't influence the exact same lines of code. (except for some indentation changes, and the `backgroundColor` flag removal)

### Testing

- 👍 Tested in Maya 2020 
- 👍 Tested in Maya 2022 (after I merged it into a branch with #2445 - I just pushed that [branch](https://github.com/BigRoy/OpenPype/tree/issue2539_merged2445) too if you'd like to test.)