### PR TITLE
Hiero: Fix import of 'register_event_callback'

### DIFF
--- a/openpype/hosts/hiero/api/events.py
+++ b/openpype/hosts/hiero/api/events.py
@@ -1,12 +1,12 @@
 import os
 import hiero.core.events
 from openpype.api import Logger
+from openpype.lib import register_event_callback
 from .lib import (
     sync_avalon_data_to_workfile,
     launch_workfiles_app,
     selection_changed_timeline,
     before_project_save,
-    register_event_callback
 )
 from .tags import add_tags_to_workfile
 from .menu import update_menu_task_label


### PR DESCRIPTION
## Brief description
Function `register_event_callback` is imported from `openpype.hosts.hiero.api.lib` instead of `openpype.lib`.

## Changes
- changed import to point into `openpype.lib`

## Testing notes:
1. Open hiero/nukestudio from OpenPype
2. Implementation should work