### PR TITLE
NewPublisher: Prepared implementation of optional pyblish plugin

### DIFF
--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -41,7 +41,8 @@ from .publish import (
     PublishValidationError,
     PublishXmlValidationError,
     KnownPublishError,
-    OpenPypePyblishPluginMixin
+    OpenPypePyblishPluginMixin,
+    OptionalPyblishPluginMixin,
 )
 
 from .actions import (
@@ -105,6 +106,7 @@ __all__ = (
     "PublishXmlValidationError",
     "KnownPublishError",
     "OpenPypePyblishPluginMixin",
+    "OptionalPyblishPluginMixin",
 
     # --- Actions ---
     "LauncherAction",

--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -3,6 +3,7 @@ from .publish_plugins import (
     PublishXmlValidationError,
     KnownPublishError,
     OpenPypePyblishPluginMixin,
+    OptionalPyblishPluginMixin,
 )
 
 from .lib import (
@@ -18,6 +19,7 @@ __all__ = (
     "PublishXmlValidationError",
     "KnownPublishError",
     "OpenPypePyblishPluginMixin",
+    "OptionalPyblishPluginMixin",
 
     "DiscoverResult",
     "publish_plugins_discover",

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -111,7 +111,7 @@ class OpenPypePyblishPluginMixin:
         return attribute_values
 
     def get_attr_values_from_data(self, data):
-        """Get attribute values for attribute definitoins from data.
+        """Get attribute values for attribute definitions from data.
 
         Args:
             data(dict): Data from instance or context.

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -130,10 +130,13 @@ class OptionalPyblishPluginMixin(OpenPypePyblishPluginMixin):
     prepares method which will check if is active or not.
 
     ```
-    def process(self, instance):
-        # Skip the instance if is not active by data on the instance
-        if not self.is_active(instance.data):
-            return
+    class ValidateScene(
+        pyblish.api.InstancePlugin, OptionalPyblishPluginMixin
+    ):
+        def process(self, instance):
+            # Skip the instance if is not active by data on the instance
+            if not self.is_active(instance.data):
+                return
     ```
     """
 

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -151,8 +151,9 @@ class OptionalPyblishPluginMixin(OpenPypePyblishPluginMixin):
         # Get active value from class as default value
         active = getattr(cls, "active", True)
         # Return boolean stored under 'active' key with label of the class name
+        label = cls.label or cls.__name__
         return [
-            BoolDef("active", default=active, label=cls.__name__)
+            BoolDef("active", default=active, label=label)
         ]
 
     def is_active(self, data):


### PR DESCRIPTION
## Brief description
Optional plugins must be set to active/inactive in new publisher UI somehow. The way is to implement `get_attribute_definitions` in `OpenPypePyblishPluginMixin`.

## Description
Implemented `OptionalPyblishPluginMixin` which will check optional attribute and will care about attributes for the plugin. Publish plugin must inherit from the mixin to be able use it. Should be backwards compatible with current publisher.

## Testing notes:
1. Add plugin which inherit from `OptionalPyblishPluginMixin`
2. Make the validator optional
3. Open new publisher in context where the plugin should be visible and check publish attributes