### PR TITLE
Nuke: prerender with review knob

### DIFF
--- a/openpype/hosts/nuke/plugins/create/create_write_prerender.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_prerender.py
@@ -98,13 +98,13 @@ class CreateWritePrerender(plugin.OpenPypeCreator):
                                    "/{subset}.{frame}.{ext}")})
 
         self.log.info("write_data: {}".format(write_data))
-
+        reviewable = self.presets.get("reviewable")
         write_node = create_write_node(
             self.data["subset"],
             write_data,
             input=selected_node,
             prenodes=[],
-            review=False,
+            review=reviewable,
             linked_knobs=["channels", "___", "first", "last", "use_limit"])
 
         # relinking to collected connections

--- a/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/default_modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -23,6 +23,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         "setdress": "setdress",
         "pointcache": "cache",
         "render": "render",
+        "prerender": "render",
         "render2d": "render",
         "nukescript": "comp",
         "write": "render",
@@ -50,6 +51,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         asset_type = instance.data.get("ftrackFamily")
         if not asset_type and family_low in self.family_mapping:
             asset_type = self.family_mapping[family_low]
+
+        self.log.debug(self.family_mapping)
+        self.log.debug(family_low)
 
         # Ignore this instance if neither "ftrackFamily" or a family mapping is
         # found.

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -292,7 +292,8 @@
                     ],
                     "families": [
                         "write",
-                        "render"
+                        "render",
+                        "prerender"
                     ],
                     "task_types": [],
                     "tasks": [],
@@ -353,6 +354,7 @@
                 "setdress": "setdress",
                 "pointcache": "cache",
                 "render": "render",
+                "prerender": "render",
                 "render2d": "render",
                 "nukescript": "comp",
                 "write": "render",

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -32,7 +32,8 @@
                 "Fg01",
                 "Branch01",
                 "Part01"
-            ]
+            ],
+            "reviewable": false
         }
     },
     "publish": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
@@ -131,6 +131,11 @@
                             "object_type": {
                                 "type": "text"
                             }
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "reviewable",
+                            "label": "Add reviewable toggle"
                         }
                     ]
                 }


### PR DESCRIPTION
## Brief description
Adding re-viewable option to prerender instance.

## Description
This will allow to publish reviewable components to Ftrack for example.

## Testing notes:
1. make sure the settings `project_settings/nuke/create/CreateWritePrerender/reviewable` is set to ON
2. make sure there are no project overrides on `project_settings/ftrack/publish/CollectFtrackFamily/profiles/6/families/2` and `prerender` family is available there
3. also make sure `project_settings/ftrack/publish/IntegrateFtrackInstance/family_mapping` is not having project overides and `prerender` key is available in mappings.
4. open your nuke testing workfile and create a prerender. 
5. review toggle should be set on and set for example some frame range constrain in rendering attribures on the prerender node.
6. publish and notice new version in ftrack with the prerender family