### PR TITLE
Maya: Refactor/Cleanup Create Render, Render Settigns and Render Products

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -80,6 +80,13 @@ IMAGE_PREFIXES = {
 }
 
 
+def has_tokens(string, tokens):
+    """Return whether any of tokens is in input string (case-insensitive)"""
+    pattern = "({})".format("|".join(re.escape(token) for token in tokens))
+    match = re.search(pattern, string, re.IGNORECASE)
+    return bool(match)
+
+
 @attr.s
 class LayerMetadata(object):
     """Data class for Render Layer metadata."""
@@ -950,7 +957,11 @@ class RenderProductsRedshift(ARenderProducts):
 
         """
         prefix = super(RenderProductsRedshift, self).get_renderer_prefix()
-        prefix = "{}.<aov>".format(prefix)
+
+        # Only append .<aov> if no <renderpass> or <aov> is specified
+        if not has_tokens(prefix, ["<aov>", "<renderpass>"]):
+            prefix = "{}.<aov>".format(prefix)
+
         return prefix
 
     def get_render_products(self):

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -720,6 +720,8 @@ class RenderProductsVray(ARenderProducts):
         return prefix
 
     def _get_aov_separator(self):
+        # type: () -> str
+        """Return the V-Ray AOV/Render Elements separator"""
         return self._get_attr(
             "vraySettings.fileNameRenderElementSeparator"
         )

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -284,10 +284,10 @@ class CreateRender(plugin.Creator):
             rs = renderSetup.instance()
             layers = rs.getRenderLayers()
             if use_selection:
-                print(">>> processing existing layers")
+                self.log.info("Processing existing layers")
                 sets = []
                 for layer in layers:
-                    print("  - creating set for {}:{}".format(
+                    self.log.info("  - creating set for {}:{}".format(
                         namespace, layer.name()))
                     render_set = cmds.sets(
                         n="{}:{}".format(namespace, layer.name()))
@@ -301,6 +301,7 @@ class CreateRender(plugin.Creator):
                 collection = render_layer.createCollection("defaultCollection")
                 collection.getSelector().setPattern('*')
 
+            self.log.info("Applying default render settings..")
             RenderSettings.apply_defaults()
         return self.instance
 

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -52,7 +52,14 @@ class RenderSettings(object):
         self._project_settings = project_settings
 
     @staticmethod
-    def apply_defaults(renderer, project_settings=None):
+    def apply_defaults(renderer=None, project_settings=None):
+        if renderer is None:
+            renderer = cmds.getAttr(
+                'defaultRenderGlobals.currentRenderer').lower()
+            # handle various renderman names
+            if renderer.startswith('renderman'):
+                renderer = 'renderman'
+
         if project_settings is None:
             project_settings = get_project_settings(Session["AVALON_PROJECT"])
 
@@ -294,13 +301,7 @@ class CreateRender(plugin.Creator):
                 collection = render_layer.createCollection("defaultCollection")
                 collection.getSelector().setPattern('*')
 
-            renderer = cmds.getAttr(
-                'defaultRenderGlobals.currentRenderer').lower()
-            # handle various renderman names
-            if renderer.startswith('renderman'):
-                renderer = 'renderman'
-
-            RenderSettings.apply_defaults(renderer)
+            RenderSettings.apply_defaults()
         return self.instance
 
     def _deadline_webservice_changed(self):

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -281,16 +281,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             self.log.info("collecting layer: {}".format(layer_name))
             # Get layer specific settings, might be overrides
 
-            try:
-                aov_separator = self._aov_chars[(
-                    context.data["project_settings"]
-                    ["create"]
-                    ["CreateRender"]
-                    ["aov_separator"]
-                )]
-            except KeyError:
-                aov_separator = "_"
-
             data = {
                 "subset": expected_layer_name,
                 "attachTo": attach_to,

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -49,7 +49,8 @@ import maya.app.renderSetup.model.renderSetup as renderSetup
 
 import pyblish.api
 
-from avalon import maya, api
+import avalon.maya
+from avalon import api
 from openpype.hosts.maya.api.lib_renderproducts import get as get_layer_render_products  # noqa: E501
 from openpype.hosts.maya.api import lib
 
@@ -352,16 +353,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                         instance.data["version"] = context.data["version"]
 
             # Apply each user defined attribute as data
-            for attr in cmds.listAttr(layer, userDefined=True) or list():
-                try:
-                    value = cmds.getAttr("{}.{}".format(layer, attr))
-                except Exception:
-                    # Some attributes cannot be read directly,
-                    # such as mesh and color attributes. These
-                    # are considered non-essential to this
-                    # particular publishing pipeline.
-                    value = None
-
+            for attr, value in avalon.maya.read(layer).items():
                 data[attr] = value
 
             # handle standalone renderers
@@ -401,7 +393,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             dict: only overrides with values
 
         """
-        attributes = maya.read(render_globals)
+        attributes = avalon.maya.read(render_globals)
 
         options = {"renderGlobals": {}}
         options["renderGlobals"]["Priority"] = attributes["priority"]

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -135,22 +135,21 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 self.log.warning(msg)
                 continue
 
-            # test if there are sets (subsets) to attach render to
+            # detect if there are sets (subsets) to attach render to
             sets = cmds.sets(layer, query=True) or []
             attach_to = []
-            if sets:
-                for s in sets:
-                    if "family" not in cmds.listAttr(s):
-                        continue
+            for s in sets:
+                if not cmds.attributeQuery("family", node=s, exists=True):
+                    continue
 
-                    attach_to.append(
-                        {
-                            "version": None,  # we need integrator for that
-                            "subset": s,
-                            "family": cmds.getAttr("{}.family".format(s)),
-                        }
-                    )
-                    self.log.info(" -> attach render to: {}".format(s))
+                attach_to.append(
+                    {
+                        "version": None,  # we need integrator for that
+                        "subset": s,
+                        "family": cmds.getAttr("{}.family".format(s)),
+                    }
+                )
+                self.log.info(" -> attach render to: {}".format(s))
 
             layer_name = "rs_{}".format(expected_layer_name)
 

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -160,22 +160,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             if renderer.startswith("renderman"):
                 renderer = "renderman"
 
-            try:
-                aov_separator = self._aov_chars[(
-                    context.data["project_settings"]
-                    ["create"]
-                    ["CreateRender"]
-                    ["aov_separator"]
-                )]
-            except KeyError:
-                aov_separator = "_"
-
-            render_instance.data["aovSeparator"] = aov_separator
-
             # return all expected files for all cameras and aovs in given
             # frame range
-            layer_render_products = get_layer_render_products(
-                layer_name, render_instance)
+            layer_render_products = get_layer_render_products(layer_name)
             render_products = layer_render_products.layer_data.products
             assert render_products, "no render products generated"
             exp_files = []

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -215,6 +215,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     full_paths.append(full_path)
                     publish_meta_path = os.path.dirname(full_path)
                 aov_dict[aov.keys()[0]] = full_paths
+            full_exp_files.append(aov_dict)
 
             frame_start_render = int(self.get_render_attribute(
                 "startFrame", layer=layer_name))
@@ -237,8 +238,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 frame_end = frame_end_render
                 frame_start_handle = frame_start_render
                 frame_end_handle = frame_end_render
-
-            full_exp_files.append(aov_dict)
 
             # find common path to store metadata
             # so if image prefix is branching to many directories

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -104,13 +104,12 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
 
         if deadline_settings["enabled"]:
             deadline_url = render_instance.data.get("deadlineUrl")
-        self._rs = renderSetup.instance()
-        current_layer = self._rs.getVisibleRenderLayer()
-        maya_render_layers = {
-            layer.name(): layer for layer in self._rs.getRenderLayers()
-        }
 
-        self.maya_layers = maya_render_layers
+        # Retrieve render setup layers
+        rs = renderSetup.instance()
+        maya_render_layers = {
+            layer.name(): layer for layer in rs.getRenderLayers()
+        }
 
         for layer in collected_render_layers:
             try:
@@ -472,10 +471,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             pool_b = None
 
         return pool_a, pool_b
-
-    def _get_overrides(self, layer):
-        rset = self.maya_layers[layer].renderSettingsCollectionInstance()
-        return rset.getOverrides()
 
     @staticmethod
     def get_render_attribute(attr, layer):

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -155,9 +155,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             layer_name = "rs_{}".format(expected_layer_name)
 
             # collect all frames we are expecting to be rendered
-            renderer = cmds.getAttr(
-                "defaultRenderGlobals.currentRenderer"
-            ).lower()
+            renderer = self.get_render_attribute("currentRenderer",
+                                                 layer=layer_name)
             # handle various renderman names
             if renderer.startswith("renderman"):
                 renderer = "renderman"

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -310,8 +310,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "byFrameStep": int(
                     self.get_render_attribute("byFrameStep",
                                               layer=layer_name)),
-                "renderer": self.get_render_attribute("currentRenderer",
-                                                      layer=layer_name),
+                "renderer": renderer,
                 # instance subset
                 "family": "renderlayer",
                 "families": ["renderlayer"],

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -71,7 +71,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
     def process(self, context):
         """Entry point to collector."""
         render_instance = None
-        deadline_url = None
 
         for instance in context:
             if "rendering" in instance.data["families"]:
@@ -94,16 +93,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
         filepath = context.data["currentFile"].replace("\\", "/")
         asset = api.Session["AVALON_ASSET"]
         workspace = context.data["workspaceDir"]
-
-        deadline_settings = (
-            context.data
-            ["system_settings"]
-            ["modules"]
-            ["deadline"]
-        )
-
-        if deadline_settings["enabled"]:
-            deadline_url = render_instance.data.get("deadlineUrl")
 
         # Retrieve render setup layers
         rs = renderSetup.instance()
@@ -348,8 +337,12 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "aovSeparator": aov_separator
             }
 
-            if deadline_url:
-                data["deadlineUrl"] = deadline_url
+            # Collect Deadline url if Deadline module is enabled
+            deadline_settings = (
+                context.data["system_settings"]["modules"]["deadline"]
+            )
+            if deadline_settings["enabled"]:
+                data["deadlineUrl"] = render_instance.data.get("deadlineUrl")
 
             if self.sync_workfile_version:
                 data["version"] = context.data["version"]


### PR DESCRIPTION
## Brief description

As #2640 PR just opened I thought it'd be good to also open this as a draft PR. Some of the things in this PR somewhat align with changes implemented in that PR.

What this PR does:
- Don't force separator from OP settings into the filepath, but actually retrieve it from the render settigns in the current scene. This would fix #2636
- Work towards `lib_renderproducts` detecting the `aov_separator` so we could add a validator for it.
- Cleanup/simplify CreateRender logic - by removing some duplicated code, using available library functions, moving logic closer together, etc.
- Creates functionality for "RenderSettings" separately from Create Render - because I'd like to also be able to 'set the render defaults' without requiring to create a render instance. We tend to have multiple renderers used on a project in a scene, and each of those layers would have to get the defaults applied correctly. I'd personally opt for having it removed from `CreateRender` and pushed somewhere else. E.g. add it to the top menu for artists `OpenPype > Set Default Render settings for current renderer` and also add a Validator that actually ensures the output is valid for the current project.

@antirotor - it could be worth investigating how we could either join the effort, or have one step back and push the other step first with a higher priority. The issues we're facing with rendering currently are getting in the way of our current production so would love to tackle this somewhat soon and actually fix and validate our production cases. :)