### PR TITLE
Loader: Remove default family states for hosts from code

### DIFF
--- a/openpype/hosts/flame/api/pipeline.py
+++ b/openpype/hosts/flame/api/pipeline.py
@@ -28,18 +28,6 @@ log = Logger.get_logger(__name__)
 
 
 def install():
-    # Disable all families except for the ones we explicitly want to see
-    family_states = [
-        "imagesequence",
-        "render2d",
-        "plate",
-        "render",
-        "mov",
-        "clip"
-    ]
-    avalon.data["familiesStateDefault"] = False
-    avalon.data["familiesStateToggled"] = family_states
-
 
     pyblish.register_host("flame")
     pyblish.register_plugin_path(PUBLISH_PATH)

--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -31,13 +31,6 @@ def install():
 
     """
 
-    # Disable all families except for the ones we explicitly want to see
-    family_states = ["imagesequence",
-                     "camera",
-                     "pointcache"]
-    avalon.data["familiesStateDefault"] = False
-    avalon.data["familiesStateToggled"] = family_states
-
     log.info("openpype.hosts.fusion installed")
 
     pyblish.register_host("fusion")

--- a/openpype/hosts/hiero/api/pipeline.py
+++ b/openpype/hosts/hiero/api/pipeline.py
@@ -51,16 +51,6 @@ def install():
     # register callback for switching publishable
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
-    # Disable all families except for the ones we explicitly want to see
-    family_states = [
-        "write",
-        "review",
-        "plate"
-    ]
-
-    avalon.data["familiesStateDefault"] = False
-    avalon.data["familiesStateToggled"] = family_states
-
     # install menu
     menu.menu_install()
 

--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -60,12 +60,6 @@ def install():
         "instanceToggled", on_pyblish_instance_toggled
     )
 
-    log.info("Setting default family states for loader..")
-    avalon.api.data["familiesStateToggled"] = [
-        "imagesequence",
-        "review"
-    ]
-
     self._has_been_setup = True
     # add houdini vendor packages
     hou_pythonpath = os.path.join(os.path.dirname(HOST_DIR), "vendor")

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -76,9 +76,6 @@ def install():
     avalon.api.on("taskChanged", on_task_changed)
     avalon.api.on("before.workfile.save", before_workfile_save)
 
-    log.info("Setting default family states for loader..")
-    avalon.api.data["familiesStateToggled"] = ["imagesequence"]
-
 
 def _set_project():
     """Sets the maya project to the current Session's work directory.

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -108,17 +108,6 @@ def install():
     pyblish.api.register_callback(
         "instanceToggled", on_pyblish_instance_toggled)
     workfile_settings = WorkfileSettings()
-    # Disable all families except for the ones we explicitly want to see
-    family_states = [
-        "write",
-        "review",
-        "nukenodes",
-        "model",
-        "gizmo"
-    ]
-
-    avalon.api.data["familiesStateDefault"] = False
-    avalon.api.data["familiesStateToggled"] = family_states
 
     # Set context settings.
     nuke.addOnCreate(workfile_settings.set_context_settings, nodeClass="Root")

--- a/openpype/hosts/resolve/api/pipeline.py
+++ b/openpype/hosts/resolve/api/pipeline.py
@@ -35,18 +35,6 @@ def install():
     """
     from .. import get_resolve_module
 
-    # Disable all families except for the ones we explicitly want to see
-    family_states = [
-        "imagesequence",
-        "render2d",
-        "plate",
-        "render",
-        "mov",
-        "clip"
-    ]
-    avalon.data["familiesStateDefault"] = False
-    avalon.data["familiesStateToggled"] = family_states
-
     log.info("openpype.hosts.resolve installed")
 
     pyblish.register_host("resolve")


### PR DESCRIPTION
## Description

This removes the Avalon data being set for `familiesStateToggled` and `familiesStateDefault` from the `install()` logic for hosts. 

Specifically:
- `avalon.api.data["familiesStateToggled"]`
- `avalon.api.data["familiesStateDefault"]` 

This can be removed since the code does nothing within OpenPype due to overriding this behavior with the admin settings with `project_settings/global/tools/loader/family_filter_profiles`

## Question

Even though it currently did nothing within OpenPype - would we like to save default settings with OpenPype that match what this code did originally. The [current OpenPype default settings define **no** filtering whatsoever](https://github.com/pypeclub/OpenPype/blob/3d1ad1258161e2bba15746b1c0f41271b5755bcf/openpype/settings/defaults/project_settings/global.json#L327-L336).

## Testing notes:

1. Run OpenPype **without!** this PR and confirm the original code indeed does nothing in OpenPype.
2. Run a host **with** this PR and make sure the tools, specifically loader and library loader still work.

I tested both in Maya + Houdini. Also tested with custom settings set in Admin Settings for a host and with settings removed in OpenPype for a host. Behavior was the same before and after - nothing being filtered when not set in settings.