### PR TITLE
Ftrack: Hierarchical attributes are queried properly

### DIFF
--- a/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_links.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_server/event_sync_links.py
@@ -128,7 +128,7 @@ class SyncLinksToAvalon(BaseEvent):
 
     def _get_mongo_ids_by_ftrack_ids(self, session, attr_id, ftrack_ids):
         output = query_custom_attributes(
-            session, [attr_id], ftrack_ids
+            session, [attr_id], ftrack_ids, True
         )
         mongo_id_by_ftrack_id = {}
         for item in output:

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_clean_hierarchical_attributes.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_clean_hierarchical_attributes.py
@@ -19,8 +19,8 @@ class CleanHierarchicalAttrsAction(BaseAction):
         " from TypedContext where project_id is \"{}\""
     )
     cust_attr_query = (
-        "select value, entity_id from CustomAttributeValue "
-        "where entity_id in ({}) and configuration_id is \"{}\""
+        "select value, entity_id from CustomAttributeValue"
+        " where entity_id in ({}) and configuration_id is \"{}\""
     )
     settings_key = "clean_hierarchical_attr"
 
@@ -65,17 +65,14 @@ class CleanHierarchicalAttrsAction(BaseAction):
                 )
             )
             configuration_id = attr["id"]
-            call_expr = [{
-                "action": "query",
-                "expression": self.cust_attr_query.format(
+            values = session.query(
+                self.cust_attr_query.format(
                     entity_ids_joined, configuration_id
                 )
-            }]
-
-            [values] = self.session.call(call_expr)
+            ).all()
 
             data = {}
-            for item in values["data"]:
+            for item in values:
                 value = item["value"]
                 if value is None:
                     data[item["entity_id"]] = value
@@ -90,10 +87,10 @@ class CleanHierarchicalAttrsAction(BaseAction):
                 len(data), configuration_key
             ))
             for entity_id, value in data.items():
-                entity_key = collections.OrderedDict({
-                    "configuration_id": configuration_id,
-                    "entity_id": entity_id
-                })
+                entity_key = collections.OrderedDict((
+                    ("configuration_id", configuration_id),
+                    ("entity_id", entity_id)
+                ))
                 session.recorded_operations.push(
                     ftrack_api.operation.DeleteEntityOperation(
                         "CustomAttributeValue",

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_create_cust_attrs.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_create_cust_attrs.py
@@ -332,10 +332,10 @@ class CustomAttributes(BaseAction):
                 cust_attr_query.format(attr_def["id"])
             ).all()
             for value in values:
-                table_values = collections.OrderedDict((
+                table_values = collections.OrderedDict([
                     ("configuration_id", hierarchical_attr["id"]),
                     ("entity_id", value["entity_id"])
-                ))
+                ])
 
                 session.recorded_operations.push(
                     ftrack_api.operation.UpdateEntityOperation(

--- a/openpype/modules/default_modules/ftrack/event_handlers_user/action_create_cust_attrs.py
+++ b/openpype/modules/default_modules/ftrack/event_handlers_user/action_create_cust_attrs.py
@@ -306,8 +306,8 @@ class CustomAttributes(BaseAction):
         }
 
         cust_attr_query = (
-            "select value, entity_id from ContextCustomAttributeValue "
-            "where configuration_id is {}"
+            "select value, entity_id from CustomAttributeValue"
+            " where configuration_id is {}"
         )
         for attr_def in object_type_attrs:
             attr_ent_type = attr_def["entity_type"]
@@ -328,21 +328,14 @@ class CustomAttributes(BaseAction):
             self.log.debug((
                 "Converting Avalon MongoID attr for Entity type \"{}\"."
             ).format(entity_type_label))
-
-            call_expr = [{
-                "action": "query",
-                "expression": cust_attr_query.format(attr_def["id"])
-            }]
-            if hasattr(session, "call"):
-                [values] = session.call(call_expr)
-            else:
-                [values] = session._call(call_expr)
-
-            for value in values["data"]:
-                table_values = collections.OrderedDict({
-                    "configuration_id": hierarchical_attr["id"],
-                    "entity_id": value["entity_id"]
-                })
+            values = session.query(
+                cust_attr_query.format(attr_def["id"])
+            ).all()
+            for value in values:
+                table_values = collections.OrderedDict((
+                    ("configuration_id", hierarchical_attr["id"]),
+                    ("entity_id", value["entity_id"])
+                ))
 
                 session.recorded_operations.push(
                     ftrack_api.operation.UpdateEntityOperation(

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -304,7 +304,7 @@ class FtrackModule(
             # TODO add value validations
             # - value type and list items
             entity_key = collections.OrderedDict([
-                ("configuration_id", configuration["id"])
+                ("configuration_id", configuration["id"]),
                 ("entity_id", project_id)
             ])
 

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -303,10 +303,10 @@ class FtrackModule(
             # TODO add add permissions check
             # TODO add value validations
             # - value type and list items
-            entity_key = collections.OrderedDict((
+            entity_key = collections.OrderedDict([
                 ("configuration_id", configuration["id"])
                 ("entity_id", project_id)
-            ))
+            ])
 
             session.recorded_operations.push(
                 ftrack_api.operation.UpdateEntityOperation(

--- a/openpype/modules/default_modules/ftrack/ftrack_module.py
+++ b/openpype/modules/default_modules/ftrack/ftrack_module.py
@@ -303,9 +303,10 @@ class FtrackModule(
             # TODO add add permissions check
             # TODO add value validations
             # - value type and list items
-            entity_key = collections.OrderedDict()
-            entity_key["configuration_id"] = configuration["id"]
-            entity_key["entity_id"] = project_id
+            entity_key = collections.OrderedDict((
+                ("configuration_id", configuration["id"])
+                ("entity_id", project_id)
+            ))
 
             session.recorded_operations.push(
                 ftrack_api.operation.UpdateEntityOperation(

--- a/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/default_modules/ftrack/lib/avalon_sync.py
@@ -1763,10 +1763,10 @@ class SyncEntitiesFactory:
                 configuration_id = self.entities_dict[ftrack_id][
                     "avalon_attrs_id"][CUST_ATTR_ID_KEY]
 
-                _entity_key = collections.OrderedDict({
-                    "configuration_id": configuration_id,
-                    "entity_id": ftrack_id
-                })
+                _entity_key = collections.OrderedDict([
+                    ("configuration_id", configuration_id),
+                    ("entity_id", ftrack_id)
+                ])
 
                 self.session.recorded_operations.push(
                     ftrack_api.operation.UpdateEntityOperation(

--- a/openpype/modules/default_modules/ftrack/lib/custom_attributes.py
+++ b/openpype/modules/default_modules/ftrack/lib/custom_attributes.py
@@ -88,26 +88,36 @@ def join_query_keys(keys):
     return ",".join(["\"{}\"".format(key) for key in keys])
 
 
-def query_custom_attributes(session, conf_ids, entity_ids, table_name=None):
+def query_custom_attributes(
+    session, conf_ids, entity_ids, only_set_values=False
+):
     """Query custom attribute values from ftrack database.
 
     Using ftrack call method result may differ based on used table name and
     version of ftrack server.
+
+    For hierarchical attributes you shou always use `only_set_values=True`
+    otherwise result will be default value of custom attribute and it would not
+    be possible to differentiate if value is set on entity or default value is
+    used.
 
     Args:
         session(ftrack_api.Session): Connected ftrack session.
         conf_id(list, set, tuple): Configuration(attribute) ids which are
             queried.
         entity_ids(list, set, tuple): Entity ids for which are values queried.
-        table_name(str): Table nam from which values are queried. Not
-            recommended to change until you know what it means.
+        only_set_values(bool): Entities that don't have explicitly set
+            value won't return a value. If is set to False then default custom
+            attribute value is returned if value is not set.
     """
     output = []
     # Just skip
     if not conf_ids or not entity_ids:
         return output
 
-    if table_name is None:
+    if only_set_values:
+        table_name = "CustomAttributeValue"
+    else:
         table_name = "ContextCustomAttributeValue"
 
     # Prepare values to query
@@ -122,19 +132,16 @@ def query_custom_attributes(session, conf_ids, entity_ids, table_name=None):
         entity_ids_joined = join_query_keys(
             entity_ids[idx:idx + chunk_size]
         )
-
-        call_expr = [{
-            "action": "query",
-            "expression": (
-                "select value, entity_id from {}"
-                " where entity_id in ({}) and configuration_id in ({})"
-            ).format(table_name, entity_ids_joined, attributes_joined)
-        }]
-        if hasattr(session, "call"):
-            [result] = session.call(call_expr)
-        else:
-            [result] = session._call(call_expr)
-
-        for item in result["data"]:
-            output.append(item)
+        output.extend(
+            session.query(
+                (
+                    "select value, entity_id from {}"
+                    " where entity_id in ({}) and configuration_id in ({})"
+                ).format(
+                    table_name,
+                    entity_ids_joined,
+                    attributes_joined
+                )
+            ).all()
+        )
     return output


### PR DESCRIPTION
## Brief description
It was discovered that `ContextCustomAttributeValue` does return default value of custom attribute if entity does not have set value explicitly which is an issue for querying of hierarchical attribute values.

## Changes
- 'query_custom_attributes' has ability to return only explicitly set values or all values with defaults
    - added new argument `only_set_values` to define if `CustomAttributeValue` or `ContextCustomAttributeValue` table is used to get values
- almost all places that query custom attributes are using 'query_custom_attributes'

## Testing notes:
### Prereq
- Create new project with some structure
- Find one hierarchical custom attribute (e.g. `fps`) and set default value to something

### Sync to avalon - action
1. Set different then defaut value on project
2. Run sync to avalon
3. Check attribute values on assets (e.g. in project manager) they should be same as project value

### Sync to avalon - event
1. Run event server
2. Turn on auto sync on the project
3. Change `fps` on project
4. Check if the value is propagated in avalon and on all assets that should inherit the value

### Push hierarchical values
- this pushes changes from hierarchical custom attribute to non-hierarchical (and back for event)
1. Find/Create custom attribute that has both hierarchical and non-hierarchical version (e.g. `frameStart` on `Shot`)
2. Run ftrack event server
3. Change value on one of them
4. The value should be change on the other too
- same way it works for action but the value is propagated only from hierarchical to non-hierarchical