### PR TITLE
fix menu callbacks to use lambda to avoid passing unexpected arguments

### DIFF
--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -108,17 +108,17 @@ def install():
 
         cmds.menuItem(
             "Reset Frame Range",
-            command=reset_frame_range
+            command=lambda *args: reset_frame_range()
         )
 
         cmds.menuItem(
             "Reset Resolution",
-            command=lib.reset_scene_resolution
+            command=lambda *args: lib.reset_scene_resolution()
         )
 
         cmds.menuItem(
             "Set Colorspace",
-            command=lib.set_colorspace,
+            command=lambda *args: lib.set_colorspace(),
         )
         cmds.menuItem(divider=True, parent=MENU_NAME)
         cmds.menuItem(


### PR DESCRIPTION
## Brief description
PR https://github.com/pypeclub/OpenPype/pull/2649 broke Maya menu callbacks.

## Changes
- menu callbacks are passed using `lambda` to avoid passing unexpected arguments to registered functions

## Testing notes:
1. Open Maya using OpenPype
2. Try run `Reset resolution`, `Reset frame range` or `Set colorspace`