### PR TITLE
nuke: bypass baking

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_data.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data.py
@@ -25,7 +25,7 @@ class ExtractReviewData(openpype.api.Extractor):
             instance.data["families"].remove("review")
 
         for repre in representations:
-            if ext not in repre["ext"]:
+            if ext != repre["ext"]:
                 continue
 
             if not repre.get("tags"):

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data.py
@@ -21,9 +21,15 @@ class ExtractReviewData(openpype.api.Extractor):
 
         representations = instance.data.get("representations", [])
 
-        if "render.farm" in instance.data["families"]:
+        # review can be removed since `ProcessSubmittedJobOnFarm` will create
+        # reviable representation if needed
+        if (
+            "render.farm" in instance.data["families"]
+            and "review" in instance.data["families"]
+        ):
             instance.data["families"].remove("review")
 
+        # iterate representations and add `review` tag
         for repre in representations:
             if ext != repre["ext"]:
                 continue

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data.py
@@ -1,0 +1,41 @@
+import os
+import pyblish.api
+import openpype
+from pprint import pformat
+
+
+class ExtractReviewData(openpype.api.Extractor):
+    """Extracts review tag into available representation
+    """
+
+    order = pyblish.api.ExtractorOrder + 0.01
+    # order = pyblish.api.CollectorOrder + 0.499
+    label = "Extract Review Data"
+
+    families = ["review"]
+    hosts = ["nuke"]
+
+    def process(self, instance):
+        fpath = instance.data["path"]
+        ext = os.path.splitext(fpath)[-1][1:]
+
+        representations = instance.data.get("representations", [])
+
+        if "render.farm" in instance.data["families"]:
+            instance.data["families"].remove("review")
+
+        for repre in representations:
+            if ext not in repre["ext"]:
+                continue
+
+            if not repre.get("tags"):
+                repre["tags"] = []
+
+            if "review" not in repre["tags"]:
+                repre["tags"].append("review")
+
+            self.log.debug("Matching representation: {}".format(
+                pformat(repre)
+            ))
+
+        instance.data["representations"] = representations

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -106,6 +106,9 @@
                 ]
             }
         },
+        "ExtractReviewData": {
+            "enabled": false
+        },
         "ExtractReviewDataLut": {
             "enabled": false
         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -142,6 +142,21 @@
             "type": "dict",
             "collapsible": true,
             "checkbox_key": "enabled",
+            "key": "ExtractReviewData",
+            "label": "ExtractReviewData",
+            "is_group": true,
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "checkbox_key": "enabled",
             "key": "ExtractReviewDataLut",
             "label": "ExtractReviewDataLut",
             "is_group": true,


### PR DESCRIPTION
## Brief description
Added support for review without baking

## Description
Since someone can set workfow rendering to png with sRGB so screenspace already baked into image sequence, they can skip baking because only purpose of it is to bake screen space into reviewable files. 

## Testing notes:
1. go to settings on your project and disable `project_settings/nuke/publish/ExtractReviewDataMov`
2. go to settings on your project and enable `project_settings/nuke/publish/ExtractReviewData`
3. go to settings `project_anatomy/imageio/nuke/nodes/requiredNodes` and set `CreateWriteRender` to be png `file_type`, remove [`compression`, `cropped`], set `datatype` to "16 bit" and `colorspace` to "sRGB" or "Output - sRGB" (if you are in ACES)
4. Render locally, on farm, from rendered files
5. all should look the same and produce reviewable version on Ftrack