### PR TITLE
Project Manager: Only allow scroll wheel edits when spinbox is active

### DIFF
--- a/openpype/tools/project_manager/project_manager/delegates.py
+++ b/openpype/tools/project_manager/project_manager/delegates.py
@@ -2,7 +2,9 @@ from Qt import QtWidgets, QtCore
 
 from .widgets import (
     NameTextEdit,
-    FilterComboBox
+    FilterComboBox,
+    SpinBoxScrollFixed,
+    DoubleSpinBoxScrollFixed
 )
 from .multiselection_combobox import MultiSelectionComboBox
 
@@ -89,9 +91,9 @@ class NumberDelegate(QtWidgets.QStyledItemDelegate):
 
     def createEditor(self, parent, option, index):
         if self.decimals > 0:
-            editor = QtWidgets.QDoubleSpinBox(parent)
+            editor = DoubleSpinBoxScrollFixed(parent)
         else:
-            editor = QtWidgets.QSpinBox(parent)
+            editor = SpinBoxScrollFixed(parent)
 
         editor.setObjectName("NumberEditor")
         # Set min/max

--- a/openpype/tools/project_manager/project_manager/widgets.py
+++ b/openpype/tools/project_manager/project_manager/widgets.py
@@ -429,3 +429,29 @@ class ConfirmProjectDeletion(QtWidgets.QDialog):
     def _on_confirm_text_change(self):
         enabled = self._confirm_input.text() == self._project_name
         self._confirm_btn.setEnabled(enabled)
+
+
+class SpinBoxScrollFixed(QtWidgets.QSpinBox):
+    """QSpinBox which only allow edits change with scroll wheel when active"""
+    def __init__(self, *args, **kwargs):
+        super(SpinBoxScrollFixed, self).__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+    def wheelEvent(self, event):
+        if not self.hasFocus():
+            event.ignore()
+        else:
+            super(SpinBoxScrollFixed, self).wheelEvent(event)
+
+
+class DoubleSpinBoxScrollFixed(QtWidgets.QDoubleSpinBox):
+    """QDoubleSpinBox which only allow edits with scroll wheel when active"""
+    def __init__(self, *args, **kwargs):
+        super(DoubleSpinBoxScrollFixed, self).__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+    def wheelEvent(self, event):
+        if not self.hasFocus():
+            event.ignore()
+        else:
+            super(DoubleSpinBoxScrollFixed, self).wheelEvent(event)


### PR DESCRIPTION
## Brief description

Implements #2677 

## Testing notes:

1. Open Project Manager with some assets in a test project
2. Test whether scrolling over float and integer fields changes values - it shouldn't.
3. No click inside the float/integer field to give it focus, confirm it now does allow you to change value with scroll wheel.