### PR TITLE
PS: fix renaming subset incorrectly in PS

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -29,7 +29,8 @@ class ValidateNamingRepair(pyblish.api.Action):
         stub = photoshop.stub()
         for instance in instances:
             self.log.info("validate_naming instance {}".format(instance))
-            metadata = stub.read(instance[0])
+            layer_item = instance.data["layer"]
+            metadata = stub.read(layer_item)
             self.log.info("metadata instance {}".format(metadata))
             layer_name = None
             if metadata.get("uuid"):
@@ -43,11 +44,11 @@ class ValidateNamingRepair(pyblish.api.Action):
                     stub.rename_layer(instance.data["uuid"], layer_name)
 
             subset_name = re.sub(invalid_chars, replace_char,
-                                 instance.data["name"])
+                                 instance.data["subset"])
 
-            instance[0].Name = layer_name or subset_name
+            layer_item.name = layer_name or subset_name
             metadata["subset"] = subset_name
-            stub.imprint(instance[0], metadata)
+            stub.imprint(layer_item, metadata)
 
         return True
 

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -18,7 +18,7 @@
             "active": true
         },
         "ValidateNaming": {
-            "invalid_chars": "[ \\\\/+\\*\\?\\(\\)\\[\\]\\{\\}:,]",
+            "invalid_chars": "[ \\\\/+\\*\\?\\(\\)\\[\\]\\{\\}:,;]",
             "replace_char": "_"
         },
         "ExtractImage": {


### PR DESCRIPTION
## Brief description
Validator Repair method used layer name as a subset name.

## Testing notes:
1. create multiple layers with broken names (layer name containing `/`, or `;` ...)
2. create for all of them instances (in single Creator, 'Use Selection')
3. use `Repair` action when `Validate Naming` fails
4. compare published file names format with unbroken layer names