### PR TITLE
General: Add settings for CleanUpFarm and disable the plugin by default

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -208,6 +208,9 @@
         "CleanUp": {
             "paterns": [],
             "remove_temp_renders": false
+        },
+        "CleanUpFarm": {
+            "enabled": false
         }
     },
     "tools": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -677,8 +677,22 @@
                     "label": "Remove Temp renders",
                     "default": false
                 }
-
             ]
+        },
+        {
+          "type": "dict",
+          "collapsible": false,
+          "key": "CleanUpFarm",
+          "label": "Clean Up Farm",
+          "is_group": true,
+          "checkbox_key": "enabled",
+          "children": [
+              {
+                  "type": "boolean",
+                  "key": "enabled",
+                  "label": "Enabled"
+              }
+          ]
         }
     ]
 }


### PR DESCRIPTION
## Brief description
It could be potentially dangerous to have CleanUpFarm plugin enabled by default https://github.com/pypeclub/OpenPype/pull/2390#issuecomment-1032811166.

## Changes
- added settings for `CleanUpFarm` plugin and disable the plugin by default