### PR TITLE
Global: Optimize OpenPype startup

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -23,7 +23,8 @@ from .user_settings import (
     OpenPypeSettingsRegistry
 )
 from .tools import (
-    get_openpype_path_from_db,
+    get_openpype_global_settings,
+    get_openpype_path_from_settings,
     get_expected_studio_version_str
 )
 
@@ -1263,7 +1264,8 @@ class BootstrapRepos:
         openpype_path = None
         # try to get OpenPype path from mongo.
         if location.startswith("mongodb"):
-            openpype_path = get_openpype_path_from_db(location)
+            global_settings = get_openpype_global_settings(location)
+            openpype_path = get_openpype_path_from_settings(global_settings)
             if not openpype_path:
                 self._print("cannot find OPENPYPE_PATH in settings.")
                 return None

--- a/igniter/install_dialog.py
+++ b/igniter/install_dialog.py
@@ -12,7 +12,6 @@ from Qt.QtCore import QTimer  # noqa
 from .install_thread import InstallThread
 from .tools import (
     validate_mongo_connection,
-    get_openpype_path_from_db,
     get_openpype_icon_path
 )
 

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -161,18 +161,17 @@ def get_openpype_global_settings(url: str) -> dict:
     return global_settings.get("data") or {}
 
 
-def get_openpype_path_from_db(url: str) -> Union[str, None]:
+def get_openpype_path_from_db(settings: dict) -> Union[str, None]:
     """Get OpenPype path from global settings.
 
     Args:
-        url (str): mongodb url.
+        settings (dict): mongodb url.
 
     Returns:
         path to OpenPype or None if not found
     """
-    global_settings = get_openpype_global_settings(url)
     paths = (
-        global_settings
+        settings
         .get("openpype_path", {})
         .get(platform.system().lower())
     ) or []

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -161,7 +161,7 @@ def get_openpype_global_settings(url: str) -> dict:
     return global_settings.get("data") or {}
 
 
-def get_openpype_path_from_db(settings: dict) -> Union[str, None]:
+def get_openpype_path_from_settings(settings: dict) -> Union[str, None]:
     """Get OpenPype path from global settings.
 
     Args:

--- a/start.py
+++ b/start.py
@@ -281,12 +281,11 @@ def run(arguments: list, env: dict = None) -> int:
     return p.returncode
 
 
-def run_disk_mapping_commands(mongo_url):
+def run_disk_mapping_commands(settings):
     """ Run disk mapping command
 
         Used to map shared disk for OP to pull codebase.
     """
-    settings = get_openpype_global_settings(mongo_url)
 
     low_platform = platform.system().lower()
     disk_mapping = settings.get("disk_mapping")
@@ -923,12 +922,14 @@ def boot():
     os.environ["OPENPYPE_DATABASE_NAME"] = \
         os.environ.get("OPENPYPE_DATABASE_NAME") or "openpype"
 
+    global_settings = get_openpype_global_settings(openpype_mongo)
+
     _print(">>> run disk mapping command ...")
-    run_disk_mapping_commands(openpype_mongo)
+    run_disk_mapping_commands(global_settings)
 
     # Get openpype path from database and set it to environment so openpype can
     # find its versions there and bootstrap them.
-    openpype_path = get_openpype_path_from_db(openpype_mongo)
+    openpype_path = get_openpype_path_from_db(global_settings)
 
     if getattr(sys, 'frozen', False):
         local_version = bootstrap.get_version(Path(OPENPYPE_ROOT))

--- a/start.py
+++ b/start.py
@@ -86,7 +86,7 @@ Todo:
     Move or remove bootstrapping environments out of the code.
 
 Attributes:
-    silent_commands (list): list of commands for which we won't print OpenPype
+    silent_commands (set): list of commands for which we won't print OpenPype
         logo and info header.
 
 .. _MongoDB:
@@ -202,8 +202,8 @@ from igniter.tools import (
 from igniter.bootstrap_repos import OpenPypeVersion  # noqa: E402
 
 bootstrap = BootstrapRepos()
-silent_commands = ["run", "igniter", "standalonepublisher",
-                   "extractenvironments"]
+silent_commands = {"run", "igniter", "standalonepublisher",
+                   "extractenvironments"}
 
 
 def list_versions(openpype_versions: list, local_version=None) -> None:
@@ -1057,29 +1057,30 @@ def boot():
     _print("  - for modules ...")
     set_modules_environments()
 
-    from openpype import cli
-    from openpype.lib import terminal as t
-    from openpype.version import __version__
-
     assert version_path, "Version path not defined."
-    info = get_info(use_staging)
-    info.insert(0, f">>> Using OpenPype from [ {version_path} ]")
 
-    t_width = 20
-    try:
-        t_width = os.get_terminal_size().columns - 2
-    except (ValueError, OSError):
-        # running without terminal
-        pass
+    # print info when not running scripts defined in 'silent commands'
+    if all(arg not in silent_commands for arg in sys.argv):
+        from openpype.lib import terminal as t
+        from openpype.version import __version__
 
-    _header = f"*** OpenPype [{__version__}] "
+        info = get_info(use_staging)
+        info.insert(0, f">>> Using OpenPype from [ {version_path} ]")
 
-    info.insert(0, _header + "-" * (t_width - len(_header)))
-    for i in info:
-        # don't show for running scripts
-        if all(item not in sys.argv for item in silent_commands):
+        t_width = 20
+        try:
+            t_width = os.get_terminal_size().columns - 2
+        except (ValueError, OSError):
+            # running without terminal
+            pass
+
+        _header = f"*** OpenPype [{__version__}] "
+        info.insert(0, _header + "-" * (t_width - len(_header)))
+
+        for i in info:
             t.echo(i)
 
+    from openpype import cli
     try:
         cli.main(obj={}, prog_name="openpype")
     except Exception:  # noqa

--- a/start.py
+++ b/start.py
@@ -195,7 +195,7 @@ import igniter  # noqa: E402
 from igniter import BootstrapRepos  # noqa: E402
 from igniter.tools import (
     get_openpype_global_settings,
-    get_openpype_path_from_db,
+    get_openpype_path_from_settings,
     validate_mongo_connection,
     OpenPypeVersionNotFound
 )  # noqa
@@ -929,7 +929,7 @@ def boot():
 
     # Get openpype path from database and set it to environment so openpype can
     # find its versions there and bootstrap them.
-    openpype_path = get_openpype_path_from_db(global_settings)
+    openpype_path = get_openpype_path_from_settings(global_settings)
 
     if getattr(sys, 'frozen', False):
         local_version = bootstrap.get_version(Path(OPENPYPE_ROOT))


### PR DESCRIPTION
## Brief description

This is a draft PR to implement some changes to optimize some pieces from the OpenPype startup and is related to #2592 to allow less overhead when initializing to the environment.

I've gone ahead and started some minor tweaks. Some are just optimizations I figured could work glancing over the code (e.g. restructuring validate dir/zip logic) which only would make it faster in certain cases (for that particular case only when files would be missing).

The bigger improvement is to keep `global settings` around during startup and re-use it. With our network database [that ` get_openpype_global_settings` query alone](https://github.com/pypeclub/OpenPype/blob/1964e30246480bd33f4ebf9464130bba7bc14416/igniter/tools.py#L131-L161) takes 2+ seconds. So every time we avoid calling that would already gain us 2 seconds in our production use case. In `start.py` reducing the two calls to just one was that first step.

But that change should also be processed in Igniter `bootstrap_repos.py` so that the data could stay around more. (I've also not [refactored the use of `get_openpype_path_from_db` (changed signature)](https://github.com/pypeclub/OpenPype/commit/2373d13348f4d04e2da5063a74e618e696822bd6) in that bootstrap repos file which would be required for this to completely work in the build. (For now have been testing the changes running over the live code - less overhead/ faster results to check) But there's definitely optimization wiggle room in `bootstrap_repos` too.

---

Just setting up this **Draft** Pull Request to start a discussion. Would it be nice to change that signature of `get_openpype_path_from_db` like I did in this [commit](https://github.com/pypeclub/OpenPype/commit/2373d13348f4d04e2da5063a74e618e696822bd6).

Best case scenario the logic remains simple but we hit the database as little as possible.
