### PR TITLE
Docker: enhance dockerfiles with metadata, fix pyenv initialization

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,11 +1,15 @@
 # Build Pype docker image
 FROM centos:7 AS builder
-ARG OPENPYPE_PYTHON_VERSION=3.7.10
+ARG OPENPYPE_PYTHON_VERSION=3.7.12
 
 LABEL org.opencontainers.image.name="pypeclub/openpype"
 LABEL org.opencontainers.image.title="OpenPype Docker Image"
 LABEL org.opencontainers.image.url="https://openpype.io/"
 LABEL org.opencontainers.image.source="https://github.com/pypeclub/pype"
+LABEL org.opencontainers.image.documentation="https://openpype.io/docs/system_introduction"
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$VERSION
+
 
 USER root
 

--- a/tools/docker_build.sh
+++ b/tools/docker_build.sh
@@ -68,7 +68,7 @@ main () {
 
   echo -e "${BIGreen}>>>${RST} Running docker build ..."
   # docker build --pull --no-cache -t pypeclub/openpype:$openpype_version .
-  docker build --pull --iidfile $openpype_root/build/docker-image.id -t pypeclub/openpype:$openpype_version -f $dockerfile .
+  docker build --pull --iidfile $openpype_root/build/docker-image.id --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg VERSION=$openpype_version -t pypeclub/openpype:$openpype_version -f $dockerfile .
   if [ $? -ne 0 ] ; then
     echo $?
     echo -e "${BIRed}!!!${RST} Docker build failed."


### PR DESCRIPTION
## Description

This is fixing pyenv initialization in dockerfile for ubuntu, where `.bashrc` wasn't for some reason sourced even when it was done explicitely. It's initialization was moved to another script file. Changed base image from debian to Ubuntu 20.04 Focal LTS to meet various dependency issues between versions of available glibc and ncurses.

Added additional metadata to image about build date and openpype version. 