### PR TITLE
General: anatomy data with correct task short key

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1705,7 +1705,7 @@ def _get_task_context_data_for_anatomy(
         "task": {
             "name": task_name,
             "type": task_type,
-            "short_name": project_task_type_data["short_name"]
+            "short": project_task_type_data["short_name"]
         }
     }
 


### PR DESCRIPTION
## Brief description
Fixing data consistency

## Description
All anatomy data should have `short` used as key for task code.