### PR TITLE
WebPublisher: Fix wrong number of frames for video file

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -130,3 +130,23 @@ def is_oiio_supported():
         ))
         return False
     return True
+
+
+def get_fps(str_value):
+    """Returns (str) value of fps from ffprobe frame format (120/1)"""
+    if str_value == "0/0":
+        print("WARNING: Source has \"r_frame_rate\" value set to \"0/0\".")
+        return "Unknown"
+
+    items = str_value.split("/")
+    if len(items) == 1:
+        fps = float(items[0])
+
+    elif len(items) == 2:
+        fps = float(items[0]) / float(items[1])
+
+    # Check if fps is integer or float number
+    if int(fps) == fps:
+        fps = int(fps)
+
+    return str(fps)

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -6,6 +6,7 @@ import platform
 import json
 import opentimelineio_contrib.adapters.ffmpeg_burnins as ffmpeg_burnins
 import openpype.lib
+from openpype.lib.vendor_bin_utils import get_fps
 
 
 ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
@@ -48,25 +49,6 @@ def _get_ffprobe_data(source):
     if proc.returncode != 0:
         raise RuntimeError("Failed to run: %s" % command)
     return json.loads(out)
-
-
-def get_fps(str_value):
-    if str_value == "0/0":
-        print("WARNING: Source has \"r_frame_rate\" value set to \"0/0\".")
-        return "Unknown"
-
-    items = str_value.split("/")
-    if len(items) == 1:
-        fps = float(items[0])
-
-    elif len(items) == 2:
-        fps = float(items[0]) / float(items[1])
-
-    # Check if fps is integer or float number
-    if int(fps) == fps:
-        fps = int(fps)
-
-    return str(fps)
 
 
 def _prores_codec_args(stream_data, source_ffmpeg_cmd):


### PR DESCRIPTION
## Brief description
Wrong value 0-1 was hardcoded, now `ffprobe` is used to try get frame count from a file

## Description
In the case of any weird video format, fallback to values stored in DB (Ftrack) is used.

## Testing notes:
1. Publish any video file as a 'render' family via WebPublisher
2. Compare number of frames in the file and in published record (shoul be visible in Loader or when Loaded to Nuke)