### PR TITLE
NewPublisher: Changing task on publishing instance

### DIFF
--- a/openpype/hosts/testhost/plugins/publish/collect_context.py
+++ b/openpype/hosts/testhost/plugins/publish/collect_context.py
@@ -19,7 +19,7 @@ class CollectContextDataTestHost(
     hosts = ["testhost"]
 
     @classmethod
-    def get_instance_attr_defs(cls):
+    def get_attribute_defs(cls):
         return [
             attribute_definitions.BoolDef(
                 "test_bool",

--- a/openpype/hosts/testhost/plugins/publish/collect_instance_1.py
+++ b/openpype/hosts/testhost/plugins/publish/collect_instance_1.py
@@ -20,7 +20,7 @@ class CollectInstanceOneTestHost(
     hosts = ["testhost"]
 
     @classmethod
-    def get_instance_attr_defs(cls):
+    def get_attribute_defs(cls):
         return [
             attribute_definitions.NumberDef(
                 "version",

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1005,12 +1005,14 @@ class CreateContext:
         if not instances:
             return
 
-        task_names_by_asset_name = collections.defaultdict(set)
+        task_names_by_asset_name = {}
         for instance in instances:
             task_name = instance.get("task")
             asset_name = instance.get("asset")
-            if asset_name and task_name:
-                task_names_by_asset_name[asset_name].add(task_name)
+            if asset_name:
+                task_names_by_asset_name[asset_name] = set()
+                if task_name:
+                    task_names_by_asset_name[asset_name].add(task_name)
 
         asset_names = [
             asset_name

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -192,10 +192,14 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 "short": task_code
             }
 
-        else:
+        elif "task" in anatomy_data:
             # Just set 'task_name' variable to context task
             task_name = anatomy_data["task"]["name"]
             task_type = anatomy_data["task"]["type"]
+
+        else:
+            task_name = None
+            task_type = None
 
         # Fill family in anatomy data
         anatomy_data["family"] = instance.data.get("family")
@@ -816,8 +820,12 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         #   - is there a chance that task name is not filled in anatomy
         #       data?
         #   - should we use context task in that case?
-        task_name = instance.data["anatomyData"]["task"]["name"]
-        task_type = instance.data["anatomyData"]["task"]["type"]
+        anatomy_data = instance.data["anatomyData"]
+        task_name = None
+        task_type = None
+        if "task" in anatomy_data:
+            task_name = anatomy_data["task"]["name"]
+            task_type = anatomy_data["task"]["type"]
         filtering_criteria = {
             "families": instance.data["family"],
             "hosts": instance.context.data["hostName"],

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -873,8 +873,6 @@ class PublisherController:
         """
         for idx, plugin in enumerate(self.publish_plugins):
             self._publish_progress = idx
-            # Add plugin to publish report
-            self._publish_report.add_plugin_iter(plugin, self._publish_context)
 
             # Reset current plugin validations error
             self._publish_current_plugin_validation_errors = None
@@ -901,6 +899,9 @@ class PublisherController:
                 and self._publish_validation_errors
             ):
                 yield MainThreadItem(self.stop_publish)
+
+            # Add plugin to publish report
+            self._publish_report.add_plugin_iter(plugin, self._publish_context)
 
             # Trigger callback that new plugin is going to be processed
             self._trigger_callbacks(

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -8,7 +8,7 @@ try:
 except Exception:
     commonmark = None
 from Qt import QtWidgets, QtCore, QtGui
-
+from openpype.lib import TaskNotSetError
 from openpype.pipeline.create import (
     CreatorError,
     SUBSET_NAME_ALLOWED_SYMBOLS
@@ -566,10 +566,9 @@ class CreateDialog(QtWidgets.QDialog):
         if variant_value is None:
             variant_value = self.variant_input.text()
 
-        match = self._compiled_name_pattern.match(variant_value)
-        valid = bool(match)
-        self.create_btn.setEnabled(valid)
-        if not valid:
+        self.create_btn.setEnabled(True)
+        if not self._compiled_name_pattern.match(variant_value):
+            self.create_btn.setEnabled(False)
             self._set_variant_state_property("invalid")
             self.subset_name_input.setText("< Invalid variant >")
             return
@@ -579,9 +578,16 @@ class CreateDialog(QtWidgets.QDialog):
 
         asset_doc = copy.deepcopy(self._asset_doc)
         # Calculate subset name with Creator plugin
-        subset_name = self._selected_creator.get_subset_name(
-            variant_value, task_name, asset_doc, project_name
-        )
+        try:
+            subset_name = self._selected_creator.get_subset_name(
+                variant_value, task_name, asset_doc, project_name
+            )
+        except TaskNotSetError:
+            self.create_btn.setEnabled(False)
+            self._set_variant_state_property("invalid")
+            self.subset_name_input.setText("< Missing task >")
+            return
+
         self.subset_name_input.setText(subset_name)
 
         self._validate_subset_name(subset_name, variant_value)

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -467,12 +467,22 @@ class InstanceListView(AbstractInstanceView):
         else:
             active = False
 
+        group_names = set()
         for instance_id in selected_instance_ids:
             widget = self._widgets_by_id.get(instance_id)
-            if widget is not None:
-                widget.set_active(active)
+            if widget is None:
+                continue
+
+            widget.set_active(active)
+            group_name = self._group_by_instance_id.get(instance_id)
+            if group_name is not None:
+                group_names.add(group_name)
+
+        for group_name in group_names:
+            self._update_group_checkstate(group_name)
 
     def _update_group_checkstate(self, group_name):
+        """Update checkstate of one group."""
         widget = self._group_widgets.get(group_name)
         if widget is None:
             return

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -937,7 +937,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         family_value_widget.set_value()
         subset_value_widget.set_value()
 
-        submit_btn = QtWidgets.QPushButton("Submit", self)
+        submit_btn = QtWidgets.QPushButton("Confirm", self)
         cancel_btn = QtWidgets.QPushButton("Cancel", self)
         submit_btn.setEnabled(False)
         cancel_btn.setEnabled(False)

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1072,7 +1072,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
                 instance.set_asset_invalid(False)
 
             if task_name is not None:
-                instance["task"] = task_name
+                instance["task"] = task_name or None
                 instance.set_task_invalid(False)
 
             instance["subset"] = new_subset_name

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1156,9 +1156,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
             variants.add(instance.get("variant") or self.unknown_value)
             families.add(instance.get("family") or self.unknown_value)
             asset_name = instance.get("asset") or self.unknown_value
-            task_name = instance.get("task")
-            if task_name is None:
-                 task_name = self.unknown_value
+            task_name = instance.get("task") or ""
             asset_names.add(asset_name)
             asset_task_combinations.append((asset_name, task_name))
             subset_names.add(instance.get("subset") or self.unknown_value)


### PR DESCRIPTION
## Brief description
Change of task on publishing instance does not fix invalid instance and it is not possible to have instance without set task which may be needed in some cases of publishing.

## Changes
- changed `Submit` label to `Confirm`
- instance does not need to have set task but can have empty task (stored as `None`)
- change of invalid task on existing instance is propagated to instance properly
     - invalid task doesn't mean invalid asset
- it is captured `TaskNotSetError` in both creator dialog and publisher
- publish plugin `IntegrateNew` does not require task in anatomy data
- change of checkbox states using keys (space, backspace, enter) will also trigger change state of group checkbox
- tasks in combobox are sorted
- plugin is added to report after checks if should stop/pause publishing

## Testing notes:
Try change subset template in settings to be with/without `task` and create instances or change their context afterwards.
- Ideal test scenario:
1. create instance with subset template with `task`
2. change subset template in settings to not contain `task`
3. change task on the instance to empty task and press confirm
- The same thing in oposite way
This has an issue that current hosts using new publisher probably does not support this test.