### PR TITLE
Settings UI: Add simple tooltips for settings entities

### DIFF
--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -28,6 +28,10 @@ class BaseEntity:
 
     def __init__(self, schema_data, *args, **kwargs):
         self.schema_data = schema_data
+        tooltip = None
+        if schema_data:
+            tooltip = schema_data.get("tooltip")
+        self.tooltip = tooltip
 
         # Entity id
         self._id = uuid4()

--- a/openpype/settings/entities/schemas/README.md
+++ b/openpype/settings/entities/schemas/README.md
@@ -14,6 +14,7 @@
         - this keys is not allowed for all inputs as they may have not reason for that
         - key is validated, can be only once in hierarchy but is not required
 - currently there are `system settings` and `project settings`
+- all entities can have set `"tooltip"` key with description which will be shown in UI
 
 ## Inner schema
 - GUI schemas are huge json files, to be able to split whole configuration into multiple schema there's type `schema`

--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -30,6 +30,9 @@ class BaseWidget(QtWidgets.QWidget):
         if not self.entity.gui_type:
             self.entity.on_change_callbacks.append(self._on_entity_change)
 
+        if self.entity.tooltip:
+            self.setToolTip(self.entity.tooltip)
+
         self.label_widget = None
         self.create_ui()
 


### PR DESCRIPTION
## Brief description
Add ability to set `"tooltip"` in schemas which is then shown in UI on hover.

## Changes
- each entity may have `"tooltip"` in schemas
- each widget has set tooltip if it's entity has set it

## Testing notes:
1. Set tooltip on entity in schema
2. Open settings UI
3. Hover over the entity's widget