### PR TITLE
Settings: PathInput strip passed string

### DIFF
--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -469,6 +469,17 @@ class PathInput(InputEntity):
         # GUI attributes
         self.placeholder_text = self.schema_data.get("placeholder")
 
+    def set(self, value):
+        # Strip value
+        super(PathInput, self).set(value.strip())
+
+    def set_override_state(self, state, ignore_missing_defaults):
+        super(PathInput, self).set_override_state(
+            state, ignore_missing_defaults
+        )
+        # Strip current value
+        self._current_value = self._current_value.strip()
+
 
 class RawJsonEntity(InputEntity):
     schema_types = ["raw-json"]


### PR DESCRIPTION
## Brief description
PathInput makes sure there are no whitesymbols at the start/end of value.

## Changes
- strip value of PathInput on set and on loading of settings values

## Testing notes:
1. Try to pass any path starting/ending with space