### PR TITLE
Maya: Do not pass `set` to maya commands (fixes support for older maya versions)

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1511,7 +1511,7 @@ def get_container_members(container):
 
     members = cmds.sets(container, query=True) or []
     members = cmds.ls(members, long=True, objectsOnly=True) or []
-    members = set(members)
+    all_members = set(members)
 
     # Include any referenced nodes from any reference in the container
     # This is required since we've removed adding ALL nodes of a reference
@@ -1530,9 +1530,9 @@ def get_container_members(container):
         reference_members = cmds.ls(reference_members,
                                     long=True,
                                     objectsOnly=True)
-        members.update(reference_members)
+        all_members.update(reference_members)
 
-    return members
+    return list(all_members)
 
 
 # region LOOKDEV


### PR DESCRIPTION
## Implementation

This fixes support for Maya 2018

Older versions of Maya do not allow `set` type to be passed to Maya commands and will result in e.g. "RuntimeError: # Syntax error: unexpected end ( at position 4 while parsing"

E.g. error as [reported on discord](https://discord.com/channels/517362899170230292/563751989075378201/955419340826628157):

```
# Traceback (most recent call last):
#   File "C:\Users\22DOGS\OpenPype\openpype\tools\mayalookassigner\app.py", line 253, in on_process_selected
#     assign_look_by_version(nodes, version_id=version["_id"])
#   File "C:\Users\22DOGS\OpenPype\openpype\hosts\maya\api\lib.py", line 1600, in assign_look_by_version
#     shader_nodes = get_container_members(container_node)
#   File "C:\Users\22DOGS\OpenPype\openpype\hosts\maya\api\lib.py", line 1519, in get_container_members
#     for ref in cmds.ls(members, exactType="reference", objectsOnly=True):
# RuntimeError: # Syntax error: unexpected end ( at position 4 while parsing:
#     set([u'Props_lookMain_01_RN'])
#        ^
: set([u'Props_lookMain_01_RN'])
```

## Brief description

This fixes loaded version updating, shader assignments and more areas that relied on `get_container_members`. 

## Testing notes:
1. start maya versions
2. ensure updating versions of loaded content continues to work, and lookdev shader assignments still work