### PR TITLE
LookAssigner: Fix imports after moving code to OpenPype repository

### DIFF
--- a/openpype/tools/mayalookassigner/models.py
+++ b/openpype/tools/mayalookassigner/models.py
@@ -2,9 +2,9 @@ from collections import defaultdict
 
 from Qt import QtCore
 
-from avalon.tools import models
 from avalon.vendor import qtawesome
 from avalon.style import colors
+from openpype.tools.utils import models
 
 
 class AssetModel(models.TreeModel):

--- a/openpype/tools/mayalookassigner/vray_proxies.py
+++ b/openpype/tools/mayalookassigner/vray_proxies.py
@@ -10,11 +10,9 @@ import six
 import alembic.Abc
 from maya import cmds
 
-import avalon.io as io
-import avalon.maya
-import avalon.api as api
+from avalon import io, api
 
-import openpype.hosts.maya.api.lib as lib
+from openpype.hosts.maya.api import lib
 
 
 log = logging.getLogger(__name__)
@@ -203,7 +201,7 @@ def load_look(version_id):
             raise RuntimeError("Could not find LookLoader, this is a bug")
 
         # Reference the look file
-        with avalon.maya.maintained_selection():
+        with lib.maintained_selection():
             container_node = api.load(loader, look_representation)
 
     return cmds.sets(container_node, query=True)

--- a/openpype/tools/mayalookassigner/widgets.py
+++ b/openpype/tools/mayalookassigner/widgets.py
@@ -16,8 +16,6 @@ from . import views
 
 from maya import cmds
 
-MODELINDEX = QtCore.QModelIndex()
-
 
 class AssetOutliner(QtWidgets.QWidget):
     refreshed = QtCore.Signal()


### PR DESCRIPTION
## Brief description
Some imports from avalon are invalid now when code was moved to OpenPype.

## Changes
- changed import of maya lib function to be imported from openpype maya
- changed import of tools models to be imported from openpype

## Testing notes:
1. Try look manager functions in Maya