### PR TITLE
Fix open workfile on launch in photoshop

### DIFF
--- a/openpype/hosts/photoshop/api/lib.py
+++ b/openpype/hosts/photoshop/api/lib.py
@@ -2,7 +2,7 @@ import os
 import sys
 import contextlib
 import traceback
-import ast
+
 from Qt import QtWidgets
 
 import avalon.api
@@ -10,6 +10,7 @@ import avalon.api
 from openpype.api import Logger
 from openpype.tools.utils import host_tools
 from openpype.lib.remote_publish import headless_publish
+from openpype.lib import env_value_to_bool
 
 from .launch_logic import ProcessLauncher, stub
 
@@ -34,21 +35,19 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
-    if os.environ.get("HEADLESS_PUBLISH"):
+    if env_value_to_bool("HEADLESS_PUBLISH"):
         launcher.execute_in_main_thread(
             headless_publish,
             log,
             "ClosePS",
             os.environ.get("IS_TEST")
         )
-    elif ast.literal_eval(
-            os.getenv("AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH", True)):
-        save = False
-        if os.getenv("WORKFILES_SAVE_AS"):
-            save = True
+    elif env_value_to_bool("AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH",
+                           default=True):
 
         launcher.execute_in_main_thread(
-            host_tools.show_workfiles, save=save
+            host_tools.show_workfiles,
+            save=env_value_to_bool("WORKFILES_SAVE_AS")
         )
 
     sys.exit(app.exec_())

--- a/openpype/hosts/photoshop/api/lib.py
+++ b/openpype/hosts/photoshop/api/lib.py
@@ -2,7 +2,7 @@ import os
 import sys
 import contextlib
 import traceback
-
+import ast
 from Qt import QtWidgets
 
 import avalon.api
@@ -41,7 +41,8 @@ def main(*subprocess_args):
             "ClosePS",
             os.environ.get("IS_TEST")
         )
-    elif os.environ.get("AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH", True):
+    elif ast.literal_eval(
+            os.getenv("AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH", True)):
         save = False
         if os.getenv("WORKFILES_SAVE_AS"):
             save = True


### PR DESCRIPTION
Fixed AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH environment variable not being retrieved correctly.