### PR TITLE
Nuke: ReviewDataMov Read RAW attribute

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -450,6 +450,7 @@ class ExporterReviewMov(ExporterReview):
 
     def generate_mov(self, farm=False, **kwargs):
         self.publish_on_farm = farm
+        read_raw = kwargs["read_raw"]
         reformat_node_add = kwargs["reformat_node_add"]
         reformat_node_config = kwargs["reformat_node_config"]
         bake_viewer_process = kwargs["bake_viewer_process"]
@@ -483,6 +484,9 @@ class ExporterReviewMov(ExporterReview):
         r_node["last"].setValue(self.last_frame)
         r_node["origlast"].setValue(self.last_frame)
         r_node["colorspace"].setValue(self.write_colorspace)
+
+        if read_raw:
+            r_node["raw"].setValue(1)
 
         # connect
         self._temp_nodes[subset].append(r_node)

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -119,11 +119,10 @@
                         "families": [],
                         "sebsets": []
                     },
-                    "extension": "mov",
+                    "read_raw": false,
                     "viewer_process_override": "",
                     "bake_viewer_process": true,
                     "bake_viewer_input_process": true,
-                    "add_tags": [],
                     "reformat_node_add": false,
                     "reformat_node_config": [
                         {
@@ -151,7 +150,9 @@
                             "name": "pbb",
                             "value": false
                         }
-                    ]
+                    ],
+                    "extension": "mov",
+                    "add_tags": []
                 }
             }
         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -208,9 +208,10 @@
                                 "type": "separator"
                             },
                             {
-                                "type": "text",
-                                "key": "extension",
-                                "label": "File extension"
+                                "type": "boolean",
+                                "key": "read_raw",
+                                "label": "Read colorspace RAW",
+                                "default": false
                             },
                             {
                                 "type": "text",
@@ -228,12 +229,6 @@
                                 "label": "Bake Viewer Input Process (LUTs)"
                             },
                             {
-                                "key": "add_tags",
-                                "label": "Add additional tags to representations",
-                                "type": "list",
-                                "object_type": "text"
-                            },
-                            {
                                 "type": "separator"
                             },
                             {
@@ -246,7 +241,7 @@
                                 "type": "collapsible-wrap",
                                 "label": "Reformat Node Knobs",
                                 "collapsible": true,
-                                "collapsed": false,
+                                "collapsed": true,
                                 "children": [
                                     {
                                         "type": "list",
@@ -347,6 +342,20 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "type": "separator"
+                            },
+                            {
+                                "type": "text",
+                                "key": "extension",
+                                "label": "Write node file type"
+                            },
+                            {
+                                "key": "add_tags",
+                                "label": "Add additional tags to representations",
+                                "type": "list",
+                                "object_type": "text"
                             }
                         ]
                     }


### PR DESCRIPTION
## Brief description
Adding Read Raw bool attribute.

## Description
This way we can bake unmanaged color space into bake mov files. 

## Testing notes:
1. open your testing nuke workfile
2. create/modify output profile and activate `project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/read_raw` 
3. publish render instance with `review` on
4. check rendered review video and see the gamma is linear.