### PR TITLE
Launcher: Fix Actions not working in Launcher due to no .data attribute

### DIFF
--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -239,10 +239,13 @@ class ActionBar(QtWidgets.QWidget):
         is_variant_group = index.data(VARIANT_GROUP_ROLE)
         if not is_group and not is_variant_group:
             action = index.data(ACTION_ROLE)
-            if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
-                action.data["start_last_workfile"] = False
-            else:
-                action.data.pop("start_last_workfile", None)
+            if hasattr(action, "data"):
+                # Only Applications have `data` attribute. Actions do not.
+                # So we make sure we only consider the data if it exists.
+                if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
+                    action.data["start_last_workfile"] = False
+                else:
+                    action.data.pop("start_last_workfile", None)
             self._start_animation(index)
             self.action_clicked.emit(action)
             return


### PR DESCRIPTION

## Brief description

This fixes an issue introduced by #2536 where the Launcher can't run any regular Actions but only support Applications.

The error was:

```python
Traceback (most recent call last):
  File "S:\openpype\OpenPype\openpype\tools\launcher\widgets.py", line 245, in on_clicked
    action.data.pop("start_last_workfile", None)
AttributeError: type object 'DebugShell' has no attribute 'data'
```

It's because `avalon.pipeline.Action` from which you build those actions has no `data` attribute.

---

### Additional context

Here are some example actions that would fail before this fix:
- [Explore Here Action](https://github.com/BigRoy/OpenPype/blob/colorbleed/openpype/modules/default_modules/colorbleed_module/launcher_actions/explore_here_action.py)
- [Debug Shell](https://github.com/BigRoy/OpenPype/blob/colorbleed/openpype/modules/default_modules/colorbleed_module/launcher_actions/debug_shell.py)