### PR TITLE
Nuke: add concurrency attr to deadline job

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1057,12 +1057,19 @@ def add_deadline_tab(node):
     node.addKnob(knob)
 
     knob = nuke.Int_Knob("deadlineConcurrentTasks", "Concurrent tasks")
+    #  zero as default will trigger value from Setting during collection
+    # look to precollect_write.py
     knob.setValue(0)
     node.addKnob(knob)
 
 
 def get_deadline_knob_names():
-    return ["Deadline", "deadlineChunkSize", "deadlinePriority"]
+    return [
+        "Deadline",
+        "deadlineChunkSize",
+        "deadlinePriority",
+        "deadlineConcurrentTasks"
+    ]
 
 
 def create_backdrop(label="", color=None, layer=0,

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1057,8 +1057,8 @@ def add_deadline_tab(node):
     node.addKnob(knob)
 
     knob = nuke.Int_Knob("deadlineConcurrentTasks", "Concurrent tasks")
-    #  zero as default will trigger value from Setting during collection
-    # look to precollect_write.py
+    # zero as default will get value from Settings during collection
+    # instead of being an explicit user override, see precollect_write.py
     knob.setValue(0)
     node.addKnob(knob)
 

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -1048,12 +1048,16 @@ def add_review_knob(node):
 def add_deadline_tab(node):
     node.addKnob(nuke.Tab_Knob("Deadline"))
 
+    knob = nuke.Int_Knob("deadlinePriority", "Priority")
+    knob.setValue(50)
+    node.addKnob(knob)
+
     knob = nuke.Int_Knob("deadlineChunkSize", "Chunk Size")
     knob.setValue(0)
     node.addKnob(knob)
 
-    knob = nuke.Int_Knob("deadlinePriority", "Priority")
-    knob.setValue(50)
+    knob = nuke.Int_Knob("deadlineConcurrentTasks", "Concurrent tasks")
+    knob.setValue(0)
     node.addKnob(knob)
 
 

--- a/openpype/hosts/nuke/plugins/publish/precollect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_writes.py
@@ -128,13 +128,17 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
         }
 
         group_node = [x for x in instance if x.Class() == "Group"][0]
-        deadlineChunkSize = 1
+        dl_chunk_size = 1
         if "deadlineChunkSize" in group_node.knobs():
-            deadlineChunkSize = group_node["deadlineChunkSize"].value()
+            dl_chunk_size = group_node["deadlineChunkSize"].value()
 
-        deadlinePriority = 50
+        dl_priority = 50
         if "deadlinePriority" in group_node.knobs():
-            deadlinePriority = group_node["deadlinePriority"].value()
+            dl_priority = group_node["deadlinePriority"].value()
+
+        dl_concurrent_tasks = 0
+        if "deadlineConcurrentTasks" in group_node.knobs():
+            dl_concurrent_tasks = group_node["deadlineConcurrentTasks"].value()
 
         instance.data.update({
             "versionData": version_data,
@@ -144,8 +148,9 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             "label": label,
             "outputType": output_type,
             "colorspace": colorspace,
-            "deadlineChunkSize": deadlineChunkSize,
-            "deadlinePriority": deadlinePriority
+            "deadlineChunkSize": dl_chunk_size,
+            "deadlinePriority": dl_priority,
+            "deadlineConcurrentTasks": dl_concurrent_tasks
         })
 
         if self.is_prerender(_families_test):

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -27,6 +27,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
     # presets
     priority = 50
     chunk_size = 1
+    concurent_task = 1
     primary_pool = ""
     secondary_pool = ""
     group = ""
@@ -177,6 +178,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
 
                 "Priority": priority,
                 "ChunkSize": chunk_size,
+                "ConcurrentTasks": self.concurent_task,
                 "Department": self.department,
 
                 "Pool": self.primary_pool,

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -150,16 +150,16 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             pass
 
         # define chunk and priority
-        chunk_size = instance.data.get("deadlineChunkSize")
+        chunk_size = instance.data["deadlineChunkSize"]
         if chunk_size == 0 and self.chunk_size:
             chunk_size = self.chunk_size
 
         # define chunk and priority
-        concurrent_tasks = instance.data.get("deadlineConcurrentTasks")
+        concurrent_tasks = instance.data["deadlineConcurrentTasks"]
         if concurrent_tasks == 0 and self.concurrent_tasks:
             concurrent_tasks = self.concurrent_tasks
 
-        priority = instance.data.get("deadlinePriority")
+        priority = instance.data["deadlinePriority"]
         if not priority:
             priority = self.priority
 

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -27,7 +27,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
     # presets
     priority = 50
     chunk_size = 1
-    concurent_task = 1
+    concurrent_tasks = 1
     primary_pool = ""
     secondary_pool = ""
     group = ""
@@ -154,6 +154,11 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         if chunk_size == 0 and self.chunk_size:
             chunk_size = self.chunk_size
 
+        # define chunk and priority
+        concurrent_tasks = instance.data.get("deadlineConcurrentTasks")
+        if concurrent_tasks == 0 and self.concurrent_tasks:
+            concurrent_tasks = self.concurrent_tasks
+
         priority = instance.data.get("deadlinePriority")
         if not priority:
             priority = self.priority
@@ -178,7 +183,8 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
 
                 "Priority": priority,
                 "ChunkSize": chunk_size,
-                "ConcurrentTasks": self.concurent_task,
+                "ConcurrentTasks": concurrent_tasks,
+
                 "Department": self.department,
 
                 "Pool": self.primary_pool,

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -62,7 +62,7 @@
             "use_published": true,
             "priority": 50,
             "chunk_size": 10,
-            "concurent_task": 1,
+            "concurrent_tasks": 1,
             "primary_pool": "",
             "secondary_pool": "",
             "group": "",

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -62,6 +62,7 @@
             "use_published": true,
             "priority": 50,
             "chunk_size": 10,
+            "concurent_task": 1,
             "primary_pool": "",
             "secondary_pool": "",
             "group": "",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -207,8 +207,8 @@
                         },
                         {
                             "type": "number",
-                            "key": "concurent_task",
-                            "label": "Number of concurent tasks"
+                            "key": "concurrent_tasks",
+                            "label": "Number of concurrent tasks"
                         },
                         {
                             "type": "splitter"

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -193,6 +193,9 @@
                             "label": "Use Published scene"
                         },
                         {
+                            "type": "splitter"
+                        },
+                        {
                             "type": "number",
                             "key": "priority",
                             "label": "Priority"
@@ -201,6 +204,14 @@
                             "type": "number",
                             "key": "chunk_size",
                             "label": "Chunk Size"
+                        },
+                        {
+                            "type": "number",
+                            "key": "concurent_task",
+                            "label": "Number of concurent tasks"
+                        },
+                        {
+                            "type": "splitter"
                         },
                         {
                             "type": "text",
@@ -216,6 +227,9 @@
                             "type": "text",
                             "key": "group",
                             "label": "Group"
+                        },
+                        {
+                            "type": "splitter"
                         },
                         {
                             "type": "text",


### PR DESCRIPTION
## Brief description
Adding support for `ConcurrentTask` Deadline Job attibute.

## Description
Some productions might want to use Deadline feature for concurrent tasks on one Worker. This will allow to either set this in settings for Nuke submission or even let user to decide how many concurrent task he wants to use on Rendering node Deadline Tab.

## Testing notes:
1. Make sure you are having Deadline Worker with at least some Concurrent task defined > Super user needs to be ON and RMB click on worker and go to Worker Settings/Concurrent Tasks. If zero is in it it will detect your maximum available threads and use it. 
2. Open Settings and save on your project override. To to `project_settings/deadline/publish/NukeSubmitDeadline/concurrent_tasks` and define it to _5_.
2. Open your favorite Nuke workfile.
3. Test 1 render publish with already created render node (this will not have available attribut in DeadlineTab, but we want to test even backward compatibilitiy)
4. Go to Deadline Monitor and look at the first job details and see if the Concurrent Task attribute is set to 5
5. Now remove the write render node and create new one. 
6. go to Deadline Tab and set Concurrent Tasks to _6_
7. Submit to farm and go to Monitor to the new job and see if it is set to _6_
 