### PR TITLE
Harmony: Rendering in Deadline didn't work in other machines than submitter

### DIFF
--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -320,7 +320,8 @@ class HarmonySubmitDeadline(
             / published_scene.stem
             / f"{published_scene.stem}.xstage"
         )
-
+        self.log.info("published_scene:: {}".format(published_scene))
+        self.log.info("xstage_path:: {}".format(xstage_path))
         unzip_dir = (published_scene.parent / published_scene.stem)
         with _ZipFile(published_scene, "r") as zip_ref:
             zip_ref.extractall(unzip_dir.as_posix())
@@ -351,12 +352,12 @@ class HarmonySubmitDeadline(
         # use that one.
         if not ideal_scene:
             xstage_path = xstage_files[0]
-
+        self.log.info("xstage_path:: {}".format(xstage_path))
         return xstage_path
 
     def get_plugin_info(self):
         work_scene = Path(self._instance.data["source"])
-
+        self.log.info("work scene:: {}".format(work_scene))
         # this is path to published scene workfile _ZIP_. Before
         # rendering, we need to unzip it.
         published_scene = Path(
@@ -368,14 +369,13 @@ class HarmonySubmitDeadline(
         # for submit_publish job to create .json file in
         self._instance.data["outputDir"] = render_path
         new_expected_files = []
-        work_path_str = str(work_scene.parent.as_posix())
         render_path_str = str(render_path.as_posix())
         for file in self._instance.data["expectedFiles"]:
             _file = str(Path(file).as_posix())
+            expected_dir_str = os.path.dirname(_file)
             new_expected_files.append(
-                _file.replace(work_path_str, render_path_str)
+                _file.replace(expected_dir_str, render_path_str)
             )
-
         audio_file = self._instance.data.get("audioFile")
         if audio_file:
             abs_path = xstage_path.parent / audio_file

--- a/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/default_modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -320,8 +320,6 @@ class HarmonySubmitDeadline(
             / published_scene.stem
             / f"{published_scene.stem}.xstage"
         )
-        self.log.info("published_scene:: {}".format(published_scene))
-        self.log.info("xstage_path:: {}".format(xstage_path))
         unzip_dir = (published_scene.parent / published_scene.stem)
         with _ZipFile(published_scene, "r") as zip_ref:
             zip_ref.extractall(unzip_dir.as_posix())
@@ -352,12 +350,9 @@ class HarmonySubmitDeadline(
         # use that one.
         if not ideal_scene:
             xstage_path = xstage_files[0]
-        self.log.info("xstage_path:: {}".format(xstage_path))
         return xstage_path
 
     def get_plugin_info(self):
-        work_scene = Path(self._instance.data["source"])
-        self.log.info("work scene:: {}".format(work_scene))
         # this is path to published scene workfile _ZIP_. Before
         # rendering, we need to unzip it.
         published_scene = Path(


### PR DESCRIPTION
## Brief description
DL used `c:/Users/SUBMITTER` folder to render files, which didn't work on different machine than submitter.

## Description
Because work folder in Harmony is local, it must be replaced with folder where workfile will be finally published. In some cases naming convention of expected files didn't match correct value, which resulted in not updating the path.
This explicitly replaces dir name of expected file with staging folder where renders will be created on a DL machine.


## Additional info
The rest will be ignored in changelog and should contain any additional
technical information.
