### PR TITLE
WebPublisher: Fix for proper parsing of ffmpeg output arguments

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -694,13 +694,13 @@ class ExtractReview(pyblish.api.InstancePlugin):
         audio_args_dentifiers = ["-af", "-filter:a"]
         for arg in tuple(output_args):
             for identifier in video_args_dentifiers:
-                if identifier in arg:
+                if arg.startswith("{} ".format(identifier)):
                     output_args.remove(arg)
                     arg = arg.replace(identifier, "").strip()
                     video_filters.append(arg)
 
             for identifier in audio_args_dentifiers:
-                if identifier in arg:
+                if arg.startswith("{} ".format(identifier)):
                     output_args.remove(arg)
                     arg = arg.replace(identifier, "").strip()
                     audio_filters.append(arg)

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,8 +12,6 @@ Structure:
     
 How to run:
 ----------
-- single test class could be run by PyCharm and its pytest runner directly
-- OR
 - use Openpype command 'runtests' from command line (`.venv` in ${OPENPYPE_ROOT} must be activated to use configured Python!)
 -- `${OPENPYPE_ROOT}/python start.py runtests`
   

--- a/tests/unit/openpype/plugins/publish/test_extract_review.py
+++ b/tests/unit/openpype/plugins/publish/test_extract_review.py
@@ -1,0 +1,30 @@
+from openpype.plugins.publish.extract_review import ExtractReview
+
+
+def test_fix_ffmpeg_full_args_filters():
+    """Tests because of wrong resolution of audio filters."""
+    plugin = ExtractReview()
+    output_arg = "c:/test-afbdc"
+    ret = plugin.ffmpeg_full_args([], [], [], [output_arg])
+    assert len(ret) == 2, "Parsed wrong"
+    assert ret[-1] == output_arg
+
+    ret = plugin.ffmpeg_full_args([], [], ["adeclick"], [output_arg])
+    assert len(ret) == 4, "Parsed wrong"
+    assert ret[-1] == output_arg
+    assert ret[-2] == '"adeclick"'
+    assert ret[-3] == "-filter:a"
+
+    ret = plugin.ffmpeg_full_args([], [], [], [output_arg, "-af adeclick"])
+    assert len(ret) == 4, "Parsed wrong"
+    assert ret[-1] == output_arg
+    assert ret[-2] == '"adeclick"'
+    assert ret[-3] == "-filter:a"
+
+    ret = plugin.ffmpeg_full_args([], [], ["adeclick"],
+                                  [output_arg, "-af adeclick"])
+    assert len(ret) == 4, "Parsed wrong"
+    assert ret[-1] == output_arg
+    assert ret[-2] == '"adeclick,addeclick"' # TODO fix this duplication
+    assert ret[-3] == "-filter:a"
+

--- a/tests/unit/openpype/plugins/publish/test_extract_review.py
+++ b/tests/unit/openpype/plugins/publish/test_extract_review.py
@@ -25,6 +25,5 @@ def test_fix_ffmpeg_full_args_filters():
                                   [output_arg, "-af adeclick"])
     assert len(ret) == 4, "Parsed wrong"
     assert ret[-1] == output_arg
-    assert ret[-2] == '"adeclick,addeclick"' # TODO fix this duplication
+    assert ret[-2] == '"adeclick,adeclick"'  # TODO fix this duplication
     assert ret[-3] == "-filter:a"
-


### PR DESCRIPTION
## Brief description
Batch names containing `-af` or `-vf` were triggering failure of `ExtractReview` with 
```At least one output file must be specified```

## Description
There is logic which handles presence of audio/video filters in output arguments for ffmpeg to yank them into proper position. They were just simple presence filters which hit on an issue that output arguments for files coming from WP contain batch name with `-` characters. 

## Additional info
In specific cases batch name could contain `-af` which broke parsing and produces command like 
```
"C:\Program Files (x86)\OpenPype\vendor\bin\ffmpeg\windows\bin\ffmpeg" -apply_trc gamma22 -i W:\4c9c1954-d342-44f6-962d-af347c59c83b\be9709f0-b370-47c5-bbde-f973c48464bb\wsb_sh060_2d_rough_b_v001.mp4 -filter:a "W:\4c9c1954-d342-44f6-962d347c59c83b\be9709f0-b370-47c5-bbde-f973c48464bb\wsb_sh060_2d_rough_b_v001_h264.mp4" -pix_fmt yuv420p -b:v 40M -minrate: 40M -maxrate: 40M -bufsize: 40M -intra -y
```
(See missing value at the end after -y)


## Testing notes:
1. Reprocess any batch that contains `-af` in its name
2. Configure `ExtractReview` to contain some audio/video filters to make sure they are correctly propagated
![Screenshot 2022-02-15 152425](https://user-images.githubusercontent.com/4457962/154083816-d42e792a-7383-4215-9a82-eb8d0ec72f91.png)

