### PR TITLE
Version Up: Preserve parts of filename after version number (like subversion) on version_up

### DIFF
--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -51,12 +51,6 @@ def version_up(filepath):
                                                      padding=padding)
         new_label = label.replace(version, new_version, 1)
         new_basename = _rreplace(basename, label, new_label)
-
-    if not new_basename.endswith(new_label):
-        index = (new_basename.find(new_label))
-        index += len(new_label)
-        new_basename = new_basename[:index]
-
     new_filename = "{}{}".format(new_basename, ext)
     new_filename = os.path.join(dirname, new_filename)
     new_filename = os.path.normpath(new_filename)
@@ -65,8 +59,19 @@ def version_up(filepath):
         raise RuntimeError("Created path is the same as current file,"
                            "this is a bug")
 
+    # We check for version clashes against the current file for any file
+    # that matches completely in name up to the {version} label found. Thus
+    # if source file was test_v001_test.txt we want to also check clashes
+    # against test_v002.txt but do want to preserve the part after the version
+    # label for our new filename
+    clash_basename = new_basename
+    if not clash_basename.endswith(new_label):
+        index = (clash_basename.find(new_label))
+        index += len(new_label)
+        clash_basename = clash_basename[:index]
+
     for file in os.listdir(dirname):
-        if file.endswith(ext) and file.startswith(new_basename):
+        if file.endswith(ext) and file.startswith(clash_basename):
             log.info("Skipping existing version %s" % new_label)
             return version_up(new_filename)
 


### PR DESCRIPTION
## Brief description

When publishing in Maya with a workfile enabled the current workfile will increment its version - however upon doing so the filename will not preserve its subversion comment string that I user might have set.

The previous logic was to strip anything after the version label. This PR implements new logic that will preserve anything after the version string as it was.

**Before:**
```
my_file_v001_test.ma
my_file_v002.ma
```

**After**
```
my_file_v001_test.ma
my_file_v002_test.ma
```

If there are existing files in the folder, the logic is the same as before to skip existing files:

```
my_file_v001_test.ma # <--- version up on this file
my_file_v002.ma
my_file_v003_other.ma
my_file_v004_test.ma
my_file_v005.ma
my_file_v006_test.ma # <--- will version up to here - skipping any matches up to the version string
```

## Additional info

Note that this logic is separate from the Work Files tool logic.

## Testing notes:

1. create a file with subversion string and without
2. ensure publishing with workfile enable increments your work file and correctly skips existing work files that might have a higher version number + that it preserves subversion string