### PR TITLE
General: `METADATA_KEYS` constant as `frozenset` for optimal immutable lookup

### DIFF
--- a/openpype/settings/constants.py
+++ b/openpype/settings/constants.py
@@ -8,11 +8,11 @@ M_ENVIRONMENT_KEY = "__environment_keys__"
 # Metadata key for storing dynamic created labels
 M_DYNAMIC_KEY_LABEL = "__dynamic_keys_labels__"
 
-METADATA_KEYS = (
+METADATA_KEYS = frozenset([
     M_OVERRIDDEN_KEY,
     M_ENVIRONMENT_KEY,
     M_DYNAMIC_KEY_LABEL
-)
+])
 
 # Keys where studio's system overrides are stored
 GLOBAL_SETTINGS_KEY = "global_settings"


### PR DESCRIPTION
## Brief description

Potential micro-optimization by changing `METADATA_KEYS` into an immutable set (`frozenset`) because the keys are often used for a `if x in METADATA_KEYS` look up.

## Testing notes:

1. test settings - in particular dict conditionals seem to use the keys