### PR TITLE
General: Set context environments for non host applications

### DIFF
--- a/openpype/hooks/pre_global_host_data.py
+++ b/openpype/hooks/pre_global_host_data.py
@@ -2,7 +2,7 @@ from openpype.api import Anatomy
 from openpype.lib import (
     PreLaunchHook,
     EnvironmentPrepData,
-    prepare_host_environments,
+    prepare_app_environments,
     prepare_context_environments
 )
 
@@ -41,8 +41,7 @@ class GlobalHostDataHook(PreLaunchHook):
             "log": self.log
         })
 
-        if app.is_host:
-            prepare_host_environments(temp_data, self.launch_context.env_group)
+        prepare_app_environments(temp_data, self.launch_context.env_group)
         prepare_context_environments(temp_data)
 
         temp_data.pop("log")

--- a/openpype/hooks/pre_global_host_data.py
+++ b/openpype/hooks/pre_global_host_data.py
@@ -14,14 +14,6 @@ class GlobalHostDataHook(PreLaunchHook):
 
     def execute(self):
         """Prepare global objects to `data` that will be used for sure."""
-        if not self.application.is_host:
-            self.log.info(
-                "Skipped hook {}. Application is not marked as host.".format(
-                    self.__class__.__name__
-                )
-            )
-            return
-
         self.prepare_global_data()
 
         if not self.data.get("asset_doc"):
@@ -49,7 +41,8 @@ class GlobalHostDataHook(PreLaunchHook):
             "log": self.log
         })
 
-        prepare_host_environments(temp_data, self.launch_context.env_group)
+        if app.is_host:
+            prepare_host_environments(temp_data, self.launch_context.env_group)
         prepare_context_environments(temp_data)
 
         temp_data.pop("log")

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -130,7 +130,7 @@ from .applications import (
     PostLaunchHook,
 
     EnvironmentPrepData,
-    prepare_host_environments,
+    prepare_app_environments,
     prepare_context_environments,
     get_app_environments_for_context,
     apply_project_environments_value
@@ -261,7 +261,7 @@ __all__ = [
     "PreLaunchHook",
     "PostLaunchHook",
     "EnvironmentPrepData",
-    "prepare_host_environments",
+    "prepare_app_environments",
     "prepare_context_environments",
     "get_app_environments_for_context",
     "apply_project_environments_value",

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1508,10 +1508,12 @@ def prepare_context_environments(data, env_group=None):
         "AVALON_PROJECT": project_doc["name"],
         "AVALON_ASSET": asset_doc["name"],
         "AVALON_TASK": task_name,
-        "AVALON_APP": app.host_name,
         "AVALON_APP_NAME": app.full_name,
         "AVALON_WORKDIR": workdir
     }
+    if app.is_host:
+        context_env["AVALON_APP"]: app.host_name
+
     log.debug(
         "Context environments set:\n{}".format(
             json.dumps(context_env, indent=4)

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1295,7 +1295,7 @@ def get_app_environments_for_context(
         "env": env
     })
 
-    prepare_host_environments(data, env_group)
+    prepare_app_environments(data, env_group)
     prepare_context_environments(data, env_group)
 
     # Discard avalon connection
@@ -1316,7 +1316,7 @@ def _merge_env(env, current_env):
     return result
 
 
-def prepare_host_environments(data, env_group=None, implementation_envs=True):
+def prepare_app_environments(data, env_group=None, implementation_envs=True):
     """Modify launch environments based on launched app and context.
 
     Args:
@@ -1474,6 +1474,22 @@ def prepare_context_environments(data, env_group=None):
     )
 
     app = data["app"]
+    context_env = {
+        "AVALON_PROJECT": project_doc["name"],
+        "AVALON_ASSET": asset_doc["name"],
+        "AVALON_TASK": task_name,
+        "AVALON_APP_NAME": app.full_name
+    }
+
+    log.debug(
+        "Context environments set:\n{}".format(
+            json.dumps(context_env, indent=4)
+        )
+    )
+    data["env"].update(context_env)
+    if not app.is_host:
+        return
+
     workdir_data = get_workdir_data(
         project_doc, asset_doc, task_name, app.host_name
     )
@@ -1504,22 +1520,8 @@ def prepare_context_environments(data, env_group=None):
                 "Couldn't create workdir because: {}".format(str(exc))
             )
 
-    context_env = {
-        "AVALON_PROJECT": project_doc["name"],
-        "AVALON_ASSET": asset_doc["name"],
-        "AVALON_TASK": task_name,
-        "AVALON_APP_NAME": app.full_name,
-        "AVALON_WORKDIR": workdir
-    }
-    if app.is_host:
-        context_env["AVALON_APP"]: app.host_name
-
-    log.debug(
-        "Context environments set:\n{}".format(
-            json.dumps(context_env, indent=4)
-        )
-    )
-    data["env"].update(context_env)
+    data["env"]["AVALON_APP"] = app.host_name
+    data["env"]["AVALON_WORKDIR"] = workdir
 
     _prepare_last_workfile(data, workdir)
 


### PR DESCRIPTION
## Brief description
Other applications don't have set context environments.

## Changes
- set context environments on non host application start
- set `AVALON_APP` only is application has host implementation

## Testing notes:
1. Add custom applications in system settings (set executable to app where you can check environments)
2. Add the application to some project
3. Run the application through launcher
4. Check if environments contain `AVALON_PROJECT` `AVALON_ASSET` and `AVALON_TASK`