### PR TITLE
Houdini: Remove unused code

### DIFF
--- a/openpype/hosts/houdini/api/__init__.py
+++ b/openpype/hosts/houdini/api/__init__.py
@@ -24,8 +24,7 @@ from .lib import (
     lsattrs,
     read,
 
-    maintained_selection,
-    unique_name
+    maintained_selection
 )
 
 
@@ -51,8 +50,7 @@ __all__ = [
     "lsattrs",
     "read",
 
-    "maintained_selection",
-    "unique_name"
+    "maintained_selection"
 ]
 
 # Backwards API compatibility

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -99,65 +99,6 @@ def get_id_required_nodes():
     return list(nodes)
 
 
-def get_additional_data(container):
-    """Not implemented yet!"""
-    return container
-
-
-def set_parameter_callback(node, parameter, language, callback):
-    """Link a callback to a parameter of a node
-
-    Args:
-        node(hou.Node): instance of the nodee
-        parameter(str): name of the parameter
-        language(str): name of the language, e.g.: python
-        callback(str): command which needs to be triggered
-
-    Returns:
-        None
-
-    """
-
-    template_grp = node.parmTemplateGroup()
-    template = template_grp.find(parameter)
-    if not template:
-        return
-
-    script_language = (hou.scriptLanguage.Python if language == "python" else
-                       hou.scriptLanguage.Hscript)
-
-    template.setScriptCallbackLanguage(script_language)
-    template.setScriptCallback(callback)
-
-    template.setTags({"script_callback": callback,
-                      "script_callback_language": language.lower()})
-
-    # Replace the existing template with the adjusted one
-    template_grp.replace(parameter, template)
-
-    node.setParmTemplateGroup(template_grp)
-
-
-def set_parameter_callbacks(node, parameter_callbacks):
-    """Set callbacks for multiple parameters of a node
-
-    Args:
-        node(hou.Node): instance of a hou.Node
-        parameter_callbacks(dict): collection of parameter and callback data
-            example:  {"active" :
-                        {"language": "python",
-                         "callback": "print('hello world)'"}
-                     }
-    Returns:
-        None
-    """
-    for parameter, data in parameter_callbacks.items():
-        language = data["language"]
-        callback = data["callback"]
-
-        set_parameter_callback(node, parameter, language, callback)
-
-
 def get_output_parameter(node):
     """Return the render output parameter name of the given node
 
@@ -187,19 +128,6 @@ def get_output_parameter(node):
             return node.parm("ar_ass_file")
 
     raise TypeError("Node type '%s' not supported" % node_type)
-
-
-@contextmanager
-def attribute_values(node, data):
-
-    previous_attrs = {key: node.parm(key).eval() for key in data.keys()}
-    try:
-        node.setParms(data)
-        yield
-    except Exception as exc:
-        pass
-    finally:
-        node.setParms(previous_attrs)
 
 
 def set_scene_fps(fps):
@@ -349,10 +277,6 @@ def render_rop(ropnode):
         raise RuntimeError("Render failed: {0}".format(exc))
 
 
-def children_as_string(node):
-    return [c.name() for c in node.children()]
-
-
 def imprint(node, data):
     """Store attributes with value on a node
 
@@ -471,53 +395,6 @@ def read(node):
     # `spareParms` returns a tuple of hou.Parm objects
     return {parameter.name(): parameter.eval() for
             parameter in node.spareParms()}
-
-
-def unique_name(name, format="%03d", namespace="", prefix="", suffix="",
-                separator="_"):
-    """Return unique `name`
-
-    The function takes into consideration an optional `namespace`
-    and `suffix`. The suffix is included in evaluating whether a
-    name exists - such as `name` + "_GRP" - but isn't included
-    in the returned value.
-
-    If a namespace is provided, only names within that namespace
-    are considered when evaluating whether the name is unique.
-
-    Arguments:
-        format (str, optional): The `name` is given a number, this determines
-            how this number is formatted. Defaults to a padding of 2.
-            E.g. my_name01, my_name02.
-        namespace (str, optional): Only consider names within this namespace.
-        suffix (str, optional): Only consider names with this suffix.
-
-    Example:
-        >>> name = hou.node("/obj").createNode("geo", name="MyName")
-        >>> assert hou.node("/obj/MyName")
-        True
-        >>> unique = unique_name(name)
-        >>> assert hou.node("/obj/{}".format(unique))
-        False
-
-    """
-
-    iteration = 1
-
-    parts = [prefix, name, format % iteration, suffix]
-    if namespace:
-        parts.insert(0, namespace)
-
-    unique = separator.join(parts)
-    children = children_as_string(hou.node("/obj"))
-    while unique in children:
-        iteration += 1
-        unique = separator.join(parts)
-
-    if suffix:
-        return unique[:-len(suffix)]
-
-    return unique
 
 
 @contextmanager


### PR DESCRIPTION
## Brief description

Similar to what #2709 does for Maya this tries to remove unused code from the Houdini lib.

---

Houdini also has `set_id` and `get_id` functions similar to Maya that, as far as I know, are unused outside the fact they do seem to "generate" on save callback. Are those used anywhere? Do we ever intend to use them? If not, we might want to drop that logic too. The issue #2723 might shed more light on that but guessing based on how Houdini works the current implemenation of setting the ids isn't that useful anyway.
Thoughts?


## Testing notes:
1. launch houdini, make sure things work as expected.