### PR TITLE
Photoshop add scriptmenu

### DIFF
--- a/openpype/hosts/photoshop/api/extension/index.html
+++ b/openpype/hosts/photoshop/api/extension/index.html
@@ -12,7 +12,7 @@
       }
       button {width: 100%;}
     </style>
-    
+
     <style>
       button {width: 100%;}
       body {margin:0; padding:0; height: 100%;}
@@ -20,7 +20,7 @@
     </style>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js">
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#workfiles-button").bind("click", function() {
@@ -31,7 +31,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#creator-button").bind("click", function() {
@@ -42,7 +42,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#loader-button").bind("click", function() {
@@ -53,7 +53,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#publish-button").bind("click", function() {
@@ -64,7 +64,18 @@
               });
             });
     </script>
-    
+
+    <script type=text/javascript>
+      $(function() {
+        $("a#studio-tools-button").bind("click", function() {
+          RPC.call('Photoshop.studio_tools_route').then(function (data) {
+          }, function (error) {
+              alert(error);
+          });
+        });
+      });
+    </script>
+
     <script type=text/javascript>
             $(function() {
               $("a#sceneinventory-button").bind("click", function() {
@@ -86,7 +97,7 @@
               });
             });
     </script>
-    
+
     <script type=text/javascript>
             $(function() {
               $("a#experimental-button").bind("click", function() {
@@ -102,16 +113,17 @@
   <script type="text/javascript" src="./client/wsrpc.js"></script>
   <script type="text/javascript" src="./client/CSInterface.js"></script>
   <script type="text/javascript" src="./client/loglevel.min.js"></script>
-  
+
   <!-- helper library for better debugging of .jsx check its license! -->
   <script type="text/javascript" src="./host/JSX.js"></script>
-  
+
   <script type="text/javascript" src="./client/client.js"></script>
-  
+
     <a href=# id=workfiles-button><button>Workfiles...</button></a>
     <a href=# id=creator-button><button>Create...</button></a>
     <a href=# id=loader-button><button>Load...</button></a>
     <a href=# id=publish-button><button>Publish...</button></a>
+    <a href=# id=studio-tools-button><button>Studio Tools...</button></a>
     <a href=# id=sceneinventory-button><button>Manage...</button></a>
     <a href=# id=subsetmanager-button><button>Subset Manager...</button></a>
     <a href=# id=experimental-button><button>Experimental Tools...</button></a>

--- a/openpype/hosts/photoshop/api/launch_logic.py
+++ b/openpype/hosts/photoshop/api/launch_logic.py
@@ -347,6 +347,9 @@ class PhotoshopRoute(WebSocketRoute):
     async def publish_route(self):
         self._tool_route("publish")
 
+    async def studio_tools_route(self):
+        self._tool_route("studio_tools")
+
     async def sceneinventory_route(self):
         self._tool_route("sceneinventory")
 

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -49,13 +49,13 @@
         "definition": [
             {
                 "type": "action",
-                "command": "import openpype.hosts.maya.api.commands as op_cmds; op_cmds.edit_shader_definitions()",
+                "command": "import sys; sys.stdout.write('Hello');",
                 "sourcetype": "python",
-                "title": "Edit shader name definitions",
-                "tooltip": "Edit shader name definitions used in validation and renaming.",
+                "title": "Example script",
+                "tooltip": "A polite example script",
                 "tags": [
                     "pipeline",
-                    "shader"
+                    "test"
                 ]
             }
         ]

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -44,6 +44,22 @@
             }
         }
     },
+    "scriptsmenu": {
+        "name": "OpenPype Tools",
+        "definition": [
+            {
+                "type": "action",
+                "command": "import openpype.hosts.maya.api.commands as op_cmds; op_cmds.edit_shader_definitions()",
+                "sourcetype": "python",
+                "title": "Edit shader name definitions",
+                "tooltip": "Edit shader name definitions used in validation and renaming.",
+                "tags": [
+                    "pipeline",
+                    "shader"
+                ]
+            }
+        ]
+    },
     "workfile_builder": {
         "create_first_version": false,
         "custom_templates": []

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -183,6 +183,10 @@
             ]
         },
         {
+            "type": "schema",
+            "name": "schema_photoshop_scriptsmenu"
+        },
+        {
             "type": "schema_template",
             "name": "template_workfile_options",
             "skip_paths": [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_photoshop_scriptsmenu.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_photoshop_scriptsmenu.json
@@ -1,0 +1,22 @@
+{
+  "type": "dict",
+  "collapsible": true,
+  "key": "scriptsmenu",
+  "label": "Scripts Menu Definition",
+  "children": [
+    {
+      "type": "text",
+      "key": "name",
+      "label": "Menu Name"
+    },
+    {
+      "type": "splitter"
+    },
+    {
+      "type": "raw-json",
+      "key": "definition",
+      "label": "Menu definition",
+      "is_list": true
+    }
+  ]
+}

--- a/openpype/tools/studio_tools/__init__.py
+++ b/openpype/tools/studio_tools/__init__.py
@@ -1,0 +1,9 @@
+from .app import (
+    StudioToolsDialog,
+    show
+)
+
+__all__ = [
+    "StudioToolsDialog",
+    "show"
+]

--- a/openpype/tools/studio_tools/app.py
+++ b/openpype/tools/studio_tools/app.py
@@ -1,8 +1,8 @@
 import sys
 import os
-import PySide2.QtCore as QtCore
-import PySide2.QtWidgets as QtWidgets
-from pyblish_pype import util
+from Qt import QtCore
+from Qt import QtWidgets
+from openpype import style
 from openpype.settings import get_project_settings
 from openpype.tools.utils import lib as tools_lib
 
@@ -19,14 +19,7 @@ class StudioToolsDialog(QtWidgets.QWidget):
         super(StudioToolsDialog, self).__init__(parent)
 
         self.resize(400, 300)
-        with open(util.get_asset("app.css")) as f:
-            css = f.read()
-
-        # Make relative paths absolute
-        root = util.get_asset("").replace("\\", "/")
-        css = css.replace("url(\"", "url(\"%s" % root)
-
-        self.setStyleSheet(css)
+        self.setStyleSheet(style.load_stylesheet())
 
         project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
         host = os.getenv("AVALON_APP")

--- a/openpype/tools/studio_tools/app.py
+++ b/openpype/tools/studio_tools/app.py
@@ -1,0 +1,100 @@
+import sys
+import os
+import PySide2.QtCore as QtCore
+import PySide2.QtWidgets as QtWidgets
+from pyblish_pype import util
+from openpype.settings import get_project_settings
+from avalon import api
+from openpype.tools.utils import lib as tools_lib
+
+import scriptsmenu
+import logging
+
+log = logging.getLogger(__name__)
+module = sys.modules[__name__]
+module.window = None
+
+class StudioToolsDialog(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super(StudioToolsDialog, self).__init__(parent)
+
+        self.resize(400, 300)
+        with open(util.get_asset("app.css")) as f:
+            css = f.read()
+
+        # Make relative paths absolute
+        root = util.get_asset("").replace("\\", "/")
+        css = css.replace("url(\"", "url(\"%s" % root)
+
+        self.setStyleSheet(css)
+
+        project_settings = get_project_settings(os.getenv("AVALON_PROJECT"))
+        host = os.getenv("AVALON_APP")
+        config = project_settings[host]["scriptsmenu"]["definition"]
+        _menu = project_settings[host]["scriptsmenu"]["name"]
+        self.setWindowTitle(_menu)
+
+        title = _menu.title()
+        objectName = _menu.title().lower().replace(" ", "_")
+
+        layout = QtWidgets.QVBoxLayout()
+
+        try:
+            log.info("Attempting to build menu ...")
+            object_name = objectName or title.lower()
+            menu = scriptsmenu.ScriptsMenu(title=title,
+                                        parent=parent,
+                                        objectName=object_name)
+            layout.addWidget(menu)
+            menu.aboutToHide.connect(menu.show) #IF menu try to hide -> Don't
+        except Exception as e:
+            log.error(e)
+            return
+        finally:
+            self.setLayout(layout)
+
+        # apply configuration
+        self.layout = layout
+        menu.build_from_configuration(menu, config)
+        self.menu = menu
+
+def show(debug=False, parent=None):
+    """Display Loader GUI
+
+    Arguments:
+        debug (bool, optional): Run loader in debug-mode,
+            defaults to False
+        parent (QtCore.QObject, optional): The Qt object to parent to.
+        use_context (bool): Whether to apply the current context upon launch
+
+    """
+    # Remember window
+    if module.window is not None:
+        try:
+            module.window.show()
+
+            # If the window is minimized then unminimize it.
+            if module.window.windowState() & QtCore.Qt.WindowMinimized:
+                module.window.setWindowState(QtCore.Qt.WindowActive)
+
+            # Raise and activate the window
+            module.window.raise_()             # for MacOS
+            module.window.activateWindow()     # for Windows
+            module.window.refresh()
+            return
+        except RuntimeError as e:
+            if not e.message.rstrip().endswith("already deleted."):
+                raise
+
+            # Garbage collected
+            module.window = None
+
+    if debug:
+        import traceback
+        sys.excepthook = lambda typ, val, tb: traceback.print_last()
+
+    with tools_lib.qt_app_context():
+        window = StudioToolsDialog(parent)
+        window.show()
+
+        module.window = window

--- a/openpype/tools/studio_tools/app.py
+++ b/openpype/tools/studio_tools/app.py
@@ -4,7 +4,6 @@ import PySide2.QtCore as QtCore
 import PySide2.QtWidgets as QtWidgets
 from pyblish_pype import util
 from openpype.settings import get_project_settings
-from avalon import api
 from openpype.tools.utils import lib as tools_lib
 
 import scriptsmenu
@@ -13,6 +12,7 @@ import logging
 log = logging.getLogger(__name__)
 module = sys.modules[__name__]
 module.window = None
+
 
 class StudioToolsDialog(QtWidgets.QWidget):
     def __init__(self, parent=None):
@@ -43,10 +43,10 @@ class StudioToolsDialog(QtWidgets.QWidget):
             log.info("Attempting to build menu ...")
             object_name = objectName or title.lower()
             menu = scriptsmenu.ScriptsMenu(title=title,
-                                        parent=parent,
-                                        objectName=object_name)
+                                           parent=parent,
+                                           objectName=object_name)
             layout.addWidget(menu)
-            menu.aboutToHide.connect(menu.show) #IF menu try to hide -> Don't
+            menu.aboutToHide.connect(menu.show)  # IF menu try to hide -> Don't
         except Exception as e:
             log.error(e)
             return
@@ -57,6 +57,7 @@ class StudioToolsDialog(QtWidgets.QWidget):
         self.layout = layout
         menu.build_from_configuration(menu, config)
         self.menu = menu
+
 
 def show(debug=False, parent=None):
     """Display Loader GUI

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -30,6 +30,7 @@ class HostToolsHelper:
         self._library_loader_tool = None
         self._look_assigner_tool = None
         self._experimental_tools_dialog = None
+        self._studio_tools_dialog = None
 
     @property
     def log(self):
@@ -247,6 +248,24 @@ class HostToolsHelper:
             dialog.raise_()
             dialog.activateWindow()
 
+    def get_studio_tools_dialog(self, parent=None):
+        if self._studio_tools_dialog is None:
+            from openpype.tools.studio_tools import (
+                StudioToolsDialog
+            )
+
+            self._studio_tools_dialog = StudioToolsDialog(parent)
+        return self._studio_tools_dialog
+
+    def show_studio_tools_dialog(self, parent=None):
+        """Show dialog with experimental tools."""
+        with qt_app_context():
+            dialog = self.get_studio_tools_dialog(parent)
+
+            dialog.show()
+            dialog.raise_()
+            dialog.activateWindow()
+
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.
 
@@ -278,6 +297,9 @@ class HostToolsHelper:
 
         elif tool_name == "experimental_tools":
             return self.get_experimental_tools_dialog(parent, *args, **kwargs)
+
+        elif tool_name == "studio_tools":
+            return self.get_studio_tools_dialog(parent, *args, **kwargs)
 
         else:
             self.log.warning(
@@ -315,6 +337,9 @@ class HostToolsHelper:
 
         elif tool_name == "experimental_tools":
             self.show_experimental_tools_dialog(parent, *args, **kwargs)
+
+        elif tool_name == "studio_tools":
+            self.show_studio_tools_dialog(parent, *args, **kwargs)
 
         else:
             self.log.warning(


### PR DESCRIPTION
## Brief description
Add a scriptable menu to photoshop using settings

## Description
Used Colorbleed's Scriptmenu with photoshop extension to add a menu parametrizable from openpype settings.

## Testing notes:
1. To test this branch, first sign the photoshop extension (in openpype>hosts>photoshop>api>extension) with ZXP Command
2. Install extension using Anastasyi
3. Edit settings in : StudioSettings > Project > *Your project* > Photoshop > Script menu definition
4. try it on photoshop