### PR TITLE
General: Fix use of Anatomy roots

### DIFF
--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -502,7 +502,7 @@ def get_representation_path_from_context(context):
     session_project = Session.get("AVALON_PROJECT")
     if project_doc and project_doc["name"] != session_project:
         anatomy = Anatomy(project_doc["name"])
-        root = anatomy.roots_obj
+        root = anatomy.roots
 
     return get_representation_path(representation, root)
 


### PR DESCRIPTION
## Brief description
Get representation path used `roots_obj` from Anatomy instead of `roots`.

## Changes
- use `roots` attribute from Anatomy object instead of `roots_obj` when different project roots should be used

## Testing notes:
1. Try copy path from loader launched from tray