### PR TITLE
General: Do not validate version if build does not support it

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -37,6 +37,7 @@ jobs:
     - name: 🔨 Build
       shell: pwsh
       run: |
+        $env:SKIP_THIRD_PARTY_VALIDATION = "1"
         ./tools/build.ps1
 
   Ubuntu-latest:
@@ -61,6 +62,7 @@ jobs:
 
     - name: 🔨 Build
       run: |
+        echo "1" >> $SKIP_THIRD_PARTY_VALIDATION
         ./tools/build.sh
 
   # MacOS-latest:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -36,8 +36,9 @@ jobs:
 
     - name: 🔨 Build
       shell: pwsh
+      env:
+          SKIP_THIRD_PARTY_VALIDATION: "1"
       run: |
-        $env:SKIP_THIRD_PARTY_VALIDATION = "1"
         ./tools/build.ps1
 
   Ubuntu-latest:
@@ -61,6 +62,8 @@ jobs:
         ./tools/create_env.sh
 
     - name: 🔨 Build
+      env:
+          SKIP_THIRD_PARTY_VALIDATION: "1"
       run: |
         echo "1" >> $SKIP_THIRD_PARTY_VALIDATION
         ./tools/build.sh

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: 🔨 Build
       run: |
-        export SKIP_THIRD_PARTY_VALIDATION=1
+        export SKIP_THIRD_PARTY_VALIDATION="1"
         ./tools/build.sh
 
   # MacOS-latest:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: 🔨 Build
       shell: pwsh
       env:
-          SKIP_THIRD_PARTY_VALIDATION: "1"
+        SKIP_THIRD_PARTY_VALIDATION: 1
       run: |
         ./tools/build.ps1
 
@@ -63,9 +63,8 @@ jobs:
 
     - name: 🔨 Build
       env:
-          SKIP_THIRD_PARTY_VALIDATION: "1"
+        SKIP_THIRD_PARTY_VALIDATION: 1
       run: |
-        echo "1" >> $SKIP_THIRD_PARTY_VALIDATION
         ./tools/build.sh
 
   # MacOS-latest:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -36,9 +36,8 @@ jobs:
 
     - name: 🔨 Build
       shell: pwsh
-      env:
-        SKIP_THIRD_PARTY_VALIDATION: 1
       run: |
+        $env:SKIP_THIRD_PARTY_VALIDATION="1"
         ./tools/build.ps1
 
   Ubuntu-latest:
@@ -62,9 +61,8 @@ jobs:
         ./tools/create_env.sh
 
     - name: 🔨 Build
-      env:
-        SKIP_THIRD_PARTY_VALIDATION: 1
       run: |
+        export SKIP_THIRD_PARTY_VALIDATION=1
         ./tools/build.sh
 
   # MacOS-latest:

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -169,6 +169,7 @@ from .editorial import (
 )
 
 from .openpype_version import (
+    op_version_control_available,
     get_openpype_version,
     get_build_version,
     get_expected_version,
@@ -306,6 +307,7 @@ __all__ = [
     "create_workdir_extra_folders",
     "get_project_basic_paths",
 
+    "op_version_control_available",
     "get_openpype_version",
     "get_build_version",
     "get_expected_version",

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -16,6 +16,7 @@ from openpype.api import (
 )
 from openpype.lib import (
     get_openpype_execute_args,
+    op_version_control_available,
     is_current_version_studio_latest,
     is_running_from_build,
     is_running_staging,
@@ -218,7 +219,7 @@ class TrayManager:
 
     def _on_version_check_timer(self):
         # Check if is running from build and stop future validations if yes
-        if not is_running_from_build():
+        if not is_running_from_build() or not op_version_control_available():
             self._version_check_timer.stop()
             return
 


### PR DESCRIPTION
## Brief description
Current check of updates does not expect that version check is not available for current openpype build.

## Changes
- skip version validation if build does not store `OpenPypeVersion` to `sys.modules`.

## Testing notes:
1. Run OpenPype zip from this branch in older OpenPype build