### PR TITLE
Maya Redshift fixes

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -911,7 +911,7 @@ class RenderProductsRedshift(ARenderProducts):
 
         """
         prefix = super(RenderProductsRedshift, self).get_renderer_prefix()
-        prefix = "{}.<aov>".format(prefix)
+        prefix = "{}{}<aov>".format(prefix, self.aov_separator)
         return prefix
 
     def get_render_products(self):

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -86,7 +86,7 @@ class CreateRender(plugin.Creator):
         'vray': 'maya/<scene>/<Layer>/<Layer>',
         'arnold': 'maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>',  # noqa
         'renderman': 'maya/<Scene>/<layer>/<layer>{aov_separator}<aov>',
-        'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>'  # noqa
+        'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>'  # noqa
     }
 
     _aov_chars = {
@@ -455,9 +455,7 @@ class CreateRender(plugin.Creator):
         if renderer == "vray":
             self._set_vray_settings(asset)
         if renderer == "redshift":
-            _ = self._set_renderer_option(
-                "RedshiftOptions", "{}.imageFormat", 1
-            )
+            cmds.setAttr("redshiftOptions.imageFormat", 1)
 
             # resolution
             cmds.setAttr(

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -329,7 +329,8 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 for aov in rs_aovs:
                     # fix AOV prefixes
                     cmds.setAttr(
-                        "{}.filePrefix".format(aov), redshift_AOV_prefix)
+                        "{}.filePrefix".format(aov),
+                        redshift_AOV_prefix, type="string")
                     # fix AOV file format
                     default_ext = cmds.getAttr(
                         "redshiftOptions.imageFormat", asString=True)

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -172,8 +172,8 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                     cls.log.error(("AOV ({}) image prefix is not set "
                                    "correctly {} != {}").format(
                         cmds.getAttr("{}.name".format(aov)),
-                        cmds.getAttr("{}.filePrefix".format(aov)),
-                        aov_prefix
+                        aov_prefix,
+                        redshift_AOV_prefix
                     ))
                     invalid = True
                 # get aov format


### PR DESCRIPTION
## Fixes for Redshift in Maya

this is fixing various issues there were for Redshift support (#2446, #1825), invalid default image prefix and ignoring AOV character separator option.

Close #2446
Close #1825