### PR TITLE
Blender: Fixed parameters for FBX export of the camera

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_camera.py
+++ b/openpype/hosts/blender/plugins/publish/extract_camera.py
@@ -50,6 +50,10 @@ class ExtractCamera(api.Extractor):
             filepath=filepath,
             use_active_collection=False,
             use_selection=True,
+            bake_anim_use_nla_strips=False,
+            bake_anim_use_all_actions=False,
+            add_leaf_bones=False,
+            armature_nodetype='ROOT',
             object_types={'CAMERA'},
             bake_anim_simplify_factor=0.0
         )


### PR DESCRIPTION
## Brief description
Fixed parameters for the export of FBX camera from Blender.

## Description
Blender changed the FBX exporter plugin with version 2.93. The camera extractor has been updated to include some parameters to make the camera working as before these changes.