### PR TITLE
Ftrack: Sync description to assets

### DIFF
--- a/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
@@ -304,7 +304,7 @@ class SyncEntitiesFactory:
         " from Project where full_name is \"{}\""
     )
     entities_query = (
-        "select id, name, type_id, parent_id, link"
+        "select id, name, type_id, parent_id, link, description"
         " from TypedContext where project_id is \"{}\""
     )
     ignore_custom_attr_key = "avalon_ignore_sync"
@@ -1231,6 +1231,8 @@ class SyncEntitiesFactory:
                 data[key] = val
 
             if ftrack_id != self.ft_project_id:
+                data["description"] = entity["description"]
+
                 ent_path_items = [ent["name"] for ent in entity["link"]]
                 parents = ent_path_items[1:len(ent_path_items) - 1:]
 


### PR DESCRIPTION
## Brief description
Sync description key from ftrack entities to assets in avalon db.

## Changes
- sync action will also sync `"description"`
- sync event cares about changes of description

## Testing notes:
### Action
1. Run Sync to avalon
2. description should be synced

### Event
1. Run eventserver
2. turn on auto sync on project
3. change description on asset
4. description should be changed