### PR TITLE
Fix python install in docker for centos7

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -42,7 +42,8 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         patchelf \
         automake \
         autoconf \
-	    ncurses \
+        patch \
+        ncurses \
 	    ncurses-devel \
         qt5-qtbase-devel \
         xcb-util-wm \


### PR DESCRIPTION
Add path to fix this problem:
```
Downloading Python-3.7.12.tar.xz...
-> https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tar.xz
Installing Python-3.7.12...
/root/.pyenv/plugins/python-build/bin/python-build: line 1638: patch: command not found

BUILD FAILED (CentOS Linux 7 using python-build 20180424)
```