### PR TITLE
Fix `OPENPYPE_LOG_NO_COLORS` being True actually resulting in `use_colors` being False

### DIFF
--- a/openpype/lib/terminal.py
+++ b/openpype/lib/terminal.py
@@ -49,8 +49,8 @@ class Terminal:
         """
 
         from openpype.lib import env_value_to_bool
-        use_colors = env_value_to_bool(
-            "OPENPYPE_LOG_NO_COLORS", default=Terminal.use_colors
+        use_colors = not env_value_to_bool(
+            "OPENPYPE_LOG_NO_COLORS", default=not Terminal.use_colors
         )
         if not use_colors:
             Terminal.use_colors = use_colors

--- a/openpype/lib/terminal.py
+++ b/openpype/lib/terminal.py
@@ -54,7 +54,7 @@ class Terminal:
         )
         if log_no_colors is not None:
             Terminal.use_colors = not log_no_colors
-        
+
         if not Terminal.use_colors:
             Terminal._initialized = True
             return

--- a/openpype/lib/terminal.py
+++ b/openpype/lib/terminal.py
@@ -49,11 +49,13 @@ class Terminal:
         """
 
         from openpype.lib import env_value_to_bool
-        use_colors = not env_value_to_bool(
-            "OPENPYPE_LOG_NO_COLORS", default=not Terminal.use_colors
+        log_no_colors = env_value_to_bool(
+            "OPENPYPE_LOG_NO_COLORS", default=None
         )
-        if not use_colors:
-            Terminal.use_colors = use_colors
+        if log_no_colors is not None:
+            Terminal.use_colors = not log_no_colors
+        
+        if not Terminal.use_colors:
             Terminal._initialized = True
             return
 


### PR DESCRIPTION
## Brief description

If I'm not mistaken the logic for `OPENPYPE_LOG_NO_COLORS` was incorrectly setting `use_colors` to True when `OPENPYPE_LOG_NO_COLORS` was set to True.

I believe this would fix that - and thus would avoid this printed output when the value is enabled for hosts that don't support `blessed`:
> Module `blessed` failed on import or terminal creation. Pype terminal won't use colors.

## Testing notes:
1. Make sure I'm not misreading the logic. 😄 
2. Test it for hosts that have `OPENPYPE_LOG_NO_COLORS` set.