### PR TITLE
Hosts: Remove path existence checks in 'add_implementation_envs'

### DIFF
--- a/openpype/hosts/blender/__init__.py
+++ b/openpype/hosts/blender/__init__.py
@@ -29,12 +29,12 @@ def add_implementation_envs(env, _app):
         env.get("OPENPYPE_BLENDER_USER_SCRIPTS") or ""
     )
     for path in openpype_blender_user_scripts.split(os.pathsep):
-        if path and os.path.exists(path):
+        if path:
             previous_user_scripts.add(os.path.normpath(path))
 
     blender_user_scripts = env.get("BLENDER_USER_SCRIPTS") or ""
     for path in blender_user_scripts.split(os.pathsep):
-        if path and os.path.exists(path):
+        if path:
             previous_user_scripts.add(os.path.normpath(path))
 
     # Remove implementation path from user script paths as is set to

--- a/openpype/hosts/hiero/__init__.py
+++ b/openpype/hosts/hiero/__init__.py
@@ -10,7 +10,7 @@ def add_implementation_envs(env, _app):
     ]
     old_hiero_path = env.get("HIERO_PLUGIN_PATH") or ""
     for path in old_hiero_path.split(os.pathsep):
-        if not path or not os.path.exists(path):
+        if not path:
             continue
 
         norm_path = os.path.normpath(path)

--- a/openpype/hosts/houdini/__init__.py
+++ b/openpype/hosts/houdini/__init__.py
@@ -15,7 +15,7 @@ def add_implementation_envs(env, _app):
     old_houdini_menu_path = env.get("HOUDINI_MENU_PATH") or ""
 
     for path in old_houdini_path.split(os.pathsep):
-        if not path or not os.path.exists(path):
+        if not path:
             continue
 
         norm_path = os.path.normpath(path)
@@ -23,7 +23,7 @@ def add_implementation_envs(env, _app):
             new_houdini_path.append(norm_path)
 
     for path in old_houdini_menu_path.split(os.pathsep):
-        if not path or not os.path.exists(path):
+        if not path:
             continue
 
         norm_path = os.path.normpath(path)

--- a/openpype/hosts/maya/__init__.py
+++ b/openpype/hosts/maya/__init__.py
@@ -9,7 +9,7 @@ def add_implementation_envs(env, _app):
     ]
     old_python_path = env.get("PYTHONPATH") or ""
     for path in old_python_path.split(os.pathsep):
-        if not path or not os.path.exists(path):
+        if not path:
             continue
 
         norm_path = os.path.normpath(path)

--- a/openpype/hosts/nuke/__init__.py
+++ b/openpype/hosts/nuke/__init__.py
@@ -10,7 +10,7 @@ def add_implementation_envs(env, _app):
     ]
     old_nuke_path = env.get("NUKE_PATH") or ""
     for path in old_nuke_path.split(os.pathsep):
-        if not path or not os.path.exists(path):
+        if not path:
             continue
 
         norm_path = os.path.normpath(path)


### PR DESCRIPTION
## Brief description
Function `add_implementation_envs` should not remove not existing paths because they may be not yet resolved environment value.

## Description
Resolving of environment variable values is finished after collection of all environments. Last step is that host implementation may modify environments value in `add_implementation_envs` function. But in some cases are also verifying existence of paths that may still have unfilled values of other environments. This should not happen at all, it is better to keep the invalid value then  remove it completely which cause confusion.

## Changes
- host's implementation of `add_implementation_envs` does not remove not existing paths from env values

## Testing notes:
1. Hosts should still work
2. It should be possible to use env keys in variables that are modified in host implementation

Resolves https://github.com/pypeclub/OpenPype/issues/3003