### PR TITLE
SceneInventory: Fix import of load function

### DIFF
--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -31,6 +31,7 @@ from .load import (
 
     loaders_from_representation,
     get_representation_path,
+    get_repres_contexts,
 )
 
 from .publish import (
@@ -75,6 +76,7 @@ __all__ = (
 
     "loaders_from_representation",
     "get_representation_path",
+    "get_repres_contexts",
 
     # --- Publish ---
     "PublishValidationError",

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -61,7 +61,7 @@ class SceneInventoryWindow(QtWidgets.QDialog):
 
         icon = qtawesome.icon("fa.refresh", color="white")
         refresh_button = QtWidgets.QPushButton(self)
-        update_all_button.setToolTip("Refresh")
+        refresh_button.setToolTip("Refresh")
         refresh_button.setIcon(icon)
 
         control_layout = QtWidgets.QHBoxLayout()


### PR DESCRIPTION
## Brief description
Function `get_repres_contexts` is not available in `openpype.pipeline` so switch dialog crashes on initialization.

## Changes
- added `get_repres_contexts` function to `openpype.pipeline.__init__.py`
- fixed tooltips of refresh and update to latest buttons

## Testing notes:
1. Open scene inventory tool
2. Try switch version
3. Validate tooltips of buttons