### PR TITLE
Photoshop: Fix subset name match creator if use selection

### DIFF
--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -62,8 +62,7 @@ class CreateImage(openpype.api.Creator):
                 # No selection creates an empty group.
                 create_group = True
         else:
-            stub.select_layers(stub.get_layers())
-            group = stub.group_selected_layers(self.name)
+            group = stub.create_group(self.name)
             groups.append(group)
 
         if create_group:

--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -17,9 +17,7 @@ class CreateImage(openpype.api.Creator):
         create_group = False
 
         stub = photoshop.stub()
-        useSelection = False
         if (self.options or {}).get("useSelection"):
-            useSelection = True
             multiple_instances = False
             selection = stub.get_selected_layers()
             self.log.info("selection {}".format(selection))
@@ -82,19 +80,13 @@ class CreateImage(openpype.api.Creator):
             group.name = group.name.replace(stub.PUBLISH_ICON, ''). \
                 replace(stub.LOADED_ICON, '')
 
-            if useSelection:
-                subset_name = self.data["subset"] + group.name
-            else:
-                # use value provided by user from Creator
-                subset_name = self.data["subset"]
-
             if group.long_name:
                 for directory in group.long_name[::-1]:
                     name = directory.replace(stub.PUBLISH_ICON, '').\
                                       replace(stub.LOADED_ICON, '')
                     long_names.append(name)
 
-            self.data.update({"subset": subset_name})
+            self.data.update({"subset": self.data["subset"]})
             self.data.update({"uuid": str(group.id)})
             self.data.update({"long_name": "_".join(long_names)})
             stub.imprint(group, self.data)

--- a/openpype/hosts/photoshop/plugins/create/create_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_image.py
@@ -75,10 +75,15 @@ class CreateImage(openpype.api.Creator):
             group = stub.group_selected_layers(layer.name)
             groups.append(group)
 
+        creator_subset_name = self.data["subset"]
         for group in groups:
             long_names = []
             group.name = group.name.replace(stub.PUBLISH_ICON, ''). \
                 replace(stub.LOADED_ICON, '')
+
+            subset_name = creator_subset_name
+            if len(groups) > 1:
+                subset_name += group.name.title().replace(" ", "")
 
             if group.long_name:
                 for directory in group.long_name[::-1]:
@@ -86,7 +91,7 @@ class CreateImage(openpype.api.Creator):
                                       replace(stub.LOADED_ICON, '')
                     long_names.append(name)
 
-            self.data.update({"subset": self.data["subset"]})
+            self.data.update({"subset": subset_name})
             self.data.update({"uuid": str(group.id)})
             self.data.update({"long_name": "_".join(long_names)})
             stub.imprint(group, self.data)


### PR DESCRIPTION
Photoshop Creator Behavior:

- if `use selection`:
  - if you create a subset group for the whole selection, the subset takes the name of the interface.
    ![image](https://user-images.githubusercontent.com/7068597/149949644-038acefb-0b5f-4a1d-8099-d7c95980e4a4.png)
    ![image](https://user-images.githubusercontent.com/7068597/149948908-37a6a9ee-5ebb-4866-83c2-252f53280f49.png)
  - if several objects are selected, the subset takes the name of the interface + the group
   ![image](https://user-images.githubusercontent.com/7068597/149949742-0baac12b-10e4-486e-ab67-f3b36f3c8589.png)
   ![image](https://user-images.githubusercontent.com/7068597/149949420-cc981c0a-2978-4c7a-a6ad-fef47e4bdd72.png)
- if not `use selection`, create an empty group subset in top level with the name of the interface subset 
 ![image](https://user-images.githubusercontent.com/7068597/149947972-1b380e39-eb0f-42dd-904e-dc939f3418ff.png)

