### PR TITLE
TVPaint: Render scene family

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
@@ -27,12 +27,13 @@ class CollectRenderScene(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder - 0.4
     hosts = ["tvpaint"]
 
+    # Value of 'render_pass' in subset name template
+    render_pass = "beauty"
+
     # Settings attributes
     enabled = False
-    # Value of 'renderLayer' for subset name template
-    render_layer_name = "Scene"
-    # Value of 'renderPass' for subset name template
-    render_pass_name = "Beauty"
+    # Value of 'render_layer' and 'variant' in subset name template
+    render_layer = "Main"
 
     def process(self, context):
         # Check if there are created instances of renderPass and renderLayer
@@ -65,10 +66,10 @@ class CollectRenderScene(pyblish.api.ContextPlugin):
         # Host name from environment variable
         host_name = context.data["hostName"]
         # Variant is using render pass name
-        variant = self.render_pass_name
+        variant = self.render_layer
         dynamic_data = {
-            "renderLayer": self.render_layer_name,
-            "renderPass": self.render_pass_name,
+            "render_layer": self.render_layer,
+            "render_pass": self.render_pass
         }
         task_name = io.Session["AVALON_TASK"]
         subset_name = get_subset_name_with_asset_doc(

--- a/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
@@ -1,0 +1,104 @@
+import json
+import copy
+import pyblish.api
+from avalon import io
+
+from openpype.lib import get_subset_name_with_asset_doc
+
+
+class CollectRenderScene(pyblish.api.ContextPlugin):
+    """Collect instance which renders whole scene in PNG.
+
+    Creates instance with family 'renderScene' which will have all layers
+    to render which will be composite into one result. The instance is not
+    collected from scene.
+
+    Scene will be rendered with all visible layers similar way like review is.
+
+    Instance is disabled if there are any created instances of 'renderLayer'
+    or 'renderPass'. That is because it is expected that this instance is
+    used as lazy publish of TVPaint file.
+
+    Subset name is created similar way like 'renderLayer' family. It can use
+    `renderPass` and `renderLayer` keys which can be set using settings and
+    `variant` is filled using `renderPass` value.
+    """
+    label = "Collect Render Scene"
+    order = pyblish.api.CollectorOrder - 0.4
+    hosts = ["tvpaint"]
+
+    # Settings attributes
+    enabled = False
+    # Value of 'renderLayer' for subset name template
+    render_layer_name = "Scene"
+    # Value of 'renderPass' for subset name template
+    render_pass_name = "Beauty"
+
+    def process(self, context):
+        # Check if there are created instances of renderPass and renderLayer
+        # - that will define if renderScene instance is enabled after
+        #   collection
+        any_created_instance = False
+        for instance in context:
+            family = instance.data["family"]
+            if family in ("renderPass", "renderLayer"):
+                any_created_instance = True
+                break
+
+        # Global instance data modifications
+        # Fill families
+        family = "renderScene"
+        # Add `review` family for thumbnail integration
+        families = [family, "review"]
+
+        # Collect asset doc to get asset id
+        # - not sure if it's good idea to require asset id in
+        #   get_subset_name?
+        asset_name = context.data["workfile_context"]["asset"]
+        asset_doc = io.find_one({
+            "type": "asset",
+            "name": asset_name
+        })
+
+        # Project name from workfile context
+        project_name = context.data["workfile_context"]["project"]
+        # Host name from environment variable
+        host_name = context.data["hostName"]
+        # Variant is using render pass name
+        variant = self.render_pass_name
+        dynamic_data = {
+            "renderLayer": self.render_layer_name,
+            "renderPass": self.render_pass_name,
+        }
+        task_name = io.Session["AVALON_TASK"]
+        subset_name = get_subset_name_with_asset_doc(
+            family,
+            variant,
+            task_name,
+            asset_doc,
+            project_name,
+            host_name,
+            dynamic_data=dynamic_data
+        )
+
+        instance_data = {
+            "family": family,
+            "families": families,
+            "fps": context.data["sceneFps"],
+            "name": subset_name,
+            "label": "{} [{}-{}]".format(
+                subset_name,
+                context.data["sceneMarkIn"] + 1,
+                context.data["sceneMarkOut"] + 1
+            ),
+            "active": not any_created_instance,
+            "publish": not any_created_instance,
+            "representations": [],
+            "layers": copy.deepcopy(context.data["layersData"])
+        }
+
+        instance = context.create_instance(**instance_data)
+
+        self.log.debug("Created instance: {}\n{}".format(
+            instance, json.dumps(instance.data, indent=4)
+        ))

--- a/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
@@ -24,7 +24,7 @@ class CollectRenderScene(pyblish.api.ContextPlugin):
     `variant` is filled using `renderPass` value.
     """
     label = "Collect Render Scene"
-    order = pyblish.api.CollectorOrder - 0.4
+    order = pyblish.api.CollectorOrder - 0.39
     hosts = ["tvpaint"]
 
     # Value of 'render_pass' in subset name template

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -18,7 +18,7 @@ from openpype.hosts.tvpaint.lib import (
 class ExtractSequence(pyblish.api.Extractor):
     label = "Extract Sequence"
     hosts = ["tvpaint"]
-    families = ["review", "renderPass", "renderLayer"]
+    families = ["review", "renderPass", "renderLayer", "renderScene"]
 
     # Modifiable with settings
     review_bg = [255, 255, 255, 255]
@@ -159,7 +159,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         # Fill tags and new families
         tags = []
-        if family_lowered in ("review", "renderlayer"):
+        if family_lowered in ("review", "renderlayer", "renderScene"):
             tags.append("review")
 
         # Sequence of one frame
@@ -185,7 +185,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         instance.data["representations"].append(new_repre)
 
-        if family_lowered in ("renderpass", "renderlayer"):
+        if family_lowered in ("renderpass", "renderlayer", "renderscene"):
             # Change family to render
             instance.data["family"] = "render"
 

--- a/openpype/hosts/tvpaint/plugins/publish/validate_layers_visibility.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_layers_visibility.py
@@ -8,7 +8,7 @@ class ValidateLayersVisiblity(pyblish.api.InstancePlugin):
 
     label = "Validate Layers Visibility"
     order = pyblish.api.ValidatorOrder
-    families = ["review", "renderPass", "renderLayer"]
+    families = ["review", "renderPass", "renderLayer", "renderScene"]
 
     def process(self, instance):
         layer_names = set()

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -1,6 +1,10 @@
 {
     "stop_timer_on_application_exit": false,
     "publish": {
+        "CollectRenderScene": {
+            "enabled": false,
+            "render_layer": "Main"
+        },
         "ExtractSequence": {
             "review_bg": [
                 255,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -19,6 +19,30 @@
                 {
                     "type": "dict",
                     "collapsible": true,
+                    "key": "CollectRenderScene",
+                    "label": "Collect Render Scene",
+                    "is_group": true,
+                    "checkbox_key": "enabled",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "label",
+                            "label": "It is possible to fill 'render_layer' or 'variant' in subset name template with custom value. Value of 'render_pass' is \"Beauty\"."
+                        },
+                        {
+                            "type": "text",
+                            "key": "render_layer",
+                            "label": "Render Layer"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
                     "key": "ExtractSequence",
                     "label": "ExtractSequence",
                     "is_group": true,


### PR DESCRIPTION
## Brief description
Added `renderScene` family which is created during publishing and will create render of whole scene for all visible layers.

## Description
The instance is collected dynamically during publishing and it's result are all visible layers in the scene published as PNG sequences. The plugin is by default disabled. Since the result is almost the same as render layer, it is possible to define layer name (or variant) for subset name template to fill, render pass is filled with `"beauty"`. Instance is disabled if there are other `renderPass` or `renderLayer` instances collected from the scene, the reason is that it can be used as lazy publishing of files from remote artists.

## Testing notes:
1. Open TVPaint without any created instances
2. Run publishing
3. Render scene instance should be created and enabled
4. Publishing should result with image sequence of the file

5. Open TVPaint with created instances
6. Run publishing
7. The render scene instance should be disabled