### PR TITLE
Fix - remove doubled dot in workfile created from template

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1965,6 +1965,7 @@ def get_last_workfile(
         data.pop("comment", None)
         if not data.get("ext"):
             data["ext"] = extensions[0]
+        data["ext"] = data["ext"].replace('.', '')
         filename = StringTemplate.format_strict_template(file_template, data)
 
     if full_path:


### PR DESCRIPTION
## Brief description
Newly created workfile contained 2 dots before extension
