### PR TITLE
hotfix: OIIO tool path - add extension on windows

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -34,11 +34,17 @@ def get_vendor_bin_path(bin_app):
 def get_oiio_tools_path(tool="oiiotool"):
     """Path to vendorized OpenImageIO tool executables.
 
+    On Window it adds .exe extension if missing from tool argument.
+
     Args:
         tool (string): Tool name (oiiotool, maketx, ...).
             Default is "oiiotool".
     """
     oiio_dir = get_vendor_bin_path("oiio")
+    if platform.system().lower() == "windows" and not tool.lower().endswith(
+        ".exe"
+    ):
+        tool = "{}.exe".format(tool)
     return os.path.join(oiio_dir, tool)
 
 


### PR DESCRIPTION
## Bug

`get_oiio_tools_path()` didn't take into account extension on windows. So trying to get path for `maketx` - returned path like `C:\foo\bar\oiio\bin\maketx` that is invalid on Windows because it should be `C:\foo\bar\oiio\bin\maketx.exe`. This PR is providing simple fix to add `.exe` on windows if it is missing. Note that it will not work for other executable files on windows, like shell scripts, and so on, but because this is strictly **OIIO tool** specific I don't see problem with it.

Without this fix, extracting looks from maya on windows will fail.