### PR TITLE
General: Fix loading of unused chars in xml format

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -197,6 +197,8 @@ def parse_oiio_xml_output(xml_string, logger=None):
     # Fix values with ampresand (lazy fix)
     # - oiiotool exports invalid xml which ElementTree can't handle
     #   e.g. "&#01;"
+    # WARNING: this will affect even valid character entities. If you need those values correctly, this must
+    # take care of valid character ranges. See https://github.com/pypeclub/OpenPype/pull/2729
     matches = XML_CHAR_REF_REGEX_HEX.findall(xml_string)
     for match in matches:
         new_value = match.replace("&", "&amp;")

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -31,37 +31,9 @@ INT_TAGS = {
     "subimages",
 }
 
-XML_UNUSED_CHARS = {
-    "&#00;",
-    "&#01;",
-    "&#02;",
-    "&#03;",
-    "&#04;",
-    "&#05;",
-    "&#06;",
-    "&#07;",
-    "&#08;",
-    "&#11;",
-    "&#12;",
-    "&#14;",
-    "&#15;",
-    "&#16;",
-    "&#17;",
-    "&#18;",
-    "&#19;",
-    "&#20;",
-    "&#21;",
-    "&#22;",
-    "&#23;",
-    "&#24;",
-    "&#25;",
-    "&#26;",
-    "&#27;",
-    "&#28;",
-    "&#29;",
-    "&#30;",
-    "&#31;"
-}
+CHAR_REF_REGEX_DECIMAL = re.compile(r"&#[0-9]+;")
+CHAR_REF_REGEX_HEX = re.compile(r"&#x[0-9a-zA-Z]+;")
+
 # Regex to parse array attributes
 ARRAY_TYPE_REGEX = re.compile(r"^(int|float|string)\[\d+\]$")
 
@@ -226,10 +198,13 @@ def parse_oiio_xml_output(xml_string, logger=None):
     # Fix values with ampresand (lazy fix)
     # - ElementTree can't handle all escaped values with ampresand
     #   e.g. "&#01;"
-    for unused_char in XML_UNUSED_CHARS:
-        if unused_char in xml_string:
-            new_char = unused_char.replace("&", "&amp;")
-            xml_string = xml_string.replace(unused_char, new_char)
+    matches = (
+        set(CHAR_REF_REGEX_HEX.findall(xml_string))
+        | set(CHAR_REF_REGEX_DECIMAL.findall(xml_string))
+    )
+    for match in matches:
+        new_value = match.replace("&", "&amp;")
+        xml_string = xml_string.replace(match, new_value)
 
     if logger is None:
         logger = logging.getLogger("OIIO-xml-parse")

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -197,8 +197,9 @@ def parse_oiio_xml_output(xml_string, logger=None):
     # Fix values with ampresand (lazy fix)
     # - oiiotool exports invalid xml which ElementTree can't handle
     #   e.g. "&#01;"
-    # WARNING: this will affect even valid character entities. If you need those values correctly, this must
-    # take care of valid character ranges. See https://github.com/pypeclub/OpenPype/pull/2729
+    # WARNING: this will affect even valid character entities. If you need
+    #   those values correctly, this must take care of valid character ranges.
+    #   See https://github.com/pypeclub/OpenPype/pull/2729
     matches = XML_CHAR_REF_REGEX_HEX.findall(xml_string)
     for match in matches:
         new_value = match.replace("&", "&amp;")

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -30,6 +30,38 @@ INT_TAGS = {
     "deep",
     "subimages",
 }
+
+XML_UNUSED_CHARS = {
+    "&#00;",
+    "&#01;",
+    "&#02;",
+    "&#03;",
+    "&#04;",
+    "&#05;",
+    "&#06;",
+    "&#07;",
+    "&#08;",
+    "&#11;",
+    "&#12;",
+    "&#14;",
+    "&#15;",
+    "&#16;",
+    "&#17;",
+    "&#18;",
+    "&#19;",
+    "&#20;",
+    "&#21;",
+    "&#22;",
+    "&#23;",
+    "&#24;",
+    "&#25;",
+    "&#26;",
+    "&#27;",
+    "&#28;",
+    "&#29;",
+    "&#30;",
+    "&#31;"
+}
 # Regex to parse array attributes
 ARRAY_TYPE_REGEX = re.compile(r"^(int|float|string)\[\d+\]$")
 
@@ -190,6 +222,14 @@ def parse_oiio_xml_output(xml_string, logger=None):
     output = {}
     if not xml_string:
         return output
+
+    # Fix values with ampresand (lazy fix)
+    # - ElementTree can't handle all escaped values with ampresand
+    #   e.g. "&#01;"
+    for unused_char in XML_UNUSED_CHARS:
+        if unused_char in xml_string:
+            new_char = unused_char.replace("&", "&amp;")
+            xml_string = xml_string.replace(unused_char, new_char)
 
     if logger is None:
         logger = logging.getLogger("OIIO-xml-parse")

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -31,8 +31,7 @@ INT_TAGS = {
     "subimages",
 }
 
-CHAR_REF_REGEX_DECIMAL = re.compile(r"&#[0-9]+;")
-CHAR_REF_REGEX_HEX = re.compile(r"&#x[0-9a-zA-Z]+;")
+XML_CHAR_REF_REGEX_HEX = re.compile(r"&#x?[0-9a-fA-F]+;")
 
 # Regex to parse array attributes
 ARRAY_TYPE_REGEX = re.compile(r"^(int|float|string)\[\d+\]$")
@@ -196,12 +195,9 @@ def parse_oiio_xml_output(xml_string, logger=None):
         return output
 
     # Fix values with ampresand (lazy fix)
-    # - ElementTree can't handle all escaped values with ampresand
+    # - oiiotool exports invalid xml which ElementTree can't handle
     #   e.g. "&#01;"
-    matches = (
-        set(CHAR_REF_REGEX_HEX.findall(xml_string))
-        | set(CHAR_REF_REGEX_DECIMAL.findall(xml_string))
-    )
+    matches = XML_CHAR_REF_REGEX_HEX.findall(xml_string)
     for match in matches:
         new_value = match.replace("&", "&amp;")
         xml_string = xml_string.replace(match, new_value)


### PR DESCRIPTION
## Brief description
Class `ElementTree` in xml parser don't know how to handle all escaped values which cause parse error.

## Description
Not sure what is proper fix. Propably would be to modify xml parser which is more complicated or define all possible espace values (e.g. from this [source](https://www.obkb.com/dcljr/charstxt.html)). It currently breaks loading of data for some exr.

## Changes
- replace `&` in some unused xml ampresand characters with `&amp;` so `ElementTree` can parse it