### PR TITLE
Add root keys and project keys to create starting folder

### DIFF
--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -151,8 +151,8 @@ def concatenate_splitted_paths(split_paths, anatomy):
                     log.debug("Root {} path path {} not exist on \
                         computer!".format(root, root_path))
                     continue
-                clean_items = [f"{{root[{root}]}}", "{project[name]}"] \
-                    + clean_items[1:]
+                clean_items = ["{{root[{}]}}".format(root),
+                               r"{project[name]}"] + clean_items[1:]
                 output.append(os.path.normpath(os.path.sep.join(clean_items)))
             continue
 

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -333,7 +333,7 @@
             ]
         }
     },
-    "project_folder_structure": "{\"__project_root__\": {\"prod\": {}, \"resources\": {\"footage\": {\"plates\": {}, \"offline\": {}}, \"audio\": {}, \"art_dept\": {}}, \"editorial\": {}, \"assets[ftrack.Library]\": {\"characters[ftrack]\": {}, \"locations[ftrack]\": {}}, \"shots[ftrack.Sequence]\": {\"scripts\": {}, \"editorial[ftrack.Folder]\": {}}}}",
+    "project_folder_structure": "{\"__project_root__\": {\"prod\": {}, \"resources\": {\"footage\": {\"plates\": {}, \"offline\": {}}, \"audio\": {}, \"art_dept\": {}}, \"editorial\": {}, \"assets\": {\"characters\": {}, \"locations\": {}}, \"shots\": {}}}",
     "sync_server": {
         "enabled": false,
         "config": {


### PR DESCRIPTION
While keeping the previous operation of create_starting_folder, the project[name], project[code] and root[work..] keys can be used in project folder structure, for example:
```
{
     "{root[work]}": {
         "project[code]": {
             "template": {}
         }
}
```