### PR TITLE
Nuke: removing redundant Ftrack asset when farm publishing

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -123,6 +123,7 @@ class ExtractReviewDataMov(openpype.api.Extractor):
         if generated_repres:
             # assign to representations
             instance.data["representations"] += generated_repres
+            instance.data["hasReviewableRepresentations"] = True
         else:
             instance.data["families"].remove("review")
             self.log.info((

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -528,11 +528,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             # preview video rendering
             for app in self.aov_filter.keys():
                 if os.environ.get("AVALON_APP", "") == app:
-                    # no need to add review if baking in nuke present
-                    if (
-                        app == "nuke"
-                        and instance.get("bakingNukeScripts")
-                    ):
+                    # no need to add review if `hasReviewableRepresentations`
+                    if instance.get("hasReviewableRepresentations"):
                         break
 
                     # iteratre all aov filters

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -509,8 +509,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         most cases, but if not - we create representation from each of them.
 
         Arguments:
-            instance (pyblish.plugin.Instance): instance for which we are
-                                                setting representations
+            instance (dict): instance data for which we are
+                             setting representations
             exp_files (list): list of expected files
 
         Returns:
@@ -528,6 +528,14 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             # preview video rendering
             for app in self.aov_filter.keys():
                 if os.environ.get("AVALON_APP", "") == app:
+                    # no need to add review if baking in nuke present
+                    if (
+                        app == "nuke"
+                        and instance.get("bakingNukeScripts")
+                    ):
+                        break
+
+                    # iteratre all aov filters
                     for aov in self.aov_filter[app]:
                         if re.match(
                             aov,

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -190,8 +190,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 for _sci in src_components_to_add:
                     _sci["asset_data"]["name"] = extended_asset_name
 
-                first_thumbnail_component[
-                    "asset_data"]["name"] = extended_asset_name
+                # rename also first thumbnail component if any
+                if first_thumbnail_component is not None:
+                    first_thumbnail_component[
+                        "asset_data"]["name"] = extended_asset_name
 
             frame_start = repre.get("frameStartFtrack")
             frame_end = repre.get("frameEndFtrack")

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -35,6 +35,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         "image": "img",
         "reference": "reference"
     }
+    nicer_asset_name = False
 
     def process(self, instance):
         self.log.debug("instance {}".format(instance))
@@ -175,7 +176,11 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
             # condition for multiple reviewable representations
             # expand name to better label componenst
-            if is_first_review_repre and len(review_representations) > 1:
+            if (
+                self.nicer_asset_name is not False
+                and is_first_review_repre
+                and len(review_representations) > 1
+            ):
                 asset_name = review_item["asset_data"]["name"]
                 # define new extended name
                 extended_asset_name = "_".join(
@@ -278,7 +283,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             other_item = copy.deepcopy(base_component_item)
 
             # add extended name if any
-            if extended_asset_name:
+            if (
+                    self.nicer_asset_name is not False
+                    and extended_asset_name is not False
+            ):
                 other_item["asset_data"]["name"] = extended_asset_name
 
             other_item["component_data"] = {

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -2,7 +2,7 @@ import os
 import json
 import copy
 import pyblish.api
-from pprint import pformat
+
 
 class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
     """Collect ftrack component data (not integrate yet).

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -35,7 +35,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         "image": "img",
         "reference": "reference"
     }
-    nicer_asset_name = False
+    keep_first_subset_name_for_review = True
 
     def process(self, instance):
         self.log.debug("instance {}".format(instance))
@@ -177,7 +177,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             # condition for multiple reviewable representations
             # expand name to better label componenst
             if (
-                self.nicer_asset_name is not False
+                not self.keep_first_subset_name_for_review
                 and is_first_review_repre
                 and len(review_representations) > 1
             ):
@@ -284,7 +284,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
             # add extended name if any
             if (
-                    self.nicer_asset_name is not False
+                    not self.keep_first_subset_name_for_review
                     and extended_asset_name is not False
             ):
                 other_item["asset_data"]["name"] = extended_asset_name

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -396,7 +396,7 @@
                 "redshiftproxy": "cache",
                 "usd": "usd"
             },
-            "nicer_asset_name": false
+            "keep_first_subset_name_for_review": true
         }
     }
 }

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -395,7 +395,8 @@
                 "vrayproxy": "cache",
                 "redshiftproxy": "cache",
                 "usd": "usd"
-            }
+            },
+            "nicer_asset_name": false
         }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -787,9 +787,9 @@
                         },
                         {
                             "type": "boolean",
-                            "key": "nicer_asset_name",
-                            "label": "Nicer Asset name if multiple reviewable",
-                            "default": false
+                            "key": "keep_first_subset_name_for_review",
+                            "label": "Make subset name as first asset name",
+                            "default": true
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -784,6 +784,12 @@
                             "object_type": {
                                 "type": "text"
                             }
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "nicer_asset_name",
+                            "label": "Nicer Asset name if multiple reviewable",
+                            "default": false
                         }
                     ]
                 }


### PR DESCRIPTION
## Brief description
No need to publish sequence with review if baked profiles are used. 

## Description
This was happenning due wild card regex match but since we are adding `bakingNukeScripts` atribute to instance data, it is quite clear we don't need to review also .exr image sequence.

## Additional info
We had also not very nice way of Ftrack asset naming in case multiple reviewable representations were processed. I had hopefully preserved backward compatibility for single reviewable, but it needs to be tested. The feature was made optional and can be activated in settings `project_settings/ftrack/publish/IntegrateFtrackInstance/nicer_asset_name`

## Testing notes:
Ideal test scenarios are following:
- activate `project_settings/ftrack/publish/IntegrateFtrackInstance/nicer_asset_name` on your project
- nuke single baking preset - ftrack component asset name should be in old way (subset name)
- nuke multiple baking presets - asset name should be in new way (each component {subset}_{repre.name}) 
![image](https://user-images.githubusercontent.com/40640033/161234079-da30fc4f-e7c8-412b-b439-b9221f927e42.png)


# Todo:
- I have noticed we are also generating correct thumbnails for each reviewable, but those are not used anywhere. Anyway `IntegrateFttrackInstances` is not supporting multiple Thumbnails so this could be also improved. 
![image](https://user-images.githubusercontent.com/40640033/161234480-ef2df30e-93fe-4358-9999-f71508d0dd2c.png)
Problem is that each of the representations (noLut, withLut) is having differently looking image and this will be great to display as thumbnail.