### PR TITLE
Pyblish Pype - ensure current state is correct when entering new group order

### DIFF
--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -389,6 +389,9 @@ class Controller(QtCore.QObject):
                     new_current_group_order
                 )
 
+                # Force update to the current state
+                self._set_state_by_order()
+
                 if self.collect_state == 0:
                     self.collect_state = 1
                     self._current_state = (


### PR DESCRIPTION
This fixes #2834 

## Brief description

Ensures "Extraction" and "Integrating" is actually shown correctly whilst those orders are currently processing. Previously it kept saying "Validating" during those steps.

## Testing notes:
1. publish with a slow extractor and integrator
2. the bottom left labels on the Pyblish UI should always state the correct current 'state'