### PR TITLE
SceneInventory: Fix imports in UI

### DIFF
--- a/openpype/pipeline/actions.py
+++ b/openpype/pipeline/actions.py
@@ -115,10 +115,8 @@ def discover_inventory_actions():
     filtered_actions = []
     for action in actions:
         if action is not InventoryAction:
-            print("DISCOVERED", action)
             filtered_actions.append(action)
-        else:
-            print("GOT SOURCE")
+
     return filtered_actions
 
 

--- a/openpype/tools/sceneinventory/switch_dialog.py
+++ b/openpype/tools/sceneinventory/switch_dialog.py
@@ -4,11 +4,12 @@ from Qt import QtWidgets, QtCore
 import qtawesome
 from bson.objectid import ObjectId
 
-from avalon import io, pipeline
-from openpype.pipeline import (
+from avalon import io
+from openpype.pipeline.load import (
     discover_loader_plugins,
     switch_container,
     get_repres_contexts,
+    loaders_from_repre_context,
 )
 
 from .widgets import (
@@ -370,7 +371,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
 
         loaders = None
         for repre_context in repre_contexts.values():
-            _loaders = set(pipeline.loaders_from_repre_context(
+            _loaders = set(loaders_from_repre_context(
                 available_loaders, repre_context
             ))
             if loaders is None:


### PR DESCRIPTION
## Brief description
Remained usage of `loaders_from_repre_context` from avalon repository cause crashes in scene inventory tool. Bug since [this PR](https://github.com/pypeclub/OpenPype/pull/2886).

## Description
Fixed import of function used from `avalon.pipeline`.

## Testing notes:
1. Open SceneInventory tool
2. Call switch asset on any referenced item and dialog shoud show