### PR TITLE
Houdini Explicitly collect correct frame name even in case of single frame render when `frameStart` is provided

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/collect_frames.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_frames.py
@@ -14,6 +14,8 @@ class CollectFrames(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
+        import hou
+
         ropnode = instance[0]
 
         start_frame = instance.data.get("frameStart", None)

--- a/openpype/hosts/houdini/plugins/publish/collect_frames.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_frames.py
@@ -15,8 +15,6 @@ class CollectFrames(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        import hou
-
         ropnode = instance[0]
 
         start_frame = instance.data.get("frameStart", None)

--- a/openpype/hosts/houdini/plugins/publish/collect_frames.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_frames.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+import hou
 import pyblish.api
 from openpype.hosts.houdini.api import lib
 

--- a/openpype/hosts/houdini/plugins/publish/collect_frames.py
+++ b/openpype/hosts/houdini/plugins/publish/collect_frames.py
@@ -16,8 +16,17 @@ class CollectFrames(pyblish.api.InstancePlugin):
 
         ropnode = instance[0]
 
+        start_frame = instance.data.get("frameStart", None)
+        end_frame = instance.data.get("frameEnd", None)
+
         output_parm = lib.get_output_parameter(ropnode)
-        output = output_parm.eval()
+        if start_frame is not None:
+            # When rendering only a single frame still explicitly
+            # get the name for that particular frame instead of current frame
+            output = output_parm.evalAtFrame(start_frame)
+        else:
+            self.log.warning("Using current frame: {}".format(hou.frame()))
+            output = output_parm.eval()
 
         _, ext = os.path.splitext(output)
         file_name = os.path.basename(output)
@@ -29,9 +38,6 @@ class CollectFrames(pyblish.api.InstancePlugin):
         # is a frame pattern in the name
         pattern = r"\w+\.(\d+)" + re.escape(ext)
         match = re.match(pattern, file_name)
-
-        start_frame = instance.data.get("frameStart", None)
-        end_frame = instance.data.get("frameEnd", None)
 
         if match and start_frame is not None:
 


### PR DESCRIPTION
(cherry picked from commit 0f82a753560e362be731d0d14177c4f3edbf1db0)

## Brief description

There was a bug in Houdini that whenever you do have a frame range set of just a single frame, e.g. `1001-1001` then `collect_frames` would actually eval the filename on the current frame instead of that start frame. Thus if you're writing to a file with `$F` the file would be named different than what the ROP node would actually output


## Additional info

Here's an example error that could happen. The integrator here fails to copy the file becuase the ROP node actually rendered another file than was "collected" as expected resulting filename from the ROP node.

```
Instance: 
vdbcachesmoke_room (160) [1001.0 - 1001.0]
Message: 
[WinError -2147024894] The system cannot find the file specified
Line: 
933
Traceback: 
Traceback (most recent call last):
  File "C:\Program Files (x86)\OpenPype\dependencies\pyblish\plugin.py", line 522, in __explicit_process
    runner(*args)
  File "C:\Users\User\AppData\Local\pypeclub\openpype\openpype-v3.8.1\openpype\plugins\publish\integrate_new.py", line 138, in process
  File "C:\Program Files (x86)\OpenPype\dependencies\six.py", line 719, in reraise
    raise value
  File "C:\Users\User\AppData\Local\pypeclub\openpype\openpype-v3.8.1\openpype\plugins\publish\integrate_new.py", line 129, in process
  File "C:\Users\User\AppData\Local\pypeclub\openpype\openpype-v3.8.1\openpype\plugins\publish\integrate_new.py", line 597, in register
  File "C:\Users\User\AppData\Local\pypeclub\openpype\openpype-v3.8.1\openpype\plugins\publish\integrate_new.py", line 653, in integrate
  File "C:\Users\User\AppData\Local\pypeclub\openpype\openpype-v3.8.1\openpype\plugins\publish\integrate_new.py", line 699, in copy_file
  File "C:\Program Files (x86)\OpenPype\dependencies\speedcopy\__init__.py", line 289, in copyfile
    '\\\\?\\' + dest_file, None)
  File "_ctypes/callproc.c", line 933, in GetResult
OSError: [WinError -2147024894] The system cannot find the file specified
```

## Testing notes:
1. Create a vdbCache instance to extract from frame 1001 to 1001.
2. Set current frame to 1002 in timeline.
3. Publish.

The render rop will render `1001` however the collect_frames and thus integrator thinks `1002` should be published.


## Additional Context

I've also added a warning if it's rendering without a frame range set and thus renders current frame - since that is less reliable in a production environment and thus discouraged?