### PR TITLE
General: Don't use 'objectName' from loaded references

### DIFF
--- a/openpype/plugins/publish/collect_scene_loaded_versions.py
+++ b/openpype/plugins/publish/collect_scene_loaded_versions.py
@@ -45,7 +45,6 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
             # NOTE:
             # may have more then one representation that are same version
             version = {
-                "objectName": con["objectName"],  # container node name
                 "subsetName": con["name"],
                 "representation": io.ObjectId(con["representation"]),
                 "version": version_by_repr[con["representation"]],  # _id


### PR DESCRIPTION
## Brief description
Plugin `CollectSceneLoadedVersions` expect that object returned using `ls` will return dictionary with key `objectName` which is available only in few hosts and is not required (and used). Was found out in TVPaint where reference was loaded.

## Changes
- do not store and use `objectName`