### PR TITLE
Tools: Don't use avalon tools code

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -202,13 +202,10 @@ def reload_pipeline(*args):
     avalon.api.uninstall()
 
     for module in (
-            "avalon.io",
-            "avalon.lib",
-            "avalon.pipeline",
-            "avalon.tools.creator.app",
-            "avalon.tools.manager.app",
-            "avalon.api",
-            "avalon.tools",
+        "avalon.io",
+        "avalon.lib",
+        "avalon.pipeline",
+        "avalon.api",
     ):
         module = importlib.import_module(module)
         importlib.reload(module)

--- a/openpype/hosts/harmony/api/lib.py
+++ b/openpype/hosts/harmony/api/lib.py
@@ -361,7 +361,7 @@ def zip_and_move(source, destination):
     log.debug(f"Saved '{source}' to '{destination}'")
 
 
-def show(module_name):
+def show(tool_name):
     """Call show on "module_name".
 
     This allows to make a QApplication ahead of time and always "exec_" to
@@ -374,13 +374,6 @@ def show(module_name):
     # Requests often get doubled up when showing tools, so we wait a second for
     # requests to be received properly.
     time.sleep(1)
-
-    # Get tool name from module name
-    # TODO this is for backwards compatibility not sure if `TB_sceneOpened.js`
-    #   is automatically updated.
-    # Previous javascript sent 'module_name' which contained whole tool import
-    #   string e.g. "avalon.tools.workfiles" now it should be only "workfiles"
-    tool_name = module_name.split(".")[-1]
 
     kwargs = {}
     if tool_name == "loader":

--- a/openpype/hosts/maya/api/commands.py
+++ b/openpype/hosts/maya/api/commands.py
@@ -37,17 +37,17 @@ class ToolWindows:
 
 
 def edit_shader_definitions():
-    from avalon.tools import lib
     from Qt import QtWidgets
     from openpype.hosts.maya.api.shader_definition_editor import (
         ShaderDefinitionsEditor
     )
+    from openpype.tools.utils import qt_app_context
 
     top_level_widgets = QtWidgets.QApplication.topLevelWidgets()
     main_window = next(widget for widget in top_level_widgets
                        if widget.objectName() == "MayaWindow")
 
-    with lib.application():
+    with qt_app_context():
         window = ToolWindows.get_window("shader_definition_editor")
         if not window:
             window = ShaderDefinitionsEditor(parent=main_window)

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -36,7 +36,7 @@ def install():
         return
 
     def deferred():
-        from avalon.tools import publish
+        pyblish_icon = host_tools.get_pyblish_icon()
         parent_widget = get_main_window()
         cmds.menu(
             MENU_NAME,
@@ -80,7 +80,7 @@ def install():
             command=lambda *args: host_tools.show_publish(
                 parent=parent_widget
             ),
-            image=publish.ICON
+            image=pyblish_icon
         )
 
         cmds.menuItem(

--- a/openpype/tools/mayalookassigner/widgets.py
+++ b/openpype/tools/mayalookassigner/widgets.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 from Qt import QtWidgets, QtCore
 
-# TODO: expose this better in avalon core
 from openpype.tools.utils.models import TreeModel
 from openpype.tools.utils.lib import (
     preserve_expanded_rows,

--- a/openpype/tools/mayalookassigner/widgets.py
+++ b/openpype/tools/mayalookassigner/widgets.py
@@ -4,8 +4,11 @@ from collections import defaultdict
 from Qt import QtWidgets, QtCore
 
 # TODO: expose this better in avalon core
-from avalon.tools import lib
-from avalon.tools.models import TreeModel
+from openpype.tools.utils.models import TreeModel
+from openpype.tools.utils.lib import (
+    preserve_expanded_rows,
+    preserve_selection,
+)
 
 from .models import (
     AssetModel,
@@ -88,8 +91,8 @@ class AssetOutliner(QtWidgets.QWidget):
         """Add all items from the current scene"""
 
         items = []
-        with lib.preserve_expanded_rows(self.view):
-            with lib.preserve_selection(self.view):
+        with preserve_expanded_rows(self.view):
+            with preserve_selection(self.view):
                 self.clear()
                 nodes = commands.get_all_asset_nodes()
                 items = commands.create_items_from_nodes(nodes)
@@ -100,8 +103,8 @@ class AssetOutliner(QtWidgets.QWidget):
     def get_selected_assets(self):
         """Add all selected items from the current scene"""
 
-        with lib.preserve_expanded_rows(self.view):
-            with lib.preserve_selection(self.view):
+        with preserve_expanded_rows(self.view):
+            with preserve_selection(self.view):
                 self.clear()
                 nodes = commands.get_selected_nodes()
                 items = commands.create_items_from_nodes(nodes)

--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -8,7 +8,7 @@ from avalon import api, io, style, schema
 from avalon.vendor import qtawesome
 
 from avalon.lib import HeroVersionType
-from avalon.tools.models import TreeModel, Item
+from openpype.tools.utils.models import TreeModel, Item
 
 from .lib import (
     get_site_icons,

--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -7,9 +7,13 @@ from Qt import QtWidgets, QtCore
 from avalon import io, api, style
 from avalon.vendor import qtawesome
 from avalon.lib import HeroVersionType
-from avalon.tools import lib as tools_lib
 
 from openpype.modules import ModulesManager
+from openpype.tools.utils.lib import (
+    get_progress_for_repre,
+    iter_model_rows,
+    format_version
+)
 
 from .switch_dialog import SwitchAssetDialog
 from .model import InventoryModel
@@ -373,7 +377,7 @@ class SceneInvetoryView(QtWidgets.QTreeView):
             if not repre_doc:
                 continue
 
-            progress = tools_lib.get_progress_for_repre(
+            progress = get_progress_for_repre(
                 repre_doc,
                 active_site,
                 remote_site
@@ -544,7 +548,7 @@ class SceneInvetoryView(QtWidgets.QTreeView):
             "toggle": selection_model.Toggle,
         }[options.get("mode", "select")]
 
-        for item in tools_lib.iter_model_rows(model, 0):
+        for item in iter_model_rows(model, 0):
             item = item.data(InventoryModel.ItemRole)
             if item.get("isGroupNode"):
                 continue
@@ -704,7 +708,7 @@ class SceneInvetoryView(QtWidgets.QTreeView):
         labels = []
         for version in all_versions:
             is_hero = version["type"] == "hero_version"
-            label = tools_lib.format_version(version["name"], is_hero)
+            label = format_version(version["name"], is_hero)
             labels.append(label)
             versions_by_label[label] = version["name"]
 

--- a/openpype/tools/standalonepublish/publish.py
+++ b/openpype/tools/standalonepublish/publish.py
@@ -3,10 +3,10 @@ import sys
 
 import openpype
 import pyblish.api
+from openpype.tools.utils.host_tools import show_publish
 
 
 def main(env):
-    from avalon.tools import publish
     # Registers pype's Global pyblish plugins
     openpype.install()
 
@@ -19,7 +19,7 @@ def main(env):
             continue
         pyblish.api.register_plugin_path(path)
 
-    return publish.show()
+    return show_publish()
 
 
 if __name__ == "__main__":

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -15,6 +15,7 @@ from .lib import (
     get_warning_pixmap,
     set_style_property,
     DynamicQThread,
+    qt_app_context,
 )
 
 from .models import (
@@ -39,6 +40,7 @@ __all__ = (
     "get_warning_pixmap",
     "set_style_property",
     "DynamicQThread",
+    "qt_app_context",
 
     "RecursiveSortFilterProxyModel",
 )

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -207,7 +207,7 @@ class HostToolsHelper:
         pyblish_show = self._discover_pyblish_gui()
         return pyblish_show(parent)
 
-    def _discover_pyblish_gui():
+    def _discover_pyblish_gui(self):
         """Return the most desirable of the currently registered GUIs"""
         # Prefer last registered
         guis = list(reversed(pyblish.api.registered_guis()))

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -3,8 +3,9 @@
 It is possible to create `HostToolsHelper` in host implementation or
 use singleton approach with global functions (using helper anyway).
 """
-
+import os
 import avalon.api
+import pyblish.api
 from .lib import qt_app_context
 
 
@@ -196,10 +197,29 @@ class HostToolsHelper:
             library_loader_tool.refresh()
 
     def show_publish(self, parent=None):
-        """Publish UI."""
-        from avalon.tools import publish
+        """Try showing the most desirable publish GUI
 
-        publish.show(parent)
+        This function cycles through the currently registered
+        graphical user interfaces, if any, and presents it to
+        the user.
+        """
+
+        pyblish_show = self._discover_pyblish_gui()
+        return pyblish_show(parent)
+
+    def _discover_pyblish_gui():
+        """Return the most desirable of the currently registered GUIs"""
+        # Prefer last registered
+        guis = list(reversed(pyblish.api.registered_guis()))
+        for gui in guis:
+            try:
+                gui = __import__(gui).show
+            except (ImportError, AttributeError):
+                continue
+            else:
+                return gui
+
+        raise ImportError("No Pyblish GUI found")
 
     def get_look_assigner_tool(self, parent):
         """Create, cache and return look assigner tool window."""
@@ -394,3 +414,11 @@ def show_publish(parent=None):
 
 def show_experimental_tools_dialog(parent=None):
     _SingletonPoint.show_tool_by_name("experimental_tools", parent)
+
+
+def get_pyblish_icon():
+    pyblish_dir = os.path.abspath(os.path.dirname(pyblish.api.__file__))
+    icon_path = os.path.join(pyblish_dir, "icons", "logo-32x32.svg")
+    if os.path.exists(icon_path):
+        return icon_path
+    return None

--- a/openpype/tools/workfiles/model.py
+++ b/openpype/tools/workfiles/model.py
@@ -1,11 +1,11 @@
 import os
 import logging
 
-from Qt import QtCore, QtGui
+from Qt import QtCore
 
 from avalon import style
 from avalon.vendor import qtawesome
-from avalon.tools.models import TreeModel, Item
+from openpype.tools.utils.models import TreeModel, Item
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Brief description
Planned movement of code requires to cleanup code in openpype first. One change is that 

## Description
Changed imports to not use lib functions and models from `avalon.tools` but from `openpype.tools.utils`.

## Changes
- changed imports
- moved pyblish gui discover logic into openpype

## Testing notes:
Nothing should change. Affected places:
- Standalone publishing should show publish tool
- Scene inventory should display versions correctly
- Maya should have pyblish icon in menu
- mayalookassigner should work before
- workfiles tool should work as before