### PR TITLE
Webpublisher: Thumbnail extractor

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/webpublisher/plugins/publish/extract_thumbnail.py
@@ -1,47 +1,32 @@
 import os
+import shutil
 
 import pyblish.api
 from openpype.lib import (
     get_ffmpeg_tool_path,
 
     run_subprocess,
-    path_to_subprocess_arg,
 
     get_transcode_temp_directory,
     convert_for_ffmpeg,
     should_convert_for_ffmpeg
 )
 
-import shutil
 
+class ExtractThumbnail(pyblish.api.InstancePlugin):
+    """Create jpg thumbnail from input using ffmpeg."""
 
-class ExtractJpegEXR(pyblish.api.InstancePlugin):
-    """Create jpg thumbnail from sequence using ffmpeg"""
-
-    label = "Extract Jpeg EXR"
+    label = "Extract Thumbnail"
     order = pyblish.api.ExtractorOrder
     families = [
-        "imagesequence", "render", "render2d",
-        "source", "plate", "take"
+        "render",
+        "image"
     ]
-    hosts = ["shell", "fusion", "resolve"]
-    enabled = False
-
-    # presetable attribute
-    ffmpeg_args = None
+    hosts = ["webpublisher"]
+    targets = ["filespublish"]
 
     def process(self, instance):
         self.log.info("subset {}".format(instance.data['subset']))
-
-        # skip crypto passes.
-        if 'crypto' in instance.data['subset']:
-            self.log.info("Skipping crypto passes.")
-            return
-
-        # Skip if review not set.
-        if not instance.data.get("review", True):
-            self.log.info("Skipping - no review set on instance.")
-            return
 
         filtered_repres = self._get_filtered_repres(instance)
         for repre in filtered_repres:
@@ -55,7 +40,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             stagingdir = os.path.normpath(repre["stagingDir"])
 
             full_input_path = os.path.join(stagingdir, input_file)
-            self.log.info("input {}".format(full_input_path))
+            self.log.info("Input filepath: {}".format(full_input_path))
 
             do_convert = should_convert_for_ffmpeg(full_input_path)
             # If result is None the requirement of conversion can't be
@@ -84,43 +69,26 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
                 full_input_path = os.path.join(convert_dir, filename)
 
             filename = os.path.splitext(input_file)[0]
-            if not filename.endswith('.'):
-                filename += "."
-            jpeg_file = filename + "jpg"
-            full_output_path = os.path.join(stagingdir, jpeg_file)
+            while filename.endswith("."):
+                filename = filename[:-1]
+            thumbnail_filename = filename + "_thumbnail.jpg"
+            full_output_path = os.path.join(stagingdir, thumbnail_filename)
 
             self.log.info("output {}".format(full_output_path))
 
-            ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
-            ffmpeg_args = self.ffmpeg_args or {}
-
-            jpeg_items = []
-            jpeg_items.append(path_to_subprocess_arg(ffmpeg_path))
-            # override file if already exists
-            jpeg_items.append("-y")
-            # use same input args like with mov
-            jpeg_items.extend(ffmpeg_args.get("input") or [])
-            # input file
-            jpeg_items.append("-i {}".format(
-                path_to_subprocess_arg(full_input_path)
-            ))
-            # output arguments from presets
-            jpeg_items.extend(ffmpeg_args.get("output") or [])
-
-            # If its a movie file, we just want one frame.
-            if repre["ext"] == "mov":
-                jpeg_items.append("-vframes 1")
-
-            # output file
-            jpeg_items.append(path_to_subprocess_arg(full_output_path))
-
-            subprocess_command = " ".join(jpeg_items)
+            ffmpeg_args = [
+                get_ffmpeg_tool_path("ffmpeg"),
+                "-y",
+                "-i", full_input_path,
+                "-vframes", "1",
+                full_output_path
+            ]
 
             # run subprocess
-            self.log.debug("{}".format(subprocess_command))
+            self.log.debug("{}".format(" ".join(ffmpeg_args)))
             try:  # temporary until oiiotool is supported cross platform
                 run_subprocess(
-                    subprocess_command, shell=True, logger=self.log
+                    ffmpeg_args, logger=self.log
                 )
             except RuntimeError as exp:
                 if "Compression" in str(exp):
@@ -134,7 +102,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             new_repre = {
                 "name": "thumbnail",
                 "ext": "jpg",
-                "files": jpeg_file,
+                "files": thumbnail_filename,
                 "stagingDir": stagingdir,
                 "thumbnail": True,
                 "tags": ["thumbnail"]
@@ -150,12 +118,15 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
 
     def _get_filtered_repres(self, instance):
         filtered_repres = []
-        src_repres = instance.data.get("representations") or []
-        for repre in src_repres:
+        repres = instance.data.get("representations") or []
+        for repre in repres:
             self.log.debug(repre)
             tags = repre.get("tags") or []
-            valid = "review" in tags or "thumb-nuke" in tags
-            if not valid:
+            # Skip instance if already has thumbnail representation
+            if "thumbnail" in tags:
+                return []
+
+            if "review" not in tags:
                 continue
 
             if not repre.get("files"):


### PR DESCRIPTION
## Brief description
Current thumbnail extractor in global is based on specific workflow which should work in different way in webpublisher so easier way is to create webpublisher specific plugin for thumbnail extraction.

## Changes
- removed `webpublisher` from global plugin `ExtractJpegExr`
- created new thumbnail extractor in webpublisher host

## Notes
I've added `image` and `render` families there but if any others should be added there then do it (@kalisp or @64qam).