### PR TITLE
WebPublisher: Fix username stored in DB

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/collect_username.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_username.py
@@ -23,8 +23,11 @@ class CollectUsername(pyblish.api.ContextPlugin):
         Expects "pype.club" user created on Ftrack and FTRACK_BOT_API_KEY env
         var set up.
 
+        Resets `context.data["user"] to correctly populate `version.author` and
+        `representation.context.username`
+
     """
-    order = pyblish.api.CollectorOrder - 0.488
+    order = pyblish.api.CollectorOrder + 0.0015
     label = "Collect ftrack username"
     hosts = ["webpublisher", "photoshop"]
     targets = ["remotepublish", "filespublish", "tvpaint_worker"]
@@ -65,3 +68,4 @@ class CollectUsername(pyblish.api.ContextPlugin):
         if '@' in burnin_name:
             burnin_name = burnin_name[:burnin_name.index('@')]
         os.environ["WEBPUBLISH_OPENPYPE_USERNAME"] = burnin_name
+        context.data["user"] = burnin_name


### PR DESCRIPTION
## Brief description
Burnin name, version.author and representation.username is set to same value


## Testing notes:
1. Publish something with WP
2. Check burnin left bottom corner
3. Check version author value in Loader