### PR TITLE
Maya configurable unit validator

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/openpype/hosts/maya/plugins/publish/validate_maya_units.py
@@ -30,8 +30,8 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
     def process(self, context):
 
         # Collected units
-        linearunits = context.data('linearUnits')
-        angularunits = context.data('angularUnits')
+        linearunits = context.data.get('linearUnits')
+        angularunits = context.data.get('angularUnits')
         # TODO(antirotor): This is hack as for framerates having multiple
         # decimal places. FTrack is ceiling decimal values on
         # fps to two decimal places but Maya 2019+ is reporting those fps
@@ -39,7 +39,7 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         # rounding, we have to round those numbers coming from Maya.
         # NOTE: this must be revisited yet again as it seems that Ftrack is
         # now flooring the value?
-        fps = float_round(context.data['fps'], 2, ceil)
+        fps = float_round(context.data.get('fps'), 2, ceil)
 
         asset_fps = lib.get_asset()["data"]["fps"]
 

--- a/openpype/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/openpype/hosts/maya/plugins/publish/validate_maya_units.py
@@ -37,6 +37,8 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         # fps to two decimal places but Maya 2019+ is reporting those fps
         # with much higher resolution. As we currently cannot fix Ftrack
         # rounding, we have to round those numbers coming from Maya.
+        # NOTE: this must be revisited yet again as it seems that Ftrack is
+        # now flooring the value?
         fps = float_round(context.data['fps'], 2, ceil)
 
         asset_fps = lib.get_asset()["data"]["fps"]
@@ -53,7 +55,8 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
             and linearunits
             and linearunits != self.linear_units
         ):
-            self.log.error("Scene linear units must be centimeters")
+            self.log.error("Scene linear units must be {}".format(
+                self.linear_units))
             valid = False
 
         if (
@@ -61,7 +64,8 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
             and angularunits
             and angularunits != self.angular_units
         ):
-            self.log.error("Scene angular units must be degrees")
+            self.log.error("Scene angular units must be {}".format(
+                self.angular_units))
             valid = False
 
         if self.validate_fps and fps and fps != asset_fps:

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -188,17 +188,26 @@
             "whitelist_native_plugins": false,
             "authorized_plugins": []
         },
+        "ValidateMayaUnits": {
+            "enabled": true,
+            "optional": false,
+            "validate_linear_units": true,
+            "linear_units": "cm",
+            "validate_angular_units": true,
+            "angular_units": "deg",
+            "validate_fps": true
+        },
+        "ValidateUnrealStaticMeshName": {
+            "enabled": true,
+            "validate_mesh": false,
+            "validate_collision": true
+        },
         "ValidateCycleError": {
             "enabled": true,
             "optional": false,
             "families": [
                 "rig"
             ]
-        },
-        "ValidateUnrealStaticMeshName": {
-            "enabled": true,
-            "validate_mesh": false,
-            "validate_collision": true
         },
         "ValidateRenderSettings": {
             "arnold_render_attributes": [],

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -160,9 +160,9 @@
                           "enum_items": [
                             {"mm": "millimeter"},
                             {"cm": "centimeter"},
-                            {"m":  "meter"},
-                            {"km":  "kilometer"},
-                            {"in":  "inch"},
+                            {"m": "meter"},
+                            {"km": "kilometer"},
+                            {"in": "inch"},
                             {"ft": "foot"},
                             {"yd": "yard"},
                             {"mi": "mile"}

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -71,7 +71,6 @@
                 }
             ]
         },
-
         {
             "type": "schema_template",
             "name": "template_publish_plugin",
@@ -82,7 +81,6 @@
                 }
             ]
         },
-
         {
             "type": "dict",
             "collapsible": true,
@@ -102,7 +100,6 @@
                 }
             ]
         },
-
         {
             "type": "dict",
             "collapsible": true,
@@ -128,7 +125,6 @@
                 }
             ]
         },
-
         {
             "type": "dict",
             "collapsible": true,
@@ -141,7 +137,7 @@
                     "key": "enabled",
                     "label": "Enabled"
                 },
-                 {
+                {
                     "type": "boolean",
                     "key": "optional",
                     "label": "Optional"
@@ -152,21 +148,21 @@
                     "label": "Validate linear units"
                 },
                 {
-                          "key": "linear_units",
-                          "label": "Linear units",
-                          "type": "enum",
-                          "multiselection": false,
-                          "defaults": "cm",
-                          "enum_items": [
-                            {"mm": "millimeter"},
-                            {"cm": "centimeter"},
-                            {"m": "meter"},
-                            {"km": "kilometer"},
-                            {"in": "inch"},
-                            {"ft": "foot"},
-                            {"yd": "yard"},
-                            {"mi": "mile"}
-                          ]
+                    "key": "linear_units",
+                    "label": "Linear units",
+                    "type": "enum",
+                    "multiselection": false,
+                    "defaults": "cm",
+                    "enum_items": [
+                        {"mm": "millimeter"},
+                        {"cm": "centimeter"},
+                        {"m": "meter"},
+                        {"km": "kilometer"},
+                        {"in": "inch"},
+                        {"ft": "foot"},
+                        {"yd": "yard"},
+                        {"mi": "mile"}
+                    ]
                 },
                 {
                     "type": "boolean",
@@ -174,15 +170,15 @@
                     "label": "Validate angular units"
                 },
                 {
-                          "key": "angular_units",
-                          "label": "Angular units",
-                          "type": "enum",
-                          "multiselection": false,
-                          "defaults": "cm",
-                          "enum_items": [
-                            {"deg": "degree"},
-                            {"rad": "radian"}
-                          ]
+                    "key": "angular_units",
+                    "label": "Angular units",
+                    "type": "enum",
+                    "multiselection": false,
+                    "defaults": "cm",
+                    "enum_items": [
+                        {"deg": "degree"},
+                        {"rad": "radian"}
+                    ]
                 },
                 {
                     "type": "boolean",
@@ -191,7 +187,6 @@
                 }
             ]
         },
-
         {
             "type": "dict",
             "collapsible": true,
@@ -216,7 +211,6 @@
                 }
             ]
         },
-
         {
             "type": "dict",
             "collapsible": true,
@@ -243,7 +237,6 @@
                 }
             ]
         },
-
         {
             "type": "dict",
             "collapsible": true,
@@ -347,7 +340,7 @@
                     "label": "Validate Model Content",
                     "checkbox_key": "enabled",
                     "children": [
-                         {
+                        {
                             "type": "boolean",
                             "key": "enabled",
                             "label": "Enabled"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -179,7 +179,7 @@
                 },
                 {
                     "type": "boolean",
-                    "key": "fps",
+                    "key": "validate_fps",
                     "label": "Validate fps"
                 }
             ]

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -132,6 +132,62 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "ValidateMayaUnits",
+            "label": "Validate Maya Units",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "validate_linear_units",
+                    "label": "Validate linear units"
+                },
+                {
+                          "key": "linear_units",
+                          "label": "Linear units",
+                          "type": "enum",
+                          "multiselection": false,
+                          "defaults": "cm",
+                          "enum_items": [
+                            {"mm": "millimeter"},
+                            {"cm": "centimeter"},
+                            {"m":  "meter"},
+                            {"in":  "inch"},
+                            {"ft": "foot"},
+                            {"yd": "yard"}
+                          ]
+                },
+                {
+                    "type": "boolean",
+                    "key": "validate_angular_units",
+                    "label": "Validate angular units"
+                },
+                {
+                          "key": "angular_units",
+                          "label": "Angular units",
+                          "type": "enum",
+                          "multiselection": false,
+                          "defaults": "cm",
+                          "enum_items": [
+                            {"deg": "degree"},
+                            {"rad": "radian"}
+                          ]
+                },
+                {
+                    "type": "boolean",
+                    "key": "fps",
+                    "label": "Validate fps"
+                }
+            ]
+        },
+
+        {
+            "type": "dict",
+            "collapsible": true,
             "key": "ValidateUnrealStaticMeshName",
             "label": "Validate Unreal Static Mesh Name",
             "checkbox_key": "enabled",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -141,6 +141,11 @@
                     "key": "enabled",
                     "label": "Enabled"
                 },
+                 {
+                    "type": "boolean",
+                    "key": "optional",
+                    "label": "Optional"
+                },
                 {
                     "type": "boolean",
                     "key": "validate_linear_units",
@@ -156,9 +161,11 @@
                             {"mm": "millimeter"},
                             {"cm": "centimeter"},
                             {"m":  "meter"},
+                            {"km":  "kilometer"},
                             {"in":  "inch"},
                             {"ft": "foot"},
-                            {"yd": "yard"}
+                            {"yd": "yard"},
+                            {"mi": "mile"}
                           ]
                 },
                 {


### PR DESCRIPTION
## Feature

this is adding configurable options for Maya Units validator.

![image](https://user-images.githubusercontent.com/33513211/153171801-d45601aa-2095-4845-a3b8-5e596f2ef7bc.png)

Most of the options should be set later in different place - by something like scene defaults settings.

🗒️ There is also issue #2620 with fps decimal rounding that needs to be investigated between supported maya versions and ftrack.
