### PR TITLE
Maya: Stop creation of reviews for Cryptomattes

### DIFF
--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -34,7 +34,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
         self.log.info("subset {}".format(instance.data['subset']))
 
         # skip crypto passes.
-        if 'crypto' in instance.data['subset']:
+        if 'crypto' in instance.data['subset'].lower():
             self.log.info("Skipping crypto passes.")
             return
 

--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -34,6 +34,11 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
         self.log.info("subset {}".format(instance.data['subset']))
 
         # skip crypto passes.
+        # TODO: This is just a quick fix and has its own side-effects - it is
+        #       affecting every subset name with `crypto` in its name.
+        #       This must be solved properly, maybe using tags on
+        #       representation that can be determined much earlier and
+        #       with better precision.
         if 'crypto' in instance.data['subset'].lower():
             self.log.info("Skipping crypto passes.")
             return


### PR DESCRIPTION
## Quick fix

This is fixing an issue where cryptomattes were still used for generation review videos even if they shouldn't. This then caused crash with ffmpeg during publishing because it cannot handle data stored in exrs.

---

### How to test

Publish render from Maya with cryptomattes enabled in any AOV.

🗒️ This is really just quick fix and proper solution is needed. Currently we are looking for `crypto` string in subset name but this is too broad definition.