### PR TITLE
Loader: Allow to toggle default family filters between "include" or "exclude" filtering

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -297,6 +297,7 @@
             "family_filter_profiles": [
                 {
                     "hosts": [],
+                    "is_include": true,
                     "task_types": [],
                     "filter_families": []
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -269,11 +269,7 @@
                             {
                                 "type": "boolean",
                                 "key": "is_include",
-                                "label": "Exclude (OFF) / Include (ON)"
-                            },
-                            {
-                                "type": "label",
-                                "label": "Include: <b>show</b> selected families by default. Hides others by default.<br>Exclude: <b>hide</b> selected families by default. Shows others by default."
+                                "label": "Exclude / Include"
                             },
                             {
                                 "type": "template",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -267,7 +267,13 @@
                                 "label": "Task types"
                             },
                             {
-                                "type": "splitter"
+                                "type": "boolean",
+                                "key": "is_include",
+                                "label": "Exclude (OFF) / Include (ON)"
+                            },
+                            {
+                                "type": "label",
+                                "label": "Include: <b>show</b> selected families by default. Hides others by default.<br>Exclude: <b>hide</b> selected families by default. Shows others by default."
                             },
                             {
                                 "type": "template",

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -228,6 +228,7 @@ class FamilyConfigCache:
         self.dbcon = dbcon
         self.family_configs = {}
         self._family_filters_set = False
+        self._family_filters_is_include = True
         self._require_refresh = True
 
     @classmethod
@@ -249,7 +250,7 @@ class FamilyConfigCache:
                 "icon": self.default_icon()
             }
             if self._family_filters_set:
-                item["state"] = False
+                item["state"] = not self._family_filters_is_include
         return item
 
     def refresh(self, force=False):
@@ -313,20 +314,23 @@ class FamilyConfigCache:
             matching_item = filter_profiles(profiles, profiles_filter)
 
         families = []
+        is_include = True
         if matching_item:
             families = matching_item["filter_families"]
+            is_include = matching_item["is_include"]
 
         if not families:
             return
 
         self._family_filters_set = True
+        self._family_filters_is_include = is_include
 
         # Replace icons with a Qt icon we can use in the user interfaces
         for family in families:
             family_info = {
                 "name": family,
                 "icon": self.default_icon(),
-                "state": True
+                "state": is_include
             }
 
             self.family_configs[family] = family_info


### PR DESCRIPTION
## Brief description

This implements #2516 

It adds an extra boolean checkbox in Admin Settings for Family Filters to decide whether the filtering is to "include" what you've selected or to "exclude" what you've selected.

Like the label describes in settings it works like this:

- Include: **show** selected families by default. Hides others by default.
- Exclude: **hide** selected families by default. Shows others by default.

So on Exclude always all families will be enabled except for those selected in the filter. On Include, it behaves like before, only the families you select in settings are enabled by default in the Loader.

## Screenshot

This is how it looks in Settings:
![family_filter_include_exclude](https://user-images.githubusercontent.com/2439881/149657057-ced2f9f8-5502-4fca-afc5-a1b9efe82965.png)


## Testing notes:

👍 I tested it in Maya 2020 on both include and exclude mode and it worked as intended.