### PR TITLE
nuke: imageio adding ocio config version 1.2

### DIFF
--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -196,6 +196,9 @@
                                             "aces_1.1": "aces_1.1"
                                         },
                                         {
+                                            "aces_1.1": "aces_1.2"
+                                        },
+                                        {
                                             "custom": "custom"
                                         }
                                     ]


### PR DESCRIPTION
## Brief description
Adding new ocio aces config version

# testing notes
1. In imageio nuke on your project set aces_1.2 ocio config version
2. open Nuke > 13.1 on your project
3. see the ocio config was set to the version
