### PR TITLE
Deadline: Add headless argument

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -236,6 +236,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 environment["OPENPYPE_MONGO"] = mongo_url
 
         args = [
+            "--headless",
             'publish',
             roothless_metadata_path,
             "--targets", "deadline",

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -46,6 +46,7 @@ def inject_openpype_environment(deadlinePlugin):
 
         args = [
             openpype_app,
+            "--headless",
             'extractenvironments',
             export_url
         ]


### PR DESCRIPTION
## Brief description
Deadling jobs don't use `--headless` argument at all when running OpenPype and `OPENPYPE_HEADLESS` may not get to publish job.

## Changes
- added `--headless` when running OpenPype executable on deadline

## Note
- this change requires update of deadline repository plugin - see [Admin Docs -> Deadline Module](https://openpype.io/docs/module_deadline/)

## Testing notes:
1. Submit publish job to deadline
2. Pause the job before publishing
3. Add newer version of OpenPype into version repository so opening of OpenPype requires update
4. Continue with publish job
5. Publishing should success