### PR TITLE
General: Fix hardlink for windows

### DIFF
--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -43,6 +43,7 @@ def create_hard_link(src_path, dst_path):
         res = CreateHardLink(dst_path, src_path, None)
         if res == 0:
             raise ctypes.WinError()
+        return
     # Raises not implemented error if gets here
     raise NotImplementedError(
         "Implementation of hardlink for current environment is missing."


### PR DESCRIPTION
## Brief description
[This PR](https://github.com/pypeclub/OpenPype/pull/2848) implemented `create_hard_link` which has special condition for windows but when is successfull it continues right into raise of exception.

## Changes
- added `return` for windows specific condition

## Testing notes:
1. Run `create_hard_link` on windows in host with Python 2