### PR TITLE
General: Host name was formed from obsolete code

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -952,7 +952,7 @@ class BuildWorkfile:
         Returns:
             (dict): preset per entered task name
         """
-        host_name = avalon.api.registered_host().__name__.rsplit(".", 1)[-1]
+        host_name = os.environ["AVALON_APP"]
         project_settings = get_project_settings(
             avalon.io.Session["AVALON_PROJECT"]
         )


### PR DESCRIPTION
## Brief description
Build workfile was not returning presets from settings

## Description
This issue was effecting all hosts supporting Build workfile feature.

## Testing notes:
1. start with this step
2. follow this step