### PR TITLE
few typos fixed

### DIFF
--- a/website/docs/artist_concepts.md
+++ b/website/docs/artist_concepts.md
@@ -26,7 +26,7 @@ Each published variant can come out of the software in multiple representations.
 
 ### Family
 
-Each published [subset][3b89d8e0] can have exactly one family assigned to it. Family determines the type of data that the subset holds. Family doesn't dictate the file type, but can enforce certain technical specifications. For example OpenPype default configuration expects `model` family to only contain geometry without any shaders or joins when it is published.
+Each published [subset][3b89d8e0] can have exactly one family assigned to it. Family determines the type of data that the subset holds. Family doesn't dictate the file type, but can enforce certain technical specifications. For example OpenPype default configuration expects `model` family to only contain geometry without any shaders or joints when it is published.
 
 
   [3b89d8e0]: #subset "subset"
@@ -40,7 +40,7 @@ General term for Software or Application supported by OpenPype and Avalon. These
 
 ### Tool
 
-Small piece of software usually dedicated to a particular purpose. Most of OpenPype and Avalon tools have GUI, but some are command line only
+Small piece of software usually dedicated to a particular purpose. Most of OpenPype and Avalon tools have GUI, but some are command line only.
 
 
 ### Publish
@@ -50,4 +50,4 @@ Process of exporting data from your work scene to versioned, immutable file that
 ### Load
 
 Process of importing previously published subsets into your current scene, using any of the OpenPype tools.
-Loading asset using proper tools will ensure that all your scene content stays version controlled and updatable at a later point
+Loading asset using proper tools will ensure that all your scene content stays version controlled and updatable at a later point.


### PR DESCRIPTION
## Brief description
First sentence is brief description.

## Description
Next paragraf is more elaborate text with more info. This will be displayed for example in collapsed form under the first sentence in a changelog.

## Additional info
The rest will be ignored in changelog and should contain any additional
technical information.

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. start with this step
2. follow this step