### PR TITLE
General: Avoid circular import

### DIFF
--- a/openpype/__init__.py
+++ b/openpype/__init__.py
@@ -5,7 +5,6 @@ import platform
 import functools
 import logging
 
-from openpype.pipeline import LegacyCreator
 from .settings import get_project_settings
 from .lib import (
     Anatomy,
@@ -76,6 +75,7 @@ def install():
     """Install Pype to Avalon."""
     from pyblish.lib import MessageHandler
     from openpype.modules import load_modules
+    from openpype.pipeline import LegacyCreator
     from avalon import pipeline
 
     # Make sure modules are loaded


### PR DESCRIPTION
## Brief description
Import of `LegacyCreator` cause circular import in `openpype/__init__.py`.

## Changes
- moved import to `install` function

## Testing notes:
1. OpenPype should install in hosts (Blender had an issue)