### PR TITLE
TVPaint: Set objectName with members

### DIFF
--- a/openpype/hosts/tvpaint/api/pipeline.py
+++ b/openpype/hosts/tvpaint/api/pipeline.py
@@ -377,7 +377,15 @@ def _write_instances(*args, **kwargs):
 
 
 def ls():
-    return get_workfile_metadata(SECTION_NAME_CONTAINERS)
+    output = get_workfile_metadata(SECTION_NAME_CONTAINERS)
+    if output:
+        for item in output:
+            if "objectName" not in item and "members" in item:
+                members = item["members"]
+                if isinstance(members, list):
+                    members = "|".join(members)
+                item["objectName"] = members
+    return output
 
 
 def on_instance_toggle(instance, old_value, new_value):


### PR DESCRIPTION
## Brief description
Fill `objectName` when calling `ls` in TVPaint.

## Description
TVPaint does not match container schema and does not return `objectName` key in returned container discovered during quick fix https://github.com/pypeclub/OpenPype/pull/2715 .

## Changes
- function `ls` in tvpaint fills `objectName` with joined `members`