### PR TITLE
Deadline: Be able to pass Mongo url to job

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -118,6 +118,7 @@ class CollectAERender(abstract_collect_render.AbstractCollectRender):
                 instance.anatomyData = context.data["anatomyData"]
 
                 instance.outputDir = self._get_output_dir(instance)
+                instance.context = context
 
                 settings = get_project_settings(os.getenv("AVALON_PROJECT"))
                 reviewable_subset_filter = \
@@ -142,7 +143,6 @@ class CollectAERender(abstract_collect_render.AbstractCollectRender):
                                 break
 
                 self.log.info("New instance:: {}".format(instance))
-
                 instances.append(instance)
 
         return instances

--- a/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
@@ -176,6 +176,7 @@ class CollectFarmRender(openpype.lib.abstract_collect_render.
                 ignoreFrameHandleCheck=True
 
             )
+            render_instance.context = context
             self.log.debug(render_instance)
             instances.append(render_instance)
 

--- a/openpype/lib/abstract_collect_render.py
+++ b/openpype/lib/abstract_collect_render.py
@@ -76,6 +76,7 @@ class RenderInstance(object):
     deadlineSubmissionJob = attr.ib(default=None)
     anatomyData = attr.ib(default=None)
     outputDir = attr.ib(default=None)
+    context = attr.ib(default=None)
 
     @frameStart.validator
     def check_frame_start(self, _, value):

--- a/openpype/modules/default_modules/deadline/plugins/publish/collect_default_deadline_server.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/collect_default_deadline_server.py
@@ -9,6 +9,8 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder + 0.01
     label = "Default Deadline Webservice"
 
+    pass_mongo_url = False
+
     def process(self, context):
         try:
             deadline_module = context.data.get("openPypeModules")["deadline"]
@@ -19,3 +21,5 @@ class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
         # get default deadline webservice url from deadline module
         self.log.debug(deadline_module.deadline_urls)
         context.data["defaultDeadline"] = deadline_module.deadline_urls["default"]  # noqa: E501
+
+        context.data["deadlinePassMongoUrl"] = self.pass_mongo_url

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_aftereffects_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_aftereffects_deadline.py
@@ -67,6 +67,9 @@ class AfterEffectsSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
             "OPENPYPE_DEV",
             "OPENPYPE_LOG_NO_COLORS"
         ]
+        # Add mongo url if it's enabled
+        if self._instance.context.get("deadlinePassMongoUrl"):
+            keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **api.Session)

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_aftereffects_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_aftereffects_deadline.py
@@ -68,7 +68,7 @@ class AfterEffectsSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
             "OPENPYPE_LOG_NO_COLORS"
         ]
         # Add mongo url if it's enabled
-        if self._instance.context.get("deadlinePassMongoUrl"):
+        if self._instance.context.data.get("deadlinePassMongoUrl"):
             keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -276,6 +276,9 @@ class HarmonySubmitDeadline(
             "OPENPYPE_DEV",
             "OPENPYPE_LOG_NO_COLORS"
         ]
+        # Add mongo url if it's enabled
+        if self._instance.context.get("deadlinePassMongoUrl"):
+            keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **api.Session)

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -277,7 +277,7 @@ class HarmonySubmitDeadline(
             "OPENPYPE_LOG_NO_COLORS"
         ]
         # Add mongo url if it's enabled
-        if self._instance.context.get("deadlinePassMongoUrl"):
+        if self._instance.context.data.get("deadlinePassMongoUrl"):
             keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_remote_publish.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_remote_publish.py
@@ -105,15 +105,21 @@ class HoudiniSubmitPublishDeadline(pyblish.api.ContextPlugin):
                 # Clarify job name per submission (include instance name)
                 payload["JobInfo"]["Name"] = job_name + " - %s" % instance
                 self.submit_job(
-                    payload, instances=[instance], deadline=AVALON_DEADLINE
+                    context,
+                    payload,
+                    instances=[instance],
+                    deadline=AVALON_DEADLINE
                 )
         else:
             # Submit a single job
             self.submit_job(
-                payload, instances=instance_names, deadline=AVALON_DEADLINE
+                context,
+                payload,
+                instances=instance_names,
+                deadline=AVALON_DEADLINE
             )
 
-    def submit_job(self, payload, instances, deadline):
+    def submit_job(self, context, payload, instances, deadline):
 
         # Ensure we operate on a copy, a shallow copy is fine.
         payload = payload.copy()
@@ -125,6 +131,9 @@ class HoudiniSubmitPublishDeadline(pyblish.api.ContextPlugin):
             # similar environment using it, e.g. "houdini17.5;pluginx2.3"
             "AVALON_TOOLS",
         ]
+        # Add mongo url if it's enabled
+        if context.get("deadlinePassMongoUrl"):
+            keys.append("OPENPYPE_MONGO")
 
         environment = dict(
             {key: os.environ[key] for key in keys if key in os.environ},

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_remote_publish.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_remote_publish.py
@@ -132,7 +132,7 @@ class HoudiniSubmitPublishDeadline(pyblish.api.ContextPlugin):
             "AVALON_TOOLS",
         ]
         # Add mongo url if it's enabled
-        if context.get("deadlinePassMongoUrl"):
+        if context.data.get("deadlinePassMongoUrl"):
             keys.append("OPENPYPE_MONGO")
 
         environment = dict(

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -101,6 +101,10 @@ class HoudiniSubmitRenderDeadline(pyblish.api.InstancePlugin):
             # similar environment using it, e.g. "maya2018;vray4.x;yeti3.1.9"
             "AVALON_TOOLS",
         ]
+        # Add mongo url if it's enabled
+        if context.get("deadlinePassMongoUrl"):
+            keys.append("OPENPYPE_MONGO")
+
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **api.Session)
 

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -102,7 +102,7 @@ class HoudiniSubmitRenderDeadline(pyblish.api.InstancePlugin):
             "AVALON_TOOLS",
         ]
         # Add mongo url if it's enabled
-        if context.get("deadlinePassMongoUrl"):
+        if context.data.get("deadlinePassMongoUrl"):
             keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -499,7 +499,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             "OPENPYPE_LOG_NO_COLORS"
         ]
         # Add mongo url if it's enabled
-        if instance.context.get("deadlinePassMongoUrl"):
+        if instance.context.data.get("deadlinePassMongoUrl"):
             keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -498,6 +498,9 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             "OPENPYPE_DEV",
             "OPENPYPE_LOG_NO_COLORS"
         ]
+        # Add mongo url if it's enabled
+        if instance.context.get("deadlinePassMongoUrl"):
+            keys.append("OPENPYPE_MONGO")
 
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **api.Session)

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -249,6 +249,10 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             "TOOL_ENV",
             "FOUNDRY_LICENSE"
         ]
+        # Add mongo url if it's enabled
+        if instance.context.get("deadlinePassMongoUrl"):
+            keys.append("OPENPYPE_MONGO")
+
         # add allowed keys from preset if any
         if self.env_allowed_keys:
             keys += self.env_allowed_keys

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -250,7 +250,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             "FOUNDRY_LICENSE"
         ]
         # Add mongo url if it's enabled
-        if instance.context.get("deadlinePassMongoUrl"):
+        if instance.context.data.get("deadlinePassMongoUrl"):
             keys.append("OPENPYPE_MONGO")
 
         # add allowed keys from preset if any

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
@@ -227,6 +227,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         environment["OPENPYPE_USERNAME"] = instance.context.data["user"]
         environment["OPENPYPE_PUBLISH_JOB"] = "1"
         environment["OPENPYPE_RENDER_JOB"] = "0"
+        # Add mongo url if it's enabled
+        if instance.context.get("deadlinePassMongoUrl"):
+            mongo_url = os.environ.get("OPENPYPE_MONGO")
+            if mongo_url:
+                environment["OPENPYPE_MONGO"] = mongo_url
 
         args = [
             'publish',
@@ -273,18 +278,18 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         else:
             payload["JobInfo"]["JobDependency0"] = job["_id"]
 
-        i = 0
-        for index, key in enumerate(environment):
+        index = 0
+        for key in environment:
             if key.upper() in self.enviro_filter:
                 payload["JobInfo"].update(
                     {
                         "EnvironmentKeyValue%d"
-                        % i: "{key}={value}".format(
+                        % index: "{key}={value}".format(
                             key=key, value=environment[key]
                         )
                     }
                 )
-                i += 1
+                index += 1
 
         # remove secondary pool
         payload["JobInfo"].pop("SecondaryPool", None)

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_publish_job.py
@@ -228,7 +228,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         environment["OPENPYPE_PUBLISH_JOB"] = "1"
         environment["OPENPYPE_RENDER_JOB"] = "0"
         # Add mongo url if it's enabled
-        if instance.context.get("deadlinePassMongoUrl"):
+        if instance.context.data.get("deadlinePassMongoUrl"):
             mongo_url = os.environ.get("OPENPYPE_MONGO")
             if mongo_url:
                 environment["OPENPYPE_MONGO"] = mongo_url

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -1,6 +1,9 @@
 {
     "deadline_servers": [],
     "publish": {
+        "CollectDefaultDeadlineServer": {
+            "pass_mongo_url": false
+        },
         "ValidateExpectedFiles": {
             "enabled": true,
             "active": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -20,6 +20,19 @@
                 {
                     "type": "dict",
                     "collapsible": true,
+                    "key": "CollectDefaultDeadlineServer",
+                    "label": "Default Deadline Webservice",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "pass_mongo_url",
+                            "label": "Pass Mongo url to job"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
                     "key": "ValidateExpectedFiles",
                     "label": "Validate Expected Files",
                     "checkbox_key": "enabled",


### PR DESCRIPTION
## Brief description
Add option to pass mongo url to deadline job.

## Changes
- added attributes `pass_mongo_url` to `CollectDefaultDeadlineServer` plugin which is used in submitters to define if `OPENPYPE_MONGO` environment is passed to job environments

## Testing notes:
1. Trigger deadline publishing
2. The job (worker) should not need to have set mongo url in keyring or in global environments