### PR TITLE
Webpublisher: Fix - subset names from processed .psd used wrong value for task

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_remote_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_remote_instances.py
@@ -69,7 +69,7 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
             instance.data["family"] = resolved_family
             instance.data["publish"] = layer.visible
             instance.data["asset"] = context.data["assetEntity"]["name"]
-            instance.data["task"] = context.data["taskType"]
+            instance.data["task"] = context.data["task"]
 
             fill_pairs = {
                 "variant": variant,


### PR DESCRIPTION
Subset name for color coded layer that should be published needs to use task name, not task type.


## Testing notes:
1. Use Webpublish for studio processing for Photoshop
2. Check published subset name for color coded layers, it should contain task name, not tasky type