### PR TITLE
Deadline: Fix plugin name for tile assemble

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -90,7 +90,7 @@ class RationalToInt:
         if len(parts) != 1:
             bottom = float(parts[1])
 
-        self._value = top / bottom
+        self._value = float(top) / float(bottom)
         self._string_value = string_value
 
     @property
@@ -169,6 +169,23 @@ def convert_value_by_type_name(value_type, value, logger=None):
 
     if value_type == "rational2i":
         return RationalToInt(value)
+
+    if value_type == "vector":
+        parts = [part.strip() for part in value.split(",")]
+        output = []
+        for part in parts:
+            if part == "-nan":
+                output.append(None)
+                continue
+            try:
+                part = float(part)
+            except ValueError:
+                pass
+            output.append(part)
+        return output
+
+    if value_type == "timecode":
+        return value
 
     # Array of other types is converted to list
     re_result = ARRAY_TYPE_REGEX.findall(value_type)

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -46,7 +46,7 @@
             "enabled": true,
             "optional": false,
             "active": true,
-            "tile_assembler_plugin": "oiio",
+            "tile_assembler_plugin": "OpenPypeTileAssembler",
             "use_published": true,
             "asset_dependencies": true,
             "group": "none",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -103,7 +103,7 @@
                                     "DraftTileAssembler": "Draft Tile Assembler"
                                 },
                                 {
-                                    "oiio": "Open Image IO"
+                                    "OpenPypeTileAssembler": "Open Image IO"
                                 }
                             ]
                         },


### PR DESCRIPTION
## Brief description
Deadline tile assembler plugin is called `OpenPypeTileAssembler` but in settings is available only `oiio` so the jobs are crashing.

## Changes
- changed `oiio` name to `OpenPypeTileAssembler`
- fix getting info about input files

## Note
It seems that the tile assembler is compositing tiles vertically in oposite order.

## Testing notes:
1. Set in settings to use `Open Image IO` for tiles (`project_settings/deadline/publish/MayaSubmitDeadline/tile_assembler_plugin`)
2. Submit to deadline tile job
3. Job should load