### PR TITLE
Houdini: Fix open last workfile

### DIFF
--- a/openpype/hooks/pre_add_last_workfile_arg.py
+++ b/openpype/hooks/pre_add_last_workfile_arg.py
@@ -17,6 +17,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "nuke",
         "nukex",
         "hiero",
+        "houdini",
         "nukestudio",
         "blender",
         "photoshop",


### PR DESCRIPTION
## Brief description

This fixes #2714 

## Testing notes:
1. test whether last workfile is opened when enabled in admin settings

✅ I tested this in Houdin 19.0.455 - works fine, the file argument is added on launch and the file is opened.