### PR TITLE
Slack: Added regex for filtering on subset names

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
@@ -411,9 +411,11 @@ class CollectTextures(pyblish.api.ContextPlugin):
             Raises:
                 ValueError - if broken 'input_naming_groups'
         """
+        self.log.info("{} {} {}".format(name, input_naming_patterns, input_naming_groups))
         for input_pattern in input_naming_patterns:
             for cs in color_spaces:
                 pattern = input_pattern.replace('{color_space}', cs)
+                self.log.info("{} {}".format(pattern, name))
                 regex_result = re.findall(pattern, name)
                 if regex_result:
                     idx = list(input_naming_groups).index(key)
@@ -424,6 +426,7 @@ class CollectTextures(pyblish.api.ContextPlugin):
 
                     try:
                         parsed_value = regex_result[0][idx]
+                        self.log.info("par{}".format(parsed_value))
                         return parsed_value
                     except IndexError:
                         self.log.warning("Wrong index, probably "

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
@@ -411,7 +411,6 @@ class CollectTextures(pyblish.api.ContextPlugin):
             Raises:
                 ValueError - if broken 'input_naming_groups'
         """
-        self.log.info("{} {} {}".format(name, input_naming_patterns, input_naming_groups))
         for input_pattern in input_naming_patterns:
             for cs in color_spaces:
                 pattern = input_pattern.replace('{color_space}', cs)
@@ -426,7 +425,6 @@ class CollectTextures(pyblish.api.ContextPlugin):
 
                     try:
                         parsed_value = regex_result[0][idx]
-                        self.log.info("par{}".format(parsed_value))
                         return parsed_value
                     except IndexError:
                         self.log.warning("Wrong index, probably "

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_texture.py
@@ -414,7 +414,6 @@ class CollectTextures(pyblish.api.ContextPlugin):
         for input_pattern in input_naming_patterns:
             for cs in color_spaces:
                 pattern = input_pattern.replace('{color_space}', cs)
-                self.log.info("{} {}".format(pattern, name))
                 regex_result = re.findall(pattern, name)
                 if regex_result:
                     idx = list(input_naming_groups).index(key)

--- a/openpype/modules/slack/plugins/publish/collect_slack_family.py
+++ b/openpype/modules/slack/plugins/publish/collect_slack_family.py
@@ -20,18 +20,23 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin):
     def process(self, instance):
         task_name = io.Session.get("AVALON_TASK")
         family = self.main_family_from_instance(instance)
-
         key_values = {
             "families": family,
             "tasks": task_name,
             "hosts": instance.data["anatomyData"]["app"],
+            "subsets": instance.data["subset"]
         }
 
         profile = filter_profiles(self.profiles, key_values,
                                   logger=self.log)
 
+        if not profile:
+            self.log.info("No profile found, notification won't be send")
+            return
+
         # make slack publishable
         if profile:
+            self.log.info("Found profile: {}".format(profile))
             if instance.data.get('families'):
                 instance.data['families'].append('slack')
             else:

--- a/openpype/settings/defaults/project_settings/slack.json
+++ b/openpype/settings/defaults/project_settings/slack.json
@@ -10,6 +10,7 @@
                     "hosts": [],
                     "task_types": [],
                     "tasks": [],
+                    "subsets": [],
                     "channel_messages": []
                 }
             ]

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_slack.json
@@ -70,6 +70,12 @@
                                         "object_type": "text"
                                     },
                                     {
+                                        "key": "subsets",
+                                        "label": "Subset names",
+                                        "type": "list",
+                                        "object_type": "text"
+                                    },
+                                    {
                                         "type": "separator"
                                     },
                                     {

--- a/website/docs/module_slack.md
+++ b/website/docs/module_slack.md
@@ -47,7 +47,7 @@ It is possible to create multiple tokens and configure different scopes for them
 
 ### Profiles
 Profiles are used to select when to trigger notification. One or multiple profiles
-could be configured, `Families`, `Task names` (regex available), `Host names` combination is needed.
+could be configured, `Families`, `Task names` (regex available), `Host names`, `Subset names` (regex available) combination is needed.
 
 Eg. If I want to be notified when render is published from Maya, setting is:
 


### PR DESCRIPTION
## Brief description
Subset name filtering could be used to limit notification to Slack only for specific AOVs


## Testing notes:
1. configure subset name in `project_settings/slack/publish/CollectSlackFamilies/profiles`
2. run publish