### PR TITLE
Maya: Add Validate Frame Range settings

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/maya/plugins/publish/validate_frame_range.py
@@ -5,15 +5,16 @@ from maya import cmds
 
 
 class ValidateFrameRange(pyblish.api.InstancePlugin):
-    """Valides the frame ranges.
+    """Validates the frame ranges.
 
-    This is optional validator checking if the frame range on instance
-    matches the one of asset. It also validate render frame range of render
-    layers
+    This is an optional validator checking if the frame range on instance
+    matches the frame range specified for the asset.
 
-    Repair action will change everything to match asset.
+    It also validates render frame ranges of render layers.
 
-    This can be turned off by artist to allow custom ranges.
+    Repair action will change everything to match the asset frame range.
+
+    This can be turned off by the artist to allow custom ranges.
     """
 
     label = "Validate Frame Range"

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -170,6 +170,11 @@
             "optional": true,
             "active": true
         },
+        "ValidateFrameRange": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateShaderName": {
             "enabled": false,
             "regex": "(?P<asset>.*)_(.*)_SHD"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -49,6 +49,16 @@
             ]
         },
         {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
+                    "key": "ValidateFrameRange",
+                    "label": "Validate Frame Range"
+                }
+            ]
+        },
+        {
             "type": "dict",
             "collapsible": true,
             "key": "ValidateShaderName",


### PR DESCRIPTION
## Brief description

Add Validate Frame Range plug-ins to settings to allow to disable it, toggle whether it may be optional, etc.
For some projects we'd prefer it off by default since many instances are published at different lengths.

---

I noticed there was another Plug-in with the exact name class name [here](https://github.com/pypeclub/OpenPype/blob/develop/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py#L8). What happens in that case? How do the Settings match to a particular Pyblish Plug-in?

Would this introduce a conflict now? Or is this safe for the Standalone Publisher as is?