### PR TITLE
Cosmetics: Fix some more grammar and typos in code (openpype/tools)

### DIFF
--- a/openpype/tools/assetcreator/app.py
+++ b/openpype/tools/assetcreator/app.py
@@ -87,7 +87,7 @@ class Window(QtWidgets.QDialog):
         btn_layout = QtWidgets.QHBoxLayout(btns_widget)
         btn_create_asset = QtWidgets.QPushButton("Create asset")
         btn_create_asset.setToolTip(
-            "Creates all neccessary components for asset"
+            "Creates all necessary components for asset"
         )
         checkbox_app = None
         if self.context is not None:
@@ -231,7 +231,7 @@ class Window(QtWidgets.QDialog):
         test_name = name.replace(' ', '')
         error_message = None
         message = QtWidgets.QMessageBox(self)
-        message.setWindowTitle("Some errors has occured")
+        message.setWindowTitle("Some errors have occurred")
         message.setIcon(QtWidgets.QMessageBox.Critical)
         # TODO: show error messages on any error
         if self.valid_parent is not True and test_name == '':

--- a/openpype/tools/assetcreator/widget.py
+++ b/openpype/tools/assetcreator/widget.py
@@ -44,7 +44,7 @@ def preserve_expanded_rows(tree_view,
 
     This function is created to maintain the expand vs collapse status of
     the model items. When refresh is triggered the items which are expanded
-    will stay expanded and vise versa.
+    will stay expanded and vice versa.
 
     Arguments:
         tree_view (QWidgets.QTreeView): the tree view which is
@@ -94,7 +94,7 @@ def preserve_selection(tree_view,
 
     This function is created to maintain the selection status of
     the model items. When refresh is triggered the items which are expanded
-    will stay expanded and vise versa.
+    will stay expanded and vice versa.
 
         tree_view (QWidgets.QTreeView): the tree view nested in the application
         column (int): the column to retrieve the data from
@@ -179,7 +179,7 @@ class AssetModel(TreeModel):
         """
         if silos:
             # WARNING: Silo item "_id" is set to silo value
-            # mainly because GUI issue with perserve selection and expanded row
+            # mainly because GUI issue with preserve selection and expanded row
             # and because of easier hierarchy parenting (in "assets")
             for silo in silos:
                 item = Item({

--- a/openpype/tools/context_dialog/window.py
+++ b/openpype/tools/context_dialog/window.py
@@ -46,7 +46,7 @@ class ContextDialog(QtWidgets.QDialog):
         # UI initialization
         main_splitter = QtWidgets.QSplitter(self)
 
-        # Left side widget containt project combobox and asset widget
+        # Left side widget contains project combobox and asset widget
         left_side_widget = QtWidgets.QWidget(main_splitter)
 
         project_combobox = QtWidgets.QComboBox(left_side_widget)

--- a/openpype/tools/creator/window.py
+++ b/openpype/tools/creator/window.py
@@ -354,7 +354,7 @@ class CreatorWindow(QtWidgets.QDialog):
 
         Override keyPressEvent to do nothing so that Maya's panels won't
         take focus when pressing "SHIFT" whilst mouse is over viewport or
-        outliner. This way users don't accidently perform Maya commands
+        outliner. This way users don't accidentally perform Maya commands
         whilst trying to name an instance.
 
         """

--- a/openpype/tools/experimental_tools/dialog.py
+++ b/openpype/tools/experimental_tools/dialog.py
@@ -107,7 +107,7 @@ class ExperimentalToolsDialog(QtWidgets.QDialog):
 
         # Is dialog first shown
         self._first_show = True
-        # Trigger refresh when window get's activity
+        # Trigger refresh when window gets activity
         self._refresh_on_active = True
         # Is window active
         self._window_is_active = False

--- a/openpype/tools/experimental_tools/tools_def.py
+++ b/openpype/tools/experimental_tools/tools_def.py
@@ -43,7 +43,7 @@ class ExperimentalTool:
         self._enabled = enabled
 
     def execute(self):
-        """Trigger registerd callback."""
+        """Trigger registered callback."""
         self.callback()
 
 

--- a/openpype/tools/launcher/lib.py
+++ b/openpype/tools/launcher/lib.py
@@ -29,7 +29,7 @@ class ProjectHandler(QtCore.QObject):
     Helps to organize two separate widgets handling current project selection.
 
     It is easier to trigger project change callbacks from one place than from
-    multiple differect places without proper handling or sequence changes.
+    multiple different places without proper handling or sequence changes.
 
     Args:
         dbcon(AvalonMongoDB): Mongo connection with Session.
@@ -42,7 +42,7 @@ class ProjectHandler(QtCore.QObject):
     #   that may require reshing of projects
     refresh_interval = 10000
 
-    # Signal emmited when project has changed
+    # Signal emitted when project has changed
     project_changed = QtCore.Signal(str)
     projects_refreshed = QtCore.Signal()
     timer_timeout = QtCore.Signal()

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -102,7 +102,7 @@ class ActionModel(QtGui.QStandardItemModel):
             # Groups
             group_name = getattr(action, "group", None)
 
-            # Lable variants
+            # Label variants
             label = getattr(action, "label", None)
             label_variant = getattr(action, "label_variant", None)
             if label_variant and not label:

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -171,7 +171,7 @@ class ActionBar(QtWidgets.QWidget):
         self.update()
 
     def _start_animation(self, index):
-        # Offset refresh timout
+        # Offset refresh timeout
         self.project_handler.start_timer()
         action_id = index.data(ACTION_ID_ROLE)
         item = self.model.items_by_id.get(action_id)
@@ -193,7 +193,7 @@ class ActionBar(QtWidgets.QWidget):
             self.action_clicked.emit(action)
             return
 
-        # Offset refresh timout
+        # Offset refresh timeout
         self.project_handler.start_timer()
 
         actions = index.data(ACTION_ROLE)
@@ -212,7 +212,7 @@ class ActionBar(QtWidgets.QWidget):
             by_variant_label = collections.defaultdict(list)
             orders = []
             for action in actions:
-                # Lable variants
+                # Label variants
                 label = getattr(action, "label", None)
                 label_variant = getattr(action, "label_variant", None)
                 if label_variant and not label:

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -27,7 +27,7 @@ module.window = None
 
 # Register callback on task change
 # - callback can't be defined in Window as it is weak reference callback
-#   so `WeakSet` will remove it immidiatelly
+#   so `WeakSet` will remove it immediately
 def on_context_task_change(*args, **kwargs):
     if module.window:
         module.window.on_context_task_change(*args, **kwargs)
@@ -455,7 +455,7 @@ class LoaderWindow(QtWidgets.QDialog):
         shift_pressed = QtCore.Qt.ShiftModifier & modifiers
 
         if shift_pressed:
-            print("Force quitted..")
+            print("Force quit..")
             self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         print("Good bye")

--- a/openpype/tools/loader/lib.py
+++ b/openpype/tools/loader/lib.py
@@ -46,7 +46,7 @@ def get_options(action, loader, parent, repre_contexts):
 
         Args:
             action (OptionalAction) - action in menu
-            loader (cls of api.Loader) - not initilized yet
+            loader (cls of api.Loader) - not initialized yet
             parent (Qt element to parent dialog to)
             repre_contexts (list) of dict with full info about selected repres
         Returns:

--- a/openpype/tools/mayalookassigner/widgets.py
+++ b/openpype/tools/mayalookassigner/widgets.py
@@ -233,8 +233,8 @@ class LookOutliner(QtWidgets.QWidget):
             list: list of dictionaries
         """
 
-        datas = [i.data(TreeModel.ItemRole) for i in self.view.get_indices()]
-        return [d for d in datas if d is not None]
+        items = [i.data(TreeModel.ItemRole) for i in self.view.get_indices()]
+        return [item for item in items if item is not None]
 
     def right_mouse_menu(self, pos):
         """Build RMB menu for look view"""

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -124,12 +124,12 @@ class HierarchyModel(QtCore.QAbstractItemModel):
     Main part of ProjectManager.
 
     Model should be able to load existing entities, create new, handle their
-    validations like name duplication and validate if is possible to save it's
+    validations like name duplication and validate if is possible to save its
     data.
 
     Args:
         dbcon (AvalonMongoDB): Connection to MongoDB with set AVALON_PROJECT in
-            it's Session to current project.
+            its Session to current project.
     """
 
     # Definition of all possible columns with their labels in default order
@@ -799,7 +799,7 @@ class HierarchyModel(QtCore.QAbstractItemModel):
                 for row in range(parent_item.rowCount()):
                     child_item = parent_item.child(row)
                     child_id = child_item.id
-                    # Not sure if this can happend
+                    # Not sure if this can happen
                     # TODO validate this line it seems dangerous as start/end
                     #   row is not changed
                     if child_id not in children:
@@ -1902,7 +1902,7 @@ class AssetItem(BaseItem):
         return self._data["name"]
 
     def child_parents(self):
-        """Chilren AssetItem can use this method to get it's parent names.
+        """Children AssetItem can use this method to get it's parent names.
 
         This is used for `data.parents` key on document.
         """
@@ -2006,7 +2006,7 @@ class AssetItem(BaseItem):
     @classmethod
     def data_from_doc(cls, asset_doc):
         """Convert asset document from Mongo to item data."""
-        # Minimum required data for cases that it is new AssetItem withoud doc
+        # Minimum required data for cases that it is new AssetItem without doc
         data = {
             "name": None,
             "type": "asset"
@@ -2253,7 +2253,7 @@ class TaskItem(BaseItem):
     """Item representing Task item on Asset document.
 
     Always should be AssetItem children and never should have any other
-    childrens.
+    children.
 
     It's name value should be validated with it's parent which only knows if
     has same name as other sibling under same parent.

--- a/openpype/tools/project_manager/project_manager/multiselection_combobox.py
+++ b/openpype/tools/project_manager/project_manager/multiselection_combobox.py
@@ -110,7 +110,7 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
         elif event.type() == QtCore.QEvent.KeyPress:
             # TODO: handle QtCore.Qt.Key_Enter, Key_Return?
             if event.key() == QtCore.Qt.Key_Space:
-                # toogle the current items check state
+                # toggle the current items check state
                 if (
                     index_flags & QtCore.Qt.ItemIsUserCheckable
                     and index_flags & QtCore.Qt.ItemIsTristate

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -555,7 +555,7 @@ class PublisherController:
         self.create_context.reset_avalon_context()
 
         self._reset_plugins()
-        # Publish part must be resetted after plugins
+        # Publish part must be reset after plugins
         self._reset_publish()
         self._reset_instances()
 
@@ -690,7 +690,7 @@ class PublisherController:
 
     def remove_instances(self, instances):
         """"""
-        # QUESTION Expect that instaces are really removed? In that case save
+        # QUESTION Expect that instances are really removed? In that case save
         #   reset is not required and save changes too.
         self.save_changes()
 

--- a/openpype/tools/publisher/widgets/border_label_widget.py
+++ b/openpype/tools/publisher/widgets/border_label_widget.py
@@ -51,7 +51,7 @@ class _HBottomLineWidget(QtWidgets.QWidget):
     Corners may have curve set by radius (`set_radius`). Radius should expect
     height of widget.
 
-    Bottom line is drawed at the bottom of widget. If radius is 0 then height
+    Bottom line is drawn at the bottom of widget. If radius is 0 then height
     of widget should be 1px.
 
     It is expected that parent widget will set height and radius.
@@ -94,7 +94,7 @@ class _HTopCornerLineWidget(QtWidgets.QWidget):
           or
     ```┌───────```
 
-    Horizontal line is drawed in the middle of widget.
+    Horizontal line is drawn in the middle of widget.
 
     Widget represents left or right corner. Corner may have curve set by
     radius (`set_radius`). Radius should expect height of widget (maximum half
@@ -225,7 +225,7 @@ class BorderedLabelWidget(QtWidgets.QFrame):
         self._radius = radius
 
         side_width = 1 + radius
-        # Dont't use fixed width/height as that would set also set
+        # Don't use fixed width/height as that would set also set
         #   the other size (When fixed width is set then is also set
         #   fixed height).
         self._left_w.setMinimumWidth(side_width)

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -388,7 +388,7 @@ class InstanceCardView(AbstractInstanceView):
 
     def sizeHint(self):
         """Modify sizeHint based on visibility of scroll bars."""
-        # Calculate width hint by content widget and verticall scroll bar
+        # Calculate width hint by content widget and vertical scroll bar
         scroll_bar = self._scroll_area.verticalScrollBar()
         width = (
             self._content_widget.sizeHint().width()

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -6,7 +6,7 @@ attribute on instance (Group defined by creator).
 Each item can be enabled/disabled with their checkbox, whole group
 can be enabled/disabled with checkbox on group or
 selection can be enabled disabled using checkbox or keyboard key presses:
-- Space - change state of selection to oposite
+- Space - change state of selection to opposite
 - Enter - enable selection
 - Backspace - disable selection
 
@@ -589,7 +589,7 @@ class InstanceListView(AbstractInstanceView):
         # - create new instance, update existing and remove not existing
         for group_name, group_item in self._group_items.items():
             # Instance items to remove
-            # - will contain all exising instance ids at the start
+            # - will contain all existing instance ids at the start
             # - instance ids may be removed when existing instances are checked
             to_remove = set()
             # Mapping of existing instances under group item
@@ -659,7 +659,7 @@ class InstanceListView(AbstractInstanceView):
             for instance_id in to_remove:
                 idx_to_remove.append(existing_mapping[instance_id])
 
-            # Remove them in reverse order to prevend row index changes
+            # Remove them in reverse order to prevent row index changes
             for idx in reversed(sorted(idx_to_remove)):
                 group_item.removeRows(idx, 1)
 

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -276,7 +276,7 @@ class VerticallScrollArea(QtWidgets.QScrollArea):
     The biggest difference is that the scroll area has scroll bar on left side
     and resize of content will also resize scrollarea itself.
 
-    Resize if deffered by 100ms because at the moment of resize are not yet
+    Resize if deferred by 100ms because at the moment of resize are not yet
     propagated sizes and visibility of scroll bars.
     """
     def __init__(self, *args, **kwargs):

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -749,7 +749,7 @@ class TasksCombobox(QtWidgets.QComboBox):
         self.value_changed.emit()
 
     def set_text(self, text):
-        """Set context shown in combobox without chaning selected items."""
+        """Set context shown in combobox without changing selected items."""
         if text == self._text:
             return
 
@@ -1000,7 +1000,7 @@ class VariantInputWidget(PlaceholderLineEdit):
         self.value_changed.emit()
 
     def reset_to_origin(self):
-        """Set origin value of selected instnaces."""
+        """Set origin value of selected instances."""
         self.set_value(self._origin_value)
 
     def get_value(self):
@@ -1105,7 +1105,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
 
     Subset name is or may be affected on context. Gives abiity to modify
     context and subset name of instance. This change is not autopromoted but
-    must be submited.
+    must be submitted.
 
     Warning: Until artist hit `Submit` changes must not be propagated to
     instance data.
@@ -1179,7 +1179,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         self.cancel_btn = cancel_btn
 
     def _on_submit(self):
-        """Commit changes for selected instnaces."""
+        """Commit changes for selected instances."""
         variant_value = None
         asset_name = None
         task_name = None
@@ -1363,7 +1363,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
         self._attr_def_id_to_instances = {}
         self._attr_def_id_to_attr_def = {}
 
-        # To store content of scroll area to prevend garbage collection
+        # To store content of scroll area to prevent garbage collection
         self._content_widget = None
 
     def set_instances_valid(self, valid):
@@ -1375,7 +1375,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
             self._content_widget.setEnabled(valid)
 
     def set_current_instances(self, instances):
-        """Set current instances for which are attribute definitons shown."""
+        """Set current instances for which are attribute definitions shown."""
         prev_content_widget = self._scroll_area.widget()
         if prev_content_widget:
             self._scroll_area.takeWidget()
@@ -1461,7 +1461,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
         self._attr_def_id_to_attr_def = {}
         self._attr_def_id_to_plugin_name = {}
 
-        # Store content of scroll area to prevend garbage collection
+        # Store content of scroll area to prevent garbage collection
         self._content_widget = None
 
     def set_instances_valid(self, valid):
@@ -1473,7 +1473,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
             self._content_widget.setEnabled(valid)
 
     def set_current_instances(self, instances, context_selected):
-        """Set current instances for which are attribute definitons shown."""
+        """Set current instances for which are attribute definitions shown."""
         prev_content_widget = self._scroll_area.widget()
         if prev_content_widget:
             self._scroll_area.takeWidget()

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -106,14 +106,14 @@ class Controller(QtCore.QObject):
     # ??? Emitted for each process
     was_processed = QtCore.Signal(dict)
 
-    # Emmited when reset
+    # Emitted when reset
     # - all data are reset (plugins, processing, pari yielder, etc.)
     was_reset = QtCore.Signal()
 
-    # Emmited when previous group changed
+    # Emitted when previous group changed
     passed_group = QtCore.Signal(object)
 
-    # Emmited when want to change state of instances
+    # Emitted when want to change state of instances
     switch_toggleability = QtCore.Signal(bool)
 
     # On action finished
@@ -322,7 +322,7 @@ class Controller(QtCore.QObject):
         try:
             result = pyblish.plugin.process(plugin, self.context, instance)
             # Make note of the order at which the
-            # potential error error occured.
+            # potential error error occurred.
             if result["error"] is not None:
                 self.processing["ordersWithError"].add(plugin.order)
 
@@ -564,7 +564,7 @@ class Controller(QtCore.QObject):
         case must be taken to ensure there are no memory leaks.
         Explicitly deleting objects shines a light on where objects
         may still be referenced in the form of an error. No errors
-        means this was uneccesary, but that's ok.
+        means this was unnecessary, but that's ok.
         """
 
         for instance in self.context:

--- a/openpype/tools/pyblish_pype/util.py
+++ b/openpype/tools/pyblish_pype/util.py
@@ -218,7 +218,7 @@ class OrderGroups:
     def sort_groups(_groups_dict):
         sorted_dict = collections.OrderedDict()
 
-        # make sure wont affect any dictionary as pointer
+        # make sure won't affect any dictionary as pointer
         groups_dict = copy.deepcopy(_groups_dict)
         last_order = None
         if None in groups_dict:

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -125,7 +125,7 @@ class SceneInventoryWindow(QtWidgets.QDialog):
 
         Override keyPressEvent to do nothing so that Maya's panels won't
         take focus when pressing "SHIFT" whilst mouse is over viewport or
-        outliner. This way users don't accidently perform Maya commands
+        outliner. This way users don't accidentally perform Maya commands
         whilst trying to name an instance.
 
         """

--- a/openpype/tools/settings/local_settings/constants.py
+++ b/openpype/tools/settings/local_settings/constants.py
@@ -5,7 +5,7 @@ LABEL_REMOVE_PROJECT = "Remove from project"
 LABEL_ADD_PROJECT = "Add to project"
 LABEL_DISCARD_CHANGES = "Discard changes"
 
-# Local setting contants
+# Local setting constants
 # TODO move to settings constants
 LOCAL_GENERAL_KEY = "general"
 LOCAL_PROJECTS_KEY = "projects"

--- a/openpype/tools/settings/local_settings/window.py
+++ b/openpype/tools/settings/local_settings/window.py
@@ -222,7 +222,7 @@ class LocalSettingsWindow(QtWidgets.QWidget):
         # Do not create local settings widget in init phase as it's using
         #   settings objects that must be OK to be able create this widget
         #   - we want to show dialog if anything goes wrong
-        #   - without reseting nothing is shown
+        #   - without resetting nothing is shown
         self._settings_widget = None
         self._scroll_widget = scroll_widget
         self.reset_btn = reset_btn

--- a/openpype/tools/settings/settings/README.md
+++ b/openpype/tools/settings/settings/README.md
@@ -10,7 +10,7 @@
     - `"is_file"` - this key is for storing openpype defaults in `openpype` repo
         - reasons of existence: developing new schemas does not require to create defaults manually
         - key is validated, must be once in hierarchy else it won't be possible to store openpype defaults
-    - `"is_group"` - define that all values under key in hierarchy will be overriden if any value is modified, this information is also stored to overrides
+    - `"is_group"` - define that all values under key in hierarchy will be overridden if any value is modified, this information is also stored to overrides
         - this keys is not allowed for all inputs as they may have not reason for that
         - key is validated, can be only once in hierarchy but is not required
 - currently there are `system configurations` and `project configurations`
@@ -199,7 +199,7 @@
 - number input, can be used for both integer and float
     - key `"decimal"` defines how many decimal places will be used, 0 is for integer input (Default: `0`)
     - key `"minimum"` as minimum allowed number to enter (Default: `-99999`)
-    - key `"maxium"` as maximum allowed number to enter (Default: `99999`)
+    - key `"maximum"` as maximum allowed number to enter (Default: `99999`)
 ```
 {
     "type": "number",

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -168,7 +168,7 @@ class BaseWidget(QtWidgets.QWidget):
             with self.category_widget.working_state_context():
                 self.entity.add_to_project_override
 
-        action = QtWidgets.QAction("Add to project project override")
+        action = QtWidgets.QAction("Add to project override")
         actions_mapping[action] = add_to_project_override
         menu.addAction(action)
 

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -289,7 +289,7 @@ class BaseWidget(QtWidgets.QWidget):
         action = QtWidgets.QAction("Paste", menu)
         output.append((action, paste_value))
 
-        # Paste value to matchin entity
+        # Paste value to matching entity
         def paste_value_to_path():
             with self.category_widget.working_state_context():
                 _set_entity_value(matching_entity, value)

--- a/openpype/tools/settings/settings/item_widgets.py
+++ b/openpype/tools/settings/settings/item_widgets.py
@@ -477,7 +477,7 @@ class OpenPypeVersionText(TextWidget):
             self.entity.set(value)
             self.update_style()
         else:
-            # Manually trigger hierachical style update
+            # Manually trigger hierarchical style update
             self.ignore_input_changes.set_ignore(True)
             self.ignore_input_changes.set_ignore(False)
 
@@ -675,7 +675,7 @@ class RawJsonWidget(InputWidget):
             self.entity.set(self.input_field.json_value())
             self.update_style()
         else:
-            # Manually trigger hierachical style update
+            # Manually trigger hierarchical style update
             self.ignore_input_changes.set_ignore(True)
             self.ignore_input_changes.set_ignore(False)
 
@@ -792,7 +792,7 @@ class PathWidget(BaseWidget):
         self.input_field.hierarchical_style_update()
 
     def _on_entity_change(self):
-        # No need to do anything. Styles will be updated from top hierachy.
+        # No need to do anything. Styles will be updated from top hierarchy.
         pass
 
     def update_style(self):

--- a/openpype/tools/settings/settings/lib.py
+++ b/openpype/tools/settings/settings/lib.py
@@ -7,7 +7,7 @@ VALUE_CHANGE_OFFSET_MS = 300
 
 
 def create_deffered_value_change_timer(callback):
-    """Deffer value change callback.
+    """Defer value change callback.
 
     UI won't trigger all callbacks on each value change but after predefined
     time. Timer is reset on each start so callback is triggered after user

--- a/openpype/tools/settings/settings/list_strict_widget.py
+++ b/openpype/tools/settings/settings/list_strict_widget.py
@@ -28,7 +28,7 @@ class ListStrictWidget(BaseWidget):
                 break
 
         self._any_children_has_label = any_children_has_label
-        # Change column stretch factor for verticall alignment
+        # Change column stretch factor for vertical alignment
         if not self.entity.is_horizontal:
             col_index = 2 if any_children_has_label else 1
             content_layout.setColumnStretch(col_index, 1)

--- a/openpype/tools/settings/settings/multiselection_combobox.py
+++ b/openpype/tools/settings/settings/multiselection_combobox.py
@@ -131,7 +131,7 @@ class MultiSelectionComboBox(QtWidgets.QComboBox):
         elif event.type() == QtCore.QEvent.KeyPress:
             # TODO: handle QtCore.Qt.Key_Enter, Key_Return?
             if event.key() == QtCore.Qt.Key_Space:
-                # toogle the current items check state
+                # toggle the current items check state
                 if (
                     index_flags & QtCore.Qt.ItemIsUserCheckable
                     and index_flags & QtCore.Qt.ItemIsTristate

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -153,7 +153,7 @@ class MainWidget(QtWidgets.QWidget):
     def _on_restart_required(self):
         # Don't show dialog if there are not registered slots for
         #   `trigger_restart` signal.
-        # - For example when settings are runnin as standalone tool
+        # - For example when settings are running as standalone tool
         # - PySide2 and PyQt5 compatible way how to find out
         method_index = self.metaObject().indexOfMethod("trigger_restart()")
         method = self.metaObject().method(method_index)

--- a/openpype/tools/standalonepublish/app.py
+++ b/openpype/tools/standalonepublish/app.py
@@ -99,7 +99,7 @@ class Window(QtWidgets.QDialog):
         return self._db
 
     def on_start(self):
-        ''' Things must be done when initilized.
+        ''' Things must be done when initialized.
         '''
         # Refresh asset input in Family widget
         self.on_asset_changed()

--- a/openpype/tools/standalonepublish/widgets/model_asset.py
+++ b/openpype/tools/standalonepublish/widgets/model_asset.py
@@ -68,7 +68,7 @@ class AssetModel(TreeModel):
         """
         if silos:
             # WARNING: Silo item "_id" is set to silo value
-            # mainly because GUI issue with perserve selection and expanded row
+            # mainly because GUI issue with preserve selection and expanded row
             # and because of easier hierarchy parenting (in "assets")
             for silo in silos:
                 node = Node({

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -18,7 +18,7 @@ def preserve_expanded_rows(tree_view,
 
     This function is created to maintain the expand vs collapse status of
     the model items. When refresh is triggered the items which are expanded
-    will stay expanded and vise versa.
+    will stay expanded and vice versa.
 
     Arguments:
         tree_view (QWidgets.QTreeView): the tree view which is
@@ -68,7 +68,7 @@ def preserve_selection(tree_view,
 
     This function is created to maintain the selection status of
     the model items. When refresh is triggered the items which are expanded
-    will stay expanded and vise versa.
+    will stay expanded and vice versa.
 
         tree_view (QWidgets.QTreeView): the tree view nested in the application
         column (int): the column to retrieve the data from
@@ -390,7 +390,7 @@ class AssetWidget(QtWidgets.QWidget):
             assets, (tuple, list)
         ), "Assets must be list or tuple"
 
-        # convert to list - tuple cant be modified
+        # convert to list - tuple can't be modified
         assets = list(assets)
 
         # Clear selection

--- a/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -101,7 +101,7 @@ class DropDataFrame(QtWidgets.QFrame):
         return paths
 
     def _add_item(self, data, actions=[]):
-        # Assign to self so garbage collector wont remove the component
+        # Assign to self so garbage collector won't remove the component
         # during initialization
         new_component = ComponentItem(self.components_list, self)
         new_component.set_context(data)

--- a/openpype/tools/standalonepublish/widgets/widget_family.py
+++ b/openpype/tools/standalonepublish/widgets/widget_family.py
@@ -373,7 +373,7 @@ class FamilyWidget(QtWidgets.QWidget):
 
         Override keyPressEvent to do nothing so that Maya's panels won't
         take focus when pressing "SHIFT" whilst mouse is over viewport or
-        outliner. This way users don't accidently perform Maya commands
+        outliner. This way users don't accidentally perform Maya commands
         whilst trying to name an instance.
 
         """

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -433,7 +433,7 @@ class PypeInfoSubWidget(QtWidgets.QWidget):
             pype_info.pop("version_type", self.not_applicable)
         )
         pype_info["version_value"] = version_value
-        # Prepare lable mapping
+        # Prepare label mapping
         key_label_mapping = {
             "version_value": "Running version:",
             "build_verison": "Build version:",

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -238,7 +238,7 @@ class TrayManager:
 
     @property
     def doubleclick_callback(self):
-        """Doubleclick callback for Tray icon."""
+        """Double-click callback for Tray icon."""
         callback_name = self.modules_manager.doubleclick_callback
         return self.modules_manager.doubleclick_callbacks.get(callback_name)
 
@@ -398,7 +398,7 @@ class TrayManager:
         title = "Settings miss default values"
         msg = (
             "Your OpenPype will not work as expected! \n"
-            "Some default values in settigs are missing. \n\n"
+            "Some default values in settings are missing. \n\n"
             "Please contact OpenPype team."
         )
         msg_box = QtWidgets.QMessageBox(
@@ -430,7 +430,7 @@ class TrayManager:
             message (str): Content of message.
             icon (QSystemTrayIcon.MessageIcon): Message's icon. Default is
                 Information icon, may differ by Qt version.
-            msecs (int): Duration of message visibility in miliseconds.
+            msecs (int): Duration of message visibility in milliseconds.
                 Default is 10000 msecs, may differ by Qt version.
         """
         args = [title, message]

--- a/openpype/tools/tray_app/app.py
+++ b/openpype/tools/tray_app/app.py
@@ -268,7 +268,7 @@ class ConsoleTrayApp:
     def _multiple_replace(text, adict):
         """Replace multiple tokens defined in dict.
 
-        Find and replace all occurances of strings defined in dict is
+        Find and replace all occurrences of strings defined in dict is
         supplied string.
 
         Args:

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -1,6 +1,6 @@
 """Single access point to all tools usable in hosts.
 
-It is possible to create `HostToolsHelper` in host implementaion or
+It is possible to create `HostToolsHelper` in host implementation or
 use singleton approach with global functions (using helper anyway).
 """
 
@@ -223,7 +223,7 @@ class HostToolsHelper:
         """Dialog of experimental tools.
 
         For some hosts it is not easy to modify menu of tools. For
-        those cases was addded experimental tools dialog which is Qt based
+        those cases was added experimental tools dialog which is Qt based
         and can dynamically filled by experimental tools so
         host need only single "Experimental tools" button to see them.
 
@@ -347,7 +347,7 @@ class _SingletonPoint:
         return cls.helper.get_tool_by_name(tool_name, parent, *args, **kwargs)
 
 
-# Function callbacks using singleton acces point
+# Function callbacks using singleton access point
 def get_tool_by_name(tool_name, parent=None, *args, **kwargs):
     return _SingletonPoint.get_tool_by_name(tool_name, parent, *args, **kwargs)
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -132,7 +132,7 @@ def preserve_expanded_rows(tree_view, column=0, role=None):
 
     This function is created to maintain the expand vs collapse status of
     the model items. When refresh is triggered the items which are expanded
-    will stay expanded and vise versa.
+    will stay expanded and vice versa.
 
     Arguments:
         tree_view (QWidgets.QTreeView): the tree view which is
@@ -176,7 +176,7 @@ def preserve_selection(tree_view, column=0, role=None, current_index=True):
 
     This function is created to maintain the selection status of
     the model items. When refresh is triggered the items which are expanded
-    will stay expanded and vise versa.
+    will stay expanded and vice versa.
 
         tree_view (QWidgets.QTreeView): the tree view nested in the application
         column (int): the column to retrieve the data from
@@ -372,7 +372,7 @@ class GroupsConfig:
         group_configs = []
         project_name = self.dbcon.Session.get("AVALON_PROJECT")
         if project_name:
-            # Get pre-defined group name and apperance from project config
+            # Get pre-defined group name and appearance from project config
             project_doc = self.dbcon.find_one(
                 {"type": "project"},
                 projection={"config.groups": True}

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -152,7 +152,7 @@ class OptionalMenu(QtWidgets.QMenu):
     """A subclass of `QtWidgets.QMenu` to work with `OptionalAction`
 
     This menu has reimplemented `mouseReleaseEvent`, `mouseMoveEvent` and
-    `leaveEvent` to provide better action hightlighting and triggering for
+    `leaveEvent` to provide better action highlighting and triggering for
     actions that were instances of `QtWidgets.QWidgetAction`.
 
     """

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -162,7 +162,7 @@ class NameWindow(QtWidgets.QDialog):
 
         # Build inputs
         inputs_layout = QtWidgets.QFormLayout(inputs_widget)
-        # Add version only if template contain version key
+        # Add version only if template contains version key
         # - since the version can be padded with "{version:0>4}" we only search
         #   for "{version".
         if "{version" in self.template:
@@ -170,7 +170,7 @@ class NameWindow(QtWidgets.QDialog):
         else:
             version_widget.setVisible(False)
 
-        # Add subversion only if template containt `{comment}`
+        # Add subversion only if template contains `{comment}`
         if "{comment}" in self.template:
             inputs_layout.addRow("Subversion:", subversion_input)
         else:
@@ -183,7 +183,7 @@ class NameWindow(QtWidgets.QDialog):
         main_layout.addWidget(inputs_widget)
         main_layout.addWidget(btns_widget)
 
-        # Singal callback registration
+        # Signal callback registration
         version_input.valueChanged.connect(self.on_version_spinbox_changed)
         last_version_check.stateChanged.connect(
             self.on_version_checkbox_changed
@@ -833,7 +833,7 @@ class SidePanelWidget(QtWidgets.QWidget):
         self.note_input.setEnabled(enabled)
         self.btn_note_save.setEnabled(enabled)
 
-        # Make sure workfile doc is overriden
+        # Make sure workfile doc is overridden
         self._workfile_doc = workfile_doc
         # Disable inputs and remove texts if any required arguments are missing
         if not enabled:
@@ -978,7 +978,7 @@ class Window(QtWidgets.QMainWindow):
 
         Override keyPressEvent to do nothing so that Maya's panels won't
         take focus when pressing "SHIFT" whilst mouse is over viewport or
-        outliner. This way users don't accidently perform Maya commands
+        outliner. This way users don't accidentally perform Maya commands
         whilst trying to name an instance.
 
         """


### PR DESCRIPTION
## Brief description

Some more grammar fixes in `openpype/tools`.

---

> Note there are still some typos left in there, in particular:
> - `hightlighted` -> `highlighted`
> - `overriden` -> `overridden`
> 
> It's because these typos were also used in variable names, returned string values and used in `css` styling code. We could refactor them all but I'm a bit wary at adapting those. These all tend to be in `openpype/tools/settings`. That might actually be better in a standalone PR too since it's much less _cosmetics_ only.

I've pushed those other typos into a PR of its own #2610 

### Testing notes

⚠️ These code changes should still be tested. ⚠️ 

But since **most** of these changes are in comments/strings only the changes shouldn't be problematic.