### PR TITLE
SiteSync: Download all workfile inputs

### DIFF
--- a/openpype/modules/sync_server/utils.py
+++ b/openpype/modules/sync_server/utils.py
@@ -8,6 +8,11 @@ class ResumableError(Exception):
     pass
 
 
+class SiteAlreadyPresentError(Exception):
+    """Representation has already site skeleton present."""
+    pass
+
+
 class SyncStatus:
     DO_NOTHING = 0
     DO_UPLOAD = 1

--- a/openpype/plugins/load/add_site.py
+++ b/openpype/plugins/load/add_site.py
@@ -1,6 +1,6 @@
 from openpype.modules import ModulesManager
 from openpype.pipeline import load
-:from openpype.lib.avalon_context import get_linked_ids_for_representations
+from openpype.lib.avalon_context import get_linked_ids_for_representations
 from openpype.modules.sync_server.utils import SiteAlreadyPresentError
 
 

--- a/openpype/plugins/load/add_site.py
+++ b/openpype/plugins/load/add_site.py
@@ -1,9 +1,19 @@
 from openpype.modules import ModulesManager
 from openpype.pipeline import load
+:from openpype.lib.avalon_context import get_linked_ids_for_representations
+from openpype.modules.sync_server.utils import SiteAlreadyPresentError
 
 
 class AddSyncSite(load.LoaderPlugin):
-    """Add sync site to representation"""
+    """Add sync site to representation
+
+    If family of synced representation is 'workfile', it looks for all
+    representations which are referenced (loaded) in workfile with content of
+    'inputLinks'.
+    It doesn't do any checks for site, most common use case is when artist is
+    downloading workfile to his local site, but it might be helpful when
+    artist is re-uploading broken representation on remote site also.
+    """
     representations = ["*"]
     families = ["*"]
 
@@ -12,21 +22,61 @@ class AddSyncSite(load.LoaderPlugin):
     icon = "download"
     color = "#999999"
 
+    _sync_server = None
+
+    @property
+    def sync_server(self):
+        if not self._sync_server:
+            manager = ModulesManager()
+            self._sync_server = manager.modules_by_name["sync_server"]
+
+        return self._sync_server
+
     def load(self, context, name=None, namespace=None, data=None):
         self.log.info("Adding {} to representation: {}".format(
             data["site_name"], data["_id"]))
-        self.add_site_to_representation(data["project_name"],
-                                        data["_id"],
-                                        data["site_name"])
+        family = context["representation"]["context"]["family"]
+        project_name = data["project_name"]
+        repre_id = data["_id"]
+
+        add_ids = [repre_id]
+        if family == "workfile":
+            links = get_linked_ids_for_representations(project_name,
+                                                       add_ids,
+                                                       link_type="reference")
+            add_ids.extend(links)
+
+        add_ids = set(add_ids)
+        self.log.info("Add to repre_ids {}".format(add_ids))
+        is_main = True
+        for add_repre_id in add_ids:
+            self.add_site_to_representation(project_name,
+                                            add_repre_id,
+                                            data["site_name"],
+                                            is_main)
+            is_main = False
+
         self.log.debug("Site added.")
 
-    @staticmethod
-    def add_site_to_representation(project_name, representation_id, site_name):
-        """Adds new site to representation_id, resets if exists"""
-        manager = ModulesManager()
-        sync_server = manager.modules_by_name["sync_server"]
-        sync_server.add_site(project_name, representation_id, site_name,
-                             force=True)
+    def add_site_to_representation(self, project_name, representation_id,
+                                   site_name, is_main):
+        """Adds new site to representation_id, resets if exists
+
+        Args:
+            project_name (str)
+            representation_id (ObjectId):
+            site_name (str)
+            is_main (bool): true for really downloaded, false for references,
+                force redownload main file always, for references only if
+                broken
+        """
+        try:
+            self.sync_server.add_site(project_name, representation_id,
+                                      site_name,
+                                      force=is_main,
+                                      force_only_broken=not is_main)
+        except SiteAlreadyPresentError:
+            self.log.debug("Site present", exc_info=True)
 
     def filepath_from_context(self, context):
         """No real file loading"""


### PR DESCRIPTION
## Brief description
Each workfile collects loaded containers and stores them in DB. This feature allows when artists downloads workfile for local work to all these reference files be marked for downloading also.


## Additional info
Now it seems that referenced item is only one step away, no 'referencing of referenced', function was implemented to actually support this. Probably not needed for now.

## Testing notes:
1. In non local setup (`active_site` == studio) publish workfile that contains loaded item
2. Turn on local setup (`active_site` == local site) in Local Setting
3. Try to download previously published workfile via Loader
4. Local site skeleton should be added in DB not only to workfile, but for all loaded containers (this should be visible in Site Queue list)