### PR TITLE
Loader UI: Multiple asset selection and underline colors fixed

### DIFF
--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -396,9 +396,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
             self._versionschanged()
             return
 
-        selected_subsets = self._subsets_widget.selected_subsets(
-            _merged=True, _other=False
-        )
+        selected_subsets = self._subsets_widget.get_selected_merge_items()
 
         asset_colors = {}
         asset_ids = []
@@ -423,35 +421,14 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
         self._versionschanged()
 
     def _versionschanged(self):
-        selection = self._subsets_widget.view.selectionModel()
-
-        # Active must be in the selected rows otherwise we
-        # assume it's not actually an "active" current index.
-        version_docs = None
+        items = self._subsets_widget.get_selected_subsets()
         version_doc = None
-        active = selection.currentIndex()
-        rows = selection.selectedRows(column=active.column())
-        if active and active in rows:
-            item = active.data(self._subsets_widget.model.ItemRole)
-            if (
-                item is not None
-                and not (item.get("isGroup") or item.get("isMerged"))
-            ):
-                version_doc = item["version_document"]
-
-        if rows:
-            version_docs = []
-            for index in rows:
-                if not index or not index.isValid():
-                    continue
-                item = index.data(self._subsets_widget.model.ItemRole)
-                if (
-                    item is None
-                    or item.get("isGroup")
-                    or item.get("isMerged")
-                ):
-                    continue
-                version_docs.append(item["version_document"])
+        version_docs = []
+        for item in items:
+            doc = item["version_document"]
+            version_docs.append(doc)
+            if version_doc is None:
+                version_doc = doc
 
         self._version_info_widget.set_version(version_doc)
 

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -288,9 +288,7 @@ class LoaderWindow(QtWidgets.QDialog):
         on selection change so they match current selection.
         """
         # TODO do not touch inner attributes of asset widget
-        last_asset_ids = self.data["state"]["assetIds"]
-        if last_asset_ids:
-            self._assets_widget.clear_underlines()
+        self._assets_widget.clear_underlines()
 
     def _assetschanged(self):
         """Selected assets have changed"""
@@ -329,6 +327,7 @@ class LoaderWindow(QtWidgets.QDialog):
         asset_ids = self.data["state"]["assetIds"]
         # Skip setting colors if not asset multiselection
         if not asset_ids or len(asset_ids) < 2:
+            self.clear_assets_underlines()
             self._versionschanged()
             return
 

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -1,5 +1,4 @@
 import sys
-import collections
 
 from Qt import QtWidgets, QtCore
 from avalon import api, io, pipeline

--- a/openpype/tools/loader/app.py
+++ b/openpype/tools/loader/app.py
@@ -1,4 +1,5 @@
 import sys
+import collections
 
 from Qt import QtWidgets, QtCore
 from avalon import api, io, pipeline
@@ -378,15 +379,19 @@ class LoaderWindow(QtWidgets.QDialog):
 
         version_docs = []
         if rows:
+            items = collections.deque()
             for index in rows:
                 if not index or not index.isValid():
                     continue
                 item = index.data(subsets.model.ItemRole)
-                if item is None:
-                    continue
+                if item is not None:
+                    items.append(item)
+
+            while items:
+                item = items.popleft()
                 if item.get("isGroup") or item.get("isMerged"):
                     for child in item.children():
-                        version_docs.append(child["version_document"])
+                        items.append(child)
                 else:
                     version_docs.append(item["version_document"])
 

--- a/openpype/tools/loader/lib.py
+++ b/openpype/tools/loader/lib.py
@@ -19,24 +19,6 @@ def change_visibility(model, view, column_name, visible):
     view.setColumnHidden(index, not visible)
 
 
-def get_selected_items(rows, item_role):
-    output = []
-    items = collections.deque()
-    for row_index in rows:
-        item = row_index.data(item_role)
-        items.append(item)
-
-    while items:
-        item = items.popleft()
-        if item.get("isGroup") or item.get("isMerged"):
-            for child in item.children():
-                items.append(child)
-        else:
-            if item not in output:
-                output.append(item)
-    return output
-
-
 def get_options(action, loader, parent, repre_contexts):
     """Provides dialog to select value from loader provided options.
 

--- a/openpype/tools/loader/lib.py
+++ b/openpype/tools/loader/lib.py
@@ -1,5 +1,4 @@
 import inspect
-import collections
 from Qt import QtGui
 
 from avalon.vendor import qtawesome

--- a/openpype/tools/loader/lib.py
+++ b/openpype/tools/loader/lib.py
@@ -1,4 +1,5 @@
 import inspect
+import collections
 from Qt import QtGui
 
 from avalon.vendor import qtawesome
@@ -19,23 +20,21 @@ def change_visibility(model, view, column_name, visible):
 
 
 def get_selected_items(rows, item_role):
-    items = []
+    output = []
+    items = collections.deque()
     for row_index in rows:
         item = row_index.data(item_role)
-        if item.get("isGroup"):
-            continue
+        items.append(item)
 
-        elif item.get("isMerged"):
-            for idx in range(row_index.model().rowCount(row_index)):
-                child_index = row_index.child(idx, 0)
-                item = child_index.data(item_role)
-                if item not in items:
-                    items.append(item)
-
+    while items:
+        item = items.popleft()
+        if item.get("isGroup") or item.get("isMerged"):
+            for child in item.children():
+                items.append(child)
         else:
-            if item not in items:
-                items.append(item)
-    return items
+            if item not in output:
+                output.append(item)
+    return output
 
 
 def get_options(action, loader, parent, repre_contexts):

--- a/openpype/tools/loader/model.py
+++ b/openpype/tools/loader/model.py
@@ -524,9 +524,13 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
             return
 
         self._fill_subset_items(
-            asset_docs_by_id, subset_docs_by_id, last_versions_by_subset_id,
+            asset_docs_by_id,
+            subset_docs_by_id,
+            last_versions_by_subset_id,
             repre_info_by_version_id
         )
+        self.endResetModel()
+        self.refreshed.emit(True)
 
     def create_multiasset_group(
         self, subset_name, asset_ids, subset_counter, parent_item=None
@@ -538,7 +542,6 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
         merge_group.update({
             "subset": "{} ({})".format(subset_name, len(asset_ids)),
             "isMerged": True,
-            "childRow": 0,
             "subsetColor": subset_color,
             "assetIds": list(asset_ids),
             "icon": qtawesome.icon(
@@ -547,7 +550,6 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
             )
         })
 
-        subset_counter += 1
         self.add_child(merge_group, parent_item)
 
         return merge_group
@@ -567,8 +569,7 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
             group_item = Item()
             group_item.update({
                 "subset": group_name,
-                "isGroup": True,
-                "childRow": 0
+                "isGroup": True
             })
             group_item.update(group_data)
 
@@ -665,9 +666,6 @@ class SubsetsModel(TreeModel, BaseRepresentationModel):
 
                 index = self.index(item.row(), 0, parent_index)
                 self.set_version(index, last_version)
-
-        self.endResetModel()
-        self.refreshed.emit(True)
 
     def data(self, index, role):
         if not index.isValid():
@@ -1139,7 +1137,6 @@ class RepresentationModel(TreeModel, BaseRepresentationModel):
                         "_id": doc["_id"],
                         "name": doc["name"],
                         "isMerged": True,
-                        "childRow": 0,
                         "active_site_name": self.active_site,
                         "remote_site_name": self.remote_site,
                         "icon": qtawesome.icon(

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -34,7 +34,8 @@ from .model import (
     SubsetFilterProxyModel,
     FamiliesFilterProxyModel,
     RepresentationModel,
-    RepresentationSortProxyModel
+    RepresentationSortProxyModel,
+    ITEM_ID_ROLE
 )
 from . import lib
 
@@ -351,6 +352,59 @@ class SubsetWidget(QtWidgets.QWidget):
 
         lib.change_visibility(self.model, self.view, "repre_info", enabled)
 
+    def get_selected_items(self):
+        selection_model = self.view.selectionModel()
+        indexes = selection_model.selectedIndexes()
+
+        item_ids = set()
+        for index in indexes:
+            item_id = index.data(ITEM_ID_ROLE)
+            if item_id is not None:
+                item_ids.add(item_id)
+
+        output = []
+        for item_id in item_ids:
+            item = self.model.get_item_by_id(item_id)
+            if item is not None:
+                output.append(item)
+        return output
+
+    def get_selected_merge_items(self):
+        output = []
+        items = collections.deque(self.get_selected_items())
+
+        item_ids = set()
+        while items:
+            item = items.popleft()
+            if item.get("isGroup"):
+                for child in item.children():
+                    items.appendleft(child)
+
+            elif item.get("isMerged"):
+                item_id = item["id"]
+                if item_id not in item_ids:
+                    item_ids.add(item_id)
+                    output.append(item)
+
+        return output
+
+    def get_selected_subsets(self):
+        output = []
+        items = collections.deque(self.get_selected_items())
+
+        item_ids = set()
+        while items:
+            item = items.popleft()
+            if item.get("isGroup") or item.get("isMerged"):
+                for child in item.children():
+                    items.appendleft(child)
+            else:
+                item_id = item["id"]
+                if item_id not in item_ids:
+                    item_ids.add(item_id)
+                    output.append(item)
+        return output
+
     def on_context_menu(self, point):
         """Shows menu with loader actions on Right-click.
 
@@ -367,10 +421,7 @@ class SubsetWidget(QtWidgets.QWidget):
             return
 
         # Get selected subsets without groups
-        selection = self.view.selectionModel()
-        rows = selection.selectedRows(column=0)
-
-        items = lib.get_selected_items(rows, self.model.ItemRole)
+        items = self.get_selected_subsets()
 
         # Get all representation->loader combinations available for the
         # index under the cursor, so we can list the user the options.
@@ -538,35 +589,6 @@ class SubsetWidget(QtWidgets.QWidget):
         if error_info:
             box = LoadErrorMessageBox(error_info, self)
             box.show()
-
-    def selected_subsets(self, _groups=False, _merged=False, _other=True):
-        selection = self.view.selectionModel()
-        rows = selection.selectedRows(column=0)
-
-        subsets = list()
-        if not any([_groups, _merged, _other]):
-            self.echo((
-                "This is a BUG: Selected_subsets args must contain"
-                " at least one value set to True"
-            ))
-            return subsets
-
-        for row in rows:
-            item = row.data(self.model.ItemRole)
-            if item.get("isGroup"):
-                if not _groups:
-                    continue
-
-            elif item.get("isMerged"):
-                if not _merged:
-                    continue
-            else:
-                if not _other:
-                    continue
-
-            subsets.append(item)
-
-        return subsets
 
     def group_subsets(self, name, asset_ids, items):
         field = "data.subsetGroup"
@@ -1279,7 +1301,7 @@ class RepresentationWidget(QtWidgets.QWidget):
         selection = self.tree_view.selectionModel()
         rows = selection.selectedRows(column=0)
 
-        items = lib.get_selected_items(rows, self.model.ItemRole)
+        items = self.get_selected_subsets()
 
         selected_side = self._get_selected_side(point_index, rows)
 

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -303,7 +303,7 @@ class AssetModel(QtGui.QStandardItemModel):
 
         self._doc_fetched.connect(self._on_docs_fetched)
 
-        self._items_with_color_by_id = {}
+        self._item_ids_with_color = set()
         self._items_by_asset_id = {}
 
         self._last_project_name = None
@@ -382,9 +382,11 @@ class AssetModel(QtGui.QStandardItemModel):
         self._stop_fetch_thread()
 
     def clear_underlines(self):
-        for asset_id in tuple(self._items_with_color_by_id.keys()):
-            item = self._items_with_color_by_id.pop(asset_id)
-            item.setData(None, ASSET_UNDERLINE_COLORS_ROLE)
+        for asset_id in set(self._item_ids_with_color):
+            self._item_ids_with_color.remove(asset_id)
+            item = self._items_by_asset_id.get(asset_id)
+            if item is not None:
+                item.setData(None, ASSET_UNDERLINE_COLORS_ROLE)
 
     def set_underline_colors(self, colors_by_asset_id):
         self.clear_underlines()
@@ -394,12 +396,13 @@ class AssetModel(QtGui.QStandardItemModel):
             if item is None:
                 continue
             item.setData(colors, ASSET_UNDERLINE_COLORS_ROLE)
+            self._item_ids_with_color.add(asset_id)
 
     def _clear_items(self):
         root_item = self.invisibleRootItem()
         root_item.removeRows(0, root_item.rowCount())
         self._items_by_asset_id = {}
-        self._items_with_color_by_id = {}
+        self._item_ids_with_color = set()
 
     def _on_docs_fetched(self):
         # Make sure refreshing did not change


### PR DESCRIPTION
## Brief description
Loader errors when it is clicked on a group with merge group in it and underline colors in assets widget are not cleared.

## Description
Code does not expect that group can have children item that is another group but expects it has version document which cause not updating of version info widget on click. Also underline color are not cleared at all righ now.

## Changes
- implemented missing part of clearing of underline colors in assets widget
- looping through group item expect that can have another group as children
- it is possible to show loaders on group items

## Testing notes:
1. Click on group with merged subsets in loader (multi asset selection with same subsets in same group is required)
2. Nothing should crash and should be possible to run loaders on the group
3. Underline colors should be cleared when clicked on different subset or subsets are deselected

Resolves https://github.com/pypeclub/OpenPype/issues/2728