### PR TITLE
CI: change the version bump logic

### DIFF
--- a/tools/ci_tools.py
+++ b/tools/ci_tools.py
@@ -32,7 +32,7 @@ def get_release_type_github(Log, github_token):
 
     if any(label in labels for label in minor_labels):
         return "minor"
-    else
+    else:
         return "patch"
 
     #TODO: if all is working fine, this part can be cleaned up eventually 

--- a/tools/ci_tools.py
+++ b/tools/ci_tools.py
@@ -8,8 +8,12 @@ import os
 
 def get_release_type_github(Log, github_token):
     # print(Log)
-    minor_labels = ["type: feature", "type: deprecated"]
-    patch_labels = ["type: enhancement", "type: bug"]
+    minor_labels = ["Bump Minor"]
+    # patch_labels = [
+    #     "type: enhancement",
+    #     "type: bug",
+    #     "type: deprecated",
+    #     "type: Feature"]
 
     g = Github(github_token)
     repo = g.get_repo("pypeclub/OpenPype")
@@ -28,9 +32,12 @@ def get_release_type_github(Log, github_token):
 
     if any(label in labels for label in minor_labels):
         return "minor"
-
-    if any(label in labels for label in patch_labels):
+    else
         return "patch"
+
+    #TODO: if all is working fine, this part can be cleaned up eventually 
+    # if any(label in labels for label in patch_labels):
+    #     return "patch"
             
     return None
     

--- a/tools/ci_tools.py
+++ b/tools/ci_tools.py
@@ -35,7 +35,7 @@ def get_release_type_github(Log, github_token):
     else:
         return "patch"
 
-    #TODO: if all is working fine, this part can be cleaned up eventually 
+    # TODO: if all is working fine, this part can be cleaned up eventually 
     # if any(label in labels for label in patch_labels):
     #     return "patch"
             


### PR DESCRIPTION
This PR changes the logic of CI action that determines the next OpenPype version with each nightly and production release. 

Untill now, any PR that was labeled with `type: Feature` triggered upping of the minor version, however because of that it became quite hard to tell when we need to re-deploy re-built executables, and when it's enough to use automated system with zips. 

With this change we're making this a lot more transparent. 

If a pull request requires a new build of the binaries, due to changes in the igniter, pyproject.toml or similar major changes, it is the responsibility of the Author and the Reviewer to make sure the PR is labeled as `Bump Minor`.

CI will pick this up and make sure that minor version is updated next time this PR makes it to a release. The main upside being that from now on, we should be able to easily tell if a new build needs to be deployed to studio or not, by watching out for minor version bumps. 

`3.9.0 -> 3.9.3 -> 3.9.x` - shouldn't require new build
`3.9.3 -> 3.10.1` - will require a new build to be deployed to artist. 