### PR TITLE
Nuke: ExtractReviewSlate can handle more codes and profiles

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_trim_video_audio.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_trim_video_audio.py
@@ -2,6 +2,9 @@ import os
 import pyblish.api
 import openpype.api
 
+from openpype.lib import (
+    get_ffmpeg_tool_path,
+)
 from pprint import pformat
 
 
@@ -27,7 +30,7 @@ class ExtractTrimVideoAudio(openpype.api.Extractor):
             instance.data["representations"] = list()
 
         # get ffmpet path
-        ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
         # get staging dir
         staging_dir = self.staging_dir(instance)
@@ -44,7 +47,7 @@ class ExtractTrimVideoAudio(openpype.api.Extractor):
             clip_trimed_path = os.path.join(
                 staging_dir, instance.data["name"] + ext)
             # # check video file metadata
-            # input_data = plib.ffprobe_streams(video_file_path)[0]
+            # input_data = plib.get_ffprobe_streams(video_file_path)[0]
             # self.log.debug(f"__ input_data: `{input_data}`")
 
             start = float(instance.data["clipInH"])

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -14,7 +14,11 @@ import math
 
 from avalon import io
 import pyblish.api
-from openpype.lib import prepare_template_data, get_asset, ffprobe_streams
+from openpype.lib import (
+    prepare_template_data,
+    get_asset,
+    get_ffprobe_streams
+)
 from openpype.lib.vendor_bin_utils import get_fps
 from openpype.lib.plugin_tools import (
     parse_json,
@@ -265,7 +269,7 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
     def _get_number_of_frames(self, file_url):
         """Return duration in frames"""
         try:
-            streams = ffprobe_streams(file_url, self.log)
+            streams = get_ffprobe_streams(file_url, self.log)
         except Exception as exc:
             raise AssertionError((
                 "FFprobe couldn't read information about input file: \"{}\"."

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -17,9 +17,9 @@ import pyblish.api
 from openpype.lib import (
     prepare_template_data,
     get_asset,
-    get_ffprobe_streams
+    get_ffprobe_streams,
+    convert_ffprobe_fps_value,
 )
-from openpype.lib.vendor_bin_utils import get_fps
 from openpype.lib.plugin_tools import (
     parse_json,
     get_subset_name_with_asset_doc
@@ -292,7 +292,9 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
                         "nb_frames {} not convertible".format(nb_frames))
 
                     duration = stream.get("duration")
-                    frame_rate = get_fps(stream.get("r_frame_rate", '0/0'))
+                    frame_rate = convert_ffprobe_fps_value(
+                        stream.get("r_frame_rate", '0/0')
+                    )
                     self.log.debug("duration:: {} frame_rate:: {}".format(
                         duration, frame_rate))
                     try:

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -88,6 +88,7 @@ from .transcoding import (
     get_ffprobe_streams,
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
+    convert_ffprobe_fps_value,
 )
 from .avalon_context import (
     CURRENT_DOC_SCHEMAS,
@@ -234,6 +235,7 @@ __all__ = [
     "get_ffprobe_streams",
     "get_ffmpeg_codec_args",
     "get_ffmpeg_format_args",
+    "convert_ffprobe_fps_value",
 
     "CURRENT_DOC_SCHEMAS",
     "PROJECT_NAME_ALLOWED_SYMBOLS",

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -21,7 +21,6 @@ from .vendor_bin_utils import (
     get_vendor_bin_path,
     get_oiio_tools_path,
     get_ffmpeg_tool_path,
-    ffprobe_streams,
     is_oiio_supported
 )
 from .env_tools import (
@@ -84,7 +83,9 @@ from .profiles_filtering import (
 from .transcoding import (
     get_transcode_temp_directory,
     should_convert_for_ffmpeg,
-    convert_for_ffmpeg
+    convert_for_ffmpeg,
+    get_ffprobe_data,
+    get_ffprobe_streams,
 )
 from .avalon_context import (
     CURRENT_DOC_SCHEMAS,
@@ -216,7 +217,6 @@ __all__ = [
     "get_vendor_bin_path",
     "get_oiio_tools_path",
     "get_ffmpeg_tool_path",
-    "ffprobe_streams",
     "is_oiio_supported",
 
     "import_filepath",
@@ -228,6 +228,8 @@ __all__ = [
     "get_transcode_temp_directory",
     "should_convert_for_ffmpeg",
     "convert_for_ffmpeg",
+    "get_ffprobe_data",
+    "get_ffprobe_streams",
 
     "CURRENT_DOC_SCHEMAS",
     "PROJECT_NAME_ALLOWED_SYMBOLS",

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -86,6 +86,8 @@ from .transcoding import (
     convert_for_ffmpeg,
     get_ffprobe_data,
     get_ffprobe_streams,
+    get_ffmpeg_codec_args,
+    get_ffmpeg_format_args,
 )
 from .avalon_context import (
     CURRENT_DOC_SCHEMAS,
@@ -230,6 +232,8 @@ __all__ = [
     "convert_for_ffmpeg",
     "get_ffprobe_data",
     "get_ffprobe_streams",
+    "get_ffmpeg_codec_args",
+    "get_ffmpeg_format_args",
 
     "CURRENT_DOC_SCHEMAS",
     "PROJECT_NAME_ALLOWED_SYMBOLS",

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -732,3 +732,23 @@ def _ffmpeg_dnxhd_codec_args(stream_data, source_ffmpeg_cmd):
 
     output.extend(["-g", "1"])
     return output
+
+
+def convert_ffprobe_fps_value(str_value):
+    """Returns (str) value of fps from ffprobe frame format (120/1)"""
+    if str_value == "0/0":
+        print("WARNING: Source has \"r_frame_rate\" value set to \"0/0\".")
+        return "Unknown"
+
+    items = str_value.split("/")
+    if len(items) == 1:
+        fps = float(items[0])
+
+    elif len(items) == 2:
+        fps = float(items[0]) / float(items[1])
+
+    # Check if fps is integer or float number
+    if int(fps) == fps:
+        fps = int(fps)
+
+    return str(fps)

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -152,23 +152,3 @@ def is_oiio_supported():
         ))
         return False
     return True
-
-
-def get_fps(str_value):
-    """Returns (str) value of fps from ffprobe frame format (120/1)"""
-    if str_value == "0/0":
-        print("WARNING: Source has \"r_frame_rate\" value set to \"0/0\".")
-        return "Unknown"
-
-    items = str_value.split("/")
-    if len(items) == 1:
-        fps = float(items[0])
-
-    elif len(items) == 2:
-        fps = float(items[0]) / float(items[1])
-
-    # Check if fps is integer or float number
-    if int(fps) == fps:
-        fps = int(fps)
-
-    return str(fps)

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -1,8 +1,6 @@
 import os
 import logging
-import json
 import platform
-import subprocess
 
 log = logging.getLogger("Vendor utils")
 
@@ -136,56 +134,6 @@ def get_ffmpeg_tool_path(tool="ffmpeg"):
     if platform.system().lower() == "windows":
         ffmpeg_dir = os.path.join(ffmpeg_dir, "bin")
     return find_executable(os.path.join(ffmpeg_dir, tool))
-
-
-def ffprobe_streams(path_to_file, logger=None):
-    """Load streams from entered filepath via ffprobe.
-
-    Args:
-        path_to_file (str): absolute path
-        logger (logging.getLogger): injected logger, if empty new is created
-
-    """
-    if not logger:
-        logger = log
-    logger.info(
-        "Getting information about input \"{}\".".format(path_to_file)
-    )
-    args = [
-        get_ffmpeg_tool_path("ffprobe"),
-        "-hide_banner",
-        "-loglevel", "fatal",
-        "-show_error",
-        "-show_format",
-        "-show_streams",
-        "-show_programs",
-        "-show_chapters",
-        "-show_private_data",
-        "-print_format", "json",
-        path_to_file
-    ]
-
-    logger.debug("FFprobe command: {}".format(
-        subprocess.list2cmdline(args)
-    ))
-    popen = subprocess.Popen(
-        args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
-
-    popen_stdout, popen_stderr = popen.communicate()
-    if popen_stdout:
-        logger.debug("FFprobe stdout:\n{}".format(
-            popen_stdout.decode("utf-8")
-        ))
-
-    if popen_stderr:
-        logger.warning("FFprobe stderr:\n{}".format(
-            popen_stderr.decode("utf-8")
-        ))
-
-    return json.loads(popen_stdout)["streams"]
 
 
 def is_oiio_supported():

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -13,7 +13,7 @@ import pyblish.api
 import openpype.api
 from openpype.lib import (
     get_ffmpeg_tool_path,
-    ffprobe_streams,
+    get_ffprobe_streams,
 
     path_to_subprocess_arg,
 
@@ -1146,7 +1146,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         # NOTE Skipped using instance's resolution
         full_input_path_single_file = temp_data["full_input_path_single_file"]
         try:
-            streams = ffprobe_streams(
+            streams = get_ffprobe_streams(
                 full_input_path_single_file, self.log
             )
         except Exception as exc:

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1188,8 +1188,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         # NOTE Setting only one of `width` or `heigth` is not allowed
         # - settings value can't have None but has value of 0
-        output_width = output_width or output_def.get("width") or None
-        output_height = output_height or output_def.get("height") or None
+        output_width = output_def.get("width") or output_width or None
+        output_height = output_def.get("height") or output_height or None
 
         # Overscal color
         overscan_color_value = "black"

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -1,7 +1,11 @@
 import os
 import openpype.api
-import openpype.lib
 import pyblish
+from openpype.lib import (
+    path_to_subprocess_arg,
+    get_ffmpeg_tool_path,
+    get_ffprobe_streams,
+)
 
 
 class ExtractReviewSlate(openpype.api.Extractor):
@@ -24,9 +28,9 @@ class ExtractReviewSlate(openpype.api.Extractor):
 
         suffix = "_slate"
         slate_path = inst_data.get("slateFrame")
-        ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
-        slate_streams = openpype.lib.ffprobe_streams(slate_path, self.log)
+        slate_streams = get_ffprobe_streams(slate_path, self.log)
         # Try to find first stream with defined 'width' and 'height'
         # - this is to avoid order of streams where audio can be as first
         # - there may be a better way (checking `codec_type`?)+
@@ -66,7 +70,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
                 os.path.normpath(stagingdir), repre["files"])
             self.log.debug("__ input_path: {}".format(input_path))
 
-            video_streams = openpype.lib.ffprobe_streams(
+            video_streams = get_ffprobe_streams(
                 input_path, self.log
             )
 
@@ -143,7 +147,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
             else:
                 input_args.extend(repre["outputDef"].get('input', []))
             input_args.append("-loop 1 -i {}".format(
-                openpype.lib.path_to_subprocess_arg(slate_path)
+                path_to_subprocess_arg(slate_path)
             ))
             input_args.extend([
                 "-r {}".format(fps),
@@ -216,12 +220,12 @@ class ExtractReviewSlate(openpype.api.Extractor):
 
             slate_v_path = slate_path.replace(".png", ext)
             output_args.append(
-                openpype.lib.path_to_subprocess_arg(slate_v_path)
+                path_to_subprocess_arg(slate_v_path)
             )
             _remove_at_end.append(slate_v_path)
 
             slate_args = [
-                openpype.lib.path_to_subprocess_arg(ffmpeg_path),
+                path_to_subprocess_arg(ffmpeg_path),
                 " ".join(input_args),
                 " ".join(output_args)
             ]
@@ -345,7 +349,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
 
         try:
             # Get information about input file via ffprobe tool
-            streams = openpype.lib.ffprobe_streams(full_input_path, self.log)
+            streams = get_ffprobe_streams(full_input_path, self.log)
         except Exception:
             self.log.warning(
                 "Could not get codec data from input.",

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -360,11 +360,14 @@ class ExtractReviewSlate(openpype.api.Extractor):
             )
             return codec_args
 
+        source_ffmpeg_cmd = repre.get("ffmpeg_cmd")
         codec_args.extend(
-            get_ffmpeg_format_args(ffprobe_data)
+            get_ffmpeg_format_args(ffprobe_data, source_ffmpeg_cmd)
         )
         codec_args.extend(
-            get_ffmpeg_codec_args(ffprobe_data, logger=self.log)
+            get_ffmpeg_codec_args(
+                ffprobe_data, source_ffmpeg_cmd, logger=self.log
+            )
         )
 
         return codec_args

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -5,12 +5,17 @@ import subprocess
 import platform
 import json
 import opentimelineio_contrib.adapters.ffmpeg_burnins as ffmpeg_burnins
-import openpype.lib
-from openpype.lib.vendor_bin_utils import get_fps
+
+from openpype.lib import (
+    get_ffmpeg_tool_path,
+    get_ffmpeg_codec_args,
+    get_ffmpeg_format_args,
+    convert_ffprobe_fps_value,
+)
 
 
-ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
-ffprobe_path = openpype.lib.get_ffmpeg_tool_path("ffprobe")
+ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
+ffprobe_path = get_ffmpeg_tool_path("ffprobe")
 
 
 FFMPEG = (
@@ -49,157 +54,6 @@ def _get_ffprobe_data(source):
     if proc.returncode != 0:
         raise RuntimeError("Failed to run: %s" % command)
     return json.loads(out)
-
-
-def _prores_codec_args(stream_data, source_ffmpeg_cmd):
-    output = []
-
-    tags = stream_data.get("tags") or {}
-    encoder = tags.get("encoder") or ""
-    if encoder.endswith("prores_ks"):
-        codec_name = "prores_ks"
-
-    elif encoder.endswith("prores_aw"):
-        codec_name = "prores_aw"
-
-    else:
-        codec_name = "prores"
-
-    output.extend(["-codec:v", codec_name])
-
-    pix_fmt = stream_data.get("pix_fmt")
-    if pix_fmt:
-        output.extend(["-pix_fmt", pix_fmt])
-
-    # Rest of arguments is prores_kw specific
-    if codec_name == "prores_ks":
-        codec_tag_to_profile_map = {
-            "apco": "proxy",
-            "apcs": "lt",
-            "apcn": "standard",
-            "apch": "hq",
-            "ap4h": "4444",
-            "ap4x": "4444xq"
-        }
-        codec_tag_str = stream_data.get("codec_tag_string")
-        if codec_tag_str:
-            profile = codec_tag_to_profile_map.get(codec_tag_str)
-            if profile:
-                output.extend(["-profile:v", profile])
-
-    return output
-
-
-def _h264_codec_args(stream_data, source_ffmpeg_cmd):
-    output = ["-codec:v", "h264"]
-
-    # Use arguments from source if are available source arguments
-    if source_ffmpeg_cmd:
-        copy_args = (
-            "-crf",
-            "-b:v", "-vb",
-            "-minrate", "-minrate:",
-            "-maxrate", "-maxrate:",
-            "-bufsize", "-bufsize:"
-        )
-        args = source_ffmpeg_cmd.split(" ")
-        for idx, arg in enumerate(args):
-            if arg in copy_args:
-                output.extend([arg, args[idx + 1]])
-
-    pix_fmt = stream_data.get("pix_fmt")
-    if pix_fmt:
-        output.extend(["-pix_fmt", pix_fmt])
-
-    output.extend(["-intra"])
-    output.extend(["-g", "1"])
-
-    return output
-
-
-def _dnxhd_codec_args(stream_data, source_ffmpeg_cmd):
-    output = ["-codec:v", "dnxhd"]
-
-    # Use source profile (profiles in metadata are not usable in args directly)
-    profile = stream_data.get("profile") or ""
-    # Lower profile and replace space with underscore
-    cleaned_profile = profile.lower().replace(" ", "_")
-    dnx_profiles = {
-        "dnxhd",
-        "dnxhr_lb",
-        "dnxhr_sq",
-        "dnxhr_hq",
-        "dnxhr_hqx",
-        "dnxhr_444"
-    }
-    if cleaned_profile in dnx_profiles:
-        output.extend(["-profile:v", cleaned_profile])
-
-    pix_fmt = stream_data.get("pix_fmt")
-    if pix_fmt:
-        output.extend(["-pix_fmt", pix_fmt])
-
-    # Use arguments from source if are available source arguments
-    if source_ffmpeg_cmd:
-        copy_args = (
-            "-b:v", "-vb",
-        )
-        args = source_ffmpeg_cmd.split(" ")
-        for idx, arg in enumerate(args):
-            if arg in copy_args:
-                output.extend([arg, args[idx + 1]])
-
-    output.extend(["-g", "1"])
-    return output
-
-
-def _mxf_format_args(ffprobe_data, source_ffmpeg_cmd):
-    input_format = ffprobe_data["format"]
-    format_tags = input_format.get("tags") or {}
-    product_name = format_tags.get("product_name") or ""
-    output = []
-    if "opatom" in product_name.lower():
-        output.extend(["-f", "mxf_opatom"])
-    return output
-
-
-def get_format_args(ffprobe_data, source_ffmpeg_cmd):
-    input_format = ffprobe_data.get("format") or {}
-    if input_format.get("format_name") == "mxf":
-        return _mxf_format_args(ffprobe_data, source_ffmpeg_cmd)
-    return []
-
-
-def get_codec_args(ffprobe_data, source_ffmpeg_cmd):
-    stream_data = ffprobe_data["streams"][0]
-    codec_name = stream_data.get("codec_name")
-    # Codec "prores"
-    if codec_name == "prores":
-        return _prores_codec_args(stream_data, source_ffmpeg_cmd)
-
-    # Codec "h264"
-    if codec_name == "h264":
-        return _h264_codec_args(stream_data, source_ffmpeg_cmd)
-
-    # Coded DNxHD
-    if codec_name == "dnxhd":
-        return _dnxhd_codec_args(stream_data, source_ffmpeg_cmd)
-
-    output = []
-    if codec_name:
-        output.extend(["-codec:v", codec_name])
-
-    bit_rate = stream_data.get("bit_rate")
-    if bit_rate:
-        output.extend(["-b:v", bit_rate])
-
-    pix_fmt = stream_data.get("pix_fmt")
-    if pix_fmt:
-        output.extend(["-pix_fmt", pix_fmt])
-
-    output.extend(["-g", "1"])
-
-    return output
 
 
 class ModifiedBurnins(ffmpeg_burnins.Burnins):
@@ -592,7 +446,9 @@ def burnins_from_data(
         data["resolution_height"] = stream.get("height", MISSING_KEY_VALUE)
 
     if "fps" not in data:
-        data["fps"] = get_fps(stream.get("r_frame_rate", "0/0"))
+        data["fps"] = convert_ffprobe_fps_value(
+            stream.get("r_frame_rate", "0/0")
+        )
 
     # Check frame start and add expression if is available
     if frame_start is not None:
@@ -703,10 +559,10 @@ def burnins_from_data(
 
     else:
         ffmpeg_args.extend(
-            get_format_args(burnin.ffprobe_data, source_ffmpeg_cmd)
+            get_ffmpeg_format_args(burnin.ffprobe_data, source_ffmpeg_cmd)
         )
         ffmpeg_args.extend(
-            get_codec_args(burnin.ffprobe_data, source_ffmpeg_cmd)
+            get_ffmpeg_codec_args(burnin.ffprobe_data, source_ffmpeg_cmd)
         )
         # Use arguments from source if are available source arguments
         if source_ffmpeg_cmd:

--- a/openpype/tests/test_lib_restructuralization.py
+++ b/openpype/tests/test_lib_restructuralization.py
@@ -24,7 +24,7 @@ def test_backward_compatibility(printer):
         from openpype.lib import get_hierarchy
         from openpype.lib import get_linked_assets
         from openpype.lib import get_latest_version
-        from openpype.lib import ffprobe_streams
+        from openpype.lib import get_ffprobe_streams
 
         from openpype.hosts.fusion.lib import switch_item
 


### PR DESCRIPTION
## Brief description
Plugin `ExtractReviewSlate` don't know how to reuse data from ffprobe to recreate almost same output as needed.

## Description
But we have a base of that logic in burnins so it is a good idea to move it to transcoding functions and share it across code. Also some functions from vendor lib can be moved to transcoding too.

## Changes
- function `ffprobe_streams` is split into 2 function `get_ffprobe_data` and `get_ffprobe_streams` and is moved to `transcoding`
    - changed related code to use this function
- moved function related to "recreate as close as possible" stream using ffmpeg from burnins into `transcoding`
    - changed related code to use it
- renamed function `get_fps` into `convert_ffprobe_fps_value` and moved to `transcoding`

## Testing notes:
1. Burnins should work as they did
2. ExtractReviewSlate should be able to create more outputs (dnxhd for example)