### PR TITLE
Flame: Fix version string in default settings

### DIFF
--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -135,7 +135,7 @@
                     "OPENPYPE_WIRETAP_TOOLS": "/opt/Autodesk/wiretap/tools/2021"
                 }
             },
-            "2021.1": {
+            "2021_1": {
                 "use_python_2": true,
                 "executables": {
                     "windows": [],
@@ -159,7 +159,7 @@
             },
             "__dynamic_keys_labels__": {
                 "2021": "2021",
-                "2021.1": "2021.1"
+                "2021_1": "2021.1"
             }
         }
     },


### PR DESCRIPTION
## Brief description
Default value of flame settings contains invalid character `.`.

## Changes
- changed flame name from `"2021.1"` to `"2021_1"`