### PR TITLE
Work Files: Preserve subversion comment of current filename by default

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -116,7 +116,7 @@ class CommentMatcher(object):
             "|".join(re.escape(ext[1:]) for ext in extensions)
         )
 
-        # Use placeholders that we can safely escape with regex
+        # Use placeholders that will never be in the filename
         temp_data = copy.deepcopy(data)
         temp_data["comment"] = "<<comment>>"
         temp_data["version"] = "<<version>>"
@@ -126,11 +126,14 @@ class CommentMatcher(object):
         fname_pattern = formatted[template_key]["file"]
         fname_pattern = re.escape(fname_pattern)
 
-        # Replace comment and version with something we can match with
-        # regex
-        fname_pattern = fname_pattern.replace("<<comment>>", "(.+)")
-        fname_pattern = fname_pattern.replace("<<version>>", "[0-9]+")
-        fname_pattern = fname_pattern.replace("<<ext>>", any_extension)
+        # Replace comment and version with something we can match with regex
+        replacements = {
+            "<<comment>>": "(.+)",
+            "<<version>>": "[0-9]+",
+            "<<ext>>": any_extension,
+        }
+        for src, dest in replacements.items():
+            fname_pattern = fname_pattern.replace(re.escape(src), dest)
 
         # Match from beginning to end of string to be safe
         fname_pattern = "^{}$".format(fname_pattern)

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -103,42 +103,115 @@ class CommentMatcher(object):
     """Use anatomy and work file data to parse comments from filenames"""
     def __init__(self, anatomy, template_key, data):
 
-        self.anatomy = anatomy
-        self.template_key = template_key
-        self.template = self.anatomy.templates[template_key]["file"]
-        self.data = data
+        self.fname_regex = None
 
-    def parse_comment(self, filepath):
-        """Parse the {comment} part from a filename"""
-
-        if "{comment}" not in self.template:
+        template = anatomy.templates[template_key]["file"]
+        if "{comment}" not in template:
             # Don't look for comment if template doesn't allow it
             return
 
-        # Get current extension without the dot (.)
-        ext = os.path.splitext(filepath)[1][1:]
-        current_fname = os.path.basename(filepath)
-        temp_data = copy.deepcopy(self.data)
-        temp_data["ext"] = ext
+        # Create a regex group for extensions
+        extensions = api.registered_host().file_extensions()
+        any_extension = "(?:{})".format(
+            "|".join(re.escape(ext[1:]) for ext in extensions)
+        )
 
         # Use placeholders that we can safely escape with regex
+        temp_data = copy.deepcopy(data)
         temp_data["comment"] = "<<comment>>"
         temp_data["version"] = "<<version>>"
+        temp_data["ext"] = "<<ext>>"
 
-        formatted = self.anatomy.format(temp_data)
-        fname_pattern = formatted[self.template_key]["file"]
+        formatted = anatomy.format(temp_data)
+        fname_pattern = formatted[template_key]["file"]
         fname_pattern = re.escape(fname_pattern)
 
         # Replace comment and version with something we can match with
         # regex
         fname_pattern = fname_pattern.replace("<<comment>>", "(.+)")
         fname_pattern = fname_pattern.replace("<<version>>", "[0-9]+")
+        fname_pattern = fname_pattern.replace("<<ext>>", any_extension)
 
         # Match from beginning to end of string to be safe
         fname_pattern = "^{}$".format(fname_pattern)
-        match = re.match(fname_pattern, current_fname)
+
+        self.fname_regex = re.compile(fname_pattern)
+
+    def parse_comment(self, filepath):
+        """Parse the {comment} part from a filename"""
+        if not self.fname_regex:
+            return
+
+        fname = os.path.basename(filepath)
+        match = self.fname_regex.match(fname)
         if match:
             return match.group(1)
+
+
+class SubversionLineEdit(QtWidgets.QWidget):
+    """QLineEdit with QPushButton for drop down selection of list of strings"""
+    def __init__(self, parent=None):
+        super(SubversionLineEdit, self).__init__(parent=parent)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(3)
+
+        self._input = PlaceholderLineEdit()
+        self._button = QtWidgets.QPushButton("")
+        self._button.setFixedWidth(18)
+        self._menu = QtWidgets.QMenu(self)
+        self._button.setMenu(self._menu)
+
+        layout.addWidget(self._input)
+        layout.addWidget(self._button)
+
+    @property
+    def input(self):
+        return self._input
+
+    def set_values(self, values):
+        self._update(values)
+
+    def _on_button_clicked(self):
+        self._menu.exec_()
+
+    def _on_action_clicked(self, action):
+        self._input.setText(action.text())
+
+    def _update(self, values):
+        """Create optional predefined subset names
+
+        Args:
+            default_names(list): all predefined names
+
+        Returns:
+             None
+        """
+
+        menu = self._menu
+        button = self._button
+
+        state = any(values)
+        button.setEnabled(state)
+        if state is False:
+            return
+
+        # Include an empty string
+        values = [""] + sorted(values)
+
+        # Get and destroy the action group
+        group = button.findChild(QtWidgets.QActionGroup)
+        if group:
+            group.deleteLater()
+
+        # Build new action group
+        group = QtWidgets.QActionGroup(button)
+        for name in values:
+            action = group.addAction(name)
+            menu.addAction(action)
+
+        group.triggered.connect(self._on_action_clicked)
 
 
 class NameWindow(QtWidgets.QDialog):
@@ -205,8 +278,8 @@ class NameWindow(QtWidgets.QDialog):
         preview_label = QtWidgets.QLabel("Preview filename", inputs_widget)
 
         # Subversion input
-        subversion_input = PlaceholderLineEdit(inputs_widget)
-        subversion_input.setPlaceholderText("Will be part of filename.")
+        subversion = SubversionLineEdit(inputs_widget)
+        subversion.input.setPlaceholderText("Will be part of filename.")
 
         # Extensions combobox
         ext_combo = QtWidgets.QComboBox(inputs_widget)
@@ -227,7 +300,7 @@ class NameWindow(QtWidgets.QDialog):
 
         # Add subversion only if template contains `{comment}`
         if "{comment}" in self.template:
-            inputs_layout.addRow("Subversion:", subversion_input)
+            inputs_layout.addRow("Subversion:", subversion)
 
             # Detect whether a {comment} is in the current filename - if so,
             # preserve it by default and set it in the comment/subversion field
@@ -241,10 +314,13 @@ class NameWindow(QtWidgets.QDialog):
                 if comment:
                     log.info("Detected subversion comment: {}".format(comment))
                     self.data["comment"] = comment
-                    subversion_input.setText(comment)
+                    subversion.input.setText(comment)
+
+            existing_comments = self.get_existing_comments()
+            subversion.set_values(existing_comments)
 
         else:
-            subversion_input.setVisible(False)
+            subversion.setVisible(False)
         inputs_layout.addRow("Extension:", ext_combo)
         inputs_layout.addRow("Preview:", preview_label)
 
@@ -259,7 +335,7 @@ class NameWindow(QtWidgets.QDialog):
             self.on_version_checkbox_changed
         )
 
-        subversion_input.textChanged.connect(self.on_comment_changed)
+        subversion.input.textChanged.connect(self.on_comment_changed)
         ext_combo.currentIndexChanged.connect(self.on_extension_changed)
 
         btn_ok.pressed.connect(self.on_ok_pressed)
@@ -270,7 +346,7 @@ class NameWindow(QtWidgets.QDialog):
 
         # Force default focus to comment, some hosts didn't automatically
         # apply focus to this line edit (e.g. Houdini)
-        subversion_input.setFocus()
+        subversion.input.setFocus()
 
         # Store widgets
         self.btn_ok = btn_ok
@@ -281,11 +357,31 @@ class NameWindow(QtWidgets.QDialog):
         self.last_version_check = last_version_check
 
         self.preview_label = preview_label
-        self.subversion_input = subversion_input
+        self.subversion = subversion
         self.ext_combo = ext_combo
         self._ext_delegate = ext_delegate
 
         self.refresh()
+
+    def get_existing_comments(self):
+
+        matcher = CommentMatcher(self.anatomy, self.template_key, self.data)
+        host_extensions = set(self.host.file_extensions())
+        comments = set()
+        if os.path.isdir(self.root):
+            for fname in os.listdir(self.root):
+                if not os.path.isfile(os.path.join(self.root, fname)):
+                    continue
+
+                ext = os.path.splitext(fname)[-1]
+                if ext not in host_extensions:
+                    continue
+
+                comment = matcher.parse_comment(fname)
+                if comment:
+                    comments.add(comment)
+
+        return list(comments)
 
     def on_version_spinbox_changed(self, value):
         self.data["version"] = value

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -194,7 +194,8 @@ class NameWindow(QtWidgets.QDialog):
                 temp_data["comment"] = "<<comment>>"
                 temp_data["version"] = "<<version>>"
 
-                fname_pattern = self.anatomy.format(temp_data)["work"]["file"]
+                formatted = self.anatomy.format(temp_data)
+                fname_pattern = formatted[template_key]["file"]
                 fname_pattern = re.escape(fname_pattern)
 
                 # Replace comment and version with something we can match with


### PR DESCRIPTION
## Brief description

This is an implementation for #2626 where clicking on Save in the Work Files tool the subversion field will be prefilled with what is assumed to be the current 'comment' in the filename. 

It uses regex so is always prone to error I suppose. Howevr this case should be a pretty accurate detection against the filename template because all other "data" of the current context is formatted like also used for making a new save version- then only the {comment} and {version} are parsed against the current filename.

If the regex cannot detect any comment or current filename can't be matched against the template then nothing changes. Comment field will remain empty.

## Testing notes:
1. try and break the logic
2. test against some unique filename templates used by OP teams