### PR TITLE
NewPublisher: Descriptions and Icons in creator dialog

### DIFF
--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -836,6 +836,19 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 }
 
 /* New Create/Publish UI */
+#CreateDialogHelpButton {
+    background: rgba(255, 255, 255, 31);
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    font-size: 10pt;
+    font-weight: bold;
+    padding: 3px 3px 3px 3px;
+}
+
+#CreateDialogHelpButton:hover {
+    background: rgba(255, 255, 255, 63);
+}
+
 #PublishLogConsole {
     font-family: "Noto Sans Mono";
 }

--- a/openpype/tools/publisher/widgets/assets_widget.py
+++ b/openpype/tools/publisher/widgets/assets_widget.py
@@ -3,7 +3,8 @@ import collections
 from Qt import QtWidgets, QtCore, QtGui
 from openpype.tools.utils import (
     PlaceholderLineEdit,
-    RecursiveSortFilterProxyModel
+    RecursiveSortFilterProxyModel,
+    get_asset_icon,
 )
 from openpype.tools.utils.assets_widget import (
     SingleSelectAssetsWidget,
@@ -102,11 +103,15 @@ class AssetsHierarchyModel(QtGui.QStandardItemModel):
             for name in sorted(children_by_name.keys()):
                 child = children_by_name[name]
                 child_id = child["_id"]
+                has_children = bool(assets_by_parent_id.get(child_id))
+                icon = get_asset_icon(child, has_children)
+
                 item = QtGui.QStandardItem(name)
                 item.setFlags(
                     QtCore.Qt.ItemIsEnabled
                     | QtCore.Qt.ItemIsSelectable
                 )
+                item.setData(icon, QtCore.Qt.DecorationRole)
                 item.setData(child_id, ASSET_ID_ROLE)
                 item.setData(name, ASSET_NAME_ROLE)
 

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -103,18 +103,16 @@ class CreateErrorMessageBox(ErrorMessageBox):
 
 
 # TODO add creator identifier/label to details
-class CreatorDescriptionWidget(QtWidgets.QWidget):
+class CreatorShortDescWidget(QtWidgets.QWidget):
     def __init__(self, parent=None):
-        super(CreatorDescriptionWidget, self).__init__(parent=parent)
+        super(CreatorShortDescWidget, self).__init__(parent=parent)
 
         # --- Short description widget ---
-        short_desc_widget = QtWidgets.QWidget(self)
-
-        icon_widget = IconValuePixmapLabel(None, short_desc_widget)
+        icon_widget = IconValuePixmapLabel(None, self)
         icon_widget.setObjectName("FamilyIconLabel")
 
         # --- Short description inputs ---
-        short_desc_input_widget = QtWidgets.QWidget(short_desc_widget)
+        short_desc_input_widget = QtWidgets.QWidget(self)
 
         family_label = QtWidgets.QLabel(short_desc_input_widget)
         family_label.setAlignment(
@@ -134,73 +132,69 @@ class CreatorDescriptionWidget(QtWidgets.QWidget):
         short_desc_input_layout.addWidget(description_label)
         # --------------------------------
 
-        short_desc_layout = QtWidgets.QHBoxLayout(short_desc_widget)
-        short_desc_layout.setContentsMargins(0, 0, 0, 0)
-        short_desc_layout.addWidget(icon_widget, 0)
-        short_desc_layout.addWidget(short_desc_input_widget, 1)
-        # --------------------------------
-
-        separator_widget = QtWidgets.QWidget(self)
-        separator_widget.setObjectName("Separator")
-        separator_widget.setMinimumHeight(2)
-        separator_widget.setMaximumHeight(2)
-
-        # --- Bottom part ----------------
-        bottom_widget = QtWidgets.QWidget(self)
-
-        # Precreate attributes widget
-        pre_create_widget = PreCreateWidget(bottom_widget)
-
-        # Detailed description of creator
-        detail_description_widget = QtWidgets.QTextEdit(bottom_widget)
-        detail_description_widget.setObjectName("InfoText")
-        detail_description_widget.setTextInteractionFlags(
-            QtCore.Qt.TextBrowserInteraction
-        )
-        # TODO add HELP button
-        detail_description_widget.setVisible(False)
-
-        bottom_layout = QtWidgets.QHBoxLayout(bottom_widget)
-        bottom_layout.setContentsMargins(0, 0, 0, 0)
-        bottom_layout.addWidget(pre_create_widget, 1)
-        bottom_layout.addWidget(detail_description_widget, 1)
-
-        layout = QtWidgets.QVBoxLayout(self)
+        layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(short_desc_widget, 0)
-        layout.addWidget(separator_widget, 0)
-        layout.addWidget(bottom_widget, 1)
+        layout.addWidget(icon_widget, 0)
+        layout.addWidget(short_desc_input_widget, 1)
+        # --------------------------------
 
         self._icon_widget = icon_widget
         self._family_label = family_label
         self._description_label = description_label
-        self._detail_description_widget = detail_description_widget
-        self._pre_create_widget = pre_create_widget
 
     def set_plugin(self, plugin=None):
         if not plugin:
             self._icon_widget.set_icon_def(None)
             self._family_label.setText("")
             self._description_label.setText("")
-            self._detail_description_widget.setPlainText("")
-            self._pre_create_widget.set_plugin(plugin)
             return
 
         plugin_icon = plugin.get_icon()
         description = plugin.get_description() or ""
-        detailed_description = plugin.get_detail_description() or ""
 
         self._icon_widget.set_icon_def(plugin_icon)
         self._family_label.setText("<b>{}</b>".format(plugin.family))
         self._family_label.setTextInteractionFlags(QtCore.Qt.NoTextInteraction)
         self._description_label.setText(description)
 
-        if commonmark:
-            html = commonmark.commonmark(detailed_description)
-            self._detail_description_widget.setHtml(html)
+
+class HelpButton(QtWidgets.QPushButton):
+    resized = QtCore.Signal()
+
+    def __init__(self, *args, **kwargs):
+        super(HelpButton, self).__init__(*args, **kwargs)
+        self.setObjectName("CreateDialogHelpButton")
+
+        self._expanded = None
+        self.set_expanded()
+
+    def set_expanded(self, expanded=None):
+        if self._expanded is expanded:
+            if expanded is not None:
+                return
+            expanded = False
+        self._expanded = expanded
+        if expanded:
+            text = "<"
         else:
-            self._detail_description_widget.setMarkdown(detailed_description)
-        self._pre_create_widget.set_plugin(plugin)
+            text = "?"
+        self.setText(text)
+
+        self._update_size()
+
+    def _update_size(self):
+        new_size = self.minimumSizeHint()
+        if self.size() != new_size:
+            self.resize(new_size)
+            self.resized.emit()
+
+    def showEvent(self, event):
+        super(HelpButton, self).showEvent(event)
+        self._update_size()
+
+    def resizeEvent(self, event):
+        super(HelpButton, self).resizeEvent(event)
+        self._update_size()
 
 
 class CreateDialog(QtWidgets.QDialog):
@@ -248,8 +242,7 @@ class CreateDialog(QtWidgets.QDialog):
         context_layout.addWidget(assets_widget, 2)
         context_layout.addWidget(tasks_widget, 1)
 
-        creator_description_widget = CreatorDescriptionWidget(self)
-
+        # --- Creators view ---
         creators_view = QtWidgets.QListView(self)
         creators_model = QtGui.QStandardItemModel()
         creators_view.setModel(creators_model)
@@ -288,23 +281,64 @@ class CreateDialog(QtWidgets.QDialog):
         mid_layout.addWidget(creators_view, 1)
         mid_layout.addLayout(form_layout, 0)
         mid_layout.addWidget(create_btn, 0)
+        # ------------
+
+        # --- Creator short info and attr defs ---
+        creator_attrs_widget = QtWidgets.QWidget(self)
+
+        creator_short_desc_widget = CreatorShortDescWidget(
+            creator_attrs_widget
+        )
+
+        separator_widget = QtWidgets.QWidget(self)
+        separator_widget.setObjectName("Separator")
+        separator_widget.setMinimumHeight(2)
+        separator_widget.setMaximumHeight(2)
+
+        # Precreate attributes widget
+        pre_create_widget = PreCreateWidget(creator_attrs_widget)
+
+        creator_attrs_layout = QtWidgets.QVBoxLayout(creator_attrs_widget)
+        creator_attrs_layout.setContentsMargins(0, 0, 0, 0)
+        creator_attrs_layout.addWidget(creator_short_desc_widget, 0)
+        creator_attrs_layout.addWidget(separator_widget, 0)
+        creator_attrs_layout.addWidget(pre_create_widget, 1)
+        # -------------------------------------
+
+        # --- Detailed information about creator ---
+        # Detailed description of creator
+        detail_description_widget = QtWidgets.QTextEdit(self)
+        detail_description_widget.setObjectName("InfoText")
+        detail_description_widget.setTextInteractionFlags(
+            QtCore.Qt.TextBrowserInteraction
+        )
+        detail_description_widget.setVisible(False)
+        # -------------------------------------------
 
         splitter_widget = QtWidgets.QSplitter(self)
         splitter_widget.addWidget(context_widget)
         splitter_widget.addWidget(mid_widget)
-        splitter_widget.addWidget(creator_description_widget)
+        splitter_widget.addWidget(creator_attrs_widget)
+        splitter_widget.addWidget(detail_description_widget)
         splitter_widget.setStretchFactor(0, 1)
         splitter_widget.setStretchFactor(1, 1)
         splitter_widget.setStretchFactor(2, 1)
+        splitter_widget.setStretchFactor(3, 1)
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.addWidget(splitter_widget, 1)
+
+        # Floating help button
+        help_btn = HelpButton(self)
 
         prereq_timer = QtCore.QTimer()
         prereq_timer.setInterval(50)
         prereq_timer.setSingleShot(True)
 
         prereq_timer.timeout.connect(self._on_prereq_timer)
+
+        help_btn.clicked.connect(self._on_help_btn)
+        help_btn.resized.connect(self._on_help_btn_resize)
 
         create_btn.clicked.connect(self._on_create)
         variant_input.returnPressed.connect(self._on_create)
@@ -326,7 +360,6 @@ class CreateDialog(QtWidgets.QDialog):
         self._context_widget = context_widget
         self._assets_widget = assets_widget
         self._tasks_widget = tasks_widget
-        self.creator_description_widget = creator_description_widget
 
         self.subset_name_input = subset_name_input
 
@@ -338,6 +371,11 @@ class CreateDialog(QtWidgets.QDialog):
         self.creators_model = creators_model
         self.creators_view = creators_view
         self.create_btn = create_btn
+
+        self._creator_short_desc_widget = creator_short_desc_widget
+        self._pre_create_widget = pre_create_widget
+        self._detail_description_widget = detail_description_widget
+        self._help_btn = help_btn
 
         self._prereq_timer = prereq_timer
         self._first_show = True
@@ -532,10 +570,62 @@ class CreateDialog(QtWidgets.QDialog):
             identifier = new_index.data(CREATOR_IDENTIFIER_ROLE)
         self._set_creator(identifier)
 
+    def _update_help_btn(self):
+        pos_x = self.width() - self._help_btn.width()
+        point = self._creator_short_desc_widget.rect().topRight()
+        mapped_point = self._creator_short_desc_widget.mapTo(self, point)
+        pos_y = mapped_point.y()
+        self._help_btn.move(max(0, pos_x), max(0, pos_y))
+
+    def _on_help_btn_resize(self):
+        self._update_help_btn()
+
+    def _on_help_btn(self):
+        final_size = self.size()
+        cur_sizes = self._splitter_widget.sizes()
+        spacing = self._splitter_widget.handleWidth()
+
+        sizes = []
+        for idx, value in enumerate(cur_sizes):
+            if idx < 3:
+                sizes.append(value)
+
+        now_visible = self._detail_description_widget.isVisible()
+        if now_visible:
+            width = final_size.width() - (
+                spacing + self._detail_description_widget.width()
+            )
+
+        else:
+            last_size = self._detail_description_widget.sizeHint().width()
+            width = final_size.width() + spacing + last_size
+            sizes.append(last_size)
+
+        final_size.setWidth(width)
+
+        self._detail_description_widget.setVisible(not now_visible)
+        self._splitter_widget.setSizes(sizes)
+        self.resize(final_size)
+
+        self._help_btn.set_expanded(not now_visible)
+
+    def _set_creator_detailed_text(self, creator):
+        if not creator:
+            self._detail_description_widget.setPlainText("")
+            return
+        detailed_description = creator.get_detail_description() or ""
+        if commonmark:
+            html = commonmark.commonmark(detailed_description)
+            self._detail_description_widget.setHtml(html)
+        else:
+            self._detail_description_widget.setMarkdown(detailed_description)
+
     def _set_creator(self, identifier):
         creator = self.controller.manual_creators.get(identifier)
 
-        self.creator_description_widget.set_plugin(creator)
+        self._creator_short_desc_widget.set_plugin(creator)
+        self._set_creator_detailed_text(creator)
+        self._pre_create_widget.set_plugin(creator)
 
         self._selected_creator = creator
 
@@ -694,7 +784,13 @@ class CreateDialog(QtWidgets.QDialog):
         if self._last_pos is not None:
             self.move(self._last_pos)
 
+        self._update_help_btn()
+
         self.refresh()
+
+    def resizeEvent(self, event):
+        super(CreateDialog, self).resizeEvent(event)
+        self._update_help_btn()
 
     def _on_create(self):
         indexes = self.creators_view.selectedIndexes()

--- a/openpype/tools/publisher/widgets/tasks_widget.py
+++ b/openpype/tools/publisher/widgets/tasks_widget.py
@@ -1,6 +1,7 @@
 from Qt import QtCore, QtGui
 
 from openpype.tools.utils.tasks_widget import TasksWidget, TASK_NAME_ROLE
+from openpype.tools.utils.lib import get_task_icon
 
 
 class TasksModel(QtGui.QStandardItemModel):
@@ -118,6 +119,8 @@ class TasksModel(QtGui.QStandardItemModel):
 
             item = QtGui.QStandardItem(task_name)
             item.setData(task_name, TASK_NAME_ROLE)
+            if task_name:
+                item.setData(get_task_icon(), QtCore.Qt.DecorationRole)
             self._items_by_name[task_name] = item
             new_items.append(item)
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -982,7 +982,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         btns_layout.addWidget(cancel_btn)
 
         main_layout = QtWidgets.QFormLayout(self)
-        main_layout.addRow("Name", variant_input)
+        main_layout.addRow("Variant", variant_input)
         main_layout.addRow("Asset", asset_value_widget)
         main_layout.addRow("Task", task_value_widget)
         main_layout.addRow("Family", family_value_widget)

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -16,6 +16,7 @@ from .lib import (
     set_style_property,
     DynamicQThread,
     qt_app_context,
+    get_asset_icon,
 )
 
 from .models import (

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -16,7 +16,10 @@ from .views import (
 )
 from .widgets import PlaceholderLineEdit
 from .models import RecursiveSortFilterProxyModel
-from .lib import DynamicQThread
+from .lib import (
+    DynamicQThread,
+    get_asset_icon
+)
 
 if Qt.__binding__ == "PySide":
     from PySide.QtGui import QStyleOptionViewItemV4
@@ -508,25 +511,9 @@ class AssetModel(QtGui.QStandardItemModel):
                 item.setData(asset_label, QtCore.Qt.DisplayRole)
                 item.setData(asset_label, ASSET_LABEL_ROLE)
 
-            icon_color = asset_data.get("color") or style.colors.default
-            icon_name = asset_data.get("icon")
-            if not icon_name:
-                # Use default icons if no custom one is specified.
-                # If it has children show a full folder, otherwise
-                # show an open folder
-                if item.rowCount() > 0:
-                    icon_name = "folder"
-                else:
-                    icon_name = "folder-o"
-
-            try:
-                # font-awesome key
-                full_icon_name = "fa.{0}".format(icon_name)
-                icon = qtawesome.icon(full_icon_name, color=icon_color)
-                item.setData(icon, QtCore.Qt.DecorationRole)
-
-            except Exception:
-                pass
+            has_children = item.rowCount() > 0
+            icon = get_asset_icon(asset_data, has_children)
+            item.setData(icon, QtCore.Qt.DecorationRole)
 
     def _threaded_fetch(self):
         asset_docs = self._fetch_asset_docs()

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -142,6 +142,16 @@ def get_asset_icon(asset_doc, has_children=False):
     return get_qta_icon_by_name_and_color(icon_name, icon_color)
 
 
+def get_task_icon():
+    """Get icon for a task.
+
+    TODO: Get task icon based on data in database.
+
+    Icon should be defined by task type which is stored on project.
+    """
+    return get_qta_icon_by_name_and_color("fa.male", style.colors.default)
+
+
 def schedule(func, time, channel="default"):
     """Run `func` at a later `time` in a dedicated `channel`
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -98,6 +98,48 @@ application = qt_app_context
 
 class SharedObjects:
     jobs = {}
+    icons = {}
+
+
+def get_qta_icon_by_name_and_color(icon_name, icon_color):
+    if not icon_name or not icon_color:
+        return None
+
+    full_icon_name = "{0}-{1}".format(icon_name, icon_color)
+    if full_icon_name in SharedObjects.icons:
+        return SharedObjects.icons[full_icon_name]
+
+    variants = [icon_name]
+    qta_instance = qtawesome._instance()
+    for key in qta_instance.charmap.keys():
+        variants.append("{0}.{1}".format(key, icon_name))
+
+    icon = None
+    for variant in variants:
+        try:
+            icon = qtawesome.icon(variant, color=icon_color)
+            break
+        except Exception:
+            pass
+
+    SharedObjects.icons[full_icon_name] = icon
+    return icon
+
+
+def get_asset_icon(asset_doc, has_children=False):
+    asset_data = asset_doc.get("data") or {}
+    icon_color = asset_data.get("color") or style.colors.default
+    icon_name = asset_data.get("icon")
+    if not icon_name:
+        # Use default icons if no custom one is specified.
+        # If it has children show a full folder, otherwise
+        # show an open folder
+        if has_children:
+            icon_name = "folder"
+        else:
+            icon_name = "folder-o"
+
+    return get_qta_icon_by_name_and_color(icon_name, icon_color)
 
 
 def schedule(func, time, channel="default"):


### PR DESCRIPTION
## Brief description
Creator's description is not visible in New Publisher and context UI does not show icons of assets and tasks.

## Changes
- Creator dialog has short description with creator icon visible above creator's attribute definitions
- there is a help button in creator dialog which extends the dialog window and show detailed information about creator
- context widgets in new publisher have icons (assets and tasks)

## Testing notes:
1. Open create dialog and examine

### Screenshots
![image](https://user-images.githubusercontent.com/43494761/157689196-81cdebbf-2f5a-49be-8d51-4c254962d099.png)
![image](https://user-images.githubusercontent.com/43494761/157689300-9c14b54f-3dee-4c85-b112-fedc3bf7b16c.png)
