### PR TITLE
Modules: Remove 'default_modules' folder logic

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -143,13 +143,6 @@ class _LoadCache:
     modules_loaded = False
 
 
-def get_default_modules_dir():
-    """Path to default OpenPype modules."""
-    current_dir = os.path.abspath(os.path.dirname(__file__))
-
-    return os.path.join(current_dir, "default_modules")
-
-
 def get_dynamic_modules_dirs():
     """Possible paths to OpenPype Addons of Modules.
 
@@ -185,7 +178,6 @@ def get_dynamic_modules_dirs():
 def get_module_dirs():
     """List of paths where OpenPype modules can be found."""
     _dirpaths = []
-    _dirpaths.append(get_default_modules_dir())
     _dirpaths.extend(get_dynamic_modules_dirs())
 
     dirpaths = []


### PR DESCRIPTION
## Brief description

This removes the old logic used to load modules from folder `default_modules`. With the recent move of all modules that logic has been replaced and the default folder does not exist thus this didn't do anything by default.

It also avoids the warning on startup:
```
*** WRN: >>> { ModulesLoader }: [  Could not find path when loading OpenPype modules "\openpype\modules\default_modules"  ] 
```

## Testing notes:
1. Test whether everything for modules still works.