### PR TITLE
General: OIIO conversion for ffmeg can handle sequences

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -478,8 +478,14 @@ def convert_for_ffmpeg(
             oiio_cmd.extend(["--eraseattrib", attr_name])
 
     # Add last argument - path to output
-    base_file_name = os.path.basename(first_input_path)
-    output_path = os.path.join(output_dir, base_file_name)
+    if is_sequence:
+        ext = os.path.splitext(first_input_path)[1]
+        base_filename = "tmp.%{:0>2}d{}".format(
+            len(str(input_frame_end)), ext
+        )
+    else:
+        base_filename = os.path.basename(first_input_path)
+    output_path = os.path.join(output_dir, base_filename)
     oiio_cmd.extend([
         "-o", output_path
     ])


### PR DESCRIPTION
## Brief description
Sequences now convert input into one output file so there are missing file and first frame contains last frame.

## Description
The bug is that output filepath uses filename of input without frame indexing (`%04d`) so oiio will output to same file. This was changed and filename is created like `tmp.%04d.exr`.

## Changes
- add filename with frame indexing when converting sequence for ffmpeg

## Testing notes:
1. Run publish which produce sequence that must be converted for ffmpeg
2. Publish should finish successfully (or not crash due to missing frames)

Resolves https://github.com/pypeclub/OpenPype/issues/2957