### PR TITLE
LogViewer: Don't refresh on initialization

### DIFF
--- a/openpype/modules/log_viewer/tray/app.py
+++ b/openpype/modules/log_viewer/tray/app.py
@@ -26,3 +26,12 @@ class LogsWindow(QtWidgets.QWidget):
         self.log_detail = log_detail
 
         self.setStyleSheet(style.load_stylesheet())
+
+        self._frist_show = True
+
+    def showEvent(self, event):
+        super(LogsWindow, self).showEvent(event)
+
+        if self._frist_show:
+            self._frist_show = False
+            self.logs_widget.refresh()

--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -155,6 +155,11 @@ class LogsWidget(QtWidgets.QWidget):
             QtCore.Qt.DescendingOrder
         )
 
+        refresh_triggered_timer = QtCore.QTimer()
+        refresh_triggered_timer.setSingleShot(True)
+        refresh_triggered_timer.setInterval(200)
+
+        refresh_triggered_timer.timeout.connect(self._on_refresh_timeout)
         view.selectionModel().selectionChanged.connect(self._on_index_change)
         refresh_btn.clicked.connect(self._on_refresh_clicked)
 
@@ -169,10 +174,12 @@ class LogsWidget(QtWidgets.QWidget):
         self.detail_widget = detail_widget
         self.refresh_btn = refresh_btn
 
-        # prepare
-        self.refresh()
+        self._refresh_triggered_timer = refresh_triggered_timer
 
     def refresh(self):
+        self._refresh_triggered_timer.start()
+
+    def _on_refresh_timeout(self):
         self.model.refresh()
         self.detail_widget.refresh()
 


### PR DESCRIPTION
## Brief description
Logs are refreshed on initialization of log viewer window which slows down tray application launch.

## Description
Refresh of logs is triggered on first show of the window instead of on initialization.

## Testing notes:
1. LogViewer module must be enabled
2. Start of tray should be a little bit faster
3. Log viewer should still show logs on showing the window