### PR TITLE
global: track name was failing if duplicated root word in name

### DIFF
--- a/openpype/plugins/publish/collect_otio_review.py
+++ b/openpype/plugins/publish/collect_otio_review.py
@@ -46,7 +46,7 @@ class CollectOtioReview(pyblish.api.InstancePlugin):
 
         # loop all tracks and match with name in `reviewTrack`
         for track in otio_timeline.tracks:
-            if review_track_name not in track.name:
+            if review_track_name != track.name:
                 continue
 
             # process correct track


### PR DESCRIPTION
## Brief description
Collect OTIO review fix on track names.

## Description
Track names were picked by mistake and no clips were found in them to publish as review.
