### PR TITLE
Webpublisher: Skip version collect

### DIFF
--- a/openpype/plugins/publish/collect_scene_version.py
+++ b/openpype/plugins/publish/collect_scene_version.py
@@ -35,9 +35,10 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
 
     def process(self, context):
         # tests should be close to regular publish as possible
-        if (context.data["hostName"] in self.skip_hosts_headless_publish
-                and os.environ.get("HEADLESS_PUBLISH")
-                and not os.environ.get("IS_TEST")):
+        if (
+            os.environ.get("HEADLESS_PUBLISH")
+            and not os.environ.get("IS_TEST")
+            and context.data["hostName"] in self.skip_hosts_headless_publish):
             self.log.debug("Skipping for headless publishing")
             return
 

--- a/openpype/plugins/publish/collect_scene_version.py
+++ b/openpype/plugins/publish/collect_scene_version.py
@@ -11,6 +11,7 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
 
     order = pyblish.api.CollectorOrder
     label = 'Collect Scene Version'
+    # configurable in Settings
     hosts = [
         "aftereffects",
         "blender",
@@ -26,7 +27,20 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
         "tvpaint"
     ]
 
+    # in some cases of headless publishing (for example webpublisher using PS)
+    # you want to ignore version from name and let integrate use next version
+    skip_hosts_headless_publish = [
+
+    ]
+
     def process(self, context):
+        # tests should be close to regular publish as possible
+        if (context.data["hostName"] in self.skip_hosts_headless_publish
+                and os.environ.get("HEADLESS_PUBLISH")
+                and not os.environ.get("IS_TEST")):
+            self.log.debug("Skipping for headless publishing")
+            return
+
         assert context.data.get('currentFile'), "Cannot get current file"
         filename = os.path.basename(context.data.get('currentFile'))
 

--- a/openpype/plugins/publish/collect_scene_version.py
+++ b/openpype/plugins/publish/collect_scene_version.py
@@ -29,9 +29,7 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
 
     # in some cases of headless publishing (for example webpublisher using PS)
     # you want to ignore version from name and let integrate use next version
-    skip_hosts_headless_publish = [
-
-    ]
+    skip_hosts_headless_publish = []
 
     def process(self, context):
         # tests should be close to regular publish as possible

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -3,6 +3,24 @@
         "CollectAnatomyInstanceData": {
             "follow_workfile_version": false
         },
+        "CollectSceneVersion": {
+            "hosts": [
+                "aftereffects",
+                "blender",
+                "celaction",
+                "fusion",
+                "harmony",
+                "hiero",
+                "houdini",
+                "maya",
+                "nuke",
+                "photoshop",
+                "resolve",
+                "tvpaint"
+            ],
+            "skip_hosts_headless_publish": [
+            ]
+        },
         "ValidateEditorialAssetName": {
             "enabled": true,
             "optional": false

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -21,6 +21,27 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "CollectSceneVersion",
+            "label": "Collect Version from Workfile",
+            "is_group": true,
+            "children": [
+                {
+                    "key": "hosts",
+                    "label": "Host names",
+                    "type": "hosts-enum",
+                    "multiselection": true
+                },
+                {
+                    "key": "skip_hosts_headless_publish",
+                    "label": "Skip for host if headless publish",
+                    "type": "hosts-enum",
+                    "multiselection": true
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "checkbox_key": "enabled",
             "key": "ValidateEditorialAssetName",
             "label": "Validate Editorial Asset Name",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -5,6 +5,9 @@ Contains end-to-end tests for automatic testing of OP.
 Should run headless publish on all hosts to check basic publish use cases automatically
 to limit regression issues.
 
+Uses env var `HEADLESS_PUBLISH` (set in test data zip files) to differentiate between regular publish
+and "automated" one.
+
 How to run
 ----------
 - activate `{OPENPYPE_ROOT}/.venv`


### PR DESCRIPTION
## Brief description
Added `CollectSceneVersion` to Settings. Added option to configure skipping it for headless publishing.

## Description
One might want to skip collecting/validating presence of version number in published workfile (in case of studio processing).
In that case, integrator will use next version number automatically.

![Screenshot 2022-01-25 145037](https://user-images.githubusercontent.com/4457962/150995346-5c5e20f2-8ef4-43f0-84a2-1387881050b5.png)

## Additional info
Currently applicable only for Photoshop triggered by webpublisher with studio processing.


## Testing notes:
1. Try to publish PS workfile without version number via Webpublisher (should fail)
2. Apply this PR
3. Add 'photoshop' into `Skip for host if headless publish` in `project_settings/global/publish/CollectSceneVersion`
4. Publish it again