### PR TITLE
Houdini: Fix refactor of Houdini host move for CreateArnoldAss

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_arnold_ass.py
+++ b/openpype/hosts/houdini/plugins/create/create_arnold_ass.py
@@ -1,7 +1,7 @@
-from avalon import houdini
+from openpype.hosts.houdini.api import plugin
 
 
-class CreateArnoldAss(houdini.Creator):
+class CreateArnoldAss(plugin.Creator):
     """Arnold .ass Archive"""
 
     label = "Arnold ASS"


### PR DESCRIPTION
## Brief description

https://github.com/pypeclub/OpenPype/pull/2603 implemented creation of Arnold ass files for Houdini. However, upon merging the refactor of Houdini host to OpenPype was missed. This fixes that.