### PR TITLE
General: Remove forgotten use of avalon Creator

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1594,11 +1594,13 @@ def get_creator_by_name(creator_name, case_sensitive=False):
     Returns:
         Creator: Return first matching plugin or `None`.
     """
+    from openpype.pipeline import LegacyCreator
+
     # Lower input creator name if is not case sensitive
     if not case_sensitive:
         creator_name = creator_name.lower()
 
-    for creator_plugin in avalon.api.discover(avalon.api.Creator):
+    for creator_plugin in avalon.api.discover(LegacyCreator):
         _creator_name = creator_plugin.__name__
 
         # Lower creator plugin name if is not case sensitive


### PR DESCRIPTION
## Brief description
There was one forgotten place where `Creator` plugin is not replaced with `LegacyCreator` not moved in [this PR](https://github.com/pypeclub/OpenPype/pull/2854).

## Changes
- replace `avalon.api.Creator` with `LegacyCreator` in `get_creator_by_name`

## Testing notes:
1. Call `get_creator_by_name` in any host