### PR TITLE
Avoid renaming udim indexes

### DIFF
--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -478,6 +478,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     if index_frame_start is not None:
                         dst_padding_exp = "%0{}d".format(frame_start_padding)
                         dst_padding = dst_padding_exp % (index_frame_start + frame_number)  # noqa: E501
+                    elif repre.get("udim"):
+                        dst_padding = int(i)
 
                     dst = "{0}{1}{2}".format(
                         dst_head,


### PR DESCRIPTION
## Brief description
Texture batch publishing renamed texture udim indexes like they were image sequence indexes. This fixes that, leaving udim indexes untouched.
