### PR TITLE
Settings: Enum does not store empty string if has single item to select

### DIFF
--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -12,7 +12,7 @@
                 {
                     "color_code": [],
                     "layer_name_regex": [],
-                    "family": "",
+                    "family": "image",
                     "subset_template_name": ""
                 }
             ]

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -121,6 +121,20 @@ class EnumEntity(BaseEnumEntity):
             )
         super(EnumEntity, self).schema_validations()
 
+    def set_override_state(self, *args, **kwargs):
+        super(EnumEntity, self).set_override_state(*args, **kwargs)
+
+        # Make sure current value is valid
+        if self.multiselection:
+            new_value = []
+            for key in self._current_value:
+                if key in self.valid_keys:
+                    new_value.append(key)
+            self._current_value = new_value
+
+        elif self._current_value not in self.valid_keys:
+            self._current_value = self.value_on_not_set
+
 
 class HostsEnumEntity(BaseEnumEntity):
     """Enumeration of host names.


### PR DESCRIPTION
## Brief description
Resolve issue when enum stores empty string instead of selected item.

## Changes
- make sure enum has set `_current_value` to valid key

Resolves: https://github.com/pypeclub/OpenPype/issues/2614