### PR TITLE
Nuke: Use AVALON_APP to get value for "app" key

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import six
 import platform
 import contextlib
@@ -679,10 +678,10 @@ def get_render_path(node):
     }
 
     nuke_imageio_writes = get_created_node_imageio_setting(**data_preset)
+    host_name = os.environ.get("AVALON_APP")
 
-    application = lib.get_application(os.environ["AVALON_APP_NAME"])
     data.update({
-        "application": application,
+        "app": host_name,
         "nuke_imageio_writes": nuke_imageio_writes
     })
 
@@ -805,18 +804,14 @@ def create_write_node(name, data, input=None, prenodes=None,
     '''
 
     imageio_writes = get_created_node_imageio_setting(**data)
-    app_manager = ApplicationManager()
-    app_name = os.environ.get("AVALON_APP_NAME")
-    if app_name:
-        app = app_manager.applications.get(app_name)
-
     for knob in imageio_writes["knobs"]:
         if knob["name"] == "file_type":
             representation = knob["value"]
 
+    host_name = os.environ.get("AVALON_APP")
     try:
         data.update({
-            "app": app.host_name,
+            "app": host_name,
             "imageio_writes": imageio_writes,
             "representation": representation,
         })


### PR DESCRIPTION
## Brief description
Templates fill in nuke is using deprecated or complicated way how to fill `"app"` key for templates formatting.

## Description
Deprecated way is using `which_app` that can't work because we dropped .toml files since OP3. Complicated way is getting host name from application full name which can work but using `AVALON_APP` is much simpler.

## Changes
- use `AVALON_APP` to fill `"app"` key for templates formatting in nuke lib functions

## Testing notes:
1. Add `{app}` to some template used in nuke
2. Create write node which should fill `{app}` with `nuke`