### PR TITLE
Settings UI: Search case sensitivity

### DIFF
--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -715,7 +715,12 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
             self._outdated_version_label,
             self._require_restart_label,
         }
-        if self.entity.require_restart:
+        if self.is_modifying_defaults or self.entity is None:
+            require_restart = False
+        else:
+            require_restart = self.entity.require_restart
+
+        if require_restart:
             visible_label = self._require_restart_label
         elif self._is_loaded_version_outdated:
             visible_label = self._outdated_version_label

--- a/openpype/tools/settings/settings/search_dialog.py
+++ b/openpype/tools/settings/settings/search_dialog.py
@@ -30,7 +30,7 @@ class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):
         regex = self.filterRegExp()
         if not regex.isEmpty() and regex.isValid():
             pattern = regex.pattern()
-            compiled_regex = re.compile(pattern)
+            compiled_regex = re.compile(pattern, re.IGNORECASE)
             source_model = self.sourceModel()
 
             # Check current index itself in all columns

--- a/openpype/tools/settings/settings/search_dialog.py
+++ b/openpype/tools/settings/settings/search_dialog.py
@@ -75,6 +75,7 @@ class SearchEntitiesDialog(QtWidgets.QDialog):
 
         filter_changed_timer = QtCore.QTimer()
         filter_changed_timer.setInterval(200)
+        filter_changed_timer.setSingleShot(True)
 
         view.selectionModel().selectionChanged.connect(
             self._on_selection_change


### PR DESCRIPTION
## Brief description
Search in settings is not case sensitive.

## Description
Case sensitivity is not welcommed as searching of `jpeg` won't find `JPEG`.

## Changes
- regex is case insensitive
- fixed filter text change timer to be singleshot
- fixed issue with missing entity on reset which can happen if schema is invalid or there was an issue with creation

## Testing notes:
1. Open settings UI
2. Open search dialog (CTRL + f)
3. Find something with wrong case sensitivity 