### PR TITLE
AfterEffects: Fix - removed obsolete import

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -3,7 +3,6 @@ import re
 import tempfile
 import attr
 
-from avalon import aftereffects
 import pyblish.api
 
 from openpype.settings import get_project_settings


### PR DESCRIPTION
## Brief description
Obsolete import from avalon was left behind resulting in CollectRender not getting triggered.
It's occurring only if `repos/avalon-core/aftereffects` is really missing.

## Testing notes:
1. Run publish with Local Render Instance