### PR TITLE
Flame: sequence used for reference video

### DIFF
--- a/openpype/hosts/flame/api/scripts/wiretap_com.py
+++ b/openpype/hosts/flame/api/scripts/wiretap_com.py
@@ -420,13 +420,20 @@ class WireTapCom(object):
             RuntimeError: Not able to set colorspace policy
         """
         color_policy = color_policy or "Legacy"
+
+        # check if the colour policy in custom dir
+        if not os.path.exists(color_policy):
+            color_policy = "/syncolor/policies/Autodesk/{}".format(
+                color_policy)
+
+        # create arguments
         project_colorspace_cmd = [
             os.path.join(
                 self.wiretap_tools_dir,
                 "wiretap_duplicate_node"
             ),
             "-s",
-            "/syncolor/policies/Autodesk/{}".format(color_policy),
+            color_policy,
             "-n",
             "/projects/{}/syncolor".format(project_name)
         ]

--- a/openpype/hosts/flame/hooks/pre_flame_setup.py
+++ b/openpype/hosts/flame/hooks/pre_flame_setup.py
@@ -63,7 +63,7 @@ class FlamePrelaunch(PreLaunchHook):
         _db_p_data = project_doc["data"]
         width = _db_p_data["resolutionWidth"]
         height = _db_p_data["resolutionHeight"]
-        fps = float(_db_p_data["fps"])
+        fps = float(_db_p_data["fps_string"])
 
         project_data = {
             "Name": project_doc["name"],
@@ -73,7 +73,7 @@ class FlamePrelaunch(PreLaunchHook):
             "FrameWidth": int(width),
             "FrameHeight": int(height),
             "AspectRatio": float((width / height) * _db_p_data["pixelAspect"]),
-            "FrameRate": "{} fps".format(fps),
+            "FrameRate": self._get_flame_fps(fps),
             "FrameDepth": str(imageio_flame["project"]["frameDepth"]),
             "FieldDominance": str(imageio_flame["project"]["fieldDominance"])
         }
@@ -100,6 +100,28 @@ class FlamePrelaunch(PreLaunchHook):
         app_arguments = self._get_launch_arguments(data_to_script)
 
         self.launch_context.launch_args.extend(app_arguments)
+
+    def _get_flame_fps(self, fps_num):
+        fps_table = {
+            float(23.976): "23.976 fps",
+            int(25): "25 fps",
+            int(24): "24 fps",
+            float(29.97): "29.97 fps DF",
+            int(30): "30 fps",
+            int(50): "50 fps",
+            float(59.94): "59.94 fps DF",
+            int(60): "60 fps"
+        }
+
+        match_key = min(fps_table.keys(), key=lambda x: abs(x - fps_num))
+
+        try:
+            return fps_table[match_key]
+        except KeyError as msg:
+            raise KeyError((
+                "Missing FPS key in conversion table. "
+                "Following keys are available: {}".format(fps_table.keys())
+            )) from msg
 
     def _add_pythonpath(self):
         pythonpath = self.launch_context.env.get("PYTHONPATH")

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -457,7 +457,7 @@
                                 {
                                     "type": "text",
                                     "key": "colourPolicy",
-                                    "label": "Colour Policy"
+                                    "label": "Colour Policy (name or path)"
                                 },
                                 {
                                     "type": "text",


### PR DESCRIPTION
## Brief description
Publishing from sequence will bake retimes and other timeline actions.

## Description
Publishing from clips was not good enough because retimes were not rendered into the reference videos. Also other timeline actions are not baked into the image because they are timeline segment related.

## Additional info
- fps to project creation used from `fps_string`
- colour policy can be name or path

## Testing notes:
1. start with this step
2. follow this step