### PR TITLE
WebPublisher: fix instance duplicates

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_remote_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_remote_instances.py
@@ -60,6 +60,10 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
         instance_names = []
         for layer in layers:
             self.log.debug("Layer:: {}".format(layer))
+            if layer.parents:
+                self.log.debug("!!! Not a top layer, skip")
+                continue
+
             resolved_family, resolved_subset_template = self._resolve_mapping(
                 layer
             )
@@ -69,10 +73,6 @@ class CollectRemoteInstances(pyblish.api.ContextPlugin):
 
             if not resolved_subset_template or not resolved_family:
                 self.log.debug("!!! Not found family or template, skip")
-                continue
-
-            if layer.parents:
-                self.log.debug("!!! Not a top layer, skip")
                 continue
 
             fill_pairs = {

--- a/openpype/hosts/photoshop/plugins/publish/validate_unique_subsets.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_unique_subsets.py
@@ -1,3 +1,4 @@
+import collections
 import pyblish.api
 import openpype.api
 
@@ -16,11 +17,16 @@ class ValidateSubsetUniqueness(pyblish.api.ContextPlugin):
         subset_names = []
 
         for instance in context:
+            self.log.info("instance:: {}".format(instance.data))
             if instance.data.get('publish'):
                 subset_names.append(instance.data.get('subset'))
 
+        non_unique = \
+            [item
+             for item, count in collections.Counter(subset_names).items()
+             if count > 1]
         msg = (
-            "Instance subset names are not unique. " +
-            "Remove duplicates via SubsetManager."
+            "Instance subset names {} are not unique. " +
+            "Remove duplicates via SubsetManager.".format(non_unique)
         )
-        assert len(subset_names) == len(set(subset_names)), msg
+        assert not non_unique, msg

--- a/openpype/hosts/photoshop/plugins/publish/validate_unique_subsets.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_unique_subsets.py
@@ -25,8 +25,6 @@ class ValidateSubsetUniqueness(pyblish.api.ContextPlugin):
             [item
              for item, count in collections.Counter(subset_names).items()
              if count > 1]
-        msg = (
-            "Instance subset names {} are not unique. " +
-            "Remove duplicates via SubsetManager.".format(non_unique)
-        )
+        msg = ("Instance subset names {} are not unique. ".format(non_unique) +
+               "Remove duplicates via SubsetManager.")
         assert not non_unique, msg

--- a/openpype/lib/remote_publish.py
+++ b/openpype/lib/remote_publish.py
@@ -136,6 +136,7 @@ def publish_and_log(dbcon, _id, log, close_plugin_name=None, batch_id=None):
             if close_plugin:  # close host app explicitly after error
                 context = pyblish.api.Context()
                 close_plugin().process(context)
+            return
         elif processed % log_every == 0:
             # pyblish returns progress in 0.0 - 2.0
             progress = min(round(result["progress"] / 2 * 100), 99)

--- a/openpype/lib/remote_publish.py
+++ b/openpype/lib/remote_publish.py
@@ -88,7 +88,6 @@ def publish(log, close_plugin_name=None):
             if close_plugin:  # close host app explicitly after error
                 context = pyblish.api.Context()
                 close_plugin().process(context)
-            sys.exit(1)
 
 
 def publish_and_log(dbcon, _id, log, close_plugin_name=None, batch_id=None):
@@ -137,7 +136,6 @@ def publish_and_log(dbcon, _id, log, close_plugin_name=None, batch_id=None):
             if close_plugin:  # close host app explicitly after error
                 context = pyblish.api.Context()
                 close_plugin().process(context)
-            sys.exit(1)
         elif processed % log_every == 0:
             # pyblish returns progress in 0.0 - 2.0
             progress = min(round(result["progress"] / 2 * 100), 99)

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -251,7 +251,10 @@ class PypeCommands:
 
         data = {
             "last_workfile_path": workfile_path,
-            "start_last_workfile": True
+            "start_last_workfile": True,
+            "project_name": project,
+            "asset_name": asset,
+            "task_name": task_name
         }
 
         launched_app = application_manager.launch(app_name, **data)


### PR DESCRIPTION
## Brief description
In rare cases of existing created subset in the workfile validation of subset uniqueness could fail.

## Description
Added skip condition if subset was already created.

## Testing notes:
1. Prepare workfile that contains created instance in metadata with subset name that would be created after `CollectRemoteInstances`
2. Publish it through WP