### PR TITLE
Ftrack: Disable ftrack module by default

### DIFF
--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -13,7 +13,7 @@
         }
     },
     "ftrack": {
-        "enabled": true,
+        "enabled": false,
         "ftrack_server": "",
         "ftrack_actions_path": {
             "windows": [],


### PR DESCRIPTION
## Brief description

This disables the Ftrack module by default for any new OpenPype users.

One of the first questions that tend to come up on Discord from new users is "How do I disable Ftrack?" or "I get this Ftrack error/warning. What to do?"

Since you first have to actually set an Ftrack Server URL for it to work for which you need to go into Admin Settings anyway it makes sense to just disable the module by default. If anyone wants to use Ftrack, they go to settings, enable the module **and** directly set the right Ftrack URL for their studio.

## Testing notes:

1. start a fresh openpype install/database
2. make sure things work as expected with the ftrack module disabled