### PR TITLE
TVPaint: Image loaders also work on review family

### DIFF
--- a/openpype/hosts/tvpaint/plugins/load/load_image.py
+++ b/openpype/hosts/tvpaint/plugins/load/load_image.py
@@ -5,7 +5,7 @@ from openpype.hosts.tvpaint.api import lib, plugin
 class ImportImage(plugin.Loader):
     """Load image or image sequence to TVPaint as new layer."""
 
-    families = ["render", "image", "background", "plate"]
+    families = ["render", "image", "background", "plate", "review"]
     representations = ["*"]
 
     label = "Import Image"

--- a/openpype/hosts/tvpaint/plugins/load/load_reference_image.py
+++ b/openpype/hosts/tvpaint/plugins/load/load_reference_image.py
@@ -7,7 +7,7 @@ from openpype.hosts.tvpaint.api import lib, pipeline, plugin
 class LoadImage(plugin.Loader):
     """Load image or image sequence to TVPaint as new layer."""
 
-    families = ["render", "image", "background", "plate"]
+    families = ["render", "image", "background", "plate", "review"]
     representations = ["*"]
 
     label = "Load Image"


### PR DESCRIPTION
## Brief description
It is not possible to import/load review family in TVPaint.

## Changes
- image import and reference loaders can load `review` families