### PR TITLE
Settings: Studio Project anatomy is queried using right keys

### DIFF
--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -995,7 +995,7 @@ class MongoSettingsHandler(SettingsHandler):
         # QUESTION cache?
         if version == LEGACY_SETTINGS_VERSION:
             return self.collection.find_one({
-                "type": PROJECT_SETTINGS_KEY,
+                "type": PROJECT_ANATOMY_KEY,
                 "is_default": True
             })
 
@@ -1003,7 +1003,7 @@ class MongoSettingsHandler(SettingsHandler):
             version = self._current_version
 
         return self.collection.find_one({
-            "type": self._project_settings_key,
+            "type": self._project_anatomy_key,
             "is_default": True,
             "version": version
         })


### PR DESCRIPTION
## Brief description
Querying of studio project anatomy is not using right key to get data document.

## Changes
- fix keys which are used to get studio anatomy settings

## Testing notes:
1. Change and save values in studio default project anatomy
2. Restart process and look if the values are loaded