### PR TITLE
General: Fix install thread in igniter

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -912,7 +912,6 @@ class BootstrapRepos:
                 processed_path = file
                 self._print(f"- processing {processed_path}")
 
-
                 checksums.append(
                     (
                         sha256sum(file.as_posix()),
@@ -1544,7 +1543,8 @@ class BootstrapRepos:
 
         Args:
             zip_item (Path): Zip file to test.
-            detected_version (OpenPypeVersion): Pype version detected from name.
+            detected_version (OpenPypeVersion): Pype version detected from
+                name.
 
         Returns:
            True if it is valid OpenPype version, False otherwise.

--- a/igniter/install_thread.py
+++ b/igniter/install_thread.py
@@ -60,7 +60,7 @@ class InstallThread(QThread):
         # find local version of OpenPype
         bs = BootstrapRepos(
             progress_callback=self.set_progress, message=self.message)
-        local_version = bs.get_local_live_version()
+        local_version = OpenPypeVersion.get_installed_version_str()
 
         # if user did entered nothing, we install OpenPype from local version.
         # zip content of `repos`, copy it to user data dir and append


### PR DESCRIPTION
## Brief description
InstallThread in igniter is using not existing method `get_local_live_version`.

## Changes
- replaced `get_local_live_version` with `OpenPypeVersion.get_installed_version_str`

## Testing notes:
### With local mongo
1. Turn off mongo server
2. Run openpype
3. Turn on mongo server
4. Press start
5. Process should not stuck

### With cloud mongo
1. Remove mongo url from keyring (Credentials on windows)
2. Run openpype
3. Enter valid mongo url
4. Process should not stuck