### PR TITLE
General: Move pipeline constants to OpenPype

### DIFF
--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -5,7 +5,7 @@ from Qt import QtWidgets
 
 import pyblish.api
 import avalon.api
-from avalon import io, pipeline
+from avalon import io
 
 from openpype import lib
 from openpype.api import Logger
@@ -13,6 +13,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 import openpype.hosts.aftereffects
 from openpype.lib import register_event_callback
@@ -149,7 +150,7 @@ def containerise(name,
     """
     data = {
         "schema": "openpype:container-2.0",
-        "id": pipeline.AVALON_CONTAINER_ID,
+        "id": AVALON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),

--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from Qt import QtWidgets
+from bson.objectid import ObjectId
 
 import pyblish.api
 import avalon.api
@@ -43,7 +44,7 @@ def check_inventory():
         representation = container['representation']
         representation_doc = io.find_one(
             {
-                "_id": io.ObjectId(representation),
+                "_id": ObjectId(representation),
                 "type": "representation"
             },
             projection={"parent": True}

--- a/openpype/hosts/aftereffects/api/workio.py
+++ b/openpype/hosts/aftereffects/api/workio.py
@@ -1,8 +1,8 @@
 """Host API required Work Files tool"""
 import os
 
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 from .launch_logic import get_stub
-from avalon import api
 
 
 def _active_document():
@@ -14,7 +14,7 @@ def _active_document():
 
 
 def file_extensions():
-    return api.HOST_WORKFILE_EXTENSIONS["aftereffects"]
+    return HOST_WORKFILE_EXTENSIONS["aftereffects"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -12,12 +12,12 @@ from . import ops
 import pyblish.api
 import avalon.api
 from avalon import io, schema
-from avalon.pipeline import AVALON_CONTAINER_ID
 
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.api import Logger
 from openpype.lib import (
@@ -31,7 +31,6 @@ PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
-INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 ORIGINAL_EXCEPTHOOK = sys.excepthook
 

--- a/openpype/hosts/blender/api/workio.py
+++ b/openpype/hosts/blender/api/workio.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing import List, Optional
 
 import bpy
-from avalon import api
+
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 
 
 class OpenFileCacher:
@@ -77,7 +78,7 @@ def has_unsaved_changes() -> bool:
 def file_extensions() -> List[str]:
     """Return the supported file extensions for Blender scene files."""
 
-    return api.HOST_WORKFILE_EXTENSIONS["blender"]
+    return HOST_WORKFILE_EXTENSIONS["blender"]
 
 
 def work_root(session: dict) -> str:

--- a/openpype/hosts/blender/plugins/load/load_abc.py
+++ b/openpype/hosts/blender/plugins/load/load_abc.py
@@ -6,11 +6,14 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
+
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 from openpype.hosts.blender.api import plugin, lib
 

--- a/openpype/hosts/blender/plugins/load/load_audio.py
+++ b/openpype/hosts/blender/plugins/load/load_audio.py
@@ -6,12 +6,14 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 

--- a/openpype/hosts/blender/plugins/load/load_camera_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_camera_blend.py
@@ -7,12 +7,14 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 logger = logging.getLogger("openpype").getChild(

--- a/openpype/hosts/blender/plugins/load/load_camera_fbx.py
+++ b/openpype/hosts/blender/plugins/load/load_camera_fbx.py
@@ -6,12 +6,14 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
 from openpype.hosts.blender.api import plugin, lib
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 

--- a/openpype/hosts/blender/plugins/load/load_fbx.py
+++ b/openpype/hosts/blender/plugins/load/load_fbx.py
@@ -6,12 +6,14 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
 from openpype.hosts.blender.api import plugin, lib
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 

--- a/openpype/hosts/blender/plugins/load/load_layout_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_layout_blend.py
@@ -10,12 +10,12 @@ from openpype import lib
 from openpype.pipeline import (
     legacy_create,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 

--- a/openpype/hosts/blender/plugins/load/load_layout_json.py
+++ b/openpype/hosts/blender/plugins/load/load_layout_json.py
@@ -13,12 +13,12 @@ from openpype.pipeline import (
     load_container,
     get_representation_path,
     loaders_from_representation,
+    AVALON_CONTAINER_ID,
 )
 from openpype.hosts.blender.api.pipeline import (
     AVALON_INSTANCES,
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 from openpype.hosts.blender.api import plugin
 

--- a/openpype/hosts/blender/plugins/load/load_model.py
+++ b/openpype/hosts/blender/plugins/load/load_model.py
@@ -6,12 +6,14 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 

--- a/openpype/hosts/blender/plugins/load/load_rig.py
+++ b/openpype/hosts/blender/plugins/load/load_rig.py
@@ -10,6 +10,7 @@ from openpype import lib
 from openpype.pipeline import (
     legacy_create,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.hosts.blender.api import (
     plugin,
@@ -18,7 +19,6 @@ from openpype.hosts.blender.api import (
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
     AVALON_PROPERTY,
-    AVALON_CONTAINER_ID
 )
 
 

--- a/openpype/hosts/blender/plugins/publish/extract_layout.py
+++ b/openpype/hosts/blender/plugins/publish/extract_layout.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from bson.objectid import ObjectId
+
 import bpy
 import bpy_extras
 import bpy_extras.anim_utils
@@ -140,7 +142,7 @@ class ExtractLayout(openpype.api.Extractor):
             blend = io.find_one(
                 {
                     "type": "representation",
-                    "parent": io.ObjectId(parent),
+                    "parent": ObjectId(parent),
                     "name": "blend"
                 },
                 projection={"_id": True})
@@ -151,7 +153,7 @@ class ExtractLayout(openpype.api.Extractor):
             fbx = io.find_one(
                 {
                     "type": "representation",
-                    "parent": io.ObjectId(parent),
+                    "parent": ObjectId(parent),
                     "name": "fbx"
                 },
                 projection={"_id": True})
@@ -162,7 +164,7 @@ class ExtractLayout(openpype.api.Extractor):
             abc = io.find_one(
                 {
                     "type": "representation",
-                    "parent": io.ObjectId(parent),
+                    "parent": ObjectId(parent),
                     "name": "abc"
                 },
                 projection={"_id": True})

--- a/openpype/hosts/flame/api/pipeline.py
+++ b/openpype/hosts/flame/api/pipeline.py
@@ -4,13 +4,14 @@ Basic avalon integration
 import os
 import contextlib
 from avalon import api as avalon
-from avalon.pipeline import AVALON_CONTAINER_ID
 from pyblish import api as pyblish
+
 from openpype.api import Logger
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from .lib import (
     set_segment_data_marker,

--- a/openpype/hosts/fusion/api/lib.py
+++ b/openpype/hosts/fusion/api/lib.py
@@ -3,6 +3,7 @@ import sys
 import re
 import contextlib
 
+from bson.objectid import ObjectId
 from Qt import QtGui
 
 from avalon import io
@@ -92,7 +93,7 @@ def switch_item(container,
     # Collect any of current asset, subset and representation if not provided
     # so we can use the original name from those.
     if any(not x for x in [asset_name, subset_name, representation_name]):
-        _id = io.ObjectId(container["representation"])
+        _id = ObjectId(container["representation"])
         representation = io.find_one({"type": "representation", "_id": _id})
         version, subset, asset, project = io.parenthood(representation)
 

--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -8,13 +8,13 @@ import contextlib
 
 import pyblish.api
 import avalon.api
-from avalon.pipeline import AVALON_CONTAINER_ID
 
 from openpype.api import Logger
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 import openpype.hosts.fusion
 

--- a/openpype/hosts/fusion/api/workio.py
+++ b/openpype/hosts/fusion/api/workio.py
@@ -1,12 +1,14 @@
 """Host API required Work Files tool"""
 import sys
 import os
-from avalon import api
+
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
+
 from .pipeline import get_current_comp
 
 
 def file_extensions():
-    return api.HOST_WORKFILE_EXTENSIONS["fusion"]
+    return HOST_WORKFILE_EXTENSIONS["fusion"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/harmony/api/pipeline.py
+++ b/openpype/hosts/harmony/api/pipeline.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import logging
 
+from bson.objectid import ObjectId
 import pyblish.api
 
 from avalon import io
@@ -113,7 +114,7 @@ def check_inventory():
         representation = container['representation']
         representation_doc = io.find_one(
             {
-                "_id": io.ObjectId(representation),
+                "_id": ObjectId(representation),
                 "type": "representation"
             },
             projection={"parent": True}

--- a/openpype/hosts/harmony/api/pipeline.py
+++ b/openpype/hosts/harmony/api/pipeline.py
@@ -6,7 +6,6 @@ import pyblish.api
 
 from avalon import io
 import avalon.api
-from avalon.pipeline import AVALON_CONTAINER_ID
 
 from openpype import lib
 from openpype.lib import register_event_callback
@@ -14,6 +13,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 import openpype.hosts.harmony
 import openpype.hosts.harmony.api as harmony

--- a/openpype/hosts/harmony/api/workio.py
+++ b/openpype/hosts/harmony/api/workio.py
@@ -2,20 +2,21 @@
 import os
 import shutil
 
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
+
 from .lib import (
     ProcessContext,
     get_local_harmony_path,
     zip_and_move,
     launch_zip_file
 )
-from avalon import api
 
 # used to lock saving until previous save is done.
 save_disabled = False
 
 
 def file_extensions():
-    return api.HOST_WORKFILE_EXTENSIONS["harmony"]
+    return HOST_WORKFILE_EXTENSIONS["harmony"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -8,7 +8,10 @@ import platform
 import ast
 import shutil
 import hiero
+
 from Qt import QtWidgets
+from bson.objectid import ObjectId
+
 import avalon.api as avalon
 import avalon.io
 from openpype.api import (Logger, Anatomy, get_anatomy_settings)
@@ -1006,7 +1009,7 @@ def check_inventory_versions():
             # get representation from io
             representation = io.find_one({
                 "type": "representation",
-                "_id": io.ObjectId(container["representation"])
+                "_id": ObjectId(container["representation"])
             })
 
             # Get start frame from version data

--- a/openpype/hosts/hiero/api/pipeline.py
+++ b/openpype/hosts/hiero/api/pipeline.py
@@ -4,7 +4,7 @@ Basic avalon integration
 import os
 import contextlib
 from collections import OrderedDict
-from avalon.pipeline import AVALON_CONTAINER_ID
+
 from avalon import api as avalon
 from avalon import schema
 from pyblish import api as pyblish
@@ -13,6 +13,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.tools.utils import host_tools
 from . import lib, menu, events

--- a/openpype/hosts/hiero/api/workio.py
+++ b/openpype/hosts/hiero/api/workio.py
@@ -1,14 +1,14 @@
 import os
 import hiero
-from avalon import api
+
 from openpype.api import Logger
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 
-
-log = Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 
 def file_extensions():
-    return api.HOST_WORKFILE_EXTENSIONS["hiero"]
+    return HOST_WORKFILE_EXTENSIONS["hiero"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -8,12 +8,12 @@ import hdefereval
 
 import pyblish.api
 import avalon.api
-from avalon.pipeline import AVALON_CONTAINER_ID
 from avalon.lib import find_submodule
 
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 import openpype.hosts.houdini
 from openpype.hosts.houdini.api import lib

--- a/openpype/hosts/houdini/api/workio.py
+++ b/openpype/hosts/houdini/api/workio.py
@@ -2,11 +2,11 @@
 import os
 
 import hou
-from avalon import api
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 
 
 def file_extensions():
-    return api.HOST_WORKFILE_EXTENSIONS["houdini"]
+    return HOST_WORKFILE_EXTENSIONS["houdini"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/houdini/plugins/load/load_image.py
+++ b/openpype/hosts/houdini/plugins/load/load_image.py
@@ -3,6 +3,7 @@ import os
 from openpype.pipeline import (
     load,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.hosts.houdini.api import lib, pipeline
 
@@ -73,7 +74,7 @@ class ImageLoader(load.LoaderPlugin):
         # Imprint it manually
         data = {
             "schema": "avalon-core:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "name": node_name,
             "namespace": namespace,
             "loader": str(self.__class__.__name__),

--- a/openpype/hosts/houdini/plugins/load/load_usd_layer.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_layer.py
@@ -1,8 +1,9 @@
 from openpype.pipeline import (
     load,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
-from openpype.hosts.houdini.api import lib, pipeline
+from openpype.hosts.houdini.api import lib
 
 
 class USDSublayerLoader(load.LoaderPlugin):
@@ -43,7 +44,7 @@ class USDSublayerLoader(load.LoaderPlugin):
         # Imprint it manually
         data = {
             "schema": "avalon-core:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "name": node_name,
             "namespace": namespace,
             "loader": str(self.__class__.__name__),

--- a/openpype/hosts/houdini/plugins/load/load_usd_reference.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_reference.py
@@ -1,8 +1,9 @@
 from openpype.pipeline import (
     load,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
-from openpype.hosts.houdini.api import lib, pipeline
+from openpype.hosts.houdini.api import lib
 
 
 class USDReferenceLoader(load.LoaderPlugin):
@@ -43,7 +44,7 @@ class USDReferenceLoader(load.LoaderPlugin):
         # Imprint it manually
         data = {
             "schema": "avalon-core:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "name": node_name,
             "namespace": namespace,
             "loader": str(self.__class__.__name__),

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -10,7 +10,6 @@ import pyblish.api
 import avalon.api
 
 from avalon.lib import find_submodule
-from avalon.pipeline import AVALON_CONTAINER_ID
 
 import openpype.hosts.maya
 from openpype.tools.utils import host_tools
@@ -24,6 +23,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.hosts.maya.lib import copy_workspace_mel
 from . import menu, lib

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -4,11 +4,11 @@ from maya import cmds
 
 import qargparse
 
-from avalon.pipeline import AVALON_CONTAINER_ID
 from openpype.pipeline import (
     LegacyCreator,
     LoaderPlugin,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
 
 from .pipeline import containerise

--- a/openpype/hosts/maya/api/setdress.py
+++ b/openpype/hosts/maya/api/setdress.py
@@ -6,6 +6,8 @@ import contextlib
 import copy
 
 import six
+from bson.objectid import ObjectId
+
 from maya import cmds
 
 from avalon import io
@@ -282,7 +284,7 @@ def update_package_version(container, version):
 
     # Versioning (from `core.maya.pipeline`)
     current_representation = io.find_one({
-        "_id": io.ObjectId(container["representation"])
+        "_id": ObjectId(container["representation"])
     })
 
     assert current_representation is not None, "This is a bug"
@@ -327,7 +329,7 @@ def update_package(set_container, representation):
 
     # Load the original package data
     current_representation = io.find_one({
-        "_id": io.ObjectId(set_container['representation']),
+        "_id": ObjectId(set_container['representation']),
         "type": "representation"
     })
 
@@ -478,10 +480,10 @@ def update_scene(set_container, containers, current_data, new_data, new_file):
                 # They *must* use the same asset, subset and Loader for
                 # `update_container` to make sense.
                 old = io.find_one({
-                    "_id": io.ObjectId(representation_current)
+                    "_id": ObjectId(representation_current)
                 })
                 new = io.find_one({
-                    "_id": io.ObjectId(representation_new)
+                    "_id": ObjectId(representation_new)
                 })
                 is_valid = compare_representations(old=old, new=new)
                 if not is_valid:

--- a/openpype/hosts/maya/api/workio.py
+++ b/openpype/hosts/maya/api/workio.py
@@ -1,11 +1,12 @@
 """Host API required Work Files tool"""
 import os
 from maya import cmds
-from avalon import api
+
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 
 
 def file_extensions():
-    return api.HOST_WORKFILE_EXTENSIONS["maya"]
+    return HOST_WORKFILE_EXTENSIONS["maya"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/maya/plugins/inventory/import_modelrender.py
+++ b/openpype/hosts/maya/plugins/inventory/import_modelrender.py
@@ -1,5 +1,6 @@
 import json
 from avalon import api, io
+from bson.objectid import ObjectId
 from openpype.pipeline import (
     get_representation_context,
     get_representation_path_from_context,
@@ -39,7 +40,7 @@ class ImportModelRender(api.InventoryAction):
                     nodes.append(n)
 
             repr_doc = io.find_one({
-                "_id": io.ObjectId(container["representation"]),
+                "_id": ObjectId(container["representation"]),
             })
             version_id = repr_doc["parent"]
 

--- a/openpype/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/load/load_vrayproxy.py
@@ -7,6 +7,8 @@ loader will use them instead of native vray vrmesh format.
 """
 import os
 
+from bson.objectid import ObjectId
+
 import maya.cmds as cmds
 
 from avalon import io
@@ -186,7 +188,7 @@ class VRayProxyLoader(load.LoaderPlugin):
         abc_rep = io.find_one(
             {
                 "type": "representation",
-                "parent": io.ObjectId(version_id),
+                "parent": ObjectId(version_id),
                 "name": "abc"
             })
 

--- a/openpype/hosts/maya/plugins/publish/extract_maya_scene_raw.py
+++ b/openpype/hosts/maya/plugins/publish/extract_maya_scene_raw.py
@@ -6,7 +6,7 @@ from maya import cmds
 
 import openpype.api
 from openpype.hosts.maya.api.lib import maintained_selection
-from avalon.pipeline import AVALON_CONTAINER_ID
+from openpype.pipeline import AVALON_CONTAINER_ID
 
 
 class ExtractMayaSceneRaw(openpype.api.Extractor):

--- a/openpype/hosts/nuke/api/command.py
+++ b/openpype/hosts/nuke/api/command.py
@@ -1,6 +1,7 @@
 import logging
 import contextlib
 import nuke
+from bson.objectid import ObjectId
 
 from avalon import api, io
 
@@ -70,10 +71,10 @@ def get_handles(asset):
     if "visualParent" in data:
         vp = data["visualParent"]
         if vp is not None:
-            parent_asset = io.find_one({"_id": io.ObjectId(vp)})
+            parent_asset = io.find_one({"_id": ObjectId(vp)})
 
     if parent_asset is None:
-        parent_asset = io.find_one({"_id": io.ObjectId(asset["parent"])})
+        parent_asset = io.find_one({"_id": ObjectId(asset["parent"])})
 
     if parent_asset is not None:
         return get_handles(parent_asset)

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -6,10 +6,11 @@ import contextlib
 from collections import OrderedDict
 
 import clique
+from bson.objectid import ObjectId
 
 import nuke
 
-from avalon import api, io, lib
+from avalon import api, io
 
 from openpype.api import (
     Logger,
@@ -20,7 +21,6 @@ from openpype.api import (
     get_workdir_data,
     get_asset,
     get_current_project_settings,
-    ApplicationManager
 )
 from openpype.tools.utils import host_tools
 from openpype.lib.path_tools import HostDirmap
@@ -570,7 +570,7 @@ def check_inventory_versions():
             # get representation from io
             representation = io.find_one({
                 "type": "representation",
-                "_id": io.ObjectId(avalon_knob_data["representation"])
+                "_id": ObjectId(avalon_knob_data["representation"])
             })
 
             # Failsafe for not finding the representation.

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -6,7 +6,6 @@ import nuke
 
 import pyblish.api
 import avalon.api
-from avalon import pipeline
 
 import openpype
 from openpype.api import (
@@ -19,6 +18,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.tools.utils import host_tools
 
@@ -330,7 +330,7 @@ def containerise(node,
     data = OrderedDict(
         [
             ("schema", "openpype:container-2.0"),
-            ("id", pipeline.AVALON_CONTAINER_ID),
+            ("id", AVALON_CONTAINER_ID),
             ("name", name),
             ("namespace", namespace),
             ("loader", str(loader)),

--- a/openpype/hosts/nuke/api/workio.py
+++ b/openpype/hosts/nuke/api/workio.py
@@ -1,11 +1,12 @@
 """Host API required Work Files tool"""
 import os
 import nuke
-import avalon.api
+
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 
 
 def file_extensions():
-    return avalon.api.HOST_WORKFILE_EXTENSIONS["nuke"]
+    return HOST_WORKFILE_EXTENSIONS["nuke"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/photoshop/api/pipeline.py
+++ b/openpype/hosts/photoshop/api/pipeline.py
@@ -1,5 +1,6 @@
 import os
 from Qt import QtWidgets
+from bson.objectid import ObjectId
 
 import pyblish.api
 import avalon.api
@@ -37,7 +38,7 @@ def check_inventory():
         representation = container['representation']
         representation_doc = io.find_one(
             {
-                "_id": io.ObjectId(representation),
+                "_id": ObjectId(representation),
                 "type": "representation"
             },
             projection={"parent": True}

--- a/openpype/hosts/photoshop/api/pipeline.py
+++ b/openpype/hosts/photoshop/api/pipeline.py
@@ -3,7 +3,7 @@ from Qt import QtWidgets
 
 import pyblish.api
 import avalon.api
-from avalon import pipeline, io
+from avalon import io
 
 from openpype.api import Logger
 from openpype.lib import register_event_callback
@@ -11,6 +11,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 import openpype.hosts.photoshop
 
@@ -221,7 +222,7 @@ def containerise(
 
     data = {
         "schema": "openpype:container-2.0",
-        "id": pipeline.AVALON_CONTAINER_ID,
+        "id": AVALON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),

--- a/openpype/hosts/photoshop/api/workio.py
+++ b/openpype/hosts/photoshop/api/workio.py
@@ -1,8 +1,7 @@
 """Host API required Work Files tool"""
 import os
 
-import avalon.api
-
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 from . import lib
 
 
@@ -15,7 +14,7 @@ def _active_document():
 
 
 def file_extensions():
-    return avalon.api.HOST_WORKFILE_EXTENSIONS["photoshop"]
+    return HOST_WORKFILE_EXTENSIONS["photoshop"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/resolve/api/pipeline.py
+++ b/openpype/hosts/resolve/api/pipeline.py
@@ -6,13 +6,13 @@ import contextlib
 from collections import OrderedDict
 from avalon import api as avalon
 from avalon import schema
-from avalon.pipeline import AVALON_CONTAINER_ID
 from pyblish import api as pyblish
 from openpype.api import Logger
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from . import lib
 from . import PLUGINS_DIR

--- a/openpype/hosts/tvpaint/api/pipeline.py
+++ b/openpype/hosts/tvpaint/api/pipeline.py
@@ -10,7 +10,6 @@ import pyblish.api
 import avalon.api
 
 from avalon import io
-from avalon.pipeline import AVALON_CONTAINER_ID
 
 from openpype.hosts import tvpaint
 from openpype.api import get_current_project_settings
@@ -19,6 +18,7 @@ from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 
 from .lib import (

--- a/openpype/hosts/tvpaint/api/workio.py
+++ b/openpype/hosts/tvpaint/api/workio.py
@@ -4,6 +4,7 @@
 """
 
 from avalon import api
+from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 from .lib import (
     execute_george,
     execute_george_through_file
@@ -47,7 +48,7 @@ def has_unsaved_changes():
 
 def file_extensions():
     """Return the supported file extensions for Blender scene files."""
-    return api.HOST_WORKFILE_EXTENSIONS["tvpaint"]
+    return HOST_WORKFILE_EXTENSIONS["tvpaint"]
 
 
 def work_root(session):

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -4,13 +4,13 @@ import logging
 from typing import List
 
 import pyblish.api
-from avalon.pipeline import AVALON_CONTAINER_ID
 from avalon import api
 
 from openpype.pipeline import (
     LegacyCreator,
     register_loader_plugin_path,
     deregister_loader_plugin_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.tools.utils import host_tools
 import openpype.hosts.unreal

--- a/openpype/hosts/unreal/plugins/load/load_alembic_geometrycache.py
+++ b/openpype/hosts/unreal/plugins/load/load_alembic_geometrycache.py
@@ -2,8 +2,10 @@
 """Loader for published alembics."""
 import os
 
-from avalon import pipeline
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID
+)
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 
@@ -117,7 +119,7 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/load/load_alembic_skeletalmesh.py
+++ b/openpype/hosts/unreal/plugins/load/load_alembic_skeletalmesh.py
@@ -2,8 +2,10 @@
 """Load Skeletal Mesh alembics."""
 import os
 
-from avalon import pipeline
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID
+)
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
@@ -81,7 +83,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/load/load_alembic_staticmesh.py
+++ b/openpype/hosts/unreal/plugins/load/load_alembic_staticmesh.py
@@ -2,8 +2,10 @@
 """Loader for Static Mesh alembics."""
 import os
 
-from avalon import pipeline
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID
+)
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
@@ -100,7 +102,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -3,8 +3,10 @@
 import os
 import json
 
-from avalon import pipeline
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID
+)
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
@@ -135,7 +137,7 @@ class AnimationFBXLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/load/load_camera.py
+++ b/openpype/hosts/unreal/plugins/load/load_camera.py
@@ -2,7 +2,8 @@
 """Load camera from FBX."""
 import os
 
-from avalon import io, pipeline
+from avalon import io
+from openpype.pipeline import AVALON_CONTAINER_ID
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
@@ -116,7 +117,7 @@ class CameraLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -11,12 +11,12 @@ from unreal import AssetToolsHelpers
 from unreal import FBXImportType
 from unreal import MathLibrary as umath
 
-from avalon.pipeline import AVALON_CONTAINER_ID
 from openpype.pipeline import (
     discover_loader_plugins,
     loaders_from_representation,
     load_container,
     get_representation_path,
+    AVALON_CONTAINER_ID,
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline

--- a/openpype/hosts/unreal/plugins/load/load_rig.py
+++ b/openpype/hosts/unreal/plugins/load/load_rig.py
@@ -2,8 +2,10 @@
 """Load Skeletal Meshes form FBX."""
 import os
 
-from avalon import pipeline
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID
+)
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
@@ -101,7 +103,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/load/load_staticmeshfbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmeshfbx.py
@@ -2,8 +2,10 @@
 """Load Static meshes form FBX."""
 import os
 
-from avalon import pipeline
-from openpype.pipeline import get_representation_path
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID
+)
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
@@ -95,7 +97,7 @@ class StaticMeshFBXLoader(plugin.Loader):
 
         data = {
             "schema": "openpype:container-2.0",
-            "id": pipeline.AVALON_CONTAINER_ID,
+            "id": AVALON_CONTAINER_ID,
             "asset": asset,
             "namespace": asset_dir,
             "container_name": container_name,

--- a/openpype/hosts/unreal/plugins/publish/extract_layout.py
+++ b/openpype/hosts/unreal/plugins/publish/extract_layout.py
@@ -3,6 +3,8 @@ import os
 import json
 import math
 
+from bson.objectid import ObjectId
+
 import unreal
 from unreal import EditorLevelLibrary as ell
 from unreal import EditorAssetLibrary as eal
@@ -62,7 +64,7 @@ class ExtractLayout(openpype.api.Extractor):
                 blend = io.find_one(
                     {
                         "type": "representation",
-                        "parent": io.ObjectId(parent),
+                        "parent": ObjectId(parent),
                         "name": "blend"
                     },
                     projection={"_id": True})

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1544,6 +1544,7 @@ def _prepare_last_workfile(data, workdir):
         workdir (str): Path to folder where workfiles should be stored.
     """
     import avalon.api
+    from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 
     log = data["log"]
 
@@ -1592,7 +1593,7 @@ def _prepare_last_workfile(data, workdir):
     # Last workfile path
     last_workfile_path = data.get("last_workfile_path") or ""
     if not last_workfile_path:
-        extensions = avalon.api.HOST_WORKFILE_EXTENSIONS.get(app.host_name)
+        extensions = HOST_WORKFILE_EXTENSIONS.get(app.host_name)
         if extensions:
             anatomy = data["anatomy"]
             project_settings = data["project_settings"]

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -9,6 +9,8 @@ import collections
 import functools
 import getpass
 
+from bson.objectid import ObjectId
+
 from openpype.settings import (
     get_project_settings,
     get_system_settings
@@ -168,7 +170,7 @@ def any_outdated():
 
         representation_doc = avalon.io.find_one(
             {
-                "_id": avalon.io.ObjectId(representation),
+                "_id": ObjectId(representation),
                 "type": "representation"
             },
             projection={"parent": True}

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -1,5 +1,6 @@
 from .constants import (
     AVALON_CONTAINER_ID,
+    HOST_WORKFILE_EXTENSIONS,
 )
 
 from .lib import attribute_definitions
@@ -48,6 +49,7 @@ from .publish import (
 
 __all__ = (
     "AVALON_CONTAINER_ID",
+    "HOST_WORKFILE_EXTENSIONS",
 
     "attribute_definitions",
 

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -1,3 +1,7 @@
+from .constants import (
+    AVALON_CONTAINER_ID,
+)
+
 from .lib import attribute_definitions
 
 from .create import (
@@ -43,6 +47,8 @@ from .publish import (
 
 
 __all__ = (
+    "AVALON_CONTAINER_ID",
+
     "attribute_definitions",
 
     # --- Create ---

--- a/openpype/pipeline/constants.py
+++ b/openpype/pipeline/constants.py
@@ -1,2 +1,19 @@
 # Metadata ID of loaded container into scene
 AVALON_CONTAINER_ID = "pyblish.avalon.container"
+
+# TODO get extensions from host implementations
+HOST_WORKFILE_EXTENSIONS = {
+    "blender": [".blend"],
+    "celaction": [".scn"],
+    "tvpaint": [".tvpp"],
+    "fusion": [".comp"],
+    "harmony": [".zip"],
+    "houdini": [".hip", ".hiplc", ".hipnc"],
+    "maya": [".ma", ".mb"],
+    "nuke": [".nk"],
+    "hiero": [".hrox"],
+    "photoshop": [".psd", ".psb"],
+    "premiere": [".prproj"],
+    "resolve": [".drp"],
+    "aftereffects": [".aep"]
+}

--- a/openpype/pipeline/constants.py
+++ b/openpype/pipeline/constants.py
@@ -1,0 +1,2 @@
+# Metadata ID of loaded container into scene
+AVALON_CONTAINER_ID = "pyblish.avalon.container"

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -7,6 +7,7 @@ import inspect
 import numbers
 
 import six
+from bson.objectid import ObjectId
 
 from avalon import io, schema
 from avalon.api import Session, registered_root
@@ -67,7 +68,7 @@ def get_repres_contexts(representation_ids, dbcon=None):
     _representation_ids = []
     for repre_id in representation_ids:
         if isinstance(repre_id, six.string_types):
-            repre_id = io.ObjectId(repre_id)
+            repre_id = ObjectId(repre_id)
         _representation_ids.append(repre_id)
 
     repre_docs = dbcon.find({
@@ -174,7 +175,7 @@ def get_subset_contexts(subset_ids, dbcon=None):
     _subset_ids = set()
     for subset_id in subset_ids:
         if isinstance(subset_id, six.string_types):
-            subset_id = io.ObjectId(subset_id)
+            subset_id = ObjectId(subset_id)
         _subset_ids.add(subset_id)
 
     subset_docs = dbcon.find({
@@ -217,7 +218,7 @@ def get_representation_context(representation):
     """Return parenthood context for representation.
 
     Args:
-        representation (str or io.ObjectId or dict): The representation id
+        representation (str or ObjectId or dict): The representation id
             or full representation as returned by the database.
 
     Returns:
@@ -227,9 +228,9 @@ def get_representation_context(representation):
 
     assert representation is not None, "This is a bug"
 
-    if isinstance(representation, (six.string_types, io.ObjectId)):
+    if isinstance(representation, (six.string_types, ObjectId)):
         representation = io.find_one(
-            {"_id": io.ObjectId(str(representation))})
+            {"_id": ObjectId(str(representation))})
 
     version, subset, asset, project = io.parenthood(representation)
 
@@ -340,7 +341,7 @@ def load_container(
 
     Args:
         Loader (Loader): The loader class to trigger.
-        representation (str or io.ObjectId or dict): The representation id
+        representation (str or ObjectId or dict): The representation id
             or full representation as returned by the database.
         namespace (str, Optional): The namespace to assign. Defaults to None.
         name (str, Optional): The name to assign. Defaults to subset name.
@@ -404,7 +405,7 @@ def update_container(container, version=-1):
 
     # Compute the different version from 'representation'
     current_representation = io.find_one({
-        "_id": io.ObjectId(container["representation"])
+        "_id": ObjectId(container["representation"])
     })
 
     assert current_representation is not None, "This is a bug"

--- a/openpype/plugins/publish/collect_scene_loaded_versions.py
+++ b/openpype/plugins/publish/collect_scene_loaded_versions.py
@@ -1,3 +1,4 @@
+from bson.objectid import ObjectId
 
 import pyblish.api
 from avalon import api, io
@@ -35,7 +36,7 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
 
         loaded_versions = []
         _containers = list(host.ls())
-        _repr_ids = [io.ObjectId(c["representation"]) for c in _containers]
+        _repr_ids = [ObjectId(c["representation"]) for c in _containers]
         version_by_repr = {
             str(doc["_id"]): doc["parent"] for doc in
             io.find({"_id": {"$in": _repr_ids}}, projection={"parent": 1})
@@ -46,7 +47,7 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
             # may have more then one representation that are same version
             version = {
                 "subsetName": con["name"],
-                "representation": io.ObjectId(con["representation"]),
+                "representation": ObjectId(con["representation"]),
                 "version": version_by_repr[con["representation"]],  # _id
             }
             loaded_versions.append(version)

--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -4,6 +4,7 @@ import clique
 import errno
 import shutil
 
+from bson.objectid import ObjectId
 from pymongo import InsertOne, ReplaceOne
 import pyblish.api
 from avalon import api, io, schema
@@ -161,7 +162,7 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
         if old_version:
             new_version_id = old_version["_id"]
         else:
-            new_version_id = io.ObjectId()
+            new_version_id = ObjectId()
 
         new_hero_version = {
             "_id": new_version_id,
@@ -384,7 +385,7 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
 
                 # Create representation
                 else:
-                    repre["_id"] = io.ObjectId()
+                    repre["_id"] = ObjectId()
                     bulk_writes.append(
                         InsertOne(repre)
                     )
@@ -420,7 +421,7 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
 
                 else:
                     repre["old_id"] = repre["_id"]
-                    repre["_id"] = io.ObjectId()
+                    repre["_id"] = ObjectId()
                     repre["type"] = "archived_representation"
                     bulk_writes.append(
                         InsertOne(repre)

--- a/openpype/plugins/publish/integrate_inputlinks.py
+++ b/openpype/plugins/publish/integrate_inputlinks.py
@@ -1,7 +1,9 @@
-
 from collections import OrderedDict
-from avalon import io
+
+from bson.objectid import ObjectId
 import pyblish.api
+
+from avalon import io
 
 
 class IntegrateInputLinks(pyblish.api.ContextPlugin):
@@ -104,7 +106,7 @@ class IntegrateInputLinks(pyblish.api.ContextPlugin):
         # future.
         link = OrderedDict()
         link["type"] = link_type
-        link["id"] = io.ObjectId(input_id)
+        link["id"] = ObjectId(input_id)
         link["linkedBy"] = "publish"
 
         if "inputLinks" not in version_doc["data"]:

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -9,6 +9,7 @@ import six
 import re
 import shutil
 
+from bson.objectid import ObjectId
 from pymongo import DeleteOne, InsertOne
 import pyblish.api
 from avalon import io
@@ -293,7 +294,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 bulk_writes.append(DeleteOne({"_id": repre_id}))
 
                 repre["orig_id"] = repre_id
-                repre["_id"] = io.ObjectId()
+                repre["_id"] = ObjectId()
                 repre["type"] = "archived_representation"
                 bulk_writes.append(InsertOne(repre))
 
@@ -572,7 +573,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
             # Create new id if existing representations does not match
             if repre_id is None:
-                repre_id = io.ObjectId()
+                repre_id = ObjectId()
 
             data = repre.get("data") or {}
             data.update({'path': dst, 'template': template})
@@ -781,7 +782,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         families = [instance.data["family"]]
         families.extend(instance.data.get("families", []))
         io.update_many(
-            {"type": "subset", "_id": io.ObjectId(subset["_id"])},
+            {"type": "subset", "_id": ObjectId(subset["_id"])},
             {"$set": {"data.families": families}}
         )
 
@@ -806,7 +807,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         if subset_group:
             io.update_many({
                 'type': 'subset',
-                '_id': io.ObjectId(subset_id)
+                '_id': ObjectId(subset_id)
             }, {'$set': {'data.subsetGroup': subset_group}})
 
     def _get_subset_group(self, instance):
@@ -1052,7 +1053,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         sync_project_presets = None
 
         rec = {
-            "_id": io.ObjectId(),
+            "_id": ObjectId(),
             "path": path
         }
         if size:

--- a/openpype/tools/mayalookassigner/commands.py
+++ b/openpype/tools/mayalookassigner/commands.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 import logging
 import os
 
+from bson.objectid import ObjectId
 import maya.cmds as cmds
 
 from avalon import io, api
@@ -157,7 +158,7 @@ def create_items_from_nodes(nodes):
         return asset_view_items
 
     for _id, id_nodes in id_hashes.items():
-        asset = io.find_one({"_id": io.ObjectId(_id)},
+        asset = io.find_one({"_id": ObjectId(_id)},
                             projection={"name": True})
 
         # Skip if asset id is not found

--- a/openpype/tools/mayalookassigner/vray_proxies.py
+++ b/openpype/tools/mayalookassigner/vray_proxies.py
@@ -6,6 +6,7 @@ import logging
 import json
 
 import six
+from bson.objectid import ObjectId
 
 import alembic.Abc
 from maya import cmds
@@ -231,7 +232,7 @@ def get_latest_version(asset_id, subset):
 
     """
     subset = io.find_one({"name": subset,
-                          "parent": io.ObjectId(asset_id),
+                          "parent": ObjectId(asset_id),
                           "type": "subset"})
     if not subset:
         raise RuntimeError("Subset does not exist: %s" % subset)

--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from Qt import QtCore, QtGui
 import qtawesome
+from bson.objectid import ObjectId
 
 from avalon import api, io, schema
 from openpype.pipeline import HeroVersionType
@@ -299,7 +300,7 @@ class InventoryModel(TreeModel):
         for repre_id, group_dict in sorted(grouped.items()):
             group_items = group_dict["items"]
             # Get parenthood per group
-            representation = io.find_one({"_id": io.ObjectId(repre_id)})
+            representation = io.find_one({"_id": ObjectId(repre_id)})
             if not representation:
                 not_found["representation"].append(group_items)
                 not_found_ids.append(repre_id)

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -2,6 +2,7 @@ import collections
 import logging
 from Qt import QtWidgets, QtCore
 import qtawesome
+from bson.objectid import ObjectId
 
 from avalon import io, pipeline
 from openpype.pipeline import (
@@ -146,7 +147,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         repre_ids = set()
         content_loaders = set()
         for item in self._items:
-            repre_ids.add(io.ObjectId(item["representation"]))
+            repre_ids.add(ObjectId(item["representation"]))
             content_loaders.add(item["loader"])
 
         repres = list(io.find({
@@ -1306,7 +1307,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
             repre_docs_by_parent_id_by_name[parent_id][name] = repre_doc
 
         for container in self._items:
-            container_repre_id = io.ObjectId(container["representation"])
+            container_repre_id = ObjectId(container["representation"])
             container_repre = self.content_repres[container_repre_id]
             container_repre_name = container_repre["name"]
 

--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from Qt import QtWidgets, QtCore
 import qtawesome
+from bson.objectid import ObjectId
 
 from avalon import io, api
 
@@ -78,7 +79,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
 
         repre_ids = []
         for item in items:
-            item_id = io.ObjectId(item["representation"])
+            item_id = ObjectId(item["representation"])
             if item_id not in repre_ids:
                 repre_ids.append(item_id)
 
@@ -145,7 +146,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
             def _on_switch_to_versioned(items):
                 repre_ids = []
                 for item in items:
-                    item_id = io.ObjectId(item["representation"])
+                    item_id = ObjectId(item["representation"])
                     if item_id not in repre_ids:
                         repre_ids.append(item_id)
 
@@ -195,7 +196,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
                         version_doc["name"]
 
                 for item in items:
-                    repre_id = io.ObjectId(item["representation"])
+                    repre_id = ObjectId(item["representation"])
                     version_id = version_id_by_repre_id.get(repre_id)
                     version_name = version_name_by_id.get(version_id)
                     if version_name is not None:
@@ -658,7 +659,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
         active = items[-1]
 
         # Get available versions for active representation
-        representation_id = io.ObjectId(active["representation"])
+        representation_id = ObjectId(active["representation"])
         representation = io.find_one({"_id": representation_id})
         version = io.find_one({
             "_id": representation["parent"]


### PR DESCRIPTION
## Brief description
Move constants from avalon-core repository and change import of `ObjectId`.

## Description
There are two constants in avalon pipeline `AVALON_CONTAINER_ID` and `HOST_WORKFILE_EXTENSIONS`. Also we're using `avalon.io.ObjectId` which will cause issues in future.

## Changes
- moved `AVALON_CONTAINER_ID` and `HOST_WORKFILE_EXTENSIONS` into `openpype/pipeline/constants.py`
    - modified imports related to these variables
- changed imports of `ObjectId` to be imported from `bson` python module

## Testing notes:
1. Loading and updating should work as did
2. Workfile extensions should be loaded (last workfile is added to arguments and workfiles tool can save)
3. ObjectId import should not raise an issue

Related to PR https://github.com/pypeclub/avalon-core/pull/435