### PR TITLE
Fix: Disable setuptools auto discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,5 +188,5 @@ setup(
         }
     },
     executables=executables,
-    package_dir=[]
+    packages=[]
 )

--- a/setup.py
+++ b/setup.py
@@ -187,5 +187,6 @@ setup(
             "build_dir": (openpype_root / "docs" / "build").as_posix()
         }
     },
-    executables=executables
+    executables=executables,
+    package_dir=[]
 )

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -180,6 +180,9 @@ $out = &  "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
 Set-Content -Path "$($openpype_root)\build\build.log" -Value $out
 if ($LASTEXITCODE -ne 0)
 {
+    Write-Host "------------------------------------------" -ForegroundColor Red
+    Get-Content "$($openpype_root)\build\build.log"
+    Write-Host "------------------------------------------" -ForegroundColor Red
     Write-Host "!!! " -NoNewLine -ForegroundColor Red
     Write-Host "Build failed. Check the log: " -NoNewline
     Write-Host ".\build\build.log" -ForegroundColor Yellow

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -185,9 +185,9 @@ if [ "$disable_submodule_update" == 1 ]; then
   fi
   echo -e "${BIGreen}>>>${RST} Building ..."
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    "$POETRY_HOME/bin/poetry" run python "$openpype_root/setup.py" build &> "$openpype_root/build/build.log" || { echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
+    "$POETRY_HOME/bin/poetry" run python "$openpype_root/setup.py" build &> "$openpype_root/build/build.log" || { echo -e "${BIRed}------------------------------------------${RST}"; cat "$openpype_root/build/build.log"; echo -e "${BIRed}------------------------------------------${RST}"; echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    "$POETRY_HOME/bin/poetry" run python "$openpype_root/setup.py" bdist_mac &> "$openpype_root/build/build.log" || { echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
+    "$POETRY_HOME/bin/poetry" run python "$openpype_root/setup.py" bdist_mac &> "$openpype_root/build/build.log" || { echo -e "${BIRed}------------------------------------------${RST}"; cat "$openpype_root/build/build.log"; echo -e "${BIRed}------------------------------------------${RST}"; echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
   fi
   "$POETRY_HOME/bin/poetry" run python "$openpype_root/tools/build_dependencies.py"
 


### PR DESCRIPTION
## Problem

With updated [setuptools](https://github.com/pypa/setuptools) new behaviour emerged that is not backwards compatible,
introducing non-backwards compatible breaking changes.

Setting packages to an empty list will disable autodiscovery and should permit build to run as before.

Described here pypa/setuptools#3197