### PR TITLE
Bugfix/op 2472 maya assembly collection broken

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_assembly.py
+++ b/openpype/hosts/maya/plugins/publish/collect_assembly.py
@@ -48,6 +48,9 @@ class CollectAssembly(pyblish.api.InstancePlugin):
 
             # Retrieve the hierarchy
             parent = cmds.listRelatives(root, parent=True, fullPath=True)[0]
+
+            # Retrieves children of root
+            children = cmds.listRelatives(parent, children=True, fullPath=True)[0]
             hierarchy_nodes.append(parent)
 
             # Temporary warning for GPU cache which are not supported yet

--- a/openpype/hosts/maya/plugins/publish/collect_assembly.py
+++ b/openpype/hosts/maya/plugins/publish/collect_assembly.py
@@ -52,7 +52,7 @@ class CollectAssembly(pyblish.api.InstancePlugin):
             # Retrieves children of root
             children = cmds.listRelatives(parent, children=True, fullPath=True)[0]
             hierarchy_nodes.append(parent)
-
+            hierarchy_nodes.append(children)
             # Temporary warning for GPU cache which are not supported yet
             loader = container["loader"]
             if loader == "GpuCacheLoader":


### PR DESCRIPTION
Assembly collection fix for issue #2573 

Passing matrix transforms to the instance.data by recognizing the children of the root transform as well and grabbing the transforms of the children to be passed.