### PR TITLE
General: Custom function for find executable

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -4,7 +4,6 @@ import os
 import sys
 import json
 import tempfile
-import platform
 import contextlib
 import subprocess
 from collections import OrderedDict
@@ -63,10 +62,6 @@ def maketx(source, destination, *args):
     from openpype.lib import get_oiio_tools_path
 
     maketx_path = get_oiio_tools_path("maketx")
-
-    if platform.system().lower() == "windows":
-        # Ensure .exe extension
-        maketx_path += ".exe"
 
     if not os.path.exists(maketx_path):
         print(

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -16,6 +16,14 @@ sys.path.insert(0, python_version_dir)
 site.addsitedir(python_version_dir)
 
 
+from .vendor_bin_utils import (
+    find_executable,
+    get_vendor_bin_path,
+    get_oiio_tools_path,
+    get_ffmpeg_tool_path,
+    ffprobe_streams,
+    is_oiio_supported
+)
 from .env_tools import (
     env_value_to_bool,
     get_paths_from_environ,
@@ -47,14 +55,6 @@ from .anatomy import (
 )
 
 from .config import get_datetime_data
-
-from .vendor_bin_utils import (
-    get_vendor_bin_path,
-    get_oiio_tools_path,
-    get_ffmpeg_tool_path,
-    ffprobe_streams,
-    is_oiio_supported
-)
 
 from .python_module_tools import (
     import_filepath,
@@ -184,6 +184,7 @@ from .openpype_version import (
 terminal = Terminal
 
 __all__ = [
+    "find_executable",
     "get_openpype_execute_args",
     "get_pype_execute_args",
     "get_linux_launcher_args",

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -35,8 +35,10 @@ from .python_module_tools import (
     modules_from_path,
     classes_from_module
 )
-from .execute import get_linux_launcher_args
-
+from .execute import (
+    find_executable,
+    get_linux_launcher_args
+)
 
 _logger = None
 
@@ -646,7 +648,7 @@ class ApplicationExecutable:
     def _realpath(self):
         """Check if path is valid executable path."""
         # Check for executable in PATH
-        result = distutils.spawn.find_executable(self.executable_path)
+        result = find_executable(self.executable_path)
         if result is not None:
             return result
 

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -7,7 +7,6 @@ import platform
 import collections
 import inspect
 import subprocess
-import distutils.spawn
 from abc import ABCMeta, abstractmethod
 
 import six

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -4,9 +4,9 @@ import subprocess
 import platform
 import json
 import tempfile
-import distutils.spawn
 
 from .log import PypeLogger as Logger
+from .vendor_bin_utils import find_executable
 
 # MSDN process creation flag (Windows only)
 CREATE_NO_WINDOW = 0x08000000
@@ -341,7 +341,7 @@ def get_linux_launcher_args(*args):
             os.path.dirname(openpype_executable),
             filename
         )
-        executable_path = distutils.spawn.find_executable(new_executable)
+        executable_path = find_executable(new_executable)
         if executable_path is None:
             return None
         launch_args = [executable_path]

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -58,7 +58,7 @@ def find_executable(executable):
     paths = path_str.split(os.pathsep)
     for path in paths:
         for variant in variants:
-            filepath = os.path.abspath(os.path.join(path, executable))
+            filepath = os.path.abspath(os.path.join(path, variant))
             if os.path.isfile(filepath):
                 return filepath
     return None

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -7,6 +7,25 @@ import subprocess
 log = logging.getLogger("Vendor utils")
 
 
+def is_file_executable(filepath):
+    """Filepath lead to executable file.
+
+    Args:
+        filepath(str): Full path to file.
+    """
+    if not filepath:
+        return False
+
+    if os.path.isfile(filepath):
+        if os.access(filepath, os.X_OK):
+            return True
+
+        log.info(
+            "Filepath is not available for execution \"{}\"".format(filepath)
+        )
+    return False
+
+
 def find_executable(executable):
     """Find full path to executable.
 
@@ -24,7 +43,7 @@ def find_executable(executable):
         None: When the executable was not found.
     """
     # Skip if passed path is file
-    if os.path.isfile(executable):
+    if is_file_executable(executable):
         return executable
 
     low_platform = platform.system().lower()
@@ -45,7 +64,7 @@ def find_executable(executable):
 
         for ext in exts:
             variant = executable + ext
-            if os.path.isfile(variant):
+            if is_file_executable(variant):
                 return variant
             variants.append(variant)
 
@@ -62,7 +81,7 @@ def find_executable(executable):
         for path in paths:
             for variant in variants:
                 filepath = os.path.abspath(os.path.join(path, variant))
-                if os.path.isfile(filepath):
+                if is_file_executable(filepath):
                     return filepath
     return None
 

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -23,12 +23,16 @@ def find_executable(executable):
         str: Full path to executable with extension (is file).
         None: When the executable was not found.
     """
+    # Skip if passed path is file
     if os.path.isfile(executable):
         return executable
 
     low_platform = platform.system().lower()
     _, ext = os.path.splitext(executable)
+
+    # Prepare variants for which it will be looked
     variants = [executable]
+    # Add other extension variants only if passed executable does not have one
     if not ext:
         if low_platform == "windows":
             exts = [".exe", ".ps1", ".bat"]
@@ -45,6 +49,7 @@ def find_executable(executable):
                 return variant
             variants.append(variant)
 
+    # Get paths where to look for executable
     path_str = os.environ.get("PATH", None)
     if path_str is None:
         if hasattr(os, "confstr"):
@@ -52,15 +57,13 @@ def find_executable(executable):
         elif hasattr(os, "defpath"):
             path_str = os.defpath
 
-    if not path_str:
-        return None
-
-    paths = path_str.split(os.pathsep)
-    for path in paths:
-        for variant in variants:
-            filepath = os.path.abspath(os.path.join(path, variant))
-            if os.path.isfile(filepath):
-                return filepath
+    if path_str:
+        paths = path_str.split(os.pathsep)
+        for path in paths:
+            for variant in variants:
+                filepath = os.path.abspath(os.path.join(path, variant))
+                if os.path.isfile(filepath):
+                    return filepath
     return None
 
 

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -3,7 +3,6 @@ import logging
 import json
 import platform
 import subprocess
-import distutils
 
 log = logging.getLogger("Vendor utils")
 
@@ -57,6 +56,12 @@ def find_executable(executable):
         return None
 
     paths = path_str.split(os.pathsep)
+    for path in paths:
+        for variant in variants:
+            filepath = os.path.abspath(os.path.join(path, executable))
+            if os.path.isfile(filepath):
+                return filepath
+    return None
 
 
 def get_vendor_bin_path(bin_app):
@@ -92,11 +97,7 @@ def get_oiio_tools_path(tool="oiiotool"):
             Default is "oiiotool".
     """
     oiio_dir = get_vendor_bin_path("oiio")
-    if platform.system().lower() == "windows" and not tool.lower().endswith(
-        ".exe"
-    ):
-        tool = "{}.exe".format(tool)
-    return os.path.join(oiio_dir, tool)
+    return find_executable(os.path.join(oiio_dir, tool))
 
 
 def get_ffmpeg_tool_path(tool="ffmpeg"):
@@ -112,7 +113,7 @@ def get_ffmpeg_tool_path(tool="ffmpeg"):
     ffmpeg_dir = get_vendor_bin_path("ffmpeg")
     if platform.system().lower() == "windows":
         ffmpeg_dir = os.path.join(ffmpeg_dir, "bin")
-    return os.path.join(ffmpeg_dir, tool)
+    return find_executable(os.path.join(ffmpeg_dir, tool))
 
 
 def ffprobe_streams(path_to_file, logger=None):
@@ -173,7 +174,7 @@ def is_oiio_supported():
     """
     loaded_path = oiio_path = get_oiio_tools_path()
     if oiio_path:
-        oiio_path = distutils.spawn.find_executable(oiio_path)
+        oiio_path = find_executable(oiio_path)
 
     if not oiio_path:
         log.debug("OIIOTool is not configured or not present at {}".format(


### PR DESCRIPTION
## Brief description
We're using `find_executable` from distutils but it seems that they'll get deprecated soon and may not work as expected also some older hosts have issues with using distutils too.

## Description
Added custom `find_executable` which should return full path to an executable file.

## Changes
- implemented `find_executable` in `openpype/lib`
- use the function in places where it is needed
- `maketx` in extract look does not add `".exe"`

## Testing notes:
- try run applications
- oiio and ffmpeg functions returning path should work and return full path to file