### PR TITLE
nuke: adding clear button to write nodes

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -761,7 +761,6 @@ def add_button_write_to_read(node):
     node.addKnob(knob)
 
 
-
 def add_button_clear_rendered(node, path):
     name = "clearRendered"
     label = "Clear Rendered"

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -753,11 +753,21 @@ def script_name():
 
 def add_button_write_to_read(node):
     name = "createReadNode"
-    label = "Create Read From Rendered"
+    label = "Read From Rendered"
     value = "import write_to_read;\
         write_to_read.write_to_read(nuke.thisNode(), allow_relative=False)"
     knob = nuke.PyScript_Knob(name, label, value)
     knob.clearFlag(nuke.STARTLINE)
+    node.addKnob(knob)
+
+
+
+def add_button_clear_rendered(node, path):
+    name = "clearRendered"
+    label = "Clear Rendered"
+    value = "import clear_rendered;\
+        clear_rendered.clear_rendered(\"{}\")".format(path)
+    knob = nuke.PyScript_Knob(name, label, value)
     node.addKnob(knob)
 
 
@@ -987,6 +997,9 @@ def create_write_node(name, data, input=None, prenodes=None,
 
     # adding write to read button
     add_button_write_to_read(GN)
+
+    # adding write to read button
+    add_button_clear_rendered(GN, os.path.dirname(fpath))
 
     # Deadline tab.
     add_deadline_tab(GN)

--- a/openpype/hosts/nuke/startup/clear_rendered.py
+++ b/openpype/hosts/nuke/startup/clear_rendered.py
@@ -1,0 +1,11 @@
+import os
+
+from openpype.api import Logger
+log = Logger().get_logger(__name__)
+
+
+def clear_rendered(dir_path):
+    for _f in os.listdir(dir_path):
+        _f_path = os.path.join(dir_path, _f)
+        log.info("Removing: `{}`".format(_f_path))
+        os.remove(_f_path)


### PR DESCRIPTION
## Brief description
User can use `Clear Rendered` on write node.

## Description
In case users need to remove all content of rendering folder, they can use clear button. 

## Testing notes:
1. open your testing workfile
2. in case render node is already created then remove it
3. create render/prerender node and notice `Clear Rendered` button
4. if in case you are sure some content in rendering folder exists then use the button and see that all will disapear.