### PR TITLE
Photoshop: Fix creation of subset names in PS review and workfile

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -2,6 +2,8 @@ import os
 
 import pyblish.api
 
+from openpype.lib import get_subset_name
+
 
 class CollectReview(pyblish.api.ContextPlugin):
     """Gather the active document as review instance."""
@@ -13,7 +15,13 @@ class CollectReview(pyblish.api.ContextPlugin):
     def process(self, context):
         family = "review"
         task = os.getenv("AVALON_TASK", None)
-        subset = family + task.capitalize()
+        subset = get_subset_name(
+            family,
+            "",
+            task,
+            context.data["assetEntity"]["_id"],
+            host_name="photoshop"
+        )
 
         file_path = context.data["currentFile"]
         base_name = os.path.basename(file_path)

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -11,7 +11,6 @@ class CollectReview(pyblish.api.ContextPlugin):
     label = "Review"
     order = pyblish.api.CollectorOrder + 0.1
     hosts = ["photoshop"]
-    order = pyblish.api.CollectorOrder + 0.1
 
     def process(self, context):
         family = "review"

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -2,7 +2,7 @@ import os
 
 import pyblish.api
 
-from openpype.lib import get_subset_name
+from openpype.lib import get_subset_name_with_asset_doc
 
 
 class CollectReview(pyblish.api.ContextPlugin):
@@ -14,13 +14,13 @@ class CollectReview(pyblish.api.ContextPlugin):
 
     def process(self, context):
         family = "review"
-        subset = get_subset_name(
+        subset = get_subset_name_with_asset_doc(
             family,
             "",
             context.data["anatomyData"]["task"]["name"],
-            context.data["assetEntity"]["_id"],
+            context.data["assetEntity"],
             context.data["anatomyData"]["project"]["name"],
-            host_name="photoshop"
+            host_name=context.data["hostName"]
         )
 
         file_path = context.data["currentFile"]

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -11,6 +11,7 @@ class CollectReview(pyblish.api.ContextPlugin):
     label = "Review"
     order = pyblish.api.CollectorOrder
     hosts = ["photoshop"]
+    order = pyblish.api.CollectorOrder + 0.1
 
     def process(self, context):
         family = "review"

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -9,9 +9,8 @@ class CollectReview(pyblish.api.ContextPlugin):
     """Gather the active document as review instance."""
 
     label = "Review"
-    order = pyblish.api.CollectorOrder
-    hosts = ["photoshop"]
     order = pyblish.api.CollectorOrder + 0.1
+    hosts = ["photoshop"]
 
     def process(self, context):
         family = "review"

--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -15,12 +15,12 @@ class CollectReview(pyblish.api.ContextPlugin):
 
     def process(self, context):
         family = "review"
-        task = os.getenv("AVALON_TASK", None)
         subset = get_subset_name(
             family,
             "",
-            task,
+            context.data["anatomyData"]["task"]["name"],
             context.data["assetEntity"]["_id"],
+            context.data["anatomyData"]["project"]["name"],
             host_name="photoshop"
         )
 

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -13,12 +13,12 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
     def process(self, context):
         family = "workfile"
-        task = os.getenv("AVALON_TASK", None)
         subset = get_subset_name(
             family,
             "",
-            task,
+            context.data["anatomyData"]["task"]["name"],
             context.data["assetEntity"]["_id"],
+            context.data["anatomyData"]["project"]["name"],
             host_name="photoshop"
         )
 

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -1,7 +1,7 @@
 import os
 import pyblish.api
 
-from openpype.lib import get_subset_name
+from openpype.lib import get_subset_name_with_asset_doc
 
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
@@ -13,13 +13,13 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
     def process(self, context):
         family = "workfile"
-        subset = get_subset_name(
+        subset = get_subset_name_with_asset_doc(
             family,
             "",
             context.data["anatomyData"]["task"]["name"],
-            context.data["assetEntity"]["_id"],
+            context.data["assetEntity"],
             context.data["anatomyData"]["project"]["name"],
-            host_name="photoshop"
+            host_name=context.data["hostName"]
         )
 
         file_path = context.data["currentFile"]

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -1,6 +1,8 @@
 import os
 import pyblish.api
 
+from openpype.lib import get_subset_name
+
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
     """Collect current script for publish."""
@@ -12,7 +14,13 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
     def process(self, context):
         family = "workfile"
         task = os.getenv("AVALON_TASK", None)
-        subset = family + task.capitalize()
+        subset = get_subset_name(
+            family,
+            "",
+            task,
+            context.data["assetEntity"]["_id"],
+            host_name="photoshop"
+        )
 
         file_path = context.data["currentFile"]
         staging_dir = os.path.dirname(file_path)


### PR DESCRIPTION
## Brief description
Use existing `get_subset_name` function to get subset name for workfile and review.

## Testing notes
- prepare specific tempate for workfile in PS in `project_settings/global/tools/creator/subset_name_profiles`
- try to publish and compare name of published workfile with template
- (without this it was always `workfileMytaskname`)