### PR TITLE
Pyblish Pype: Preserve comment on reset

### DIFF
--- a/openpype/tools/pyblish_pype/app.py
+++ b/openpype/tools/pyblish_pype/app.py
@@ -90,9 +90,8 @@ def show(parent=None):
         install_fonts()
         install_translator(app)
 
-        ctrl = control.Controller()
-
         if self._window is None:
+            ctrl = control.Controller()
             self._window = window.Window(ctrl, parent)
             self._window.destroyed.connect(on_destroyed)
 

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -229,7 +229,13 @@ class Controller(QtCore.QObject):
         self.log.debug("Resetting pyblish context object")
 
         comment = None
-        if self.context is not None and self.context.data.get("comment"):
+        if (
+            self.context is not None and
+            self.context.data.get("comment") and
+            # We only preserve the user typed comment if we are *not*
+            # resetting from a successful publish without errors
+            self._current_state != "Published"
+        ):
             comment = self.context.data["comment"]
 
         self.context = pyblish.api.Context()

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -228,6 +228,10 @@ class Controller(QtCore.QObject):
     def reset_context(self):
         self.log.debug("Resetting pyblish context object")
 
+        comment = None
+        if self.context is not None and self.context.data.get("comment"):
+            comment = self.context.data["comment"]
+
         self.context = pyblish.api.Context()
 
         self.context._publish_states = InstanceStates.ContextType
@@ -248,6 +252,10 @@ class Controller(QtCore.QObject):
         self.context.data["icon"] = "book"
 
         self.context.families = ("__context__",)
+
+        if comment:
+            # Preserve comment on reset if user previously had a comment
+            self.context.data["comment"] = comment
 
         self.log.debug("Reset of pyblish context object done")
 

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -1138,8 +1138,9 @@ class Window(QtWidgets.QDialog):
         if self.intent_model.has_items:
             self.intent_box.setCurrentIndex(self.intent_model.default_index)
 
-        self.comment_box.placeholder.setVisible(False)
-        self.comment_box.placeholder.setVisible(True)
+        if self.comment_box.text():
+            self.comment_box.placeholder.setVisible(False)
+            self.comment_box.placeholder.setVisible(True)
         # Launch controller reset
         self.controller.reset()
 

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -1139,10 +1139,10 @@ class Window(QtWidgets.QDialog):
             self.intent_box.setCurrentIndex(self.intent_model.default_index)
 
         self.comment_box.placeholder.setVisible(False)
-        if not self.comment_box.text():
-            self.comment_box.placeholder.setVisible(True)
         # Launch controller reset
         self.controller.reset()
+        if not self.comment_box.text():
+            self.comment_box.placeholder.setVisible(True)
 
     def validate(self):
         self.info(self.tr("Preparing validate.."))


### PR DESCRIPTION
## Brief description

Draft implementation for #2786 where the typed comment is preserved on reset.

Of course this has the side effect that if you were to keep the pyblish window open after publishing, go into another asset, then reset that your old comment would still be there. Not sure if that'd be an issue for anyone? If so, we might want to just "clear" the comment after a full publish. (e.g. Publish finished without errors)?

## Additional info

Not sure if this is the cleanest/best implementation. Let me know if you feel there's something off with this approach.

## Testing notes:

1. start pyblish, type a comment, reset. Your comment should be preserved
2. ensure the actual pyblish plug-ins are picking up the preserved comment on the publish