### PR TITLE
WebPublisher: Updated Settings

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/collect_batch_data.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_batch_data.py
@@ -59,6 +59,7 @@ class CollectBatchData(pyblish.api.ContextPlugin):
         context.data["asset"] = asset_name
         context.data["task"] = task_name
         context.data["taskType"] = task_type
+        context.data["project_name"] = project_name
 
         self._set_ctx_path(batch_data)
 

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -13,8 +13,10 @@ import tempfile
 from avalon import io
 import pyblish.api
 from openpype.lib import prepare_template_data
-from openpype.lib.plugin_tools import parse_json
-
+from openpype.lib.plugin_tools import (
+    parse_json,
+    get_subset_name_with_asset_doc
+)
 
 class CollectPublishedFiles(pyblish.api.ContextPlugin):
     """
@@ -47,8 +49,13 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
         self.log.info("task_sub:: {}".format(task_subfolders))
 
         asset_name = context.data["asset"]
+        asset_doc = io.find_one({
+            "type": "asset",
+            "name": asset_name
+        })
         task_name = context.data["task"]
         task_type = context.data["taskType"]
+        project_name = context.data["project_name"]
         for task_dir in task_subfolders:
             task_data = parse_json(os.path.join(task_dir,
                                                 "manifest.json"))
@@ -57,20 +64,21 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
             is_sequence = len(task_data["files"]) > 1
 
             _, extension = os.path.splitext(task_data["files"][0])
-            family, families, subset_template, tags = self._get_family(
+            family, families, tags = self._get_family(
                 self.task_type_to_family,
                 task_type,
                 is_sequence,
                 extension.replace(".", ''))
 
-            subset = self._get_subset_name(
-                family, subset_template, task_name, task_data["variant"]
+            subset_name = get_subset_name_with_asset_doc(
+                family, task_data["variant"], task_name, asset_doc,
+                project_name=project_name, host_name="webpublisher"
             )
-            version = self._get_last_version(asset_name, subset) + 1
+            version = self._get_last_version(asset_name, subset_name) + 1
 
-            instance = context.create_instance(subset)
+            instance = context.create_instance(subset_name)
             instance.data["asset"] = asset_name
-            instance.data["subset"] = subset
+            instance.data["subset"] = subset_name
             instance.data["family"] = family
             instance.data["families"] = families
             instance.data["version"] = version
@@ -149,7 +157,7 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
                 extension (str): without '.'
 
             Returns:
-                (family, [families], subset_template_name, tags) tuple
+                (family, [families], tags) tuple
                 AssertionError if not matching family found
         """
         task_type = task_type.lower()
@@ -184,7 +192,6 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
 
         return (found_family,
                 config["families"],
-                config["subset_template_name"],
                 config["tags"])
 
     def _get_last_version(self, asset_name, subset_name):

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -359,12 +359,20 @@ class ConfiguredExtensionsEndpoint(_RestApiEndpoint):
             "studio_exts": set(["psd", "psb", "tvpp", "tvp"])
         }
         collect_conf = sett["webpublisher"]["publish"]["CollectPublishedFiles"]
-        for _, mapping in collect_conf.get("task_type_to_family", {}).items():
-            for _family, config in mapping.items():
-                if config["is_sequence"]:
-                    configured["sequence_exts"].update(config["extensions"])
-                else:
-                    configured["file_exts"].update(config["extensions"])
+        configs = collect_conf.get("task_type_to_family", [])
+        mappings = []
+        if isinstance(configs, dict):  # backward compatibility, remove soon
+            # mappings = [mapp for mapp in configs.values() if mapp]
+            for _, conf_mappings in configs.items():
+                for conf_mapping in conf_mappings:
+                    mappings.append(conf_mapping)
+        else:
+            mappings = configs
+        for mapping in mappings:
+            if mapping["is_sequence"]:
+                configured["sequence_exts"].update(mapping["extensions"])
+            else:
+                configured["file_exts"].update(mapping["extensions"])
 
         return Response(
             status=200,

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -361,13 +361,12 @@ class ConfiguredExtensionsEndpoint(_RestApiEndpoint):
         collect_conf = sett["webpublisher"]["publish"]["CollectPublishedFiles"]
         configs = collect_conf.get("task_type_to_family", [])
         mappings = []
-        if isinstance(configs, dict):  # backward compatibility, remove soon
-            # mappings = [mapp for mapp in configs.values() if mapp]
-            for _, conf_mappings in configs.items():
-                for conf_mapping in conf_mappings:
-                    mappings.append(conf_mapping)
-        else:
-            mappings = configs
+        for _, conf_mappings in configs.items():
+            if isinstance(conf_mappings, dict):
+                conf_mappings = conf_mappings.values()
+            for conf_mapping in conf_mappings:
+                mappings.append(conf_mapping)
+
         for mapping in mappings:
             if mapping["is_sequence"]:
                 configured["sequence_exts"].update(mapping["extensions"])

--- a/openpype/settings/defaults/project_settings/webpublisher.json
+++ b/openpype/settings/defaults/project_settings/webpublisher.json
@@ -10,8 +10,7 @@
                         ],
                         "families": [],
                         "tags": [],
-                        "result_family": "workfile",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "workfile"
                     },
                     {
                         "is_sequence": true,
@@ -27,8 +26,7 @@
                         "tags": [
                             "review"
                         ],
-                        "result_family": "render",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "render"
                     }
                 ],
                 "Compositing": [
@@ -39,8 +37,7 @@
                         ],
                         "families": [],
                         "tags": [],
-                        "result_family": "workfile",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "workfile"
                     },
                     {
                         "is_sequence": true,
@@ -56,8 +53,7 @@
                         "tags": [
                             "review"
                         ],
-                        "result_family": "render",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "render"
                     }
                 ],
                 "Layout": [
@@ -68,8 +64,7 @@
                         ],
                         "families": [],
                         "tags": [],
-                        "result_family": "workfile",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "workfile"
                     },
                     {
                         "is_sequence": false,
@@ -86,8 +81,7 @@
                         "tags": [
                             "review"
                         ],
-                        "result_family": "image",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "image"
                     }
                 ],
                 "default_task_type": [
@@ -99,8 +93,7 @@
                         ],
                         "families": [],
                         "tags": [],
-                        "result_family": "workfile",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "workfile"
                     },
                     {
                         "is_sequence": true,
@@ -116,8 +109,7 @@
                         "tags": [
                             "review"
                         ],
-                        "result_family": "render",
-                        "subset_template_name": "{family}{Variant}"
+                        "result_family": "render"
                     }
                 ],
                 "__dynamic_keys_labels__": {

--- a/openpype/settings/defaults/project_settings/webpublisher.json
+++ b/openpype/settings/defaults/project_settings/webpublisher.json
@@ -2,17 +2,18 @@
     "publish": {
         "CollectPublishedFiles": {
             "task_type_to_family": {
-                "Animation": {
-                    "workfile": {
+                "Animation": [
+                    {
                         "is_sequence": false,
                         "extensions": [
                             "tvp"
                         ],
                         "families": [],
                         "tags": [],
-                        "subset_template_name": ""
+                        "result_family": "workfile",
+                        "subset_template_name": "{family}{Variant}"
                     },
-                    "render": {
+                    {
                         "is_sequence": true,
                         "extensions": [
                             "png",
@@ -26,20 +27,22 @@
                         "tags": [
                             "review"
                         ],
-                        "subset_template_name": ""
+                        "result_family": "render",
+                        "subset_template_name": "{family}{Variant}"
                     }
-                },
-                "Compositing": {
-                    "workfile": {
+                ],
+                "Compositing": [
+                    {
                         "is_sequence": false,
                         "extensions": [
                             "aep"
                         ],
                         "families": [],
                         "tags": [],
-                        "subset_template_name": ""
+                        "result_family": "workfile",
+                        "subset_template_name": "{family}{Variant}"
                     },
-                    "render": {
+                    {
                         "is_sequence": true,
                         "extensions": [
                             "png",
@@ -53,20 +56,22 @@
                         "tags": [
                             "review"
                         ],
-                        "subset_template_name": ""
+                        "result_family": "render",
+                        "subset_template_name": "{family}{Variant}"
                     }
-                },
-                "Layout": {
-                    "workfile": {
+                ],
+                "Layout": [
+                    {
                         "is_sequence": false,
                         "extensions": [
                             "psd"
                         ],
                         "families": [],
                         "tags": [],
-                        "subset_template_name": ""
+                        "result_family": "workfile",
+                        "subset_template_name": "{family}{Variant}"
                     },
-                    "image": {
+                    {
                         "is_sequence": false,
                         "extensions": [
                             "png",
@@ -81,20 +86,23 @@
                         "tags": [
                             "review"
                         ],
-                        "subset_template_name": ""
+                        "result_family": "image",
+                        "subset_template_name": "{family}{Variant}"
                     }
-                },
-                "default_task_type": {
-                    "workfile": {
+                ],
+                "default_task_type": [
+                    {
                         "is_sequence": false,
                         "extensions": [
-                            "tvp"
+                            "tvp",
+                            "psd"
                         ],
                         "families": [],
                         "tags": [],
+                        "result_family": "workfile",
                         "subset_template_name": "{family}{Variant}"
                     },
-                    "render": {
+                    {
                         "is_sequence": true,
                         "extensions": [
                             "png",
@@ -108,9 +116,10 @@
                         "tags": [
                             "review"
                         ],
+                        "result_family": "render",
                         "subset_template_name": "{family}{Variant}"
                     }
-                },
+                ],
                 "__dynamic_keys_labels__": {
                     "default_task_type": "Default task type"
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
@@ -24,10 +24,10 @@
                             "label": "Task type to family mapping",
                             "collapsible_key": true,
                             "object_type": {
-                                "type": "dict-modifiable",
-                                "collapsible": false,
+                                "type": "list",
+                                "collapsible": true,
                                 "key": "task_type",
-                                "collapsible_key": false,
+                                "collapsible_key": true,
                                 "object_type": {
                                     "type": "dict",
                                     "children": [
@@ -51,6 +51,14 @@
                                         {
                                             "type": "schema",
                                             "name": "schema_representation_tags"
+                                        },
+                                        {
+                                            "type": "separator"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "key": "result_family",
+                                            "label": "Resulting family"
                                         },
                                         {
                                             "type": "text",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
@@ -59,11 +59,6 @@
                                             "type": "text",
                                             "key": "result_family",
                                             "label": "Resulting family"
-                                        },
-                                        {
-                                            "type": "text",
-                                            "key": "subset_template_name",
-                                            "label": "Subset template name"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
## Brief description
Changed settings to list instead of dictionary to allow single frame and multiframe sequences into same family

## Description
Former implementation was dictionary, so single family couldn't be assigned to sequences (pngs) or single file (mp4).

![Screenshot 2022-02-03 171456](https://user-images.githubusercontent.com/4457962/152384421-596cba7b-845a-4a8c-b293-04bc7bd297c7.png)


## Testing notes:
1. Update `project_settings/webpublisher/publish/CollectPublishedFiles/task_type_to_family`
2. Publish single file or sequence