### PR TITLE
Nuke: Fix family test in validate_write_legacy to work with stillImage

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
@@ -34,7 +34,8 @@ class ValidateWriteLegacy(pyblish.api.InstancePlugin):
         # test if render in family test knob
         # and only one item should be available
         assert len(family_test) == 1, msg + " > More avalon attributes"
-        assert "render" in node[family_test[0]].value() or "still" in node[family_test[0]].value(), msg + \
+        assert "render" in node[family_test[0]].value() \
+            or "still" in node[family_test[0]].value(), msg + \
             " > Not correct family"
         # test if `file` knob in node, this way old
         # non-group-node write could be detected

--- a/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
@@ -34,9 +34,8 @@ class ValidateWriteLegacy(pyblish.api.InstancePlugin):
         # test if render in family test knob
         # and only one item should be available
         assert len(family_test) == 1, msg + " > More avalon attributes"
-        assert "render" in node[family_test[0]].value(), msg + \
+        assert "render" in node[family_test[0]].value() or "still" in node[family_test[0]].value(), msg + \
             " > Not correct family"
-
         # test if `file` knob in node, this way old
         # non-group-node write could be detected
         assert "file" not in node.knobs(), msg + \
@@ -74,6 +73,8 @@ class ValidateWriteLegacy(pyblish.api.InstancePlugin):
             Create_name = "CreateWriteRender"
         elif family == "prerender":
             Create_name = "CreateWritePrerender"
+        elif family == "still":
+            Create_name = "CreateWriteStill"
 
         # get appropriate plugin class
         creator_plugin = None


### PR DESCRIPTION
## Brief description
Fix Still Image publishing

## Description
Publishing StillImage from Nuke fails on family check. 

## Testing notes:
1. Go to Nuke
2. Create StillImageFrame, set it to local render
3. Publish
4. Check that publish didn't fail on "Not correct family"
