### PR TITLE
Bugfix/linux create zip

### DIFF
--- a/tools/create_zip.sh
+++ b/tools/create_zip.sh
@@ -130,8 +130,8 @@ main () {
   fi
 
   echo -e "${BIGreen}>>>${RST} Generating zip from current sources ..."
-  PYTHONPATH="$openpype_root:$PYTHONPATH"
-  OPENPYPE_ROOT="$openpype_root"
+  export PYTHONPATH="$openpype_root:$PYTHONPATH"
+  export OPENPYPE_ROOT="$openpype_root"
   "$POETRY_HOME/bin/poetry" run python3 "$openpype_root/tools/create_zip.py" "$@"
 }
 


### PR DESCRIPTION
## Issue
Some environment variables are used by the "create_zip.py" Python script.
These variables are defined in the caller shell script "create_zip.sh":
* PYTHONPATH
* OPENPYPE_ROOT

However, the variables are not exported (to environment variables), resulting in errors in the Python script.

## Fix
To fix the issue, the variables need to be exported.