### PR TITLE
General: Tools with host filters

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -571,13 +571,8 @@ class EnvironmentTool:
         # Backwards compatibility 3.9.1 - 3.9.2
         # - 'variant_data' contained only environments but contain also host
         #   and application variant filters
-        host_names = []
-        app_variants = []
-        if "host_names" in variant_data:
-            host_names = variant_data["host_names"]
-
-        if "app_variants" in variant_data:
-            app_variants = variant_data["app_variants"]
+        host_names = variant_data.get("host_names", [])
+        app_variants = variant_data.get("app_variants", [])
 
         if "environment" in variant_data:
             environment = variant_data["environment"]

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -601,6 +601,19 @@ class EnvironmentTool:
     def environment(self):
         return copy.deepcopy(self._environment)
 
+    def is_valid_for_app(self, app):
+        """Is tool valid for application.
+
+        Args:
+            app (Application): Application for which are prepared environments.
+        """
+        if self.app_variants and app.full_name not in self.app_variants:
+            return False
+
+        if self.host_names and app.host_name not in self.host_names:
+            return False
+        return True
+
 
 class ApplicationExecutable:
     """Representation of executable loaded from settings."""
@@ -1406,7 +1419,7 @@ def prepare_app_environments(data, env_group=None, implementation_envs=True):
         # Make sure each tool group can be added only once
         for key in asset_doc["data"].get("tools_env") or []:
             tool = app.manager.tools.get(key)
-            if not tool:
+            if not tool or not tool.is_valid_for_app(app):
                 continue
             groups_by_name[tool.group.name] = tool.group
             tool_by_group_name[tool.group.name][tool.name] = tool

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -580,7 +580,7 @@ class EnvironmentTool:
             app_variants = variant_data["app_variants"]
 
         if "environment" in variant_data:
-            environment = variant_data["environemnt"]
+            environment = variant_data["environment"]
         else:
             environment = variant_data
 

--- a/openpype/settings/defaults/system_settings/tools.json
+++ b/openpype/settings/defaults/system_settings/tools.json
@@ -25,10 +25,18 @@
             },
             "variants": {
                 "3-2": {
-                    "MTOA_VERSION": "3.2"
+                    "host_names": [],
+                    "app_variants": [],
+                    "environment": {
+                        "MTOA_VERSION": "3.2"
+                    }
                 },
                 "3-1": {
-                    "MTOA_VERSION": "3.1"
+                    "host_names": [],
+                    "app_variants": [],
+                    "environment": {
+                        "MTOA_VERSION": "3.1"
+                    }
                 },
                 "__dynamic_keys_labels__": {
                     "3-2": "3.2",

--- a/openpype/settings/entities/schemas/system_schema/schema_tools.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_tools.json
@@ -25,7 +25,30 @@
                         "key": "variants",
                         "collapsible_key": true,
                         "object_type": {
-                            "type": "raw-json"
+                            "type": "dict",
+                            "children": [
+                                {
+                                    "key": "host_names",
+                                    "label": "Hosts",
+                                    "type": "hosts-enum",
+                                    "multiselection": true
+                                },
+                                {
+                                    "key": "app_variants",
+                                    "label": "Applications",
+                                    "type": "apps-enum",
+                                    "multiselection": true,
+                                    "tooltip": "Applications are not \"live\" and may require to Save and refresh settings UI to update values."
+                                },
+                                {
+                                    "type": "separator"
+                                },
+                                {
+                                    "key": "environment",
+                                    "label": "Environments",
+                                    "type": "raw-json"
+                                }
+                            ]
                         }
                     }
                 ]


### PR DESCRIPTION
## Brief description
Tools can be filtered for specific host or application.

## Description
Right now are all tools environments applied to all applications which may break then and it is not possible to have different versions for different versions of application. It was added a hosts and application variants filter for each tool variant. Both filters must be matched. Missing filters mean that the tool will be used at all cases. The filtering using host will probably be used in most of cases but for more granular filtering was also added a application variant filter.

## Additional info
This change require to change how tools are stored so a "hasckish" backwards compatible conversion in settings was added when studio settings overrides are loaded so old environment values are not lost. But changes are still showed in settings.

Application variants are not "live" updated so there may be confusion on user's side. Added/renamed/removed application variant needs save and refresh to update combobox of applications.

## Changes
- changed settings schemas to contain host and app variants filter
- EnvironmentTool uses the host and app filtering which is checked using `is_valid_for_app`

## Testing notes:
1. Set filters of tool 1 for **app one** of tool 2 for **app two** and remove filters for tool 3
2. Run one of application and check if environments were added as expected