### PR TITLE
Settings: Conditional dictionary avoid invalid logs

### DIFF
--- a/openpype/settings/entities/dict_immutable_keys_entity.py
+++ b/openpype/settings/entities/dict_immutable_keys_entity.py
@@ -414,12 +414,16 @@ class DictImmutableKeysEntity(ItemEntity):
 
         return value, metadata
 
-    def update_default_value(self, value):
+    def update_default_value(self, value, log_invalid_types=True):
         """Update default values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "default")
+
+        self._default_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "default", log_invalid_types
+        )
         self.has_default_value = value is not NOT_SET
         # TODO add value validation
         value, metadata = self._prepare_value(value)
@@ -427,13 +431,13 @@ class DictImmutableKeysEntity(ItemEntity):
 
         if value is NOT_SET:
             for child_obj in self.non_gui_children.values():
-                child_obj.update_default_value(value)
+                child_obj.update_default_value(value, log_invalid_types)
             return
 
         value_keys = set(value.keys())
         expected_keys = set(self.non_gui_children)
         unknown_keys = value_keys - expected_keys
-        if unknown_keys:
+        if unknown_keys and log_invalid_types:
             self.log.warning(
                 "{} Unknown keys in default values: {}".format(
                     self.path,
@@ -443,27 +447,31 @@ class DictImmutableKeysEntity(ItemEntity):
 
         for key, child_obj in self.non_gui_children.items():
             child_value = value.get(key, NOT_SET)
-            child_obj.update_default_value(child_value)
+            child_obj.update_default_value(child_value, log_invalid_types)
 
-    def update_studio_value(self, value):
+    def update_studio_value(self, value, log_invalid_types=True):
         """Update studio override values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "studio override")
+
+        self._studio_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "studio override", log_invalid_types
+        )
         value, metadata = self._prepare_value(value)
         self._studio_override_metadata = metadata
         self.had_studio_override = metadata is not NOT_SET
 
         if value is NOT_SET:
             for child_obj in self.non_gui_children.values():
-                child_obj.update_studio_value(value)
+                child_obj.update_studio_value(value, log_invalid_types)
             return
 
         value_keys = set(value.keys())
         expected_keys = set(self.non_gui_children)
         unknown_keys = value_keys - expected_keys
-        if unknown_keys:
+        if unknown_keys and log_invalid_types:
             self.log.warning(
                 "{} Unknown keys in studio overrides: {}".format(
                     self.path,
@@ -472,27 +480,31 @@ class DictImmutableKeysEntity(ItemEntity):
             )
         for key, child_obj in self.non_gui_children.items():
             child_value = value.get(key, NOT_SET)
-            child_obj.update_studio_value(child_value)
+            child_obj.update_studio_value(child_value, log_invalid_types)
 
-    def update_project_value(self, value):
+    def update_project_value(self, value, log_invalid_types=True):
         """Update project override values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "project override")
+
+        self._project_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "project override", log_invalid_types
+        )
         value, metadata = self._prepare_value(value)
         self._project_override_metadata = metadata
         self.had_project_override = metadata is not NOT_SET
 
         if value is NOT_SET:
             for child_obj in self.non_gui_children.values():
-                child_obj.update_project_value(value)
+                child_obj.update_project_value(value, log_invalid_types)
             return
 
         value_keys = set(value.keys())
         expected_keys = set(self.non_gui_children)
         unknown_keys = value_keys - expected_keys
-        if unknown_keys:
+        if unknown_keys and log_invalid_types:
             self.log.warning(
                 "{} Unknown keys in project overrides: {}".format(
                     self.path,
@@ -502,7 +514,7 @@ class DictImmutableKeysEntity(ItemEntity):
 
         for key, child_obj in self.non_gui_children.items():
             child_value = value.get(key, NOT_SET)
-            child_obj.update_project_value(child_value)
+            child_obj.update_project_value(child_value, log_invalid_types)
 
     def _discard_changes(self, on_change_trigger):
         self._ignore_child_changes = True
@@ -694,37 +706,48 @@ class RootsDictEntity(DictImmutableKeysEntity):
         self._metadata_are_modified = False
         self._current_metadata = {}
 
-    def update_default_value(self, value):
+    def update_default_value(self, value, log_invalid_types=True):
         """Update default values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "default")
+
+        self._default_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "default", log_invalid_types
+        )
         value, _ = self._prepare_value(value)
 
         self._default_value = value
         self._default_metadata = {}
         self.has_default_value = value is not NOT_SET
 
-    def update_studio_value(self, value):
+    def update_studio_value(self, value, log_invalid_types=True):
         """Update studio override values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "studio override")
+
+        self._studio_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "studio override", log_invalid_types
+        )
         value, _ = self._prepare_value(value)
 
         self._studio_value = value
         self._studio_override_metadata = {}
         self.had_studio_override = value is not NOT_SET
 
-    def update_project_value(self, value):
+    def update_project_value(self, value, log_invalid_types=True):
         """Update project override values.
 
         Not an api method, should be called by parent.
         """
 
-        value = self._check_update_value(value, "project override")
+        self._project_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "project override", log_invalid_types
+        )
         value, _metadata = self._prepare_value(value)
 
         self._project_value = value
@@ -886,37 +909,48 @@ class SyncServerSites(DictImmutableKeysEntity):
         self._metadata_are_modified = False
         self._current_metadata = {}
 
-    def update_default_value(self, value):
+    def update_default_value(self, value, log_invalid_types=True):
         """Update default values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "default")
+
+        self._default_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "default", log_invalid_types
+        )
         value, _ = self._prepare_value(value)
 
         self._default_value = value
         self._default_metadata = {}
         self.has_default_value = value is not NOT_SET
 
-    def update_studio_value(self, value):
+    def update_studio_value(self, value, log_invalid_types=True):
         """Update studio override values.
 
         Not an api method, should be called by parent.
         """
-        value = self._check_update_value(value, "studio override")
+
+        self._studio_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "studio override", log_invalid_types
+        )
         value, _ = self._prepare_value(value)
 
         self._studio_value = value
         self._studio_override_metadata = {}
         self.had_studio_override = value is not NOT_SET
 
-    def update_project_value(self, value):
+    def update_project_value(self, value, log_invalid_types=True):
         """Update project override values.
 
         Not an api method, should be called by parent.
         """
 
-        value = self._check_update_value(value, "project override")
+        self._project_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "project override", log_invalid_types
+        )
         value, _metadata = self._prepare_value(value)
 
         self._project_value = value

--- a/openpype/settings/entities/dict_mutable_keys_entity.py
+++ b/openpype/settings/entities/dict_mutable_keys_entity.py
@@ -393,11 +393,15 @@ class DictMutableKeysEntity(EndpointEntity):
             value = self.value_on_not_set
 
         using_values_from_state = False
+        log_invalid_types = True
         if state is OverrideState.PROJECT:
+            log_invalid_types = self._project_log_invalid_types
             using_values_from_state = using_project_overrides
         elif state is OverrideState.STUDIO:
+            log_invalid_types = self._studio_log_invalid_types
             using_values_from_state = using_studio_overrides
         elif state is OverrideState.DEFAULTS:
+            log_invalid_types = self._default_log_invalid_types
             using_values_from_state = using_default_values
 
         new_value = copy.deepcopy(value)
@@ -437,11 +441,11 @@ class DictMutableKeysEntity(EndpointEntity):
                 if not label:
                     label = metadata_labels.get(new_key)
 
-            child_entity.update_default_value(_value)
+            child_entity.update_default_value(_value, log_invalid_types)
             if using_project_overrides:
-                child_entity.update_project_value(_value)
+                child_entity.update_project_value(_value, log_invalid_types)
             elif using_studio_overrides:
-                child_entity.update_studio_value(_value)
+                child_entity.update_studio_value(_value, log_invalid_types)
 
             if label:
                 children_label_by_id[child_entity.id] = label
@@ -598,8 +602,11 @@ class DictMutableKeysEntity(EndpointEntity):
                     metadata[key] = value.pop(key)
         return value, metadata
 
-    def update_default_value(self, value):
-        value = self._check_update_value(value, "default")
+    def update_default_value(self, value, log_invalid_types=True):
+        self._default_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "default", log_invalid_types
+        )
         has_default_value = value is not NOT_SET
         if has_default_value:
             for required_key in self.required_keys:
@@ -611,15 +618,21 @@ class DictMutableKeysEntity(EndpointEntity):
         self._default_value = value
         self._default_metadata = metadata
 
-    def update_studio_value(self, value):
-        value = self._check_update_value(value, "studio override")
+    def update_studio_value(self, value, log_invalid_types=True):
+        self._studio_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "studio override", log_invalid_types
+        )
         value, metadata = self._prepare_value(value)
         self._studio_override_value = value
         self._studio_override_metadata = metadata
         self.had_studio_override = value is not NOT_SET
 
-    def update_project_value(self, value):
-        value = self._check_update_value(value, "project override")
+    def update_project_value(self, value, log_invalid_types=True):
+        self._project_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "project override", log_invalid_types
+        )
         value, metadata = self._prepare_value(value)
         self._project_override_value = value
         self._project_override_metadata = metadata
@@ -686,9 +699,12 @@ class DictMutableKeysEntity(EndpointEntity):
         if not self._can_remove_from_project_override:
             return
 
+        log_invalid_types = True
         if self._has_studio_override:
+            log_invalid_types = self._studio_log_invalid_types
             value = self._studio_override_value
         elif self.has_default_value:
+            log_invalid_types = self._default_log_invalid_types
             value = self._default_value
         else:
             value = self.value_on_not_set
@@ -709,9 +725,9 @@ class DictMutableKeysEntity(EndpointEntity):
         for _key, _value in new_value.items():
             new_key = self._convert_to_regex_valid_key(_key)
             child_entity = self._add_key(new_key)
-            child_entity.update_default_value(_value)
+            child_entity.update_default_value(_value, log_invalid_types)
             if self._has_studio_override:
-                child_entity.update_studio_value(_value)
+                child_entity.update_studio_value(_value, log_invalid_types)
 
             label = metadata_labels.get(_key)
             if label:

--- a/openpype/settings/entities/input_entities.py
+++ b/openpype/settings/entities/input_entities.py
@@ -90,18 +90,27 @@ class EndpointEntity(ItemEntity):
     def require_restart(self):
         return self.has_unsaved_changes
 
-    def update_default_value(self, value):
-        value = self._check_update_value(value, "default")
+    def update_default_value(self, value, log_invalid_types=True):
+        self._default_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "default", log_invalid_types
+        )
         self._default_value = value
         self.has_default_value = value is not NOT_SET
 
-    def update_studio_value(self, value):
-        value = self._check_update_value(value, "studio override")
+    def update_studio_value(self, value, log_invalid_types=True):
+        self._studio_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "studio override", log_invalid_types
+        )
         self._studio_override_value = value
         self.had_studio_override = bool(value is not NOT_SET)
 
-    def update_project_value(self, value):
-        value = self._check_update_value(value, "project override")
+    def update_project_value(self, value, log_invalid_types=True):
+        self._project_log_invalid_types = log_invalid_types
+        value = self._check_update_value(
+            value, "project override", log_invalid_types
+        )
         self._project_override_value = value
         self.had_project_override = bool(value is not NOT_SET)
 
@@ -590,22 +599,26 @@ class RawJsonEntity(InputEntity):
                     metadata[key] = value.pop(key)
         return value, metadata
 
-    def update_default_value(self, value):
-        value = self._check_update_value(value, "default")
+    def update_default_value(self, value, log_invalid_types=True):
+        value = self._check_update_value(value, "default", log_invalid_types)
         self.has_default_value = value is not NOT_SET
         value, metadata = self._prepare_value(value)
         self._default_value = value
         self.default_metadata = metadata
 
-    def update_studio_value(self, value):
-        value = self._check_update_value(value, "studio override")
+    def update_studio_value(self, value, log_invalid_types=True):
+        value = self._check_update_value(
+            value, "studio override", log_invalid_types
+        )
         self.had_studio_override = value is not NOT_SET
         value, metadata = self._prepare_value(value)
         self._studio_override_value = value
         self.studio_override_metadata = metadata
 
-    def update_project_value(self, value):
-        value = self._check_update_value(value, "project override")
+    def update_project_value(self, value, log_invalid_types=True):
+        value = self._check_update_value(
+            value, "project override", log_invalid_types
+        )
         self.had_project_override = value is not NOT_SET
         value, metadata = self._prepare_value(value)
         self._project_override_value = value

--- a/openpype/settings/entities/item_entities.py
+++ b/openpype/settings/entities/item_entities.py
@@ -490,8 +490,8 @@ class ListStrictEntity(ItemEntity):
         if log_invalid_types:
             self.log.warning(
                 (
-                    "{} Amount of strict list items in {} values is"
-                    " not same as expected. Expected {} items. Got {} items. {}"
+                    "{} Amount of strict list items in {} values is not same"
+                    " as expected. Expected {} items. Got {} items. {}"
                 ).format(
                     self.path, value_type,
                     child_len, value_len, str(value)

--- a/openpype/settings/entities/list_entity.py
+++ b/openpype/settings/entities/list_entity.py
@@ -325,16 +325,24 @@ class ListEntity(EndpointEntity):
 
         for item in value:
             child_obj = self._add_new_item()
-            child_obj.update_default_value(item)
+            child_obj.update_default_value(
+                item, self._default_log_invalid_types
+            )
             if self._override_state is OverrideState.PROJECT:
                 if self.had_project_override:
-                    child_obj.update_project_value(item)
+                    child_obj.update_project_value(
+                        item, self._project_log_invalid_types
+                    )
                 elif self.had_studio_override:
-                    child_obj.update_studio_value(item)
+                    child_obj.update_studio_value(
+                        item, self._studio_log_invalid_types
+                    )
 
             elif self._override_state is OverrideState.STUDIO:
                 if self.had_studio_override:
-                    child_obj.update_studio_value(item)
+                    child_obj.update_studio_value(
+                        item, self._studio_log_invalid_types
+                    )
 
         for child_obj in self.children:
             child_obj.set_override_state(
@@ -466,16 +474,24 @@ class ListEntity(EndpointEntity):
 
         for item in value:
             child_obj = self._add_new_item()
-            child_obj.update_default_value(item)
+            child_obj.update_default_value(
+                item, self._default_log_invalid_types
+            )
             if self._override_state is OverrideState.PROJECT:
                 if self.had_project_override:
-                    child_obj.update_project_value(item)
+                    child_obj.update_project_value(
+                        item, self._project_log_invalid_types
+                    )
                 elif self.had_studio_override:
-                    child_obj.update_studio_value(item)
+                    child_obj.update_studio_value(
+                        item, self._studio_log_invalid_types
+                    )
 
             elif self._override_state is OverrideState.STUDIO:
                 if self.had_studio_override:
-                    child_obj.update_studio_value(item)
+                    child_obj.update_studio_value(
+                        item, self._studio_log_invalid_types
+                    )
 
             child_obj.set_override_state(
                 self._override_state, self._ignore_missing_defaults


### PR DESCRIPTION
## Brief description
Conditional dictionary which has children with same key but different types does not cause warning logs when loading settings anymore.

## Description
Added option to not log invalid value type on loading of settings which is by default enabled but (currently only) dict-conditional may disable it if is updating values of children which may have different type which is not importatnt.

## Changes
- added argument to `update_default_values`, `update_studio_values` and `update_project_values` which will define if invalid value type is logged out
- when this argument is passed and value has invalid type it is not logged out
- conditional dictionary changes the enabled logging based on enum value from the values

## Testing notes:
1. Run settings UI
2. Check logs in console if there are any warnings