### PR TITLE
Work Files: Fix parenting of save prompt QMessageBox

### DIFF
--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -544,10 +544,6 @@ class FilesWidget(QtWidgets.QWidget):
         # file on a refresh of the files model.
         self.auto_select_latest_modified = True
 
-        # Avoid crash in Blender and store the message box
-        # (setting parent doesn't work as it hides the message box)
-        self._messagebox = None
-
         files_view = FilesView(self)
 
         # Create the Files model
@@ -726,9 +722,9 @@ class FilesWidget(QtWidgets.QWidget):
         self.file_opened.emit()
 
     def save_changes_prompt(self):
-        self._messagebox = messagebox = QtWidgets.QMessageBox()
-
-        messagebox.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+        messagebox = QtWidgets.QMessageBox(parent=self)
+        messagebox.setWindowFlags(messagebox.windowFlags() |
+                                  QtCore.Qt.FramelessWindowHint)
         messagebox.setIcon(messagebox.Warning)
         messagebox.setWindowTitle("Unsaved Changes!")
         messagebox.setText(
@@ -738,10 +734,6 @@ class FilesWidget(QtWidgets.QWidget):
         messagebox.setStandardButtons(
             messagebox.Yes | messagebox.No | messagebox.Cancel
         )
-
-        # Parenting the QMessageBox to the Widget seems to crash
-        # so we skip parenting and explicitly apply the stylesheet.
-        messagebox.setStyle(self.style())
 
         result = messagebox.exec_()
         if result == messagebox.Yes:

--- a/openpype/tools/workfiles/app.py
+++ b/openpype/tools/workfiles/app.py
@@ -544,6 +544,10 @@ class FilesWidget(QtWidgets.QWidget):
         # file on a refresh of the files model.
         self.auto_select_latest_modified = True
 
+        # Avoid crash in Blender and store the message box
+        # (setting parent doesn't work as it hides the message box)
+        self._messagebox = None
+
         files_view = FilesView(self)
 
         # Create the Files model
@@ -722,7 +726,7 @@ class FilesWidget(QtWidgets.QWidget):
         self.file_opened.emit()
 
     def save_changes_prompt(self):
-        messagebox = QtWidgets.QMessageBox(parent=self)
+        self._messagebox = messagebox = QtWidgets.QMessageBox(parent=self)
         messagebox.setWindowFlags(messagebox.windowFlags() |
                                   QtCore.Qt.FramelessWindowHint)
         messagebox.setIcon(messagebox.Warning)


### PR DESCRIPTION
## Brief description

This makes the save prompt messagebox an actual child to the parent Qt UI element. 

#### Resolves issue

This fixes the save prompt appearing behind the workfiles UI in Fusion.

## Description

#### Original "crash" case

Setting the windowFlags without the original messagebox.windowFlags() was the culprit as to why the messagebox previously wouldn't show when parented. Likely because then it's missing the Dialog window flag and thus would try to embed itself into the parent UI, which you then cannot exec()

## Additional Context

(cherry picked from commit 290e2b601d0e20f4aaba356d4f053bf733de406b)

## Testing notes:
1. Test whether save prompt (when current scene has modifications and you are **opening** a file through Work Files) works as expected
2. Please test Blender integration, since original code mentioned "crashes" in Blender. ⚠️ 

I tested in Fusion 17 and Maya 2020 - those worked fine. ✅ 