### PR TITLE
Ftrack: Missing Ftrack id after editorial publish

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -199,8 +199,10 @@ class SyncToAvalonEvent(BaseEvent):
             if proj:
                 ftrack_id = proj["data"].get("ftrackId")
                 if ftrack_id is None:
-                    ftrack_id = self._update_project_ftrack_id()
-                    proj["data"]["ftrackId"] = ftrack_id
+                    self.handle_missing_ftrack_id(proj)
+                    ftrack_id = proj["data"]["ftrackId"]
+                self._avalon_ents_by_ftrack_id[ftrack_id] = proj
+
                 self._avalon_ents_by_ftrack_id[ftrack_id] = proj
                 for ent in ents:
                     ftrack_id = ent["data"].get("ftrackId")
@@ -209,15 +211,56 @@ class SyncToAvalonEvent(BaseEvent):
                     self._avalon_ents_by_ftrack_id[ftrack_id] = ent
         return self._avalon_ents_by_ftrack_id
 
-    def _update_project_ftrack_id(self):
-        ftrack_id = self.cur_project["id"]
+    def handle_missing_ftrack_id(self, doc):
+        ftrack_id = doc["data"].get("ftrackId")
+        if ftrack_id is not None:
+            return
 
+        if doc["type"] == "project":
+            ftrack_id = self.cur_project["id"]
+
+            self.dbcon.update_one(
+                {"type": "project"},
+                {"$set": {"data.ftrackId": ftrack_id}}
+            )
+
+            doc["data"]["ftrackId"] = ftrack_id
+            return
+
+        if doc["type"] != "asset":
+            return
+
+        doc_parents = doc.get("data", {}).get("parents")
+        if doc_parents is None:
+            return
+
+        entities = self.process_session.query((
+            "select id, link from TypedContext"
+            " where project_id is \"{}\" and name is \"{}\""
+        ).format(self.cur_project["id"], doc["name"])).all()
+        matching_entity = None
+        for entity in entities:
+            parents = []
+            for item in entity["link"]:
+                if item["id"] == entity["id"]:
+                    break
+                low_type = item["type"].lower()
+                if low_type == "typedcontext":
+                    parents.append(item["name"])
+            if doc_parents == parents:
+                matching_entity = entity
+                break
+
+        if matching_entity is None:
+            return
+
+        ftrack_id = matching_entity["id"]
         self.dbcon.update_one(
-            {"type": "project"},
+            {"_id": doc["_id"]},
             {"$set": {"data.ftrackId": ftrack_id}}
         )
 
-        return ftrack_id
+        self._avalon_ents_by_ftrack_id[ftrack_id] = doc
 
     @property
     def avalon_subsets_by_parents(self):
@@ -857,7 +900,14 @@ class SyncToAvalonEvent(BaseEvent):
                 if vis_par is None:
                     vis_par = proj["_id"]
                 parent_ent = self.avalon_ents_by_id[vis_par]
-                parent_ftrack_id = parent_ent["data"]["ftrackId"]
+
+                parent_ftrack_id = parent_ent["data"].get("ftrackId")
+                if parent_ftrack_id is None:
+                    self.handle_missing_ftrack_id(parent_ent)
+                    parent_ftrack_id = parent_ent["data"].get("ftrackId")
+                    if parent_ftrack_id is None:
+                        continue
+
                 parent_ftrack_ent = self.ftrack_ents_by_id.get(
                     parent_ftrack_id
                 )
@@ -2128,7 +2178,13 @@ class SyncToAvalonEvent(BaseEvent):
                 vis_par = avalon_ent["parent"]
 
             parent_ent = self.avalon_ents_by_id[vis_par]
-            parent_ftrack_id = parent_ent["data"]["ftrackId"]
+            parent_ftrack_id = parent_ent["data"].get("ftrackId")
+            if parent_ftrack_id is None:
+                self.handle_missing_ftrack_id(parent_ent)
+                parent_ftrack_id = parent_ent["data"].get("ftrackId")
+                if parent_ftrack_id is None:
+                    continue
+
             if parent_ftrack_id not in entities_dict:
                 entities_dict[parent_ftrack_id] = {
                     "children": [],

--- a/openpype/modules/ftrack/event_handlers_server/event_user_assigment.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_user_assigment.py
@@ -87,8 +87,8 @@ class UserAssigmentEvent(BaseEvent):
         if not user_id:
             return None, None
 
-        task = session.query('Task where id is "{}"'.format(task_id)).one()
-        user = session.query('User where id is "{}"'.format(user_id)).one()
+        task = session.query('Task where id is "{}"'.format(task_id)).first()
+        user = session.query('User where id is "{}"'.format(user_id)).first()
 
         return task, user
 

--- a/openpype/modules/ftrack/lib/ftrack_event_handler.py
+++ b/openpype/modules/ftrack/lib/ftrack_event_handler.py
@@ -44,7 +44,7 @@ class BaseEvent(BaseHandler):
         return self._get_entities(
             event,
             session,
-            ignore=['socialfeed', 'socialnotification']
+            ignore=['socialfeed', 'socialnotification', 'team']
         )
 
     def get_project_name_from_event(self, session, event, project_id):


### PR DESCRIPTION
## Brief description
It seems that editorial publishing is removing `ftrackId` from asset documents or project document or entities creation is not captured the right way and starts to synchronize children before parents.

## Description
I've tried to investigate what happens and why but I couldn't figure it out. The right fix is definetelly find out what is happening during editorial publishing and avoid these changes.

## Changes
- missing ftrack id of parent is tried to be fixed by lookup of entity with same parents in ftrack
    - this is slowing down synchronization and should not be handled this way

## Testing notes:
1. Run ftrack event server
2. Turn on auto sync of project of your choice
3. In mongo remove on any asset document with children it's `ftrackId` key
4. Change custom attribute that will be synced (e.g. `frameStart`) on children entity of entity matching the asset doc from step 3
5. Synchronization should not crash but figure out and fill the missing `ftrackId`