### PR TITLE
Scene Inventory: Fix type name for 'representation' in switch logic

### DIFF
--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -558,7 +558,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         repre_docs = io.find(
             {
-                "type": "rerpesentation",
+                "type": "representation",
                 "parent": subset_doc["_id"],
                 "name": {"$in": list(repre_names)}
             },


### PR DESCRIPTION
## Brief description

Detected a typo in the code for the Switch Dialog. I'm not sure what actual issues this might have caused for the code. I'm just here to refactor the actual faulty code.

Seems like it could have caused issues when both *asset* and *subset* were selected where available *representations* would not get queried correctly.