### PR TITLE
Slack: Added default for review_upload_limit for Slack

### DIFF
--- a/openpype/settings/defaults/project_settings/slack.json
+++ b/openpype/settings/defaults/project_settings/slack.json
@@ -11,6 +11,7 @@
                     "task_types": [],
                     "tasks": [],
                     "subsets": [],
+                    "review_upload_limit": 50.0,
                     "channel_messages": []
                 }
             ]


### PR DESCRIPTION
## Brief description
Previously added `review_upload_limit` was missing in Setting's default which resulted in labeling Slack collector in Settings having changes incorrectly.


## Testing notes:
1. Open Settings
2. Project without any configuration for `CollectSlackFamilies` shouldn't have highlighted section of `CollectSlackFamilies` blue.