### PR TITLE
Maya : V-Ray Proxy - load all ABC files via proxy

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -17,8 +17,8 @@ from openpype.api import get_project_settings
 class VRayProxyLoader(api.Loader):
     """Load VRay Proxy with Alembic or VrayMesh."""
 
-    families = ["vrayproxy"]
-    representations = ["vrmesh"]
+    families = ["vrayproxy", "model"]
+    representations = ["vrmesh", "abc"]
 
     label = "Import VRay Proxy"
     order = -10

--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -17,7 +17,7 @@ from openpype.api import get_project_settings
 class VRayProxyLoader(api.Loader):
     """Load VRay Proxy with Alembic or VrayMesh."""
 
-    families = ["vrayproxy", "model"]
+    families = ["vrayproxy"]
     representations = ["vrmesh", "abc"]
 
     label = "Import VRay Proxy"

--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -17,7 +17,7 @@ from openpype.api import get_project_settings
 class VRayProxyLoader(api.Loader):
     """Load VRay Proxy with Alembic or VrayMesh."""
 
-    families = ["vrayproxy", "model"]
+    families = ["vrayproxy", "model", "pointcache", "animation"]
     representations = ["vrmesh", "abc"]
 
     label = "Import VRay Proxy"

--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -17,7 +17,7 @@ from openpype.api import get_project_settings
 class VRayProxyLoader(api.Loader):
     """Load VRay Proxy with Alembic or VrayMesh."""
 
-    families = ["vrayproxy"]
+    families = ["vrayproxy", "model"]
     representations = ["vrmesh", "abc"]
 
     label = "Import VRay Proxy"


### PR DESCRIPTION
## Description
Add option to load alembic files published using `model` family with V-ray proxy loader.

## Testing notes:
1. load alembic model from OP loader with `Import VRay Proxy (abc)`.