### PR TITLE
Pyblish Pype: Improve UI updates during processing

### DIFF
--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -11,7 +11,7 @@ import inspect
 import logging
 import collections
 
-from Qt import QtCore
+from Qt import QtCore, QtWidgets
 
 import pyblish.api
 import pyblish.util
@@ -47,7 +47,7 @@ class MainThreadProcess(QtCore.QObject):
 
     This approach gives ability to update UI meanwhile plugin is in progress.
     """
-    timer_interval = 3
+    timer_interval = 0
 
     def __init__(self):
         super(MainThreadProcess, self).__init__()
@@ -73,6 +73,10 @@ class MainThreadProcess(QtCore.QObject):
 
         item = self._items_to_process.popleft()
         item.process()
+
+        # Process events directly after the item processed. This allows the
+        # to correctly show "highlighted" state for the next item to process
+        QtWidgets.QApplication.instance().processEvents()
 
     def start(self):
         if not self._timer.isActive():

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -11,7 +11,7 @@ import inspect
 import logging
 import collections
 
-from Qt import QtCore, QtWidgets
+from Qt import QtCore
 
 import pyblish.api
 import pyblish.util

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -47,7 +47,7 @@ class MainThreadProcess(QtCore.QObject):
 
     This approach gives ability to update UI meanwhile plugin is in progress.
     """
-    timer_interval = 0
+    timer_interval = 3
 
     def __init__(self):
         super(MainThreadProcess, self).__init__()

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -74,8 +74,8 @@ class MainThreadProcess(QtCore.QObject):
         item = self._items_to_process.popleft()
         item.process()
 
-        # Process events directly after the item processed. This allows the
-        # to correctly show "highlighted" state for the next item to process
+        # Process events directly after the item processed. This allows to
+        # correctly show "highlighted" state for the next item to process
         QtWidgets.QApplication.instance().processEvents()
 
     def start(self):

--- a/openpype/tools/pyblish_pype/settings.py
+++ b/openpype/tools/pyblish_pype/settings.py
@@ -25,3 +25,6 @@ TerminalFilters = {
 
 # Allow animations in GUI
 Animated = env_variable_to_bool("OPENPYPE_PYBLISH_ANIMATED", True)
+
+# Print UI info message to console
+PrintInfo = env_variable_to_bool("OPENPYPE_PYBLISH_PRINT_INFO", True)

--- a/openpype/tools/pyblish_pype/settings.py
+++ b/openpype/tools/pyblish_pype/settings.py
@@ -24,4 +24,4 @@ TerminalFilters = {
 }
 
 # Allow animations in GUI
-Animated = env_variable_to_bool("OPENPYPE_PYBLISH_ANIMATED", True)
+Animated = env_variable_to_bool("OPENPYPE_PYBLISH_ANIMATED", False)

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -1305,9 +1305,9 @@ class Window(QtWidgets.QDialog):
         self.animation_info_msg.stop()
         self.animation_info_msg.start()
 
-        # TODO(marcus): Should this be configurable? Do we want
-        # the shell to fill up with these messages?
-        util.u_print(message)
+        if settings.PrintInfo:
+            # Print message to console
+            util.u_print(message)
 
     def warning(self, message):
         """Block processing and print warning until user hits "Continue"

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -307,21 +307,12 @@ class Window(QtWidgets.QDialog):
         on.setStartValue(0)
         on.setEndValue(1)
 
-        off = QtCore.QPropertyAnimation(info_effect, b"opacity")
-        off.setDuration(0)
-        off.setStartValue(1)
-        off.setEndValue(0)
-
         fade = QtCore.QPropertyAnimation(info_effect, b"opacity")
         fade.setDuration(500)
         fade.setStartValue(1.0)
         fade.setEndValue(0.0)
 
         animation_info_msg = QtCore.QSequentialAnimationGroup()
-        animation_info_msg.addAnimation(on)
-        animation_info_msg.addPause(50)
-        animation_info_msg.addAnimation(off)
-        animation_info_msg.addPause(50)
         animation_info_msg.addAnimation(on)
         animation_info_msg.addPause(2000)
         animation_info_msg.addAnimation(fade)


### PR DESCRIPTION
There was an issue with the recent speed ups for pyblish with UI not drawing correctly.

- This now defaults to having "animations" disabled with `OPENPYPE_PYBLISH_ANIMATED` in settings. With the small timeout that was introduced recently with #2464 which sped up the publishing by tons it did mean animations didn't really visually show anyway. So disabling them doesn't make much of a difference, except for that the UI correctly updates to the latest state.
- There was some odd "on", "off', "on", "fade out" steps on the Log text bottom left of the UI. Not sure why, but that definitely didn't look good with the shorter intervals. Just having it "on", stay around for a while, and "fade out" looks much smoother and also avoids the text being drawn only half as if it's still updating the opacity. So I removed some animation steps there.