### PR TITLE
Nuke: gizmo precollect fix

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_instances.py
@@ -80,7 +80,7 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
             # Add all nodes in group instances.
             if node.Class() == "Group":
                 # only alter families for render family
-                if "write" in families_ak.lower():
+                if families_ak and "write" in families_ak.lower():
                     target = node["render"].value()
                     if target == "Use existing frames":
                         # Local rendering

--- a/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
@@ -34,7 +34,8 @@ class ValidateWriteLegacy(pyblish.api.InstancePlugin):
         # test if render in family test knob
         # and only one item should be available
         assert len(family_test) == 1, msg + " > More avalon attributes"
-        assert "render" in node[family_test[0]].value() or "still" in node[family_test[0]].value(), msg + \
+        assert "render" in node[family_test[0]].value() \
+            or "still" in node[family_test[0]].value(), msg + \
             " > Not correct family"
         # test if `file` knob in node, this way old
         # non-group-node write could be detected

--- a/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_legacy.py
@@ -34,9 +34,8 @@ class ValidateWriteLegacy(pyblish.api.InstancePlugin):
         # test if render in family test knob
         # and only one item should be available
         assert len(family_test) == 1, msg + " > More avalon attributes"
-        assert "render" in node[family_test[0]].value(), msg + \
+        assert "render" in node[family_test[0]].value() or "still" in node[family_test[0]].value(), msg + \
             " > Not correct family"
-
         # test if `file` knob in node, this way old
         # non-group-node write could be detected
         assert "file" not in node.knobs(), msg + \
@@ -74,6 +73,8 @@ class ValidateWriteLegacy(pyblish.api.InstancePlugin):
             Create_name = "CreateWriteRender"
         elif family == "prerender":
             Create_name = "CreateWritePrerender"
+        elif family == "still":
+            Create_name = "CreateWriteStill"
 
         # get appropriate plugin class
         creator_plugin = None


### PR DESCRIPTION
## Brief description
Precollect checks Nuke groups for having "write" in families. Publishing Group as OP Gizmo fails.

## Description

## Additional info

## Documentation (add _"type: documentation"_ label)

## Testing notes:
1. create group of nodes in Nuke
2. Create OP Gizmo from selected group
3. Publish