### PR TITLE
Maya: set Deadline job/batch name to original source workfile name instead of published workfile

### DIFF
--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -404,7 +404,13 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         dirname = os.path.join(workspace, default_render_file)
         renderlayer = instance.data['setMembers']       # rs_beauty
         deadline_user = context.data.get("user", getpass.getuser())
-        jobname = "%s - %s" % (filename, instance.name)
+
+        # Always use the original work file name for the Job name even when
+        # rendering is done from the published Work File. The original work
+        # file name is clearer because it can also have subversion strings,
+        # etc. which are stripped for the published file.
+        src_filename = os.path.basename(context.data["currentFile"])
+        jobname = "%s - %s" % (src_filename, instance.name)
 
         # Get the variables depending on the renderer
         render_variables = get_renderer_variables(renderlayer, dirname)
@@ -452,7 +458,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         self.payload_skeleton["JobInfo"]["Plugin"] = self._instance.data.get(
             "mayaRenderPlugin", "MayaBatch")
 
-        self.payload_skeleton["JobInfo"]["BatchName"] = filename
+        self.payload_skeleton["JobInfo"]["BatchName"] = src_filename
         # Job name, as seen in Monitor
         self.payload_skeleton["JobInfo"]["Name"] = jobname
         # Arbitrary username, for visualisation in Monitor


### PR DESCRIPTION
## Description

When submitting from Maya to deadline with Work file publish enabled Deadline will render using the published work file. The deadline batch and job name were set using that filename.

The problem however was that a user could have a work file name `shot_v001_{subversion}` like `shot_v001_testfile` as current workfile. On submitting to deadline the Deadline job would however read as batch name and job name `shot_v001` which made it harder for artists to trace back their render to their work file and track e.g. some test subversions they submitted.

This change should always force the usage of the original work file name for Job + Batch name.

## Testing notes:

1. test a deadline submission from workfile with subversion string with Use Published enabled + workfile publishing enabled as well
2. test same settings, but from workfile without subversion string.