### PR TITLE
Settings: Missing document with OP versions may break start of OpenPype

### DIFF
--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -694,7 +694,7 @@ class MongoSettingsHandler(SettingsHandler):
         return self.collection.find_one(
             {"type": self._version_order_key},
             projection
-        )
+        ) or {}
 
     def _check_version_order(self):
         """This method will work only in OpenPype process.

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import traceback
+import functools
 
 from Qt import QtWidgets, QtGui, QtCore
 
@@ -10,22 +11,6 @@ from openpype.tools.settings import CHILD_OFFSET
 from .widgets import ExpandingWidget
 from .lib import create_deffered_value_change_timer
 from .constants import DEFAULT_PROJECT_LABEL
-
-
-class _Callback:
-    """Callback wrapper which stores it's args and kwargs.
-
-    Using lambda has few issues if local variables are passed to called
-    functions in loop it may change the value of the variable in already
-    stored callback.
-    """
-    def __init__(self, func, *args, **kwargs):
-        self._func = func
-        self._args = args
-        self._kwargs = kwargs
-
-    def __call__(self):
-        self._func(*self._args, **self._kwargs)
 
 
 class BaseWidget(QtWidgets.QWidget):
@@ -341,10 +326,7 @@ class BaseWidget(QtWidgets.QWidget):
 
             action = QtWidgets.QAction(project_name)
             submenu.addAction(action)
-            # Use custom callback object instead of lambda
-            #   - project_name value is changed each value so all actions will
-            #       use the same source project
-            actions_mapping[action] = _Callback(
+            actions_mapping[action] = functools.partial(
                 self._apply_values_from_project,
                 project_name
             )


### PR DESCRIPTION
## Brief description
Settings in some cases expect that a versioned document already exists and does not handle it.

## Changes
- Make sure that function returning versioned doc makes sure that result is dictionary and not None
- Side change: Replaced `_Callback` with `functools.partial` ( [related discussion](https://github.com/pypeclub/OpenPype/pull/2820#discussion_r816644392) )

## Testing notes:
1. On fresh mongo start OpenPype with specified version that is not build version - start should not crash