### PR TITLE
General: Color dialog UI fixes

### DIFF
--- a/openpype/widgets/color_widgets/color_triangle.py
+++ b/openpype/widgets/color_widgets/color_triangle.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from math import floor, sqrt, sin, cos, acos, pi as PI
+from math import floor, ceil, sqrt, sin, cos, acos, pi as PI
 from Qt import QtWidgets, QtCore, QtGui
 
 TWOPI = PI * 2
@@ -187,10 +187,10 @@ class QtColorTriangle(QtWidgets.QWidget):
         self.outer_radius = (size - 1) / 2
 
         self.pen_width = int(
-            floor(self.outer_radius / self.ellipse_thick_ratio)
+            ceil(self.outer_radius / self.ellipse_thick_ratio)
         )
         self.ellipse_size = int(
-            floor(self.outer_radius / self.ellipse_size_ratio)
+            ceil(self.outer_radius / self.ellipse_size_ratio)
         )
 
         cx = float(self.contentsRect().center().x())
@@ -542,10 +542,10 @@ class QtColorTriangle(QtWidgets.QWidget):
         self.outer_radius = (size - 1) / 2
 
         self.pen_width = int(
-            floor(self.outer_radius / self.ellipse_thick_ratio)
+            ceil(self.outer_radius / self.ellipse_thick_ratio)
         )
         self.ellipse_size = int(
-            floor(self.outer_radius / self.ellipse_size_ratio)
+            ceil(self.outer_radius / self.ellipse_size_ratio)
         )
 
         cx = float(self.contentsRect().center().x())


### PR DESCRIPTION
## Brief description
Smaller tweaks of color dialog.

## Description
- alpha slider handler never fully goes to right side and sometimes does not draw tiled checker right way on hover
![image](https://user-images.githubusercontent.com/43494761/155992863-c90e6419-7e75-46b4-a437-97aa4d309830.png)

- thickness of circles in triangle widget are too thick in some cases
![image](https://user-images.githubusercontent.com/43494761/155992899-ec6edce2-a9cf-47a7-b7e2-5e706405e6db.png)


## Changes
- fixed alpha slider 
![image](https://user-images.githubusercontent.com/43494761/155992642-7f2b855d-9294-42b9-926e-24b8718478af.png)
- thickness of circles is calculated using `ceil` instead of `floor`
    
![image](https://user-images.githubusercontent.com/43494761/155992731-b9d8ae24-2ac1-467d-8796-16e6824b95b2.png)

## Testing notes:
1. Try show color dialog and validate changes (e.g. `project_settings/global/publish/ExtractReview/profiles/0/outputs/h264/bg_color`)