### PR TITLE
General: ffmpeg was crashing on slate merge

### DIFF
--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -347,8 +347,21 @@ class ExtractReviewSlate(openpype.api.Extractor):
 
         profile_name = no_audio_stream.get("profile")
         if profile_name:
-            profile_name = profile_name.replace(" ", "_").lower()
-            codec_args.append("-profile:v {}".format(profile_name))
+            # Rest of arguments is prores_kw specific
+            if codec_name == "prores_ks":
+                codec_tag_to_profile_map = {
+                    "apco": "proxy",
+                    "apcs": "lt",
+                    "apcn": "standard",
+                    "apch": "hq",
+                    "ap4h": "4444",
+                    "ap4x": "4444xq"
+                }
+                codec_tag_str = no_audio_stream.get("codec_tag_string")
+                if codec_tag_str:
+                    profile = codec_tag_to_profile_map.get(codec_tag_str)
+                    if profile:
+                        codec_args.extend(["-profile:v", profile])
 
         pix_fmt = no_audio_stream.get("pix_fmt")
         if pix_fmt:


### PR DESCRIPTION
## Brief description
Slate could not be converted to prores 4444

## Description
Old code was expecting to find codec profile name in tokenized profile name

## Testing notes:
1. open testing nuke scene
2. add Slate node directly above writeRender node
3. to Extract review add prores output preset with prores 4444 definition
4. Add to the output prores profile tag with `Add slate frame`
4. publish locally >> all should be fine and prores should have first frame slate frame