### PR TITLE
Multiple hosts: unify menu style across hosts

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -306,6 +306,16 @@ class LaunchManager(LaunchQtApp):
         self._window.refresh()
 
 
+class LaunchLibrary(LaunchQtApp):
+    """Launch Library Loader."""
+
+    bl_idname = "wm.library_loader"
+    bl_label = "Library..."
+    _tool_name = "libraryloader"
+
+    def before_window_show(self):
+        self._window.refresh()
+
 class LaunchWorkFiles(LaunchQtApp):
     """Launch Avalon Work Files."""
 
@@ -365,6 +375,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
             icon_value=pyblish_menu_icon_id,
         )
         layout.operator(LaunchManager.bl_idname, text="Manage...")
+        layout.operator(LaunchLibrary.bl_idname, text="Library...")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
         # TODO (jasper): maybe add 'Reload Pipeline', 'Reset Frame Range' and
@@ -382,6 +393,7 @@ classes = [
     LaunchLoader,
     LaunchPublisher,
     LaunchManager,
+    LaunchLibrary,
     LaunchWorkFiles,
     TOPBAR_MT_avalon,
 ]

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -316,6 +316,7 @@ class LaunchLibrary(LaunchQtApp):
     def before_window_show(self):
         self._window.refresh()
 
+
 class LaunchWorkFiles(LaunchQtApp):
     """Launch Avalon Work Files."""
 

--- a/openpype/hosts/flame/api/menu.py
+++ b/openpype/hosts/flame/api/menu.py
@@ -110,19 +110,19 @@ class FlameMenuProjectConnect(_FlameMenuApp):
         menu = deepcopy(self.menu)
 
         menu['actions'].append({
-            "name": "Workfiles ...",
+            "name": "Workfiles...",
             "execute": lambda x: self.tools_helper.show_workfiles()
         })
         menu['actions'].append({
-            "name": "Load ...",
+            "name": "Load...",
             "execute": lambda x: self.tools_helper.show_loader()
         })
         menu['actions'].append({
-            "name": "Manage ...",
+            "name": "Manage...",
             "execute": lambda x: self.tools_helper.show_scene_inventory()
         })
         menu['actions'].append({
-            "name": "Library ...",
+            "name": "Library...",
             "execute": lambda x: self.tools_helper.show_library_loader()
         })
         return menu
@@ -164,24 +164,27 @@ class FlameMenuTimeline(_FlameMenuApp):
         menu = deepcopy(self.menu)
 
         menu['actions'].append({
-            "name": "Create ...",
+            "name": "Create...",
             "execute": lambda x: callback_selection(
                 x, self.tools_helper.show_creator)
         })
         menu['actions'].append({
-            "name": "Publish ...",
+            "name": "Publish...",
             "execute": lambda x: callback_selection(
                 x, self.tools_helper.show_publish)
         })
         menu['actions'].append({
-            "name": "Load ...",
+            "name": "Load...",
             "execute": lambda x: self.tools_helper.show_loader()
         })
         menu['actions'].append({
-            "name": "Manage ...",
+            "name": "Manage...",
             "execute": lambda x: self.tools_helper.show_scene_inventory()
         })
-
+        menu['actions'].append({
+            "name": "Library...",
+            "execute": lambda x: self.tools_helper.show_library_loader()
+        })
         return menu
 
     def refresh(self, *args, **kwargs):

--- a/openpype/hosts/fusion/api/menu.py
+++ b/openpype/hosts/fusion/api/menu.py
@@ -54,13 +54,13 @@ class OpenPypeMenu(QtWidgets.QWidget):
         )
         self.render_mode_widget = None
         self.setWindowTitle("OpenPype")
-        workfiles_btn = QtWidgets.QPushButton("Workfiles ...", self)
-        create_btn = QtWidgets.QPushButton("Create ...", self)
-        publish_btn = QtWidgets.QPushButton("Publish ...", self)
-        load_btn = QtWidgets.QPushButton("Load ...", self)
-        inventory_btn = QtWidgets.QPushButton("Inventory ...", self)
-        libload_btn = QtWidgets.QPushButton("Library ...", self)
-        rendermode_btn = QtWidgets.QPushButton("Set render mode ...", self)
+        workfiles_btn = QtWidgets.QPushButton("Workfiles...", self)
+        create_btn = QtWidgets.QPushButton("Create...", self)
+        publish_btn = QtWidgets.QPushButton("Publish...", self)
+        load_btn = QtWidgets.QPushButton("Load...", self)
+        inventory_btn = QtWidgets.QPushButton("Inventory...", self)
+        libload_btn = QtWidgets.QPushButton("Library...", self)
+        rendermode_btn = QtWidgets.QPushButton("Set render mode...", self)
         duplicate_with_inputs_btn = QtWidgets.QPushButton(
             "Duplicate with input connections", self
         )

--- a/openpype/hosts/hiero/api/menu.py
+++ b/openpype/hosts/hiero/api/menu.py
@@ -72,7 +72,7 @@ def menu_install():
 
     menu.addSeparator()
 
-    workfiles_action = menu.addAction("Work Files ...")
+    workfiles_action = menu.addAction("Work Files...")
     workfiles_action.setIcon(QtGui.QIcon("icons:Position.png"))
     workfiles_action.triggered.connect(launch_workfiles_app)
 
@@ -82,28 +82,34 @@ def menu_install():
 
     menu.addSeparator()
 
-    publish_action = menu.addAction("Publish ...")
+    publish_action = menu.addAction("Publish...")
     publish_action.setIcon(QtGui.QIcon("icons:Output.png"))
     publish_action.triggered.connect(
         lambda *args: publish(hiero.ui.mainWindow())
     )
 
-    creator_action = menu.addAction("Create ...")
+    creator_action = menu.addAction("Create...")
     creator_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
     creator_action.triggered.connect(
         lambda: host_tools.show_creator(parent=main_window)
     )
 
-    loader_action = menu.addAction("Load ...")
+    loader_action = menu.addAction("Load...")
     loader_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
     loader_action.triggered.connect(
         lambda: host_tools.show_loader(parent=main_window)
     )
 
-    sceneinventory_action = menu.addAction("Manage ...")
+    sceneinventory_action = menu.addAction("Manage...")
     sceneinventory_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
     sceneinventory_action.triggered.connect(
         lambda: host_tools.show_scene_inventory(parent=main_window)
+    )
+
+    library_action = menu.addAction("Library...")
+    library_action.setIcon(QtGui.QIcon("icons:CopyRectangle.png"))
+    library_action.triggered.connect(
+        lambda: host_tools.show_library_loader(parent=main_window)
     )
 
     if os.getenv("OPENPYPE_DEVELOP"):

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -17,11 +17,11 @@ host_tools.show_creator(parent)
             <scriptItem id="publish">
                 <label>Publish...</label>
                 <scriptCode><![CDATA[
-            import hou
-            from openpype.tools.utils import host_tools
-            parent = hou.qt.mainWindow()
-            host_tools.show_publish(parent)
-                            ]]>    </scriptCode>
+import hou
+from openpype.tools.utils import host_tools
+parent = hou.qt.mainWindow()
+host_tools.show_publish(parent)
+]]></scriptCode>
             </scriptItem>
 
             <scriptItem id="avalon_manage">

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -14,14 +14,14 @@ host_tools.show_creator(parent)
 ]]></scriptCode>
             </scriptItem>
 
-            <scriptItem id="avalon_load">
-                <label>Load ...</label>
+            <scriptItem id="publish">
+                <label>Publish ...</label>
                 <scriptCode><![CDATA[
-import hou
-from openpype.tools.utils import host_tools
-parent = hou.qt.mainWindow()
-host_tools.show_loader(parent=parent, use_context=True)
-]]></scriptCode>
+            import hou
+            from openpype.tools.utils import host_tools
+            parent = hou.qt.mainWindow()
+            host_tools.show_publish(parent)
+                            ]]>    </scriptCode>
             </scriptItem>
 
             <scriptItem id="avalon_manage">
@@ -34,14 +34,14 @@ host_tools.show_scene_inventory(parent)
 ]]></scriptCode>
             </scriptItem>
 
-            <scriptItem id="publish">
-                <label>Publish ...</label>
+            <scriptItem id="library_load">
+                <label>Library ...</label>
                 <scriptCode><![CDATA[
 import hou
 from openpype.tools.utils import host_tools
 parent = hou.qt.mainWindow()
-host_tools.show_publish(parent)
-                ]]></scriptCode>
+host_tools.show_library_loader(parent=parent)
+]]>                </scriptCode>
             </scriptItem>
 
             <separatorItem/>

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -14,6 +14,16 @@ host_tools.show_creator(parent)
 ]]></scriptCode>
             </scriptItem>
 
+            <scriptItem id="avalon_load">
+                <label>Load...</label>
+                <scriptCode><![CDATA[
+import hou
+from openpype.tools.utils import host_tools
+parent = hou.qt.mainWindow()
+host_tools.show_loader(parent=parent, use_context=True)
+]]> </scriptCode>
+            </scriptItem>
+
             <scriptItem id="publish">
                 <label>Publish...</label>
                 <scriptCode><![CDATA[
@@ -41,7 +51,7 @@ import hou
 from openpype.tools.utils import host_tools
 parent = hou.qt.mainWindow()
 host_tools.show_library_loader(parent=parent)
-]]>                </scriptCode>
+]]></scriptCode>
             </scriptItem>
 
             <separatorItem/>
@@ -53,7 +63,7 @@ import hou
 from openpype.tools.utils import host_tools
 parent = hou.qt.mainWindow()
 host_tools.show_workfiles(parent)
-                ]]></scriptCode>
+]]></scriptCode>
             </scriptItem>
 
             <separatorItem/>
@@ -63,7 +73,8 @@ host_tools.show_workfiles(parent)
 import hou
 from openpype.tools.utils import host_tools
 parent = hou.qt.mainWindow()
-host_tools.show_experimental_tools_dialog(parent)]]></scriptCode>
+host_tools.show_experimental_tools_dialog(parent)
+]]></scriptCode>
             </scriptItem>
         </subMenu>
     </menuBar>

--- a/openpype/hosts/houdini/startup/MainMenuCommon.xml
+++ b/openpype/hosts/houdini/startup/MainMenuCommon.xml
@@ -5,7 +5,7 @@
             <label>OpenPype</label>
 
             <scriptItem id="avalon_create">
-                <label>Create ...</label>
+                <label>Create...</label>
                 <scriptCode><![CDATA[
 import hou
 from openpype.tools.utils import host_tools
@@ -15,7 +15,7 @@ host_tools.show_creator(parent)
             </scriptItem>
 
             <scriptItem id="publish">
-                <label>Publish ...</label>
+                <label>Publish...</label>
                 <scriptCode><![CDATA[
             import hou
             from openpype.tools.utils import host_tools
@@ -25,7 +25,7 @@ host_tools.show_creator(parent)
             </scriptItem>
 
             <scriptItem id="avalon_manage">
-                <label>Manage ...</label>
+                <label>Manage...</label>
                 <scriptCode><![CDATA[
 import hou
 from openpype.tools.utils import host_tools
@@ -35,7 +35,7 @@ host_tools.show_scene_inventory(parent)
             </scriptItem>
 
             <scriptItem id="library_load">
-                <label>Library ...</label>
+                <label>Library...</label>
                 <scriptCode><![CDATA[
 import hou
 from openpype.tools.utils import host_tools
@@ -47,7 +47,7 @@ host_tools.show_library_loader(parent=parent)
             <separatorItem/>
 
             <scriptItem id="workfiles">
-                <label>Work Files ...</label>
+                <label>Work Files...</label>
                 <scriptCode><![CDATA[
 import hou
 from openpype.tools.utils import host_tools

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -183,7 +183,12 @@ def _install_menu():
         "Manage...",
         lambda: host_tools.show_scene_inventory(parent=main_window)
     )
-
+    menu.addCommand(
+        "Library...",
+        lambda: host_tools.show_library_loader(
+            parent=main_window
+        )
+    )
     menu.addSeparator()
     menu.addCommand(
         "Set Resolution",

--- a/openpype/hosts/resolve/api/menu.py
+++ b/openpype/hosts/resolve/api/menu.py
@@ -54,15 +54,15 @@ class OpenPypeMenu(QtWidgets.QWidget):
         )
 
         self.setWindowTitle("OpenPype")
-        workfiles_btn = QtWidgets.QPushButton("Workfiles ...", self)
-        create_btn = QtWidgets.QPushButton("Create ...", self)
-        publish_btn = QtWidgets.QPushButton("Publish ...", self)
-        load_btn = QtWidgets.QPushButton("Load ...", self)
-        inventory_btn = QtWidgets.QPushButton("Inventory ...", self)
-        subsetm_btn = QtWidgets.QPushButton("Subset Manager ...", self)
-        libload_btn = QtWidgets.QPushButton("Library ...", self)
+        workfiles_btn = QtWidgets.QPushButton("Workfiles...", self)
+        create_btn = QtWidgets.QPushButton("Create...", self)
+        publish_btn = QtWidgets.QPushButton("Publish...", self)
+        load_btn = QtWidgets.QPushButton("Load...", self)
+        inventory_btn = QtWidgets.QPushButton("Inventory...", self)
+        subsetm_btn = QtWidgets.QPushButton("Subset Manager...", self)
+        libload_btn = QtWidgets.QPushButton("Library...", self)
         experimental_btn = QtWidgets.QPushButton(
-            "Experimental tools ...", self
+            "Experimental tools...", self
         )
         # rename_btn = QtWidgets.QPushButton("Rename", self)
         # set_colorspace_btn = QtWidgets.QPushButton(


### PR DESCRIPTION
## Brief description
Some hosts were missing Library loader menu item

## Description
This will allow to use Library loader across most of supported DCC

## Additional info
Triple dot stile `Library...` was unified to keep one style only without space between word

## Testing notes:
1. open your host
2. see there is available `Library...` under `Manage...`
3. It should open Library Loader
4. Also check the triple dots are not having space between word

# Tested hosts
- [x] Houdini
- [x] Nuke
- [x] Hiero
- [x] Fusion
- [x] Resolve
- [x] Flame