### PR TITLE
General: Move remaining plugins from avalon

### DIFF
--- a/openpype/__init__.py
+++ b/openpype/__init__.py
@@ -78,6 +78,7 @@ def install():
     from openpype.pipeline import (
         LegacyCreator,
         register_loader_plugin_path,
+        register_inventory_action,
     )
     from avalon import pipeline
 
@@ -124,7 +125,7 @@ def install():
             pyblish.register_plugin_path(path)
             register_loader_plugin_path(path)
             avalon.register_plugin_path(LegacyCreator, path)
-            avalon.register_plugin_path(avalon.InventoryAction, path)
+            register_inventory_action(path)
 
     # apply monkey patched discover to original one
     log.info("Patching discovery")

--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -29,7 +29,6 @@ PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
-INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 
 def check_inventory():

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -31,7 +31,6 @@ PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
-INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 ORIGINAL_EXCEPTHOOK = sys.excepthook
 

--- a/openpype/hosts/flame/api/pipeline.py
+++ b/openpype/hosts/flame/api/pipeline.py
@@ -26,7 +26,6 @@ PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
-INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 AVALON_CONTAINERS = "AVALON_CONTAINERS"
 
@@ -34,18 +33,17 @@ log = Logger.get_logger(__name__)
 
 
 def install():
-
     pyblish.register_host("flame")
     pyblish.register_plugin_path(PUBLISH_PATH)
     register_loader_plugin_path(LOAD_PATH)
     avalon.register_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.register_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
     log.info("OpenPype Flame plug-ins registred ...")
 
     # register callback for switching publishable
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
     log.info("OpenPype Flame host installed ...")
+
 
 def uninstall():
     pyblish.deregister_host("flame")
@@ -54,7 +52,6 @@ def uninstall():
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     deregister_loader_plugin_path(LOAD_PATH)
     avalon.deregister_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.deregister_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
 
     # register callback for switching publishable
     pyblish.deregister_callback("instanceToggled", on_pyblish_instance_toggled)

--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -15,6 +15,8 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    register_inventory_action_path,
+    deregister_inventory_action_path,
 )
 import openpype.hosts.fusion
 
@@ -69,7 +71,7 @@ def install():
 
     register_loader_plugin_path(LOAD_PATH)
     avalon.api.register_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.api.register_plugin_path(avalon.api.InventoryAction, INVENTORY_PATH)
+    register_inventory_action_path(INVENTORY_PATH)
 
     pyblish.api.register_callback(
         "instanceToggled", on_pyblish_instance_toggled
@@ -93,9 +95,7 @@ def uninstall():
 
     deregister_loader_plugin_path(LOAD_PATH)
     avalon.api.deregister_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.api.deregister_plugin_path(
-        avalon.api.InventoryAction, INVENTORY_PATH
-    )
+    deregister_inventory_action_path(INVENTORY_PATH)
 
     pyblish.api.deregister_callback(
         "instanceToggled", on_pyblish_instance_toggled

--- a/openpype/hosts/fusion/plugins/inventory/select_containers.py
+++ b/openpype/hosts/fusion/plugins/inventory/select_containers.py
@@ -1,7 +1,7 @@
-from avalon import api
+from openpype.pipeline import InventoryAction
 
 
-class FusionSelectContainers(api.InventoryAction):
+class FusionSelectContainers(InventoryAction):
 
     label = "Select Containers"
     icon = "mouse-pointer"

--- a/openpype/hosts/fusion/plugins/inventory/set_tool_color.py
+++ b/openpype/hosts/fusion/plugins/inventory/set_tool_color.py
@@ -1,6 +1,6 @@
-from avalon import api
 from Qt import QtGui, QtWidgets
 
+from openpype.pipeline import InventoryAction
 from openpype import style
 from openpype.hosts.fusion.api import (
     get_current_comp,
@@ -8,7 +8,7 @@ from openpype.hosts.fusion.api import (
 )
 
 
-class FusionSetToolColor(api.InventoryAction):
+class FusionSetToolColor(InventoryAction):
     """Update the color of the selected tools"""
 
     label = "Set Tool Color"

--- a/openpype/hosts/hiero/api/pipeline.py
+++ b/openpype/hosts/hiero/api/pipeline.py
@@ -28,7 +28,6 @@ PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish").replace("\\", "/")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load").replace("\\", "/")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create").replace("\\", "/")
-INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory").replace("\\", "/")
 
 AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 
@@ -51,7 +50,6 @@ def install():
     pyblish.register_plugin_path(PUBLISH_PATH)
     register_loader_plugin_path(LOAD_PATH)
     avalon.register_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.register_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
 
     # register callback for switching publishable
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -23,7 +23,9 @@ from openpype.lib.path_tools import HostDirmap
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
+    register_inventory_action_path,
     deregister_loader_plugin_path,
+    deregister_inventory_action_path,
 )
 from openpype.hosts.maya.lib import copy_workspace_mel
 from . import menu, lib
@@ -59,7 +61,7 @@ def install():
 
     register_loader_plugin_path(LOAD_PATH)
     avalon.api.register_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.api.register_plugin_path(avalon.api.InventoryAction, INVENTORY_PATH)
+    register_inventory_action_path(INVENTORY_PATH)
     log.info(PUBLISH_PATH)
 
     log.info("Installing callbacks ... ")
@@ -188,9 +190,7 @@ def uninstall():
 
     deregister_loader_plugin_path(LOAD_PATH)
     avalon.api.deregister_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.api.deregister_plugin_path(
-        avalon.api.InventoryAction, INVENTORY_PATH
-    )
+    deregister_inventory_action_path(INVENTORY_PATH)
 
     menu.uninstall()
 

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -1,6 +1,8 @@
 import json
-from avalon import api, io
+from avalon import io
+
 from openpype.pipeline import (
+    InventoryAction,
     get_representation_context,
     get_representation_path_from_context,
 )
@@ -10,7 +12,7 @@ from openpype.hosts.maya.api.lib import (
 )
 
 
-class ImportModelRender(api.InventoryAction):
+class ImportModelRender(InventoryAction):
 
     label = "Import Model Render Sets"
     icon = "industry"

--- a/openpype/hosts/maya/plugins/inventory/import_reference.py
+++ b/openpype/hosts/maya/plugins/inventory/import_reference.py
@@ -1,11 +1,10 @@
 from maya import cmds
 
-from avalon import api
-
+from openpype.pipeline import InventoryAction
 from openpype.hosts.maya.api.plugin import get_reference_node
 
 
-class ImportReference(api.InventoryAction):
+class ImportReference(InventoryAction):
     """Imports selected reference to inside of the file."""
 
     label = "Import Reference"

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -18,7 +18,9 @@ from openpype.lib import register_event_callback
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
+    register_inventory_action_path,
     deregister_loader_plugin_path,
+    deregister_inventory_action_path,
 )
 from openpype.tools.utils import host_tools
 
@@ -105,7 +107,7 @@ def install():
     pyblish.api.register_plugin_path(PUBLISH_PATH)
     register_loader_plugin_path(LOAD_PATH)
     avalon.api.register_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.api.register_plugin_path(avalon.api.InventoryAction, INVENTORY_PATH)
+    register_inventory_action_path(INVENTORY_PATH)
 
     # Register Avalon event for workfiles loading.
     register_event_callback("workio.open_file", check_inventory_versions)
@@ -131,6 +133,7 @@ def uninstall():
     pyblish.api.deregister_plugin_path(PUBLISH_PATH)
     deregister_loader_plugin_path(LOAD_PATH)
     avalon.api.deregister_plugin_path(LegacyCreator, CREATE_PATH)
+    deregister_inventory_action_path(INVENTORY_PATH)
 
     pyblish.api.deregister_callback(
         "instanceToggled", on_pyblish_instance_toggled)

--- a/openpype/hosts/nuke/plugins/inventory/repair_old_loaders.py
+++ b/openpype/hosts/nuke/plugins/inventory/repair_old_loaders.py
@@ -1,9 +1,9 @@
-from avalon import api
 from openpype.api import Logger
+from openpype.pipeline import InventoryAction
 from openpype.hosts.nuke.api.lib import set_avalon_knob_data
 
 
-class RepairOldLoaders(api.InventoryAction):
+class RepairOldLoaders(InventoryAction):
 
     label = "Repair Old Loaders"
     icon = "gears"

--- a/openpype/hosts/nuke/plugins/inventory/select_containers.py
+++ b/openpype/hosts/nuke/plugins/inventory/select_containers.py
@@ -1,8 +1,8 @@
-from avalon import api
+from openpype.pipeline import InventoryAction
 from openpype.hosts.nuke.api.commands import viewer_update_and_undo_stop
 
 
-class SelectContainers(api.InventoryAction):
+class SelectContainers(InventoryAction):
 
     label = "Select Containers"
     icon = "mouse-pointer"

--- a/openpype/hosts/resolve/api/pipeline.py
+++ b/openpype/hosts/resolve/api/pipeline.py
@@ -22,7 +22,6 @@ log = Logger().get_logger(__name__)
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
-INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 
@@ -48,7 +47,6 @@ def install():
 
     register_loader_plugin_path(LOAD_PATH)
     avalon.register_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.register_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
 
     # register callback for switching publishable
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
@@ -73,7 +71,6 @@ def uninstall():
 
     deregister_loader_plugin_path(LOAD_PATH)
     avalon.deregister_plugin_path(LegacyCreator, CREATE_PATH)
-    avalon.deregister_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
 
     # register callback for switching publishable
     pyblish.deregister_callback("instanceToggled", on_pyblish_instance_toggled)

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -41,6 +41,22 @@ from .publish import (
     OpenPypePyblishPluginMixin
 )
 
+from .actions import (
+    LauncherAction,
+
+    InventoryAction,
+
+    discover_launcher_actions,
+    register_launcher_action,
+    register_launcher_action_path,
+
+    discover_inventory_actions,
+    register_inventory_action,
+    register_inventory_action_path,
+    deregister_inventory_action,
+    deregister_inventory_action_path,
+)
+
 
 __all__ = (
     "attribute_definitions",
@@ -82,5 +98,19 @@ __all__ = (
     "PublishValidationError",
     "PublishXmlValidationError",
     "KnownPublishError",
-    "OpenPypePyblishPluginMixin"
+    "OpenPypePyblishPluginMixin",
+
+    # --- Plugins ---
+    "LauncherAction",
+    "InventoryAction",
+
+    "discover_launcher_actions",
+    "register_launcher_action",
+    "register_launcher_action_path",
+
+    "discover_inventory_actions",
+    "register_inventory_action",
+    "register_inventory_action_path",
+    "deregister_inventory_action",
+    "deregister_inventory_action_path",
 )

--- a/openpype/pipeline/actions.py
+++ b/openpype/pipeline/actions.py
@@ -1,0 +1,148 @@
+import os
+import copy
+import logging
+
+
+class LauncherAction(object):
+    """A custom action available"""
+    name = None
+    label = None
+    icon = None
+    color = None
+    order = 0
+
+    log = logging.getLogger("LauncherAction")
+    log.propagate = True
+
+    def is_compatible(self, session):
+        """Return whether the class is compatible with the Session."""
+        return True
+
+    def process(self, session, **kwargs):
+        pass
+
+
+class InventoryAction(object):
+    """A custom action for the scene inventory tool
+
+    If registered the action will be visible in the Right Mouse Button menu
+    under the submenu "Actions".
+
+    """
+
+    label = None
+    icon = None
+    color = None
+    order = 0
+
+    log = logging.getLogger("InventoryAction")
+    log.propagate = True
+
+    @staticmethod
+    def is_compatible(container):
+        """Override function in a custom class
+
+        This method is specifically used to ensure the action can operate on
+        the container.
+
+        Args:
+            container(dict): the data of a loaded asset, see host.ls()
+
+        Returns:
+            bool
+        """
+        return bool(container.get("objectName"))
+
+    def process(self, containers):
+        """Override function in a custom class
+
+        This method will receive all containers even those which are
+        incompatible. It is advised to create a small filter along the lines
+        of this example:
+
+        valid_containers = filter(self.is_compatible(c) for c in containers)
+
+        The return value will need to be a True-ish value to trigger
+        the data_changed signal in order to refresh the view.
+
+        You can return a list of container names to trigger GUI to select
+        treeview items.
+
+        You can return a dict to carry extra GUI options. For example:
+            {
+                "objectNames": [container names...],
+                "options": {"mode": "toggle",
+                            "clear": False}
+            }
+        Currently workable GUI options are:
+            - clear (bool): Clear current selection before selecting by action.
+                            Default `True`.
+            - mode (str): selection mode, use one of these:
+                          "select", "deselect", "toggle". Default is "select".
+
+        Args:
+            containers (list): list of dictionaries
+
+        Return:
+            bool, list or dict
+
+        """
+        return True
+
+
+# Launcher action
+def discover_launcher_actions():
+    import avalon.api
+
+    return avalon.api.discover(LauncherAction)
+
+
+def register_launcher_action(plugin):
+    import avalon.api
+
+    return avalon.api.register_plugin(LauncherAction, plugin)
+
+
+def register_launcher_action_path(path):
+    import avalon.api
+
+    return avalon.api.register_plugin_path(LauncherAction, path)
+
+
+# Inventory action
+def discover_inventory_actions():
+    import avalon.api
+
+    actions = avalon.api.discover(InventoryAction)
+    filtered_actions = []
+    for action in actions:
+        if action is not InventoryAction:
+            print("DISCOVERED", action)
+            filtered_actions.append(action)
+        else:
+            print("GOT SOURCE")
+    return filtered_actions
+
+
+def register_inventory_action(plugin):
+    import avalon.api
+
+    return avalon.api.register_plugin(InventoryAction, plugin)
+
+
+def deregister_inventory_action(plugin):
+    import avalon.api
+
+    avalon.api.deregister_plugin(InventoryAction, plugin)
+
+
+def register_inventory_action_path(path):
+    import avalon.api
+
+    return avalon.api.register_plugin_path(InventoryAction, path)
+
+
+def deregister_inventory_action_path(path):
+    import avalon.api
+
+    return avalon.api.deregister_plugin_path(InventoryAction, path)

--- a/openpype/pipeline/load/plugins.py
+++ b/openpype/pipeline/load/plugins.py
@@ -127,4 +127,5 @@ def register_loader_plugin_path(path):
 
 def deregister_loader_plugin(plugin):
     import avalon.api
+
     avalon.api.deregister_plugin(LoaderPlugin, plugin)

--- a/openpype/pipeline/thumbnails.py
+++ b/openpype/pipeline/thumbnails.py
@@ -1,0 +1,147 @@
+import os
+import copy
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def get_thumbnail_binary(thumbnail_entity, thumbnail_type, dbcon=None):
+    if not thumbnail_entity:
+        return
+
+    resolvers = discover_thumbnail_resolvers()
+    resolvers = sorted(resolvers, key=lambda cls: cls.priority)
+    if dbcon is None:
+        from avalon import io
+        dbcon = io
+
+    for Resolver in resolvers:
+        available_types = Resolver.thumbnail_types
+        if (
+            thumbnail_type not in available_types
+            and "*" not in available_types
+            and (
+                isinstance(available_types, (list, tuple))
+                and len(available_types) == 0
+            )
+        ):
+            continue
+        try:
+            instance = Resolver(dbcon)
+            result = instance.process(thumbnail_entity, thumbnail_type)
+            if result:
+                return result
+
+        except Exception:
+            log.warning("Resolver {0} failed durring process.".format(
+                Resolver.__class__.__name__, exc_info=True
+            ))
+
+
+class ThumbnailResolver(object):
+    """Determine how to get data from thumbnail entity.
+
+    "priority" - determines the order of processing in `get_thumbnail_binary`,
+        lower number is processed earlier.
+    "thumbnail_types" - it is expected that thumbnails will be used in more
+        more than one level, there is only ["thumbnail"] type at the moment
+        of creating this docstring but it is expected to add "ico" and "full"
+        in future.
+    """
+
+    priority = 100
+    thumbnail_types = ["*"]
+
+    def __init__(self, dbcon):
+        self._log = None
+        self.dbcon = dbcon
+
+    @property
+    def log(self):
+        if self._log is None:
+            self._log = logging.getLogger(self.__class__.__name__)
+        return self._log
+
+    def process(self, thumbnail_entity, thumbnail_type):
+        pass
+
+
+class TemplateResolver(ThumbnailResolver):
+
+    priority = 90
+
+    def process(self, thumbnail_entity, thumbnail_type):
+
+        if not os.environ.get("AVALON_THUMBNAIL_ROOT"):
+            return
+
+        template = thumbnail_entity["data"].get("template")
+        if not template:
+            self.log.debug("Thumbnail entity does not have set template")
+            return
+
+        project = self.dbcon.find_one(
+            {"type": "project"},
+            {
+                "name": True,
+                "data.code": True
+            }
+        )
+
+        template_data = copy.deepcopy(
+            thumbnail_entity["data"].get("template_data") or {}
+        )
+        template_data.update({
+            "_id": str(thumbnail_entity["_id"]),
+            "thumbnail_type": thumbnail_type,
+            "thumbnail_root": os.environ.get("AVALON_THUMBNAIL_ROOT"),
+            "project": {
+                "name": project["name"],
+                "code": project["data"].get("code")
+            }
+        })
+
+        try:
+            filepath = os.path.normpath(template.format(**template_data))
+        except KeyError:
+            self.log.warning((
+                "Missing template data keys for template <{0}> || Data: {1}"
+            ).format(template, str(template_data)))
+            return
+
+        if not os.path.exists(filepath):
+            self.log.warning("File does not exist \"{0}\"".format(filepath))
+            return
+
+        with open(filepath, "rb") as _file:
+            content = _file.read()
+
+        return content
+
+
+class BinaryThumbnail(ThumbnailResolver):
+    def process(self, thumbnail_entity, thumbnail_type):
+        return thumbnail_entity["data"].get("binary_data")
+
+
+# Thumbnail resolvers
+def discover_thumbnail_resolvers():
+    import avalon.api
+
+    return avalon.api.discover(ThumbnailResolver)
+
+
+def register_thumbnail_resolver(plugin):
+    import avalon.api
+
+    return avalon.api.register_plugin(ThumbnailResolver, plugin)
+
+
+def register_thumbnail_resolver_path(path):
+    import avalon.api
+
+    return avalon.api.register_plugin_path(ThumbnailResolver, path)
+
+
+register_thumbnail_resolver(TemplateResolver)
+register_thumbnail_resolver(BinaryThumbnail)

--- a/openpype/tools/launcher/actions.py
+++ b/openpype/tools/launcher/actions.py
@@ -1,6 +1,7 @@
 import os
 
-from avalon import api
+from Qt import QtWidgets, QtGui
+
 from openpype import PLUGINS_DIR
 from openpype import style
 from openpype.api import Logger, resources
@@ -8,7 +9,10 @@ from openpype.lib import (
     ApplictionExecutableNotFound,
     ApplicationLaunchFailed
 )
-from Qt import QtWidgets, QtGui
+from openpype.pipeline import (
+    LauncherAction,
+    register_launcher_action_path,
+)
 
 
 def register_actions_from_paths(paths):
@@ -29,14 +33,15 @@ def register_actions_from_paths(paths):
             print("Path was not found: {}".format(path))
             continue
 
-        api.register_plugin_path(api.Action, path)
+        register_launcher_action_path(path)
 
 
 def register_config_actions():
     """Register actions from the configuration for Launcher"""
 
     actions_dir = os.path.join(PLUGINS_DIR, "actions")
-    register_actions_from_paths([actions_dir])
+    if os.path.exists(actions_dir):
+        register_actions_from_paths([actions_dir])
 
 
 def register_environment_actions():
@@ -46,7 +51,9 @@ def register_environment_actions():
     register_actions_from_paths(paths_str.split(os.pathsep))
 
 
-class ApplicationAction(api.Action):
+# TODO move to 'openpype.pipeline.actions'
+# - remove Qt related stuff and implement exceptions to show error in launcher
+class ApplicationAction(LauncherAction):
     """Pype's application launcher
 
     Application action based on pype's ApplicationManager system.
@@ -74,7 +81,7 @@ class ApplicationAction(api.Action):
     @property
     def log(self):
         if self._log is None:
-            self._log = Logger().get_logger(self.__class__.__name__)
+            self._log = Logger.get_logger(self.__class__.__name__)
         return self._log
 
     def is_compatible(self, session):

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -8,12 +8,13 @@ import time
 import appdirs
 from Qt import QtCore, QtGui
 import qtawesome
-from avalon import api
+
 from openpype.lib import JSONSettingRegistry
 from openpype.lib.applications import (
     CUSTOM_LAUNCH_APP_GROUPS,
     ApplicationManager
 )
+from openpype.pipeline import discover_launcher_actions
 from openpype.tools.utils.lib import (
     DynamicQThread,
     get_project_icon,
@@ -68,7 +69,7 @@ class ActionModel(QtGui.QStandardItemModel):
     def discover(self):
         """Set up Actions cache. Run this for each new project."""
         # Discover all registered actions
-        actions = api.discover(api.Action)
+        actions = discover_launcher_actions()
 
         # Get available project actions and the application actions
         app_actions = self.get_application_actions()

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -7,9 +7,10 @@ import collections
 
 from Qt import QtWidgets, QtCore, QtGui
 
-from avalon import api, pipeline
+from avalon import api
 
 from openpype.pipeline import HeroVersionType
+from openpype.pipeline.thumbnails import get_thumbnail_binary
 from openpype.pipeline.load import (
     discover_loader_plugins,
     SubsetLoaderPlugin,
@@ -863,7 +864,7 @@ class ThumbnailWidget(QtWidgets.QLabel):
         if not thumbnail_ent:
             return
 
-        thumbnail_bin = pipeline.get_thumbnail_binary(
+        thumbnail_bin = get_thumbnail_binary(
             thumbnail_ent, "thumbnail", self.dbcon
         )
         if not thumbnail_bin:

--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -5,13 +5,14 @@ from functools import partial
 from Qt import QtWidgets, QtCore
 import qtawesome
 
-from avalon import io, api
+from avalon import io
 
 from openpype import style
 from openpype.pipeline import (
     HeroVersionType,
     update_container,
     remove_container,
+    discover_inventory_actions,
 )
 from openpype.modules import ModulesManager
 from openpype.tools.utils.lib import (
@@ -487,7 +488,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
         containers = containers or [dict()]
 
         # Check which action will be available in the menu
-        Plugins = api.discover(api.InventoryAction)
+        Plugins = discover_inventory_actions()
         compatible = [p() for p in Plugins if
                       any(p.is_compatible(c) for c in containers)]
 


### PR DESCRIPTION
## Brief description
Move remained plugins/actions from avalon into OpenPype.

## Description
Moved last plugins and actions from avalon repository `ThumbnailResolver `, `InventoryAction` and `Action`. Action `Action` was renamed to `LauncherAction`.

## Changes
- added `InventoryAction` and `LauncherAction` into `openpype/pipeline/actions.py`
- added `ThumbnailResolver` into `openpype/pipeline/thumbnails.py`
- removed registering of inventory path in hosts without inventory actions
- changed imports of moved code

## Testing notes:
1. launcher actions should work in Launcher UI
2. thumbnails should be visible if are published
3. actions in Scene Inventory tools should be visible

Related to https://github.com/pypeclub/avalon-core/pull/433