### PR TITLE
Settings UI: Collapsed of collapsible wrapper works as expected

### DIFF
--- a/openpype/tools/settings/settings/wrapper_widgets.py
+++ b/openpype/tools/settings/settings/wrapper_widgets.py
@@ -92,7 +92,8 @@ class CollapsibleWrapper(WrapperWidget):
         self.content_layout = content_layout
 
         if self.collapsible:
-            body_widget.toggle_content(self.collapsed)
+            if not self.entity.collapsed:
+                body_widget.toggle_content()
         else:
             body_widget.hide_toolbox(hide_content=False)
 

--- a/openpype/tools/settings/settings/wrapper_widgets.py
+++ b/openpype/tools/settings/settings/wrapper_widgets.py
@@ -92,7 +92,7 @@ class CollapsibleWrapper(WrapperWidget):
         self.content_layout = content_layout
 
         if self.collapsible:
-            if not self.entity.collapsed:
+            if not self.collapsed:
                 body_widget.toggle_content()
         else:
             body_widget.hide_toolbox(hide_content=False)


### PR DESCRIPTION
## Brief description
When `collapsible-wrap` has set `collapsed` in schemas it does in UI the opposite of what it should.

## Changes
- fix usage of collapsed value in CollapsibleWrapper

## Testing notes:
1. Add `collapsible-wrap` item into settings schema and set it's `collapsed` to `True`
2. Open settings UI where should the item be collapsed