### PR TITLE
Fix - safer pulling of task name for webpublishing from PS

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_remote_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_remote_instances.py
@@ -4,7 +4,7 @@ import re
 import pyblish.api
 
 from openpype.lib import prepare_template_data
-from openpype.lib.plugin_tools import parse_json
+from openpype.lib.plugin_tools import parse_json, get_batch_asset_task_info
 from openpype.hosts.photoshop import api as photoshop
 
 
@@ -29,26 +29,32 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
 
     def process(self, context):
         self.log.info("CollectRemoteInstances")
-        self.log.info("mapping:: {}".format(self.color_code_mapping))
+        self.log.debug("mapping:: {}".format(self.color_code_mapping))
 
         # parse variant if used in webpublishing, comes from webpublisher batch
         batch_dir = os.environ.get("OPENPYPE_PUBLISH_DATA")
-        variant = "Main"
+        task_data = None
         if batch_dir and os.path.exists(batch_dir):
             # TODO check if batch manifest is same as tasks manifests
             task_data = parse_json(os.path.join(batch_dir,
                                                 "manifest.json"))
-            if not task_data:
-                raise ValueError(
-                    "Cannot parse batch meta in {} folder".format(batch_dir))
-            variant = task_data["variant"]
+        if not task_data:
+            raise ValueError(
+                "Cannot parse batch meta in {} folder".format(batch_dir))
+        variant = task_data["variant"]
 
         stub = photoshop.stub()
         layers = stub.get_layers()
 
+        asset, task_name, task_type = get_batch_asset_task_info(
+            task_data["context"])
+
+        if not task_name:
+            task_name = task_type
+
         instance_names = []
         for layer in layers:
-            self.log.info("Layer:: {}".format(layer))
+            self.log.debug("Layer:: {}".format(layer))
             resolved_family, resolved_subset_template = self._resolve_mapping(
                 layer
             )
@@ -57,7 +63,7 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
                 resolved_subset_template))
 
             if not resolved_subset_template or not resolved_family:
-                self.log.debug("!!! Not marked, skip")
+                self.log.debug("!!! Not found family or template, skip")
                 continue
 
             if layer.parents:
@@ -68,8 +74,8 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
             instance.append(layer)
             instance.data["family"] = resolved_family
             instance.data["publish"] = layer.visible
-            instance.data["asset"] = context.data["assetEntity"]["name"]
-            instance.data["task"] = context.data["task"]
+            instance.data["asset"] = asset
+            instance.data["task"] = task_name
 
             fill_pairs = {
                 "variant": variant,
@@ -114,7 +120,6 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
 
             family_list.append(mapping["family"])
             subset_name_list.append(mapping["subset_template_name"])
-
         if len(subset_name_list) > 1:
             self.log.warning("Multiple mappings found for '{}'".
                              format(layer.name))


### PR DESCRIPTION
## Brief description
Task name and asset name pulled from batch manifest file

## Testing notes:
1. Run Webpublish with studio reprocessing for PS