### PR TITLE
Webpublisher: ftrack shows incorrect user names

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -21,6 +21,11 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
     This collector will try to find json files in provided
     `OPENPYPE_PUBLISH_DATA`. Those files _MUST_ share same context.
 
+    This covers 'basic' webpublishes, eg artists uses Standalone Publisher to
+    publish rendered frames or assets.
+
+    This is not applicable for 'studio' processing where host application is
+    called to process uploaded workfile and render frames itself.
     """
     # must be really early, context values are only in json file
     order = pyblish.api.CollectorOrder - 0.490

--- a/openpype/modules/default_modules/ftrack/plugins/publish/collect_username.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/collect_username.py
@@ -43,8 +43,8 @@ class CollectUsername(pyblish.api.ContextPlugin):
         if not user_email:
             # for basic webpublishes
             for instance in context:
-                email = instance.data["user_email"]
-                self.log.debug("Email from instance:: {}".format(email))
+                user_email = instance.data.get("user_email")
+                self.log.debug("Email from instance:: {}".format(user_email))
                 break
 
         if not user_email:

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -161,21 +161,32 @@ class PypeCommands:
         log.info("Publish finished.")
 
     @staticmethod
-    def remotepublishfromapp(project, batch_dir, host_name,
-                             user, targets=None):
+    def remotepublishfromapp(project, batch_path, host_name,
+                             user_email, targets=None):
         """Opens installed variant of 'host' and run remote publish there.
 
-            Currently implemented and tested for Photoshop where customer
-            wants to process uploaded .psd file and publish collected layers
-            from there.
+        Currently implemented and tested for Photoshop where customer
+        wants to process uploaded .psd file and publish collected layers
+        from there.
 
-            Checks if no other batches are running (status =='in_progress). If
-            so, it sleeps for SLEEP (this is separate process),
-            waits for WAIT_FOR seconds altogether.
+        Checks if no other batches are running (status =='in_progress). If
+        so, it sleeps for SLEEP (this is separate process),
+        waits for WAIT_FOR seconds altogether.
 
-            Requires installed host application on the machine.
+        Requires installed host application on the machine.
 
-            Runs publish process as user would, in automatic fashion.
+        Runs publish process as user would, in automatic fashion.
+
+        Args:
+            project (str): project to publish (only single context is expected
+                per call of remotepublish
+            batch_path (str): Path batch folder. Contains subfolders with
+                resources (workfile, another subfolder 'renders' etc.)
+            host_name (str): 'photoshop'
+            user_email (string): email address for webpublisher - used to
+                find Ftrack user with same email
+            targets (list): Pyblish targets
+                (to choose validator for example)
         """
         import pyblish.api
         from openpype.api import Logger
@@ -185,9 +196,9 @@ class PypeCommands:
 
         log.info("remotepublishphotoshop command")
 
-        task_data = get_task_data(batch_dir)
+        task_data = get_task_data(batch_path)
 
-        workfile_path = os.path.join(batch_dir,
+        workfile_path = os.path.join(batch_path,
                                      task_data["task"],
                                      task_data["files"][0])
 
@@ -196,7 +207,7 @@ class PypeCommands:
         batch_id = task_data["batch"]
         dbcon = get_webpublish_conn()
         # safer to start logging here, launch might be broken altogether
-        _id = start_webpublish_log(dbcon, batch_id, user)
+        _id = start_webpublish_log(dbcon, batch_id, user_email)
 
         batches_in_progress = list(dbcon.find({"status": "in_progress"}))
         if len(batches_in_progress) > 1:
@@ -219,10 +230,11 @@ class PypeCommands:
         print("env:: {}".format(env))
         os.environ.update(env)
 
-        os.environ["OPENPYPE_PUBLISH_DATA"] = batch_dir
+        os.environ["OPENPYPE_PUBLISH_DATA"] = batch_path
         # must pass identifier to update log lines for a batch
         os.environ["BATCH_LOG_ID"] = str(_id)
         os.environ["HEADLESS_PUBLISH"] = 'true'  # to use in app lib
+        os.environ["USER_EMAIL"] = user_email
 
         pyblish.api.register_host(host_name)
         if targets:
@@ -247,7 +259,7 @@ class PypeCommands:
             time.sleep(0.5)
 
     @staticmethod
-    def remotepublish(project, batch_path, user, targets=None):
+    def remotepublish(project, batch_path, user_email, targets=None):
         """Start headless publishing.
 
         Used to publish rendered assets, workfiles etc.
@@ -259,7 +271,8 @@ class PypeCommands:
                 per call of remotepublish
             batch_path (str): Path batch folder. Contains subfolders with
                 resources (workfile, another subfolder 'renders' etc.)
-            user (string): email address for webpublisher
+            user_email (string): email address for webpublisher - used to
+                find Ftrack user with same email
             targets (list): Pyblish targets
                 (to choose validator for example)
 
@@ -283,6 +296,7 @@ class PypeCommands:
         os.environ["OPENPYPE_PUBLISH_DATA"] = batch_path
         os.environ["AVALON_PROJECT"] = project
         os.environ["AVALON_APP"] = host_name
+        os.environ["USER_EMAIL"] = user_email
 
         pyblish.api.register_host(host_name)
 
@@ -298,7 +312,7 @@ class PypeCommands:
 
         _, batch_id = os.path.split(batch_path)
         dbcon = get_webpublish_conn()
-        _id = start_webpublish_log(dbcon, batch_id, user)
+        _id = start_webpublish_log(dbcon, batch_id, user_email)
 
         publish_and_log(dbcon, _id, log)
 


### PR DESCRIPTION
## Brief description
Ftrack username wasn't collected for 'studio' processing webpublishes (eg. workfile sent for rendering).

## Description
Added storing user  email into environment variable. This value is used first, only if not present, `user_email` on instances is checked.

## Testing notes:
1. Run webpublish from PS
2. Check Ftrack