### PR TITLE
Pyblish Pype: Remove redundant new line in installed fonts printing

### DIFF
--- a/openpype/tools/pyblish_pype/app.py
+++ b/openpype/tools/pyblish_pype/app.py
@@ -62,9 +62,9 @@ def install_fonts():
         # In hosts, this will be called each time the GUI is shown,
         # potentially installing a font each time.
         if database.addApplicationFont(path) < 0:
-            print("Could not install %s\n" % path)
+            print("Could not install %s" % path)
         else:
-            print("Installed %s\n" % font)
+            print("Installed %s" % font)
 
 
 def on_destroyed():


### PR DESCRIPTION
## Brief description

Massive PR incoming. Just kidding.

This makes sure the printing of the installed fonts doesn't have a redundant new line when Pyblish Pype starts.

**Before**
```
Using existing QApplication..
Installed opensans/OpenSans-Bold.ttf

Installed opensans/OpenSans-BoldItalic.ttf

Installed opensans/OpenSans-ExtraBold.ttf

Installed opensans/OpenSans-ExtraBoldItalic.ttf

Installed opensans/OpenSans-Italic.ttf

Installed opensans/OpenSans-Light.ttf

Installed opensans/OpenSans-LightItalic.ttf

Installed opensans/OpenSans-Regular.ttf

Installed opensans/OpenSans-Semibold.ttf

Installed opensans/OpenSans-SemiboldItalic.ttf

Installed fontawesome/fontawesome-webfont.ttf

Installed translator
```

**After:**
```
Using existing QApplication..
Installed opensans/OpenSans-Bold.ttf
Installed opensans/OpenSans-BoldItalic.ttf
Installed opensans/OpenSans-ExtraBold.ttf
Installed opensans/OpenSans-ExtraBoldItalic.ttf
Installed opensans/OpenSans-Italic.ttf
Installed opensans/OpenSans-Light.ttf
Installed opensans/OpenSans-LightItalic.ttf
Installed opensans/OpenSans-Regular.ttf
Installed opensans/OpenSans-Semibold.ttf
Installed opensans/OpenSans-SemiboldItalic.ttf
Installed fontawesome/fontawesome-webfont.ttf
Installed translator
```


## Testing notes:

1. run pyblish pype and see the amazing improvement in your console log