### PR TITLE
General: Configurable add review collector

### DIFF
--- a/openpype/plugins/publish/collect_review_family.py
+++ b/openpype/plugins/publish/collect_review_family.py
@@ -1,0 +1,107 @@
+"""
+Requires:
+    none
+
+Provides:
+    instance     -> families ([])
+"""
+import pyblish.api
+import avalon.api
+
+from openpype.lib.plugin_tools import filter_profiles
+
+
+class CollectReviewFamily(pyblish.api.InstancePlugin):
+    """
+        Adds explicitly 'review' to families to trigger ExtractReview
+
+        Uses selection by combination of hosts/families/tasks/subset names via
+        profiles resolution.
+
+        Triggered everywhere, checks instance against configured.
+
+        Checks advanced filtering which works on 'families' not on main ???
+        'family', as some variants dynamically resolves addition of review
+        based on 'families' (editorial drives it by presence of 'review').
+    """
+    label = "Collect Review Family"
+    order = pyblish.api.CollectorOrder + 0.4998
+
+    profiles = None
+
+    def process(self, instance):
+        if not self.profiles:
+            self.log.warning("No profiles present for adding review family")
+            return
+
+        task_name = instance.data.get("task",
+                                      avalon.api.Session["AVALON_TASK"])
+        host_name = avalon.api.Session["AVALON_APP"]
+        family = instance.data["family"]
+        subset_name = instance.data["subset"]
+
+        filtering_criteria = {
+            "hosts": host_name,
+            "families": family,
+            "tasks": task_name,
+            "subsets": subset_name
+        }
+
+        profile = filter_profiles(self.profiles, filtering_criteria,
+                                  logger=self.log)
+
+        if profile:
+            families = instance.data.get("families")
+            add_review_family = profile["add_review_family"]
+
+            additional_filters = profile.get("advanced_filtering")
+            if additional_filters:
+                add_review_family = \
+                    self._get_add_add_review_family_f_from_addit_filters(
+                        additional_filters,
+                        families,
+                        add_review_family
+                    )
+
+            if add_review_family:
+                self.log.debug("Adding review family for '{}'".
+                               format(instance.data.get("family")))
+
+                if families:
+                    if "review" not in families:
+                        instance.data["families"].append("review")
+                else:
+                    instance.data["families"] = ["review"]
+
+    def _get_add_review_f_from_addit_filters(self,
+                                             additional_filters,
+                                             families,
+                                             add_review_family):
+        """
+            Compares additional filters - working on instance's families.
+
+            Triggered for more detailed filtering when main family matches,
+            but content of 'families' actually matter.
+
+            Args:
+                additional_filters (dict) - from Setting
+                families (list) - subfamilies
+                add_review_family (bool) - add review to families if True
+        """
+        override_filter = None
+        override_filter_value = -1
+        for additional_filter in additional_filters:
+            filter_families = set(additional_filter["families"])
+            valid = filter_families <= set(families)  # issubset
+            if not valid:
+                continue
+
+            value = len(filter_families)
+            if value > override_filter_value:
+                override_filter = additional_filter
+                override_filter_value = value
+
+        if override_filter:
+            add_review_family = override_filter["add_review_family"]
+
+        return add_review_family

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -20,6 +20,10 @@
             ],
             "skip_hosts_headless_publish": []
         },
+        "CollectReviewFamily": {
+            "enabled": true,
+            "profiles": []
+        },
         "ValidateEditorialAssetName": {
             "enabled": true,
             "optional": false

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -43,6 +43,96 @@
             "type": "dict",
             "collapsible": true,
             "checkbox_key": "enabled",
+            "key": "CollectReviewFamily",
+            "label": "Collect Review Family",
+            "is_group": true,
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "list",
+                    "collapsible": true,
+                    "key": "profiles",
+                    "label": "Profiles",
+                    "use_label_wrap": true,
+                    "object_type": {
+                        "type": "dict",
+                        "children": [
+                            {
+                                "key": "hosts",
+                                "label": "Host names",
+                                "type": "hosts-enum",
+                                "multiselection": true
+                            },
+                            {
+                                "key": "families",
+                                "label": "Families",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
+                            },
+                            {
+                                "key": "tasks",
+                                "label": "Task names",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "key": "subsets",
+                                "label": "Subset names",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "type": "separator"
+                            },
+                            {
+                                "key": "add_review_family",
+                                "label": "Add Review Family",
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "list",
+                                "collapsible": true,
+                                "key": "advanced_filtering",
+                                "label": "Advanced adding if additional families present",
+                                "use_label_wrap": true,
+                                "object_type": {
+                                    "type": "dict",
+                                    "children": [
+                                        {
+                                            "key": "families",
+                                            "label": "Additional Families",
+                                            "type": "list",
+                                            "object_type": "text"
+                                        },
+                                        {
+                                            "key": "add_review_family",
+                                            "label": "Add Review Family",
+                                            "type": "boolean"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "separator"
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "checkbox_key": "enabled",
             "key": "ValidateEditorialAssetName",
             "label": "Validate Editorial Asset Name",
             "is_group": true,


### PR DESCRIPTION
## Brief description
Adds 'review' family to instance 

## Description
Configuration based on profiles on:
- host name
- task type
- task name
- subset name

![Screenshot 2022-03-18 173224](https://user-images.githubusercontent.com/4457962/159044885-19ba7f7a-d5a0-4f09-bd83-257387bc81f2.png)


## Additional info
**Still WIP - will be discussed if advanced filtering is useful.**
Hosts should be updated to use this in separate PR, when necessary.

Added mainly for hosts that have functionality to render locally (AE, Harmony). Currently only place to add review to instance based on subset name is in Deadline `submit_publish_job`.

In the future I think that only this collector should be adding review family to simplify review situation, if possible.

## Testing notes:
1. Configure in `Settings:project_settings/global/publish/CollectReviewFamily`
2. Publish in configured hosts