### PR TITLE
Nuke: fixing unicode type detection in effect loaders

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -1,6 +1,7 @@
 import json
 from collections import OrderedDict
 import nuke
+import six
 
 from avalon import io
 
@@ -333,7 +334,7 @@ class LoadEffects(load.LoaderPlugin):
                     for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
-        elif isinstance(input, str):
+        elif isinstance(input, six.text_type):
             return str(input)
         else:
             return input

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -1,6 +1,6 @@
 import json
 from collections import OrderedDict
-
+import six
 import nuke
 
 from avalon import io
@@ -353,7 +353,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
                     for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
-        elif isinstance(input, str):
+        elif isinstance(input, six.text_type):
             return str(input)
         else:
             return input

--- a/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_gizmo_ip.py
@@ -1,5 +1,5 @@
 import nuke
-
+import six
 from avalon import io
 
 from openpype.pipeline import (
@@ -243,8 +243,8 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
                     for key, value in input.items()}
         elif isinstance(input, list):
             return [self.byteify(element) for element in input]
-        elif isinstance(input, unicode):
-            return input.encode('utf-8')
+        elif isinstance(input, six.text_type):
+            return str(input)
         else:
             return input
 


### PR DESCRIPTION
## Brief description
Fixing unicode type detection in effect loaders

## Testing notes:
1. open testing nuke workfile in nuke12
2. Load Effect family subset to scene either as Input process or as nodes