### PR TITLE
General: Missing time function

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import attr
 from avalon import api
 
+from openpype.lib import get_formatted_current_time
 import openpype.lib.abstract_collect_render
 import openpype.hosts.harmony.api as harmony
 from openpype.lib.abstract_collect_render import RenderInstance
@@ -138,7 +139,7 @@ class CollectFarmRender(openpype.lib.abstract_collect_render.
 
             render_instance = HarmonyRenderInstance(
                 version=version,
-                time=api.time(),
+                time=get_formatted_current_time(),
                 source=context.data["currentFile"],
                 label=node.split("/")[1],
                 subset=subset_name,

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -50,6 +50,7 @@ import maya.app.renderSetup.model.renderSetup as renderSetup
 import pyblish.api
 
 from avalon import api
+from openpype.lib import get_formatted_current_time
 from openpype.hosts.maya.api.lib_renderproducts import get as get_layer_render_products  # noqa: E501
 from openpype.hosts.maya.api import lib
 
@@ -328,7 +329,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "family": "renderlayer",
                 "families": ["renderlayer"],
                 "asset": asset,
-                "time": api.time(),
+                "time": get_formatted_current_time(),
                 "author": context.data["user"],
                 # Add source to allow tracing back to the scene from
                 # which was submitted originally

--- a/openpype/hosts/maya/plugins/publish/collect_vrayscene.py
+++ b/openpype/hosts/maya/plugins/publish/collect_vrayscene.py
@@ -7,6 +7,7 @@ from maya import cmds
 
 import pyblish.api
 from avalon import api
+from openpype.lib import get_formatted_current_time
 from openpype.hosts.maya.api import lib
 
 
@@ -117,7 +118,7 @@ class CollectVrayScene(pyblish.api.InstancePlugin):
                 "family": "vrayscene_layer",
                 "families": ["vrayscene_layer"],
                 "asset": api.Session["AVALON_ASSET"],
-                "time": api.time(),
+                "time": get_formatted_current_time(),
                 "author": context.data["user"],
                 # Add source to allow tracing back to the scene from
                 # which was submitted originally

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -63,7 +63,10 @@ from .anatomy import (
     Anatomy
 )
 
-from .config import get_datetime_data
+from .config import (
+    get_datetime_data,
+    get_formatted_current_time
+)
 
 from .python_module_tools import (
     import_filepath,
@@ -309,6 +312,7 @@ __all__ = [
     "Anatomy",
 
     "get_datetime_data",
+    "get_formatted_current_time",
 
     "PypeLogger",
     "get_default_components",

--- a/openpype/lib/abstract_collect_render.py
+++ b/openpype/lib/abstract_collect_render.py
@@ -26,7 +26,7 @@ class RenderInstance(object):
 
     # metadata
     version = attr.ib()  # instance version
-    time = attr.ib()  # time of instance creation (avalon.api.time())
+    time = attr.ib()  # time of instance creation (get_formatted_current_time)
     source = attr.ib()  # path to source scene file
     label = attr.ib()  # label to show in GUI
     subset = attr.ib()  # subset name

--- a/openpype/lib/config.py
+++ b/openpype/lib/config.py
@@ -74,3 +74,9 @@ def get_datetime_data(datetime_obj=None):
         "S": str(int(seconds)),
         "SS": str(seconds),
     }
+
+
+def get_formatted_current_time():
+    return datetime.datetime.now().strftime(
+        "%Y%m%dT%H%M%SZ"
+    )

--- a/openpype/plugins/publish/collect_time.py
+++ b/openpype/plugins/publish/collect_time.py
@@ -1,12 +1,12 @@
 import pyblish.api
-from avalon import api
+from openpype.lib import get_formatted_current_time
 
 
 class CollectTime(pyblish.api.ContextPlugin):
     """Store global time at the time of publish"""
 
     label = "Collect Current Time"
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder - 0.499
 
     def process(self, context):
-        context.data["time"] = api.time()
+        context.data["time"] = get_formatted_current_time()


### PR DESCRIPTION
## Brief description
During [this PR](https://github.com/pypeclub/avalon-core/pull/425) was removed function `time` which is used at few places.

## Changes
- added function `get_formatted_current_time` in openpype lib
- replaced usage of `avalon.lib.time` with the function 

## Testing notes:
1. Try publishing with latest avalon main