### PR TITLE
General: adding limitations for pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,19 @@ hash = "de63a8bf7f6c45ff59ecafeba13123f710c2cbc1783ec9e0b938e980d4f5c37f"
 [openpype.thirdparty.oiio.darwin]
 url = "https://distribute.openpype.io/thirdparty/oiio-2.2.0-darwin.tgz"
 hash = "sha256:..."
+
+[tool.pyright]
+include = [
+    "igniter",
+    "openpype",
+    "repos",
+    "vendor"
+]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__"
+]
+ignore = ["website", "docs", ".git"]
+
+reportMissingImports = true
+reportMissingTypeStubs = false


### PR DESCRIPTION
## Brief description
Limiting Pyright in projects.toml

## Description
It is speeding up indexing of source files within project.

## Additional info
python language servers are usually looking into all source files within workspace or project and it was taking too long at indexing phase. 
It is tested only on vscode.
