### PR TITLE
Maya - added transparency into review creator

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_review.py
+++ b/openpype/hosts/maya/plugins/create/create_review.py
@@ -15,6 +15,14 @@ class CreateReview(plugin.Creator):
     keepImages = False
     isolate = False
     imagePlane = True
+    transparency = [
+        "preset",
+        "simple",
+        "object sorting",
+        "weighted average",
+        "depth peeling",
+        "alpha cut"
+    ]
 
     def __init__(self, *args, **kwargs):
         super(CreateReview, self).__init__(*args, **kwargs)
@@ -28,5 +36,6 @@ class CreateReview(plugin.Creator):
         data["isolate"] = self.isolate
         data["keepImages"] = self.keepImages
         data["imagePlane"] = self.imagePlane
+        data["transparency"] = self.transparency
 
         self.data = data

--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -73,6 +73,11 @@ class ExtractPlayblast(openpype.api.Extractor):
         pm.currentTime(refreshFrameInt - 1, edit=True)
         pm.currentTime(refreshFrameInt, edit=True)
 
+        # Override transparency if requested.
+        transparency = instance.data.get("transparency", 0)
+        if transparency != 0:
+            preset["viewport2_options"]["transparencyAlgorithm"] = transparency
+
         # Isolate view is requested by having objects in the set besides a
         # camera.
         if preset.pop("isolate_view", False) and instance.data.get("isolate"):


### PR DESCRIPTION
## Brief description
Transparency configuration was missing from `CreateReview`

## Testing notes:
1. Create camera in Maya scene and Create Review family
2. check created review group, there should be new item to select transparency
3. publish and check that selected transparency was applied