### PR TITLE
General: Fix getattr clalback on dynamic modules

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -61,6 +61,7 @@ class _ModuleClass(object):
     def __init__(self, name):
         # Call setattr on super class
         super(_ModuleClass, self).__setattr__("name", name)
+        super(_ModuleClass, self).__setattr__("__name__", name)
 
         # Where modules and interfaces are stored
         super(_ModuleClass, self).__setattr__("__attributes__", dict())
@@ -72,7 +73,7 @@ class _ModuleClass(object):
         if attr_name not in self.__attributes__:
             if attr_name in ("__path__", "__file__"):
                 return None
-            raise ImportError("No module named {}.{}".format(
+            raise AttributeError("'{}' has not attribute '{}'".format(
                 self.name, attr_name
             ))
         return self.__attributes__[attr_name]


### PR DESCRIPTION
## Brief description
Calling `getattr` on dynamic modules in openpype (`openpype_modules` and `openpype_interfaces`) does not behave as expected because is raising `ImportError` instead of `AttributeError`.

## Changes
- dynamic module has `__name__` attribute (where is stored it's name)
- `__getattr__` method raises `AttributeError` instead of `ImportError`

## Testing notes:
Run script in python interpreter console
```
import openpype_modules

# This should return None and not crash
getattr(openpype_modules, "missing_module", None)
```