### PR TITLE
After Effects: Fix typo in name `afftereffects` -> `aftereffects`

### DIFF
--- a/openpype/hooks/pre_add_last_workfile_arg.py
+++ b/openpype/hooks/pre_add_last_workfile_arg.py
@@ -21,7 +21,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "blender",
         "photoshop",
         "tvpaint",
-        "afftereffects"
+        "aftereffects"
     ]
 
     def execute(self):

--- a/openpype/hooks/pre_copy_template_workfile.py
+++ b/openpype/hooks/pre_copy_template_workfile.py
@@ -19,7 +19,7 @@ class CopyTemplateWorkfile(PreLaunchHook):
 
     # Before `AddLastWorkfileToLaunchArgs`
     order = 0
-    app_groups = ["blender", "photoshop", "tvpaint", "afftereffects"]
+    app_groups = ["blender", "photoshop", "tvpaint", "aftereffects"]
 
     def execute(self):
         """Check if can copy template for context and do it if possible.

--- a/openpype/hooks/pre_copy_template_workfile.py
+++ b/openpype/hooks/pre_copy_template_workfile.py
@@ -44,7 +44,7 @@ class CopyTemplateWorkfile(PreLaunchHook):
             return
 
         if os.path.exists(last_workfile):
-            self.log.debug("Last workfile exits. Skipping {} process.".format(
+            self.log.debug("Last workfile exists. Skipping {} process.".format(
                 self.__class__.__name__
             ))
             return
@@ -120,7 +120,7 @@ class CopyTemplateWorkfile(PreLaunchHook):
             f"Creating workfile from template: \"{template_path}\""
         )
 
-        # Copy template workfile to new destinantion
+        # Copy template workfile to new destination
         shutil.copy2(
             os.path.normpath(template_path),
             os.path.normpath(last_workfile)


### PR DESCRIPTION
## Brief description

Fix typo in name `afftereffects` -> `aftereffects` as came up in the comments [here](https://github.com/pypeclub/OpenPype/issues/2714#issuecomment-1044673592)

Note: this being a typo is an assumption on my end - so correct me if I'm wrong. :)

## Testing notes:
1. test whether open last workfile on launch worked before (I assume it didn't) and whether it works now. 
2. test whether `pre_copy_template_workfile` does what it was intended to do for After Effects