### PR TITLE
Maya: Save current scene on workfile publish

### DIFF
--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -17,5 +17,11 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
         current = cmds.file(query=True, sceneName=True)
         assert context.data['currentFile'] == current
 
+        # If file has no modifications, skip forcing a file save
+        if not cmds.file(query=True, modified=True):
+            self.log.debug("Skipping file save as there "
+                           "are no modifications..")
+            return
+
         self.log.info("Saving current file..")
         cmds.file(save=True, force=True)

--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -9,7 +9,7 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
     label = "Save current file"
     order = pyblish.api.IntegratorOrder - 0.49
     hosts = ["maya"]
-    families = ["renderlayer"]
+    families = ["renderlayer", "workfile"]
 
     def process(self, context):
         import maya.cmds as cmds


### PR DESCRIPTION
## Brief description

Implementation for #2743 

## Testing notes:
1. make a workfile save it, change something drastic (**DONT SAVE!**), publish your file
2. ensure the published workfile contains the drastic change