### PR TITLE
Ftrack: Can sync fps as string

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -25,6 +25,11 @@ from openpype_modules.ftrack.lib import (
 
     BaseEvent
 )
+from openpype_modules.ftrack.lib.avalon_sync import (
+    convert_to_fps,
+    InvalidFpsValue,
+    FPS_KEYS
+)
 from openpype.lib import CURRENT_DOC_SCHEMAS
 
 
@@ -1149,11 +1154,30 @@ class SyncToAvalonEvent(BaseEvent):
                 "description": ftrack_ent["description"]
             }
         }
+        invalid_fps_items = []
         cust_attrs = self.get_cust_attr_values(ftrack_ent)
         for key, val in cust_attrs.items():
             if key.startswith("avalon_"):
                 continue
+
+            if key in FPS_KEYS:
+                try:
+                    val = convert_to_fps(val)
+                except InvalidFpsValue:
+                    invalid_fps_items.append((ftrack_ent["id"], val))
+                    continue
+
             final_entity["data"][key] = val
+
+        if invalid_fps_items:
+            fps_msg = (
+                "These entities have invalid fps value in custom attributes"
+            )
+            items = []
+            for entity_id, value in invalid_fps_items:
+                ent_path = self.get_ent_path(entity_id)
+                items.append("{} - \"{}\"".format(ent_path, value))
+            self.report_items["error"][fps_msg] = items
 
         _mongo_id_str = cust_attrs.get(CUST_ATTR_ID_KEY)
         if _mongo_id_str:
@@ -2155,11 +2179,19 @@ class SyncToAvalonEvent(BaseEvent):
             )
 
             convert_types_by_id[attr_id] = convert_type
+            default_value = attr["default"]
+            if key in FPS_KEYS:
+                try:
+                    default_value = convert_to_fps(default_value)
+                except InvalidFpsValue:
+                    pass
+
             entities_dict[ftrack_project_id]["hier_attrs"][key] = (
                 attr["default"]
             )
 
         # PREPARE DATA BEFORE THIS
+        invalid_fps_items = []
         avalon_hier = []
         for item in values:
             value = item["value"]
@@ -2173,7 +2205,24 @@ class SyncToAvalonEvent(BaseEvent):
 
             if convert_type:
                 value = convert_type(value)
+
+            if key in FPS_KEYS:
+                try:
+                    value = convert_to_fps(value)
+                except InvalidFpsValue:
+                    invalid_fps_items.append((entity_id, value))
+                    continue
             entities_dict[entity_id]["hier_attrs"][key] = value
+
+        if invalid_fps_items:
+            fps_msg = (
+                "These entities have invalid fps value in custom attributes"
+            )
+            items = []
+            for entity_id, value in invalid_fps_items:
+                ent_path = self.get_ent_path(entity_id)
+                items.append("{} - \"{}\"".format(ent_path, value))
+            self.report_items["error"][fps_msg] = items
 
         # Get dictionary with not None hierarchical values to pull to childs
         project_values = {}

--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -20,6 +20,7 @@ from openpype_modules.ftrack.lib import (
     query_custom_attributes,
     CUST_ATTR_ID_KEY,
     CUST_ATTR_AUTO_SYNC,
+    FPS_KEYS,
 
     avalon_sync,
 
@@ -27,8 +28,7 @@ from openpype_modules.ftrack.lib import (
 )
 from openpype_modules.ftrack.lib.avalon_sync import (
     convert_to_fps,
-    InvalidFpsValue,
-    FPS_KEYS
+    InvalidFpsValue
 )
 from openpype.lib import CURRENT_DOC_SCHEMAS
 

--- a/openpype/modules/ftrack/lib/__init__.py
+++ b/openpype/modules/ftrack/lib/__init__.py
@@ -4,7 +4,8 @@ from .constants import (
     CUST_ATTR_GROUP,
     CUST_ATTR_TOOLS,
     CUST_ATTR_APPLICATIONS,
-    CUST_ATTR_INTENT
+    CUST_ATTR_INTENT,
+    FPS_KEYS
 )
 from .settings import (
     get_ftrack_event_mongo_info
@@ -30,6 +31,8 @@ __all__ = (
     "CUST_ATTR_GROUP",
     "CUST_ATTR_TOOLS",
     "CUST_ATTR_APPLICATIONS",
+    "CUST_ATTR_INTENT",
+    "FPS_KEYS",
 
     "get_ftrack_event_mongo_info",
 

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -126,7 +126,10 @@ def convert_to_fps(source_value):
                     divident
                 )
             )
-        return float(divident) / float(divisor)
+        divisor_float = float(divisor)
+        if divisor_float == 0.0:
+            raise InvalidFpsValue("Can't divide by zero")
+        return float(divident) / divisor_float
 
     raise InvalidFpsValue(
         "Value can't be converted to number \"{}\"".format(source_value)

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -2,6 +2,9 @@ import re
 import json
 import collections
 import copy
+import numbers
+
+import six
 
 from avalon.api import AvalonMongoDB
 
@@ -31,6 +34,109 @@ CURRENT_DOC_SCHEMAS = {
     "asset": "openpype:asset-3.0",
     "config": "openpype:config-2.0"
 }
+
+FPS_KEYS = {
+    "fps",
+    # For development purposes
+    "fps_string"
+}
+
+
+class InvalidFpsValue(Exception):
+    pass
+
+
+def is_string_number(value):
+    """Can string value be converted to number (float)."""
+    if not isinstance(value, six.string_types):
+        raise TypeError("Expected {} got {}".format(
+            ", ".join(str(t) for t in six.string_types), str(type(value))
+        ))
+    if value == ".":
+        return False
+
+    if value.startswith("."):
+        value = "0" + value
+    elif value.endswith("."):
+        value = value + "0"
+
+    if re.match(r"^\d+(\.\d+)?$", value) is None:
+        return False
+    return True
+
+
+def convert_to_fps(source_value):
+    """Convert value into fps value.
+
+    Non string values are kept untouched. String is tried to convert.
+    Valid values:
+    "1000"
+    "1000.05"
+    "1000,05"
+    ",05"
+    ".05"
+    "1000,"
+    "1000."
+    "1000/1000"
+    "1000.05/1000"
+    "1000/1000.05"
+    "1000.05/1000.05"
+    "1000,05/1000"
+    "1000/1000,05"
+    "1000,05/1000,05"
+
+    Invalid values:
+    "/"
+    "/1000"
+    "1000/"
+    ","
+    "."
+    ...any other string
+
+    Returns:
+        float: Converted value.
+
+    Raises:
+        InvalidFpsValue: When value can't be converted to float.
+    """
+    if not isinstance(source_value, six.string_types):
+        if isinstance(source_value, numbers.Number):
+            return float(source_value)
+        return source_value
+
+    value = source_value.strip().replace(",", ".")
+    if not value:
+        raise InvalidFpsValue("Got empty value")
+
+    subs = value.split("/")
+    if len(subs) == 1:
+        str_value = subs[0]
+        if not is_string_number(str_value):
+            raise InvalidFpsValue(
+                "Value \"{}\" can't be converted to number.".format(value)
+            )
+        return float(str_value)
+
+    elif len(subs) == 2:
+        divident, divisor = subs
+        if not divident or not is_string_number(divident):
+            raise InvalidFpsValue(
+                "Divident value \"{}\" can't be converted to number".format(
+                    divident
+                )
+            )
+
+        if not divisor or not is_string_number(divisor):
+            raise InvalidFpsValue(
+                "Divisor value \"{}\" can't be converted to number".format(
+                    divident
+                )
+            )
+        return float(divident) / float(divisor)
+
+    raise InvalidFpsValue(
+        "Value can't be converted to number \"{}\"".format(source_value)
+    )
 
 
 def create_chunks(iterable, chunk_size=None):

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -17,7 +17,7 @@ from openpype.api import (
 )
 from openpype.lib import ApplicationManager
 
-from .constants import CUST_ATTR_ID_KEY
+from .constants import CUST_ATTR_ID_KEY, FPS_KEYS
 from .custom_attributes import get_openpype_attr, query_custom_attributes
 
 from bson.objectid import ObjectId
@@ -33,12 +33,6 @@ CURRENT_DOC_SCHEMAS = {
     "project": "openpype:project-3.0",
     "asset": "openpype:asset-3.0",
     "config": "openpype:config-2.0"
-}
-
-FPS_KEYS = {
-    "fps",
-    # For development purposes
-    "fps_string"
 }
 
 

--- a/openpype/modules/ftrack/lib/constants.py
+++ b/openpype/modules/ftrack/lib/constants.py
@@ -12,3 +12,9 @@ CUST_ATTR_APPLICATIONS = "applications"
 CUST_ATTR_TOOLS = "tools_env"
 # Intent custom attribute name
 CUST_ATTR_INTENT = "intent"
+
+FPS_KEYS = {
+    "fps",
+    # For development purposes
+    "fps_string"
+}


### PR DESCRIPTION
## Brief description
2 decimal places of fps may not be enough for some productions but ftrack numeric custom attributes have limitations into 2 decimal places.

## Description
Added option to store fps as string in ftrack custom attributes. The value can be set with multiple ways.
```
"1000"
"1000.05"
"1000,05"
",05"
".05"
"1000,"
"1000."
"1000/1000"
"1000.05/1000"
"1000/1000.05"
"1000,05/1000"
"1000/1000,05"
"1000.05/1000.05"
"1000,05/1000,05"
"1000,05/1000.05"
```
The FPS custom attribute can still be numeric so this feature is optional.

## Changes
- added function which converts fps string into float
- sync to avalon is using the function to convert fps value
    - custom attribute key must be available in `FPS_KEYS` variable
    - right now the variable containts `"fps"` and `"fps_string"` (for development and testing purposes)
- create update custom attributes does not replace `text` custom attribute `fps`

## Testing notes:
### Preparations:
Option n1:
- Without renaming of current `fps` custom attribute which may temporary break others projects, but use `fps_string` name.
1. Check that `fps_string` custom attribute is available in ftrack
    - if not then create `fps_string` custom attribute which is hierarchical has `text` type without markdown (lable is up to you)

Option n2:
1. Rename current `fps` custom attribute (to anything else)
2. Create new `fps` custom attribute which is hierarchical has `text` type without markdown

### Testing
Sync action:
1. Set fps to any valid/invalid value and run sync to avalon action

Event sync:
1. Run ftrack event server
2. Enable auto sync on a project
3. Change fps string to valid/invalid values in that project

Valid values should be synced as float to mongo and invalid values should show ftrack message.