### PR TITLE
General: Don't print log record on OSError

### DIFF
--- a/openpype/lib/log.py
+++ b/openpype/lib/log.py
@@ -98,6 +98,10 @@ class PypeStreamHandler(logging.StreamHandler):
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise
+
+        except OSError:
+            self.handleError(record)
+
         except Exception:
             print(repr(record))
             self.handleError(record)


### PR DESCRIPTION
## Brief description
It seems that crashed log emit in `openpype_gui` (windows) can sometimes raise an OSError on stream write which fallbacks to exception handling that tried do the same using `print` so crashes again.

## Changes
- don't print record if OSError is raised during writing

## Note
It would be good to find out real reason. This was discovered in Ftrack action server subprocess.

## Testing notes:
1. Run tray using `openpype_gui.exe` with enabled Ftrack module
2. Run `Prepare Project` on any project
3. A form with inputs should be shown