### PR TITLE
Ftrack: Delete action revision

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_asset.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_asset.py
@@ -172,18 +172,18 @@ class DeleteAssetSubset(BaseAction):
 
         # Remove cached action older than 2 minutes
         old_action_ids = []
-        for id, data in self.action_data_by_id.items():
+        for action_id, data in self.action_data_by_id.items():
             created_at = data.get("created_at")
             if not created_at:
-                old_action_ids.append(id)
+                old_action_ids.append(action_id)
                 continue
             cur_time = datetime.now()
             existing_in_sec = (created_at - cur_time).total_seconds()
             if existing_in_sec > 60 * 2:
-                old_action_ids.append(id)
+                old_action_ids.append(action_id)
 
-        for id in old_action_ids:
-            self.action_data_by_id.pop(id, None)
+        for action_id in old_action_ids:
+            self.action_data_by_id.pop(action_id, None)
 
         # Store data for action id
         action_id = str(uuid.uuid1())
@@ -442,7 +442,11 @@ class DeleteAssetSubset(BaseAction):
         subsets_to_delete = to_delete.get("subsets") or []
 
         # Convert asset ids to ObjectId obj
-        assets_to_delete = [ObjectId(id) for id in assets_to_delete if id]
+        assets_to_delete = [
+            ObjectId(asset_id)
+            for asset_id in assets_to_delete
+            if asset_id
+        ]
 
         subset_ids_by_parent = spec_data["subset_ids_by_parent"]
         subset_ids_by_name = spec_data["subset_ids_by_name"]
@@ -471,9 +475,8 @@ class DeleteAssetSubset(BaseAction):
                     if not ftrack_id:
                         ftrack_id = asset["data"].get("ftrackId")
 
-                    if not ftrack_id:
-                        continue
-                    ftrack_ids_to_delete.append(ftrack_id)
+                    if ftrack_id:
+                        ftrack_ids_to_delete.append(ftrack_id)
 
             children_queue = collections.deque()
             for mongo_id in assets_to_delete:
@@ -572,12 +575,12 @@ class DeleteAssetSubset(BaseAction):
                         exc_info=True
                     )
 
-        if not_deleted_entities_id:
-            joined_not_deleted = ", ".join([
+        if not_deleted_entities_id and asset_names_to_delete:
+            joined_not_deleted = ",".join([
                 "\"{}\"".format(ftrack_id)
                 for ftrack_id in not_deleted_entities_id
             ])
-            joined_asset_names = ", ".join([
+            joined_asset_names = ",".join([
                 "\"{}\"".format(name)
                 for name in asset_names_to_delete
             ])

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_asset.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_asset.py
@@ -166,7 +166,7 @@ class DeleteAssetSubset(BaseAction):
                 "success": True,
                 "message": (
                     "Didn't found entities in avalon."
-                    " You can use Ftrack's Delete button fot this selection."
+                    " You can use Ftrack's Delete button for the selection."
                 )
             }
 

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_asset.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_delete_asset.py
@@ -163,8 +163,11 @@ class DeleteAssetSubset(BaseAction):
 
         if not selected_av_entities:
             return {
-                "success": False,
-                "message": "Didn't found entities in avalon"
+                "success": True,
+                "message": (
+                    "Didn't found entities in avalon."
+                    " You can use Ftrack's Delete button fot this selection."
+                )
             }
 
         # Remove cached action older than 2 minutes


### PR DESCRIPTION
## Brief description
Ftrack delete action crashes if entity that has children was deleted using ftrack api.

## Changes
- find all children of entities to delete and delete them from bottom to the selection
- modified message which will popup when selected ftrack entities does not have avalon equivalent
    - message text: "Didn't found entities in avalon. You can use Ftrack's Delete button fot this selection."

## Testing notes:
1. Run delete asset/subset on ftrack entity that has avalon asset and published subsets with asset versions in ftrack
2. Confirm deletion
3. No error should be shown