### PR TITLE
TVPaint: Extractor to convert PNG into EXR

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -22,10 +22,12 @@ class ExtractConvertToEXR(pyblish.api.InstancePlugin):
     hosts = ["tvpaint"]
     families = ["render"]
 
-    active = False
+    enabled = False
 
+    # Replace source PNG files or just add
     replace_pngs = True
-    exr_compression = "DWAA"
+    # EXR compression
+    exr_compression = "ZIP"
 
     def process(self, instance):
         repres = instance.data.get("representations")

--- a/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -1,0 +1,96 @@
+"""Plugin converting png files from ExtractSequence into exrs.
+
+Requires:
+    ExtractSequence - source of PNG
+    ExtractReview - review was already created so we can convert to any exr
+"""
+import os
+import json
+
+import pyblish.api
+from openpype.lib import (
+    get_oiio_tools_path,
+    run_subprocess,
+)
+from openpype.pipeline import KnownPublishError
+
+
+class ExtractConvertToEXR(pyblish.api.InstancePlugin):
+    # Offset to get after ExtractSequence plugin.
+    order = pyblish.api.ExtractorOrder + 0.1
+    label = "Extract Sequence EXR"
+    hosts = ["tvpaint"]
+    families = ["render"]
+
+    active = False
+
+    replace_pngs = True
+    exr_compression = "DWAA"
+
+    def process(self, instance):
+        repres = instance.data.get("representations")
+        if not repres:
+            return
+
+        oiio_path = get_oiio_tools_path()
+        # Raise an exception when oiiotool is not available
+        # - this can currently happen on MacOS machines
+        if not os.path.exists(oiio_path):
+            KnownPublishError(
+                "OpenImageIO tool is not available on this machine."
+            )
+
+        new_repres = []
+        for repre in repres:
+            if repre["name"] != "png":
+                continue
+
+            self.log.info(
+                "Processing representation: {}".format(
+                    json.dumps(repre, sort_keys=True, indent=4)
+                )
+            )
+
+            src_filepaths = set()
+            new_filenames = []
+            for src_filename in repre["files"]:
+                dst_filename = os.path.splitext(src_filename)[0] + ".exr"
+                new_filenames.append(dst_filename)
+
+                src_filepath = os.path.join(repre["stagingDir"], src_filename)
+                dst_filepath = os.path.join(repre["stagingDir"], dst_filename)
+
+                src_filepaths.add(src_filepath)
+
+                args = [
+                    oiio_path, src_filepath,
+                    "--compression", self.exr_compression,
+                    # TODO how to define color conversion?
+                    "--colorconvert", "sRGB", "linear",
+                    "-o", dst_filepath
+                ]
+                run_subprocess(args)
+
+            new_repres.append(
+                {
+                    "name": "exr",
+                    "ext": "exr",
+                    "files": new_filenames,
+                    "stagingDir": repre["stagingDir"],
+                    "tags": list(repre["tags"])
+                }
+            )
+
+            if self.replace_pngs:
+                instance.data["representations"].remove(repre)
+                for filepath in src_filepaths:
+                    os.remove(filepath)
+
+        instance.data["representations"].extend(new_repres)
+        self.log.info(
+            "Representations: {}".format(
+                json.dumps(
+                    instance.data["representations"], sort_keys=True, indent=4
+                )
+            )
+        )

--- a/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_convert_to_exr.py
@@ -85,8 +85,9 @@ class ExtractConvertToEXR(pyblish.api.InstancePlugin):
 
             if self.replace_pngs:
                 instance.data["representations"].remove(repre)
+
                 for filepath in src_filepaths:
-                    os.remove(filepath)
+                    instance.context.data["cleanupFullPaths"].append(filepath)
 
         instance.data["representations"].extend(new_repres)
         self.log.info(

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -12,7 +12,6 @@ from openpype.hosts.tvpaint.lib import (
     fill_reference_frames,
     composite_rendered_layers,
     rename_filepaths_by_frame_start,
-    composite_images
 )
 
 

--- a/openpype/plugins/publish/collect_cleanup_keys.py
+++ b/openpype/plugins/publish/collect_cleanup_keys.py
@@ -1,0 +1,21 @@
+"""
+Requires:
+    None
+Provides:
+    context
+        - cleanupFullPaths (list)
+        - cleanupEmptyDirs (list)
+"""
+
+import pyblish.api
+
+
+class CollectCleanupKeys(pyblish.api.ContextPlugin):
+    """Prepare keys for 'ExplicitCleanUp' plugin."""
+
+    label = "Collect Cleanup Keys"
+    order = pyblish.api.CollectorOrder
+
+    def process(self, context):
+        context.data["cleanupFullPaths"] = []
+        context.data["cleanupEmptyDirs"] = []

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -28,6 +28,11 @@
             "enabled": true,
             "optional": true,
             "active": true
+        },
+        "ExtractConvertToEXR": {
+            "enabled": false,
+            "replace_pngs": true,
+            "exr_compression": "ZIP"
         }
     },
     "load": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -78,6 +78,47 @@
                             "docstring": "Validate if shot on instances metadata is same as workfiles shot"
                         }
                     ]
+                },
+                {
+                    "type": "dict",
+                    "key": "ExtractConvertToEXR",
+                    "label": "Extract Convert To EXR",
+                    "is_group": true,
+                    "checkbox_key": "enabled",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "label",
+                            "label": "<b>WARNING:</b> This plugin does not work on MacOS (using OIIO tool)."
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "replace_pngs",
+                            "label": "Replace source PNG"
+                        },
+                        {
+                            "type": "enum",
+                            "key": "exr_compression",
+                            "label": "EXR Compression",
+                            "multiselection": false,
+                            "enum_items": [
+                                {"ZIP": "ZIP"},
+                                {"ZIPS": "ZIPS"},
+                                {"DWAA": "DWAA"},
+                                {"DWAB": "DWAB"},
+                                {"PIZ": "PIZ"},
+                                {"RLE": "RLE"},
+                                {"PXR24": "PXR24"},
+                                {"B44": "B44"},
+                                {"B44A": "B44A"},
+                                {"none": "None"}
+                            ]
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Brief description
TVPaint extractor is creating PNG sequences but it may be better to store them as exr files.

## Description
Since the TVPaint extraction is based on compositing in python we can't extract EXRs directly from TVPaint. Extractor is using oiiotool to convert pngs into exr. Plugin is disabled by default. Has ability to choose output exr compression and if should replace input pngs or keep them. If pngs are replaced then their files are removed during cleanup.

Source [PR from Pype 2](https://github.com/pypeclub/OpenPype/pull/2048).

## Notes
Right now there are hardcoded color conversions `--colorconvert sRGB linear`. Not sure if we should do it or if we should add some kind of settings for this? If yes, what kind of settings?

## Testing notes:
1. Enable the plugin in project settings
2. Publish from TVPaint