### PR TITLE
Project Manager: Disable add task, add asset and save button when not in a project

### DIFF
--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -108,7 +108,9 @@ class ProjectManagerWindow(QtWidgets.QWidget):
             helper_btns_widget
         )
         add_asset_btn.setObjectName("IconBtn")
+        add_asset_btn.setEnabled(False)
         add_task_btn.setObjectName("IconBtn")
+        add_task_btn.setEnabled(False)
 
         helper_btns_layout = QtWidgets.QHBoxLayout(helper_btns_widget)
         helper_btns_layout.setContentsMargins(0, 0, 0, 0)
@@ -138,6 +140,7 @@ class ProjectManagerWindow(QtWidgets.QWidget):
 
         message_label = QtWidgets.QLabel(buttons_widget)
         save_btn = QtWidgets.QPushButton("Save", buttons_widget)
+        save_btn.setEnabled(False)
 
         buttons_layout = QtWidgets.QHBoxLayout(buttons_widget)
         buttons_layout.setContentsMargins(0, 0, 0, 0)
@@ -173,6 +176,7 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self._create_project_btn = create_project_btn
         self._create_folders_btn = create_folders_btn
         self._remove_projects_btn = remove_projects_btn
+        self._save_btn = save_btn
 
         self._add_asset_btn = add_asset_btn
         self._add_task_btn = add_task_btn
@@ -183,6 +187,9 @@ class ProjectManagerWindow(QtWidgets.QWidget):
     def _set_project(self, project_name=None):
         self._create_folders_btn.setEnabled(project_name is not None)
         self._remove_projects_btn.setEnabled(project_name is not None)
+        self._add_asset_btn.setEnabled(project_name is not None)
+        self._add_task_btn.setEnabled(project_name is not None)
+        self._save_btn.setEnabled(project_name is not None)
         self._project_proxy_model.set_filter_default(project_name is not None)
         self.hierarchy_view.set_project(project_name)
 


### PR DESCRIPTION
## Brief description

The Project manager had the add task, add asset and save button when just launched and no project was active. This was confusing as was [reported on dicord](https://discord.com/channels/517362899170230292/563751989075378201/943059891969482772).

**Before**:
![afbeelding](https://user-images.githubusercontent.com/2439881/154024173-f201170c-a4e1-4e18-a38b-4e5f04ab0e65.png)

This PR disables the buttons until you're in a project.

**After**:
![afbeelding](https://user-images.githubusercontent.com/2439881/154024089-af1f65bd-c1cb-4631-aa83-a17cb81ae0dc.png)


## Testing notes:
1. open project manager
2. confirm it still works as intended