### PR TITLE
Flame: adding validator source clip

### DIFF
--- a/openpype/hosts/flame/plugins/publish/validate_source_clip.py
+++ b/openpype/hosts/flame/plugins/publish/validate_source_clip.py
@@ -1,0 +1,21 @@
+import pyblish
+
+@pyblish.api.log
+class ValidateSourceClip(pyblish.api.InstancePlugin):
+    """Validate instance is not having empty `flameSourceClip`"""
+
+    order = pyblish.api.ValidatorOrder
+    label = "Validate Source Clip"
+    hosts = ["flame"]
+    families = ["clip"]
+
+    def process(self, instance):
+        flame_source_clip = instance.data["flameSourceClip"]
+
+        if flame_source_clip is None:
+            raise (
+                "Timeline segment `{}` is not having "
+                "relative clip in reels. Please make sure "
+                "you push `Save Sources` button in Conform Tab").format(
+                    instance.data["name"]
+                )

--- a/openpype/hosts/flame/plugins/publish/validate_source_clip.py
+++ b/openpype/hosts/flame/plugins/publish/validate_source_clip.py
@@ -1,5 +1,6 @@
 import pyblish
 
+
 @pyblish.api.log
 class ValidateSourceClip(pyblish.api.InstancePlugin):
     """Validate instance is not having empty `flameSourceClip`"""
@@ -12,10 +13,12 @@ class ValidateSourceClip(pyblish.api.InstancePlugin):
     def process(self, instance):
         flame_source_clip = instance.data["flameSourceClip"]
 
+        self.log.debug("_ flame_source_clip: {}".format(flame_source_clip))
+
         if flame_source_clip is None:
-            raise (
+            raise AttributeError((
                 "Timeline segment `{}` is not having "
                 "relative clip in reels. Please make sure "
                 "you push `Save Sources` button in Conform Tab").format(
-                    instance.data["name"]
-                )
+                    instance.data["asset"]
+            ))


### PR DESCRIPTION
## Brief description
Checking if source clip is present in reels.

## Description
Due to Flame API limits we have to have available source clips for timeline segments in Reels as they are then used for rendering rather then render all segments in timeline. 
