### PR TITLE
hiero: fix effect collector name and order

### DIFF
--- a/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
+++ b/openpype/hosts/hiero/plugins/publish/collect_clip_effects.py
@@ -2,11 +2,11 @@ import re
 import pyblish.api
 
 
-class PreCollectClipEffects(pyblish.api.InstancePlugin):
+class CollectClipEffects(pyblish.api.InstancePlugin):
     """Collect soft effects instances."""
 
-    order = pyblish.api.CollectorOrder - 0.479
-    label = "Precollect Clip Effects Instances"
+    order = pyblish.api.CollectorOrder - 0.078
+    label = "Collect Clip Effects Instances"
     families = ["clip"]
 
     def process(self, instance):


### PR DESCRIPTION
## Brief description
the order was wrong and therefore name has to change to collector only

## Description
`Collect OTIO Frame Range` had to precede this plugin otherwise `startFrame` attribute was missing in `instance.data` of effect instance.

## Testing notes:
1. open any of your testing project with a softeffect on a publishable clip
2. see that `Collect Clip Effects Instances` is shown after `Collect OTIO Frame Ranges`