### PR TITLE
nuke: python3 compatibility issue with `iteritems`

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -72,7 +72,7 @@ class LoadEffects(load.LoaderPlugin):
         # getting data from json file with unicode conversion
         with open(file, "r") as f:
             json_f = {self.byteify(key): self.byteify(value)
-                      for key, value in json.load(f).iteritems()}
+                      for key, value in json.load(f).items()}
 
         # get correct order of nodes by positions on track and subtrack
         nodes_order = self.reorder_nodes(json_f)
@@ -188,7 +188,7 @@ class LoadEffects(load.LoaderPlugin):
         # getting data from json file with unicode conversion
         with open(file, "r") as f:
             json_f = {self.byteify(key): self.byteify(value)
-                      for key, value in json.load(f).iteritems()}
+                      for key, value in json.load(f).items()}
 
         # get correct order of nodes by positions on track and subtrack
         nodes_order = self.reorder_nodes(json_f)
@@ -330,7 +330,7 @@ class LoadEffects(load.LoaderPlugin):
 
         if isinstance(input, dict):
             return {self.byteify(key): self.byteify(value)
-                    for key, value in input.iteritems()}
+                    for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
         elif isinstance(input, unicode):

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -333,8 +333,8 @@ class LoadEffects(load.LoaderPlugin):
                     for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
-        elif isinstance(input, unicode):
-            return input.encode('utf-8')
+        elif isinstance(input, str):
+            return str(input)
         else:
             return input
 

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -353,8 +353,8 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
                     for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
-        elif isinstance(input, unicode):
-            return input.encode('utf-8')
+        elif isinstance(input, str):
+            return str(input)
         else:
             return input
 

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -74,7 +74,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
         # getting data from json file with unicode conversion
         with open(file, "r") as f:
             json_f = {self.byteify(key): self.byteify(value)
-                      for key, value in json.load(f).iteritems()}
+                      for key, value in json.load(f).items()}
 
         # get correct order of nodes by positions on track and subtrack
         nodes_order = self.reorder_nodes(json_f)
@@ -194,7 +194,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
         # getting data from json file with unicode conversion
         with open(file, "r") as f:
             json_f = {self.byteify(key): self.byteify(value)
-                      for key, value in json.load(f).iteritems()}
+                      for key, value in json.load(f).items()}
 
         # get correct order of nodes by positions on track and subtrack
         nodes_order = self.reorder_nodes(json_f)
@@ -350,7 +350,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
 
         if isinstance(input, dict):
             return {self.byteify(key): self.byteify(value)
-                    for key, value in input.iteritems()}
+                    for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
         elif isinstance(input, unicode):

--- a/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
@@ -240,7 +240,7 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
 
         if isinstance(input, dict):
             return {self.byteify(key): self.byteify(value)
-                    for key, value in input.iteritems()}
+                    for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
         elif isinstance(input, unicode):

--- a/openpype/hosts/nuke/plugins/publish/validate_write_deadline_tab.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_write_deadline_tab.py
@@ -25,7 +25,7 @@ class RepairNukeWriteDeadlineTab(pyblish.api.Action):
 
             # Remove existing knobs.
             knob_names = openpype.hosts.nuke.lib.get_deadline_knob_names()
-            for name, knob in group_node.knobs().iteritems():
+            for name, knob in group_node.knobs().items():
                 if name in knob_names:
                     group_node.removeKnob(knob)
 


### PR DESCRIPTION
## Brief description
`iteritems` is python2 function and python3 was crashing.