### PR TITLE
General: Smaller fixes and typos

### DIFF
--- a/openpype/hosts/traypublisher/plugins/create/create_workfile.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_workfile.py
@@ -1,8 +1,8 @@
 from openpype.hosts.traypublisher.api import pipeline
+from openpype.lib import FileDef
 from openpype.pipeline import (
     Creator,
-    CreatedInstance,
-    lib
+    CreatedInstance
 )
 
 
@@ -80,7 +80,7 @@ class WorkfileCreator(Creator):
 
     def get_instance_attr_defs(self):
         output = [
-            lib.FileDef(
+            FileDef(
                 "filepath",
                 folders=False,
                 extensions=self.extensions,

--- a/openpype/hosts/traypublisher/plugins/publish/validate_workfile.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_workfile.py
@@ -6,7 +6,7 @@ from openpype.pipeline import PublishValidationError
 class ValidateWorkfilePath(pyblish.api.InstancePlugin):
     """Validate existence of workfile instance existence."""
 
-    label = "Collect Workfile"
+    label = "Validate Workfile"
     order = pyblish.api.ValidatorOrder - 0.49
     families = ["workfile"]
     hosts = ["traypublisher"]

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -286,21 +286,6 @@ def from_dict_to_set(data, is_project):
     return result
 
 
-def get_avalon_project_template(project_name):
-    """Get avalon template
-    Args:
-        project_name: (string)
-    Returns:
-        dictionary with templates
-    """
-    templates = Anatomy(project_name).templates
-    return {
-        "workfile": templates["avalon"]["workfile"],
-        "work": templates["avalon"]["work"],
-        "publish": templates["avalon"]["publish"]
-    }
-
-
 def get_project_apps(in_app_list):
     """ Application definitions for app name.
 

--- a/openpype/modules/log_viewer/tray/app.py
+++ b/openpype/modules/log_viewer/tray/app.py
@@ -27,11 +27,11 @@ class LogsWindow(QtWidgets.QWidget):
 
         self.setStyleSheet(style.load_stylesheet())
 
-        self._frist_show = True
+        self._first_show = True
 
     def showEvent(self, event):
         super(LogsWindow, self).showEvent(event)
 
-        if self._frist_show:
-            self._frist_show = False
+        if self._first_show:
+            self._first_show = False
             self.logs_widget.refresh()

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -271,7 +271,7 @@ class CreateDialog(QtWidgets.QDialog):
         create_btn.setEnabled(False)
 
         form_layout = QtWidgets.QFormLayout()
-        form_layout.addRow("Name:", variant_layout)
+        form_layout.addRow("Variant:", variant_layout)
         form_layout.addRow("Subset:", subset_name_input)
 
         mid_widget = QtWidgets.QWidget(self)

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -126,7 +126,7 @@ def get_qta_icon_by_name_and_color(icon_name, icon_color):
         log.info("Didn't find icon \"{}\"".format(icon_name))
 
     elif used_variant != icon_name:
-        log.info("Icon \"{}\" was not found \"{}\" is used instead".format(
+        log.debug("Icon \"{}\" was not found \"{}\" is used instead".format(
             icon_name, used_variant
         ))
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -17,6 +17,8 @@ from openpype.lib import filter_profiles
 from openpype.style import get_objected_colors
 from openpype.resources import get_image_path
 
+log = Logger.get_logger(__name__)
+
 
 def center_window(window):
     """Move window to center of it's screen."""
@@ -111,12 +113,22 @@ def get_qta_icon_by_name_and_color(icon_name, icon_color):
         variants.append("{0}.{1}".format(key, icon_name))
 
     icon = None
+    used_variant = None
     for variant in variants:
         try:
             icon = qtawesome.icon(variant, color=icon_color)
+            used_variant = variant
             break
         except Exception:
             pass
+
+    if used_variant is None:
+        log.info("Didn't find icon \"{}\"".format(icon_name))
+
+    elif used_variant != icon_name:
+        log.info("Icon \"{}\" was not found \"{}\" is used instead".format(
+            icon_name, used_variant
+        ))
 
     SharedObjects.icons[full_icon_name] = icon
     return icon

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -152,8 +152,8 @@ def get_asset_icon_name(asset_doc, has_children=True):
         return icon_name
 
     if has_children:
-        return "folder"
-    return "folder-o"
+        return "fa.folder"
+    return "fa.folder-o"
 
 
 def get_asset_icon_color(asset_doc):

--- a/openpype/widgets/attribute_defs/files_widget.py
+++ b/openpype/widgets/attribute_defs/files_widget.py
@@ -641,5 +641,6 @@ class SingleFileWidget(QtWidgets.QWidget):
                     filepaths.append(filepath)
             # TODO filter check
             if len(filepaths) == 1:
-                self.set_value(filepaths[0], False)
+                self._filepath_input.setText(filepaths[0])
+
         event.accept()


### PR DESCRIPTION
## Brief description
Fix of few smaller issues.

## Description
Fixed import of attribute definitions in tray publisher plugin. Fixed typo of attribute `_first_show`. Log information about not find icon and also log that passed icon name is not exact match of used icon name (prefix from qtawesome was added). Changed `Name:` label to `Variant:` in creator dialog window.

## Testing notes:
- Tray publisher should show workfiles creator
- log viewer should not crash
- icons should be visible in tools
- creator dialog in new publisher should show `Variant:` instead of `Name:`