### PR TITLE
Cosmetics: Refactor `hightlight` and `overriden` typos

### DIFF
--- a/openpype/hosts/flame/plugins/publish/extract_subset_resources.py
+++ b/openpype/hosts/flame/plugins/publish/extract_subset_resources.py
@@ -71,7 +71,7 @@ class ExtractSubsetResources(openpype.api.Extractor):
         staging_dir = self.staging_dir(instance)
 
         # add default preset type for thumbnail and reviewable video
-        # update them with settings and overide in case the same
+        # update them with settings and override in case the same
         # are found in there
         export_presets = deepcopy(self.default_presets)
         export_presets.update(self.export_presets_mapping)

--- a/openpype/modules/default_modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_server/lib.py
@@ -164,7 +164,7 @@ class ProcessEventHub(SocketBaseEventHub):
             sys.exit(0)
 
     def wait(self, duration=None):
-        """Overriden wait
+        """Overridden wait
         Event are loaded from Mongo DB when queue is empty. Handled event is
         set as processed in Mongo DB.
         """

--- a/openpype/modules/default_modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/default_modules/sync_server/providers/dropbox.py
@@ -95,7 +95,7 @@ class DropboxHandler(AbstractProvider):
                 "key": "acting_as_member",
                 "label": "Acting As Member"
             },
-            # roots could be overriden only on Project level, User cannot
+            # roots could be overridden only on Project level, User cannot
             {
                 "key": "root",
                 "label": "Roots",

--- a/openpype/modules/default_modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/default_modules/sync_server/providers/gdrive.py
@@ -119,7 +119,7 @@ class GDriveHandler(AbstractProvider):
         # {platform} tells that value is multiplatform and only specific OS
         # should be returned
         editable = [
-            # credentials could be overriden on Project or User level
+            # credentials could be overridden on Project or User level
             {
                 "type": "path",
                 "key": "credentials_url",
@@ -127,7 +127,7 @@ class GDriveHandler(AbstractProvider):
                 "multiplatform": True,
                 "placeholder": "Credentials url"
             },
-            # roots could be overriden only on Project leve, User cannot
+            # roots could be overridden only on Project level, User cannot
             {
                 "key": "root",
                 "label": "Roots",
@@ -414,7 +414,7 @@ class GDriveHandler(AbstractProvider):
     def delete_folder(self, path, force=False):
         """
             Deletes folder on GDrive. Checks if folder contains any files or
-            subfolders. In that case raises error, could be overriden by
+            subfolders. In that case raises error, could be overridden by
             'force' argument.
             In that case deletes folder on 'path' and all its children.
 

--- a/openpype/modules/default_modules/sync_server/providers/sftp.py
+++ b/openpype/modules/default_modules/sync_server/providers/sftp.py
@@ -97,7 +97,7 @@ class SFTPHandler(AbstractProvider):
         # {platform} tells that value is multiplatform and only specific OS
         # should be returned
         editable = [
-            # credentials could be overriden on Project or User level
+            # credentials could be overridden on Project or User level
             {
                 'key': "sftp_host",
                 'label': "SFTP host name",
@@ -129,7 +129,7 @@ class SFTPHandler(AbstractProvider):
                 'label': "SFTP user ssh key password",
                 'type': 'text'
             },
-            # roots could be overriden only on Project leve, User cannot
+            # roots could be overridden only on Project level, User cannot
             {
                 "key": "root",
                 "label": "Roots",

--- a/openpype/modules/default_modules/sync_server/sync_server_module.py
+++ b/openpype/modules/default_modules/sync_server/sync_server_module.py
@@ -1073,7 +1073,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         """
             Returns settings for 'studio' and user's local site
 
-            Returns base values from setting, not overriden by Local Settings,
+            Returns base values from setting, not overridden by Local Settings,
             eg. value used to push TO LS not to get actual value for syncing.
         """
         if not project_name:

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -115,7 +115,7 @@ class ITrayAction(ITrayModule):
     Add action to tray menu which will trigger `on_action_trigger`.
     It is expected to be used for showing tools.
 
-    Methods `tray_start`, `tray_exit` and `connect_with_modules` are overriden
+    Methods `tray_start`, `tray_exit` and `connect_with_modules` are overridden
     as it's not expected that action will use them. But it is possible if
     necessary.
     """

--- a/openpype/modules/job_queue/job_server/workers_rpc_route.py
+++ b/openpype/modules/job_queue/job_server/workers_rpc_route.py
@@ -72,7 +72,7 @@ class WorkerRpc(JsonRpc):
             self._job_queue.remove_worker(worker)
 
     async def handle_websocket_request(self, http_request):
-        """Overide this method to catch CLOSING messages."""
+        """Override this method to catch CLOSING messages."""
         http_request.msg_id = 0
         http_request.pending = {}
 

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -31,7 +31,7 @@ class DiscoverResult:
 def publish_plugins_discover(paths=None):
     """Find and return available pyblish plug-ins
 
-    Overriden function from `pyblish` module to be able collect crashed files
+    Overridden function from `pyblish` module to be able collect crashed files
     and reason of their crash.
 
     Arguments:

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -252,7 +252,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         - required IF start frame is not set when using frames or timecode burnins
 
     On initializing class can be set General options through "options_init" arg.
-    General can be overriden when adding burnin
+    General can be overridden when adding burnin
 
     '''
     TOP_CENTERED = ffmpeg_burnins.TOP_CENTERED
@@ -549,7 +549,7 @@ def burnins_from_data(
         codec_data (list): All codec related arguments in list.
         options (dict): Options for burnins.
         burnin_values (dict): Contain positioned values.
-        overwrite (bool): Output will be overriden if already exists,
+        overwrite (bool): Output will be overwritten if already exists,
             True by default.
 
     Presets must be set separately. Should be dict with 2 keys:

--- a/openpype/settings/constants.py
+++ b/openpype/settings/constants.py
@@ -2,14 +2,14 @@ import re
 
 
 # Metadata keys for work with studio and project overrides
-M_OVERRIDEN_KEY = "__overriden_keys__"
+M_OVERRIDDEN_KEY = "__overridden_keys__"
 # Metadata key for storing information about environments
 M_ENVIRONMENT_KEY = "__environment_keys__"
 # Metadata key for storing dynamic created labels
 M_DYNAMIC_KEY_LABEL = "__dynamic_keys_labels__"
 
 METADATA_KEYS = (
-    M_OVERRIDEN_KEY,
+    M_OVERRIDDEN_KEY,
     M_ENVIRONMENT_KEY,
     M_DYNAMIC_KEY_LABEL
 )
@@ -32,7 +32,7 @@ KEY_REGEX = re.compile(r"^[{}]+$".format(KEY_ALLOWED_SYMBOLS))
 
 
 __all__ = (
-    "M_OVERRIDEN_KEY",
+    "M_OVERRIDDEN_KEY",
     "M_ENVIRONMENT_KEY",
     "M_DYNAMIC_KEY_LABEL",
 

--- a/openpype/settings/constants.py
+++ b/openpype/settings/constants.py
@@ -2,7 +2,7 @@ import re
 
 
 # Metadata keys for work with studio and project overrides
-M_OVERRIDDEN_KEY = "__overridden_keys__"
+M_OVERRIDDEN_KEY = "__overriden_keys__"
 # Metadata key for storing information about environments
 M_ENVIRONMENT_KEY = "__environment_keys__"
 # Metadata key for storing dynamic created labels

--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -752,7 +752,7 @@ class BaseItemEntity(BaseEntity):
 
     @abstractmethod
     def _add_to_project_override(self, on_change_trigger):
-        """Item's implementation to set values as overriden for project.
+        """Item's implementation to set values as overridden for project.
 
         Mark item and all it's children to be stored as project overrides.
         """
@@ -794,7 +794,7 @@ class BaseItemEntity(BaseEntity):
         """Item's implementation to remove project overrides.
 
         Mark item as does not have project overrides. Must not change
-        `was_overriden` attribute value.
+        `was_overridden` attribute value.
 
         Args:
             on_change_trigger (list): Callbacks of `on_change` should be stored

--- a/openpype/settings/entities/dict_conditional.py
+++ b/openpype/settings/entities/dict_conditional.py
@@ -6,7 +6,7 @@ from .lib import (
 )
 from openpype.settings.constants import (
     METADATA_KEYS,
-    M_OVERRIDEN_KEY,
+    M_OVERRIDDEN_KEY,
     KEY_REGEX
 )
 from . import (
@@ -119,7 +119,7 @@ class DictConditionalEntity(ItemEntity):
 
         # `current_metadata` are still when schema is loaded
         # - only metadata stored with dict item are gorup overrides in
-        #   M_OVERRIDEN_KEY
+        #   M_OVERRIDDEN_KEY
         self._current_metadata = {}
         self._metadata_are_modified = False
 
@@ -377,9 +377,9 @@ class DictConditionalEntity(ItemEntity):
             ):
                 continue
 
-            if M_OVERRIDEN_KEY not in current_metadata:
-                current_metadata[M_OVERRIDEN_KEY] = []
-            current_metadata[M_OVERRIDEN_KEY].append(key)
+            if M_OVERRIDDEN_KEY not in current_metadata:
+                current_metadata[M_OVERRIDDEN_KEY] = []
+            current_metadata[M_OVERRIDDEN_KEY].append(key)
 
         # Define if current metadata are avaialble for current override state
         metadata = NOT_SET
@@ -535,7 +535,7 @@ class DictConditionalEntity(ItemEntity):
 
         enum_value = value.get(self.enum_key)
 
-        old_metadata = metadata.get(M_OVERRIDEN_KEY)
+        old_metadata = metadata.get(M_OVERRIDDEN_KEY)
         if old_metadata:
             old_metadata_set = set(old_metadata)
             new_metadata = []
@@ -547,7 +547,7 @@ class DictConditionalEntity(ItemEntity):
 
             for key in old_metadata_set:
                 new_metadata.append(key)
-            metadata[M_OVERRIDEN_KEY] = new_metadata
+            metadata[M_OVERRIDDEN_KEY] = new_metadata
 
         return value, metadata
 

--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -9,7 +9,7 @@ from .lib import (
 )
 from openpype.settings.constants import (
     METADATA_KEYS,
-    M_OVERRIDEN_KEY,
+    M_OVERRIDDEN_KEY,
     KEY_REGEX
 )
 from . import (
@@ -183,7 +183,7 @@ class DictImmutableKeysEntity(ItemEntity):
 
         # `current_metadata` are still when schema is loaded
         # - only metadata stored with dict item are gorup overrides in
-        #   M_OVERRIDEN_KEY
+        #   M_OVERRIDDEN_KEY
         self._current_metadata = {}
         self._metadata_are_modified = False
 
@@ -257,9 +257,9 @@ class DictImmutableKeysEntity(ItemEntity):
             ):
                 continue
 
-            if M_OVERRIDEN_KEY not in current_metadata:
-                current_metadata[M_OVERRIDEN_KEY] = []
-            current_metadata[M_OVERRIDEN_KEY].append(key)
+            if M_OVERRIDDEN_KEY not in current_metadata:
+                current_metadata[M_OVERRIDDEN_KEY] = []
+            current_metadata[M_OVERRIDDEN_KEY].append(key)
 
         # Define if current metadata are avaialble for current override state
         metadata = NOT_SET
@@ -399,7 +399,7 @@ class DictImmutableKeysEntity(ItemEntity):
             if key in value:
                 metadata[key] = value.pop(key)
 
-        old_metadata = metadata.get(M_OVERRIDEN_KEY)
+        old_metadata = metadata.get(M_OVERRIDDEN_KEY)
         if old_metadata:
             old_metadata_set = set(old_metadata)
             new_metadata = []
@@ -410,7 +410,7 @@ class DictImmutableKeysEntity(ItemEntity):
 
             for key in old_metadata_set:
                 new_metadata.append(key)
-            metadata[M_OVERRIDEN_KEY] = new_metadata
+            metadata[M_OVERRIDDEN_KEY] = new_metadata
 
         return value, metadata
 

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -222,7 +222,7 @@ class DictMutableKeysEntity(EndpointEntity):
         self.required_keys = self.schema_data.get("required_keys") or []
         self.collapsible_key = self.schema_data.get("collapsible_key") or False
         # GUI attributes
-        self.hightlight_content = (
+        self.highlight_content = (
             self.schema_data.get("highlight_content") or False
         )
 

--- a/openpype/settings/entities/lib.py
+++ b/openpype/settings/entities/lib.py
@@ -101,7 +101,7 @@ class OverrideState:
     - DEFAULTS - Entity cares only about default values. It is not
         possible to set higher state if any entity does not have filled
         default value.
-    - STUDIO - First layer of overrides. Hold only studio overriden values
+    - STUDIO - First layer of overrides. Hold only studio overridden values
         that are applied on top of defaults.
     - PROJECT - Second layer of overrides. Hold only project overrides that are
         applied on top of defaults and studio overrides.

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -10,7 +10,7 @@
     - `"is_file"` - this key is for storing openpype defaults in `openpype` repo
         - reasons of existence: developing new schemas does not require to create defaults manually
         - key is validated, must be once in hierarchy else it won't be possible to store openpype defaults
-    - `"is_group"` - define that all values under key in hierarchy will be overriden if any value is modified, this information is also stored to overrides
+    - `"is_group"` - define that all values under key in hierarchy will be overridden if any value is modified, this information is also stored to overrides
         - this keys is not allowed for all inputs as they may have not reason for that
         - key is validated, can be only once in hierarchy but is not required
 - currently there are `system settings` and `project settings`
@@ -767,7 +767,7 @@ Anatomy represents data stored on project document.
 
 ### anatomy
 - entity works similarly to `dict`
-- anatomy has always all keys overriden with overrides
+- anatomy has always all keys overridden with overrides
     - overrides are not applied as all anatomy data must be available from project document
     - all children must be groups
 

--- a/openpype/settings/entities/schemas/system_schema/example_schema.json
+++ b/openpype/settings/entities/schemas/system_schema/example_schema.json
@@ -11,13 +11,13 @@
         },
         {
             "type": "dict-conditional",
-            "key": "overriden_value",
-            "label": "Overriden value",
-            "enum_key": "overriden",
+            "key": "overridden_value",
+            "label": "Overridden value",
+            "enum_key": "overridden",
             "enum_is_horizontal": true,
             "enum_children": [
                 {
-                    "key": "overriden",
+                    "key": "overridden",
                     "label": "Override value",
                     "children": [
                         {

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -13,7 +13,7 @@ from .constants import (
     PROJECT_SETTINGS_KEY,
     PROJECT_ANATOMY_KEY,
     LOCAL_SETTING_KEY,
-    M_OVERRIDEN_KEY
+    M_OVERRIDDEN_KEY
 )
 from .lib import load_json_file
 
@@ -254,12 +254,12 @@ class MongoSettingsHandler(SettingsHandler):
                 continue
             # Pop key from values
             output[key] = general_data.pop(key)
-            # Pop key from overriden metadata
+            # Pop key from overridden metadata
             if (
-                M_OVERRIDEN_KEY in general_data
-                and key in general_data[M_OVERRIDEN_KEY]
+                M_OVERRIDDEN_KEY in general_data
+                and key in general_data[M_OVERRIDDEN_KEY]
             ):
-                general_data[M_OVERRIDEN_KEY].remove(key)
+                general_data[M_OVERRIDDEN_KEY].remove(key)
         return output
 
     def _apply_global_settings(
@@ -319,17 +319,17 @@ class MongoSettingsHandler(SettingsHandler):
             system_general = {}
             system_settings_data["general"] = system_general
 
-        overriden_keys = system_general.get(M_OVERRIDEN_KEY) or []
+        overridden_keys = system_general.get(M_OVERRIDDEN_KEY) or []
         for key in self.global_general_keys:
             if key not in globals_data:
                 continue
 
             system_general[key] = globals_data[key]
-            if key not in overriden_keys:
-                overriden_keys.append(key)
+            if key not in overridden_keys:
+                overridden_keys.append(key)
 
-        if overriden_keys:
-            system_general[M_OVERRIDEN_KEY] = overriden_keys
+        if overridden_keys:
+            system_general[M_OVERRIDDEN_KEY] = overridden_keys
 
         return system_settings_document
 

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -8,7 +8,7 @@ from .exceptions import (
     SaveWarningExc
 )
 from .constants import (
-    M_OVERRIDEN_KEY,
+    M_OVERRIDDEN_KEY,
     M_ENVIRONMENT_KEY,
 
     METADATA_KEYS,
@@ -546,13 +546,13 @@ def subkey_merge(_dict, value, keys):
 def merge_overrides(source_dict, override_dict):
     """Merge data from override_dict to source_dict."""
 
-    if M_OVERRIDEN_KEY in override_dict:
-        overriden_keys = set(override_dict.pop(M_OVERRIDEN_KEY))
+    if M_OVERRIDDEN_KEY in override_dict:
+        overridden_keys = set(override_dict.pop(M_OVERRIDDEN_KEY))
     else:
-        overriden_keys = set()
+        overridden_keys = set()
 
     for key, value in override_dict.items():
-        if (key in overriden_keys or key not in source_dict):
+        if (key in overridden_keys or key not in source_dict):
             source_dict[key] = value
 
         elif isinstance(value, dict) and isinstance(source_dict[key], dict):
@@ -574,7 +574,7 @@ def apply_local_settings_on_system_settings(system_settings, local_settings):
     """Apply local settings on studio system settings.
 
     ATM local settings can modify only application executables. Executable
-    values are not overriden but prepended.
+    values are not overridden but prepended.
     """
     if not local_settings or "applications" not in local_settings:
         return
@@ -914,7 +914,7 @@ def get_environments():
     """Calculated environment based on defaults and system settings.
 
     Any default environment also found in the system settings will be fully
-    overriden by the one from the system settings.
+    overridden by the one from the system settings.
 
     Returns:
         dict: Output should be ready for `acre` module.

--- a/openpype/style/data.json
+++ b/openpype/style/data.json
@@ -112,7 +112,7 @@
             "breadcrumbs-btn-bg": "rgba(127, 127, 127, 60)",
             "breadcrumbs-btn-bg-hover": "rgba(127, 127, 127, 90)",
 
-            "content-hightlighted": "rgba(19, 26, 32, 15)",
+            "content-highlighted": "rgba(19, 26, 32, 15)",
             "focus-border": "#839caf",
             "image-btn": "#bfccd6",
             "image-btn-hover": "#189aea",

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -1093,16 +1093,16 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 #ExpandLabel[state="modified"]:hover, #SettingsLabel[state="modified"]:hover {
     color: {color:settings:modified-light};
 }
-#ExpandLabel[state="overriden-modified"], #SettingsLabel[state="overriden-modified"] {
+#ExpandLabel[state="overridden-modified"], #SettingsLabel[state="overridden-modified"] {
     color: {color:settings:modified-mid};
 }
-#ExpandLabel[state="overriden-modified"]:hover, #SettingsLabel[state="overriden-modified"]:hover {
+#ExpandLabel[state="overridden-modified"]:hover, #SettingsLabel[state="overridden-modified"]:hover {
     color: {color:settings:modified-light};
 }
-#ExpandLabel[state="overriden"], #SettingsLabel[state="overriden"] {
+#ExpandLabel[state="overridden"], #SettingsLabel[state="overridden"] {
     color: {color:settings:project-mid};
 }
-#ExpandLabel[state="overriden"]:hover, #SettingsLabel[state="overriden"]:hover {
+#ExpandLabel[state="overridden"]:hover, #SettingsLabel[state="overridden"]:hover {
     color: {color:settings:project-light};
 }
 #ExpandLabel[state="invalid"], #SettingsLabel[state="invalid"] {
@@ -1116,10 +1116,10 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 #SettingsMainWidget QWidget[input-state="modified"] {
     border-color: {color:settings:modified-mid};
 }
-#SettingsMainWidget QWidget[input-state="overriden-modified"] {
+#SettingsMainWidget QWidget[input-state="overridden-modified"] {
     border-color: {color:settings:modified-mid};
 }
-#SettingsMainWidget QWidget[input-state="overriden"] {
+#SettingsMainWidget QWidget[input-state="overridden"] {
     border-color: {color:settings:project-mid};
 }
 #SettingsMainWidget QWidget[input-state="invalid"] {
@@ -1145,8 +1145,8 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 #ContentWidget {
     background-color: transparent;
 }
-#ContentWidget[content_state="hightlighted"] {
-    background-color: {color:settings:content-hightlighted};
+#ContentWidget[content_state="highlighted"] {
+    background-color: {color:settings:content-highlighted};
 }
 
 #SideLineWidget {
@@ -1172,11 +1172,11 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 #SideLineWidget[state="child-invalid"] {border-color: {color:settings:invalid-dark};}
 #SideLineWidget[state="child-invalid"]:hover {border-color: {color:settings:invalid-light};}
 
-#SideLineWidget[state="child-overriden"] {border-color: {color:settings:project-dark};}
-#SideLineWidget[state="child-overriden"]:hover {border-color: {color:settings:project-mid};}
+#SideLineWidget[state="child-overridden"] {border-color: {color:settings:project-dark};}
+#SideLineWidget[state="child-overridden"]:hover {border-color: {color:settings:project-mid};}
 
-#SideLineWidget[state="child-overriden-modified"] {border-color: {color:settings:modified-dark};}
-#SideLineWidget[state="child-overriden-modified"]:hover {border-color: {color:settings:modified-mid};}
+#SideLineWidget[state="child-overridden-modified"] {border-color: {color:settings:modified-dark};}
+#SideLineWidget[state="child-overridden-modified"]:hover {border-color: {color:settings:modified-mid};}
 
 #DictAsWidgetBody {
     background: transparent;

--- a/openpype/tests/test_avalon_plugin_presets.py
+++ b/openpype/tests/test_avalon_plugin_presets.py
@@ -32,9 +32,9 @@ def test_avalon_plugin_presets(monkeypatch, printer):
     assert MyTestCreator in plugins
     for p in plugins:
         if p.__name__ == "MyTestCreator":
-            printer("Test if we have overriden existing property")
+            printer("Test if we have overridden existing property")
             assert p.my_test_property == "B"
-            printer("Test if we have overriden superclass property")
+            printer("Test if we have overridden superclass property")
             assert p.active is False
             printer("Test if we have added new property")
             assert p.new_property == "new"

--- a/openpype/tools/settings/local_settings/projects_widget.py
+++ b/openpype/tools/settings/local_settings/projects_widget.py
@@ -126,7 +126,7 @@ class DynamicInputItem(QtCore.QObject):
                 return "studio"
         else:
             if current_value:
-                return "overriden"
+                return "overridden"
 
             if self.value_item.default_value:
                 return "studio"
@@ -512,7 +512,7 @@ class _SiteCombobox(QtWidgets.QWidget):
                 return "studio"
         else:
             if current_value:
-                return "overriden"
+                return "overridden"
 
             studio_value = self._get_local_settings_item(DEFAULT_PROJECT_KEY)
             if studio_value:

--- a/openpype/tools/settings/settings/README.md
+++ b/openpype/tools/settings/settings/README.md
@@ -10,7 +10,7 @@
     - `"is_file"` - this key is for storing openpype defaults in `openpype` repo
         - reasons of existence: developing new schemas does not require to create defaults manually
         - key is validated, must be once in hierarchy else it won't be possible to store openpype defaults
-    - `"is_group"` - define that all values under key in hierarchy will be overriden if any value is modified, this information is also stored to overrides
+    - `"is_group"` - define that all values under key in hierarchy will be overridden if any value is modified, this information is also stored to overrides
         - this keys is not allowed for all inputs as they may have not reason for that
         - key is validated, can be only once in hierarchy but is not required
 - currently there are `system configurations` and `project configurations`

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -93,7 +93,7 @@ class BaseWidget(QtWidgets.QWidget):
         if is_modified:
             return "modified"
         if has_project_override:
-            return "overriden"
+            return "overridden"
         if has_studio_override:
             return "studio"
         return ""

--- a/openpype/tools/settings/settings/dict_conditional.py
+++ b/openpype/tools/settings/settings/dict_conditional.py
@@ -183,7 +183,7 @@ class DictConditionalWidget(BaseWidget):
         content_widget.setObjectName("ContentWidget")
 
         if self.entity.highlight_content:
-            content_state = "hightlighted"
+            content_state = "highlighted"
             bottom_margin = 5
         else:
             content_state = ""

--- a/openpype/tools/settings/settings/dict_mutable_widget.py
+++ b/openpype/tools/settings/settings/dict_mutable_widget.py
@@ -354,7 +354,7 @@ class ModifiableDictItem(QtWidgets.QWidget):
         if self.entity.has_unsaved_changes:
             return "modified"
         if self.entity.has_project_override:
-            return "overriden"
+            return "overridden"
         if self.entity.has_studio_override:
             return "studio"
         return ""
@@ -600,8 +600,8 @@ class DictMutableKeysWidget(BaseWidget):
         self.input_fields = []
         self.required_inputs_by_key = {}
 
-        if self.entity.hightlight_content:
-            content_state = "hightlighted"
+        if self.entity.highlight_content:
+            content_state = "highlighted"
             bottom_margin = 5
         else:
             content_state = ""

--- a/openpype/tools/settings/settings/item_widgets.py
+++ b/openpype/tools/settings/settings/item_widgets.py
@@ -150,7 +150,7 @@ class DictImmutableKeysWidget(BaseWidget):
         content_widget.setObjectName("ContentWidget")
 
         if self.entity.highlight_content:
-            content_state = "hightlighted"
+            content_state = "highlighted"
             bottom_margin = 5
         else:
             content_state = ""

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -152,7 +152,7 @@ class OptionalMenu(QtWidgets.QMenu):
     """A subclass of `QtWidgets.QMenu` to work with `OptionalAction`
 
     This menu has reimplemented `mouseReleaseEvent`, `mouseMoveEvent` and
-    `leaveEvent` to provide better action hightlighting and triggering for
+    `leaveEvent` to provide better action highlighting and triggering for
     actions that were instances of `QtWidgets.QWidgetAction`.
 
     """

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -833,7 +833,7 @@ class SidePanelWidget(QtWidgets.QWidget):
         self.note_input.setEnabled(enabled)
         self.btn_note_save.setEnabled(enabled)
 
-        # Make sure workfile doc is overriden
+        # Make sure workfile doc is overridden
         self._workfile_doc = workfile_doc
         # Disable inputs and remove texts if any required arguments are missing
         if not enabled:


### PR DESCRIPTION
## Brief description

Fix code typos. 

Note that this includes changes to variable names and actual styling names and thus is more involved than just some typos being fixed in code comments.

I'm also making this a separate PR so we can discuss and it's clearer that we are debating whether it's worth refactoring things like this in the code base.

### Testing notes

⚠️ These code changes should still be tested. ⚠️ 