### PR TITLE
Settings UI: Fix version completer on linux

### DIFF
--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -97,6 +97,9 @@ class CompleterView(QtWidgets.QListView):
             QtCore.Qt.FramelessWindowHint
             | QtCore.Qt.Tool
         )
+
+        # Open the widget unactivated
+        self.setAttribute(QtCore.Qt.WA_ShowWithoutActivating)
         delegate = QtWidgets.QStyledItemDelegate()
         self.setItemDelegate(delegate)
 


### PR DESCRIPTION
## Brief description
Fix version input in settings which end in infinite loop of focus changes on some linux dist.

## Description
Some linux distributions cause that showing completer take focus from the text input which is then changed back to input and so on. It is forced to show completer inactive. Also was changed logic how completer is hidden by adding timer. On timer's callback is checked if line edit or completer have focus and will hide completer if both don't have it.

## Testing notes:
PreReq:
- be on centos machine
- have some versions in version repository
1. Open settings UI
2. Click in System settings into `general/production_version`
3. Focus should be in version input but popup should show
4. Test the same on Windows

Resolves https://github.com/pypeclub/OpenPype/issues/2977