### PR TITLE
Houdini: fix usd family in loader and integrators

### DIFF
--- a/openpype/hosts/houdini/plugins/load/load_usd_layer.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_layer.py
@@ -6,10 +6,7 @@ class USDSublayerLoader(api.Loader):
     """Sublayer USD file in Solaris"""
 
     families = [
-        "colorbleed.usd",
-        "colorbleed.pointcache",
-        "colorbleed.animation",
-        "colorbleed.camera",
+        "usd",
         "usdCamera",
     ]
     label = "Sublayer USD"

--- a/openpype/hosts/houdini/plugins/load/load_usd_reference.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_reference.py
@@ -6,10 +6,7 @@ class USDReferenceLoader(api.Loader):
     """Reference USD file in Solaris"""
 
     families = [
-        "colorbleed.usd",
-        "colorbleed.pointcache",
-        "colorbleed.animation",
-        "colorbleed.camera",
+        "usd",
         "usdCamera",
     ]
     label = "Reference USD"

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -100,7 +100,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 "redshiftproxy",
                 "effect",
                 "xgen",
-                "hda"
+                "hda",
+                "usd"
                 ]
     exclude_families = ["clip"]
     db_representation_context_keys = [


### PR DESCRIPTION
## Fix

This is just fixing `usd` family in loaders and integrators so publishing and loading works.