### PR TITLE
Harmony - fixed creator issue

### DIFF
--- a/openpype/hosts/harmony/api/TB_sceneOpened.js
+++ b/openpype/hosts/harmony/api/TB_sceneOpened.js
@@ -272,8 +272,8 @@ function Client() {
 
         app.avalonClient.send(
             {
-                'module': 'avalon.api',
-                'method': 'emit',
+                'module': 'openpype.lib',
+                'method': 'emit_event',
                 'args': ['application.launched']
             }, false);
     };


### PR DESCRIPTION
## Brief description
Creator failed with `'str' object does not support item assignment`

## Additional info
Missed replacement of old avalon emit to new callback method.


## Testing notes:
1. Open Harmony
2. Use Create tool