### PR TITLE
Photoshop: create image without instance

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_instances.py
@@ -1,6 +1,9 @@
+from avalon import api
 import pyblish.api
 
+from openpype.settings import get_project_settings
 from openpype.hosts.photoshop import api as photoshop
+from openpype.lib import prepare_template_data
 
 
 class CollectInstances(pyblish.api.ContextPlugin):
@@ -19,13 +22,16 @@ class CollectInstances(pyblish.api.ContextPlugin):
     families_mapping = {
         "image": []
     }
+    flatten_subset_template = ""
 
     def process(self, context):
         stub = photoshop.stub()
         layers = stub.get_layers()
         layers_meta = stub.get_layers_metadata()
         instance_names = []
+        all_layer_ids = []
         for layer in layers:
+            all_layer_ids.append(layer.id)
             layer_data = stub.read(layer, layers_meta)
 
             # Skip layers without metadata.
@@ -59,3 +65,33 @@ class CollectInstances(pyblish.api.ContextPlugin):
         if len(instance_names) != len(set(instance_names)):
             self.log.warning("Duplicate instances found. " +
                              "Remove unwanted via SubsetManager")
+
+        if len(instance_names) == 0 and self.flatten_subset_template:
+            project_name = context.data["projectEntity"]["name"]
+            variants = get_project_settings(project_name).get(
+                "photoshop", {}).get(
+                "create", {}).get(
+                "CreateImage", {}).get(
+                "defaults", [''])
+            family = "image"
+            task_name = api.Session["AVALON_TASK"]
+            asset_name = context.data["assetEntity"]["name"]
+
+            fill_pairs = {
+                "variant": variants[0],
+                "family": family,
+                "task": task_name
+            }
+
+            subset = self.flatten_subset_template.format(
+                **prepare_template_data(fill_pairs))
+
+            instance = context.create_instance(subset)
+            instance.data["family"] = family
+            instance.data["asset"] = asset_name
+            instance.data["subset"] = subset
+            instance.data["ids"] = all_layer_ids
+            instance.data["families"] = self.families_mapping[family]
+            instance.data["publish"] = True
+
+            self.log.info("flatten instance: {} ".format(instance.data))

--- a/openpype/hosts/photoshop/plugins/publish/collect_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_instances.py
@@ -12,6 +12,10 @@ class CollectInstances(pyblish.api.ContextPlugin):
     This collector takes into account assets that are associated with
     an LayerSet and marked with a unique identifier;
 
+    If no image instances are explicitly created, it looks if there is value
+    in `flatten_subset_template` (configurable in Settings), in that case it
+    produces flatten image with all visible layers.
+
     Identifier:
         id (str): "pyblish.avalon.instance"
     """
@@ -22,6 +26,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
     families_mapping = {
         "image": []
     }
+    # configurable in Settings
     flatten_subset_template = ""
 
     def process(self, context):

--- a/openpype/hosts/photoshop/plugins/publish/extract_image.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_image.py
@@ -26,8 +26,10 @@ class ExtractImage(openpype.api.Extractor):
         with photoshop.maintained_selection():
             self.log.info("Extracting %s" % str(list(instance)))
             with photoshop.maintained_visibility():
+                ids = set()
                 layer = instance.data.get("layer")
-                ids = set([layer.id])
+                if layer:
+                    ids.add(layer.id)
                 add_ids = instance.data.pop("ids", None)
                 if add_ids:
                     ids.update(set(add_ids))

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -155,6 +155,9 @@ class ExtractReview(openpype.api.Extractor):
         for image_instance in instance.context:
             if image_instance.data["family"] != "image":
                 continue
+            if not image_instance.data.get("layer"):
+                # dummy instance for flatten image
+                continue
             layers.append(image_instance.data.get("layer"))
 
         return sorted(layers)

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -12,6 +12,9 @@
             "flatten_subset_template": "",
             "color_code_mapping": []
         },
+        "CollectInstances": {
+            "flatten_subset_template": ""
+        },
         "ValidateContainers": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -109,6 +109,23 @@
                     ]
                 },
                 {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "CollectInstances",
+                    "label": "Collect Instances",
+                    "children": [
+                        {
+                            "type": "label",
+                            "label": "Name for flatten image created if no image instance present"
+                        },
+                        {
+                            "type": "text",
+                            "key": "flatten_subset_template",
+                            "label": "Subset template for flatten image"
+                        }
+                    ]
+                },
+                {
                     "type": "schema_template",
                     "name": "template_publish_plugin",
                     "template_data": [

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -42,7 +42,7 @@
                     "children": [
                         {
                             "type": "label",
-                            "label": "Set color for publishable layers, set its resulting family and template for subset name. Can create flatten image from published instances"
+                            "label": "Set color for publishable layers, set its resulting family and template for subset name. \nCan create flatten image from published instances.(Applicable only for remote publishing!)"
                         },
                         {
                             "type": "boolean",

--- a/website/docs/artist_hosts_photoshop.md
+++ b/website/docs/artist_hosts_photoshop.md
@@ -49,6 +49,12 @@ With the `Creator` you have a variety of options to create:
 - Uncheck `Use selection`.
     - This will create a single group named after the `Subset` in the `Creator`.
 
+#### Simplified publish
+
+There is a simplified workflow for simple use case where only single image should be created containing all visible layers.
+No image instances must be present in a workfile and `project_settings/photoshop/publish/CollectInstances/flatten_subset_template` must be filled in Settings.
+Then artists just need to hit 'Publish' button in menu.
+
 ### Publish
 
 When you are ready to share some work, you will need to publish. This is done by opening the `Pyblish` through the extensions `Publish` button.


### PR DESCRIPTION
## Brief description
Publish creates flatten image with configurable subset name if no image instances present in workfile

## Description
This is special use case requested by customer making publish process easier for artist. It checks if no image instances are present AND `project_settings/photoshop/publish/CollectInstances/flatten_subset_template` is filled.

## Additional 
![Screenshot 2022-04-01 153831](https://user-images.githubusercontent.com/4457962/161274797-5bd61e30-3ca2-4e45-b7a4-3c69c8af2488.png)


## Testing notes:
1. fill `project_settings/photoshop/publish/CollectInstances/flatten_subset_template` with template 
2. try to publish workfile without explicitly Creating image instances