### PR TITLE
switch distutils to sysconfig for `get_platform()`

### DIFF
--- a/tools/build_dependencies.py
+++ b/tools/build_dependencies.py
@@ -21,7 +21,7 @@ speed.
 import os
 import sys
 import site
-from distutils.util import get_platform
+from sysconfig import get_platform
 import platform
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Change

`./tools/build_dependencies.py` was using `distutils.util.get_platform()` to determine folder where openpype is built. As distutils are now [deprecated](https://docs.python.org/3/whatsnew/3.10.html#distutils), this is switching `get_platform()` to **sysconfig** module with similar functionality.

This is also fixing rare cases where platform was reported differently by distutils and sysconfig (`win32` vs. `win-amd64`).