### PR TITLE
Webpublisher: Moved error at the beginning of the log

### DIFF
--- a/openpype/lib/remote_publish.py
+++ b/openpype/lib/remote_publish.py
@@ -95,7 +95,8 @@ def publish_and_log(dbcon, _id, log, close_plugin_name=None):
                 close host app
     """
     # Error exit as soon as any error occurs.
-    error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}"
+    error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}\n"
+    error_format += "-" * 80 + "\n"
 
     close_plugin = _get_close_plugin(close_plugin_name, log)
 
@@ -111,7 +112,7 @@ def publish_and_log(dbcon, _id, log, close_plugin_name=None):
         if result["error"]:
             log.error(error_format.format(**result))
             uninstall()
-            log_lines.append(error_format.format(**result))
+            log_lines = [error_format.format(**result)] + log_lines
             dbcon.update_one(
                 {"_id": _id},
                 {"$set":


### PR DESCRIPTION
## Brief description
Previously fail message was at the end of log, which was a lot of scrolling.

## Description
Moved error message to the beginning of log. Separate by line of '-' for potential parsing

## Testing notes:
1. Run webpublish that would fail (maybe some validation error)
2. Check front end for failed log