### PR TITLE
Fix support for Renderman in Maya

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1069,7 +1069,7 @@ class RenderProductsRenderman(ARenderProducts):
         default_ext = "exr"
         displays = cmds.listConnections("rmanGlobals.displays")
         for aov in displays:
-            enabled = self._get_attr(aov, "enabled")
+            enabled = self._get_attr(aov, "enable")
             if not enabled:
                 continue
 
@@ -1085,7 +1085,7 @@ class RenderProductsRenderman(ARenderProducts):
 
         return products
 
-    def get_files(self, product, camera):
+    def get_files(self, product):
         """Get expected files.
 
         In renderman we hack it with prepending path. This path would
@@ -1094,13 +1094,13 @@ class RenderProductsRenderman(ARenderProducts):
         to mess around with this settings anyway and it is enforced in
         render settings validator.
         """
-        files = super(RenderProductsRenderman, self).get_files(product, camera)
+        files = super(RenderProductsRenderman, self).get_files(product)
 
         layer_data = self.layer_data
         new_files = []
         for file in files:
             new_file = "{}/{}/{}".format(
-                layer_data["sceneName"], layer_data["layerName"], file
+                layer_data.sceneName, layer_data.layerName, file
             )
             new_files.append(new_file)
 

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -79,6 +79,7 @@ IMAGE_PREFIXES = {
     "redshift": "defaultRenderGlobals.imageFilePrefix",
 }
 
+RENDERMAN_IMAGE_DIR = "maya/<scene>/<layer>"
 
 @attr.s
 class LayerMetadata(object):
@@ -1054,6 +1055,8 @@ class RenderProductsRenderman(ARenderProducts):
             :func:`ARenderProducts.get_render_products()`
 
         """
+        from rfm2.api.displays import get_displays  # noqa
+
         cameras = [
             self.sanitize_camera_name(c)
             for c in self.get_renderable_cameras()
@@ -1066,20 +1069,38 @@ class RenderProductsRenderman(ARenderProducts):
             ]
         products = []
 
-        default_ext = "exr"
-        displays = cmds.listConnections("rmanGlobals.displays")
-        for aov in displays:
-            enabled = self._get_attr(aov, "enable")
+        # NOTE: This is guessing extensions from renderman display types.
+        #       Some of them are just framebuffers, d_texture format can be
+        #       set in display setting. We set those now to None, but it
+        #       should be handled more gracefully.
+        display_types = {
+            "d_deepexr": "exr",
+            "d_it": None,
+            "d_null": None,
+            "d_openexr": "exr",
+            "d_png": "png",
+            "d_pointcloud": "ptc",
+            "d_targa": "tga",
+            "d_texture": None,
+            "d_tiff": "tif"
+        }
+
+        displays = get_displays()["displays"]
+        for name, display in displays.items():
+            enabled = display["params"]["enable"]["value"]
             if not enabled:
                 continue
 
-            aov_name = str(aov)
+            aov_name = name
             if aov_name == "rmanDefaultDisplay":
                 aov_name = "beauty"
 
+            extensions = display_types.get(
+                display["driverNode"]["type"], "exr")
+
             for camera in cameras:
                 product = RenderProduct(productName=aov_name,
-                                        ext=default_ext,
+                                        ext=extensions,
                                         camera=camera)
                 products.append(product)
 
@@ -1088,20 +1109,16 @@ class RenderProductsRenderman(ARenderProducts):
     def get_files(self, product):
         """Get expected files.
 
-        In renderman we hack it with prepending path. This path would
-        normally be translated from `rmanGlobals.imageOutputDir`. We skip
-        this and hardcode prepend path we expect. There is no place for user
-        to mess around with this settings anyway and it is enforced in
-        render settings validator.
         """
         files = super(RenderProductsRenderman, self).get_files(product)
 
         layer_data = self.layer_data
         new_files = []
+
+        resolved_image_dir = re.sub("<scene>", layer_data.sceneName, RENDERMAN_IMAGE_DIR, flags=re.IGNORECASE)  # noqa: E501
+        resolved_image_dir = re.sub("<layer>", layer_data.layerName, resolved_image_dir, flags=re.IGNORECASE)  # noqa: E501
         for file in files:
-            new_file = "{}/{}/{}".format(
-                layer_data.sceneName, layer_data.layerName, file
-            )
+            new_file = "{}/{}".format(resolved_image_dir, file)
             new_files.append(new_file)
 
         return new_files

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -467,7 +467,7 @@ class CreateRender(plugin.Creator):
 
         if renderer == "renderman":
             cmds.setAttr("rmanGlobals.imageOutputDir",
-                         "<ws>/maya/<scene>/<layer>", type="string")
+                         "maya/<scene>/<layer>", type="string")
 
     def _set_vray_settings(self, asset):
         # type: (dict) -> None

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -84,7 +84,9 @@ class CreateRender(plugin.Creator):
         'mentalray': 'maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>',  # noqa
         'vray': 'maya/<scene>/<Layer>/<Layer>',
         'arnold': 'maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>',  # noqa
-        'renderman': '<layer>_<aov>.<f4>.<ext>',  # this needs `imageOutputDir` set separately
+        # this needs `imageOutputDir`
+        # (<ws>/renders/maya/<scene>) set separately
+        'renderman': '<layer>_<aov>.<f4>.<ext>',
         'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>'  # noqa
     }
 

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -76,7 +76,7 @@ class CreateRender(plugin.Creator):
         'mentalray': 'defaultRenderGlobals.imageFilePrefix',
         'vray': 'vraySettings.fileNamePrefix',
         'arnold': 'defaultRenderGlobals.imageFilePrefix',
-        'renderman': 'defaultRenderGlobals.imageFilePrefix',
+        'renderman': 'rmanGlobals.imageFileFormat',
         'redshift': 'defaultRenderGlobals.imageFilePrefix'
     }
 
@@ -84,7 +84,7 @@ class CreateRender(plugin.Creator):
         'mentalray': 'maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>',  # noqa
         'vray': 'maya/<scene>/<Layer>/<Layer>',
         'arnold': 'maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>',  # noqa
-        'renderman': 'maya/<Scene>/<layer>/<layer>{aov_separator}<aov>',
+        'renderman': '<layer>_<aov>.<f4>.<ext>',  # this needs `imageOutputDir` set separately
         'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>'  # noqa
     }
 
@@ -462,6 +462,10 @@ class CreateRender(plugin.Creator):
                 asset["data"].get("resolutionHeight"))
 
             self._set_global_output_settings()
+
+        if renderer == "renderman":
+            cmds.setAttr("rmanGlobals.imageOutputDir",
+                         "<ws>/maya/<scene>/<layer>", type="string")
 
     def _set_vray_settings(self, asset):
         # type: (dict) -> None

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -117,13 +117,14 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             cls.log.error("Animation needs to be enabled. Use the same "
                           "frame for start and end to render single frame")
 
-        if renderer != "renderman":
-            if not prefix.lower().startswith(required_prefix):
-                invalid = True
-                cls.log.error(
-                    "Wrong image prefix [ {} ] - doesn't start with: '{}'".format(
-                        prefix, required_prefix)
-                )
+        if renderer != "renderman" and not prefix.lower().startswith(
+                required_prefix):
+            invalid = True
+            cls.log.error(
+                ("Wrong image prefix [ {} ] "
+                 " - doesn't start with: '{}'").format(
+                    prefix, required_prefix)
+            )
 
         if not re.search(cls.R_LAYER_TOKEN, prefix):
             invalid = True

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -130,9 +130,10 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
         if not prefix.lower().startswith(required_prefix):
             invalid = True
-            cls.log.error("Wrong image prefix [ {} ] - "
-                          "doesn't start with: '{}'".format(
-                prefix, required_prefix))
+            cls.log.error(
+                "Wrong image prefix [ {} ] - doesn't start with: '{}'".format(
+                    prefix, required_prefix)
+            )
 
         if not re.search(cls.R_LAYER_TOKEN, prefix):
             invalid = True

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -116,16 +116,23 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
         prefix = prefix.replace(
             "{aov_separator}", instance.data.get("aovSeparator", "_"))
+
+        required_prefix = "maya/<scene>"
+
+        if renderer == "renderman":
+            # renderman has prefix set differently
+            required_prefix = "<ws>/renders/{}".format(required_prefix)
+
         if not anim_override:
             invalid = True
             cls.log.error("Animation needs to be enabled. Use the same "
                           "frame for start and end to render single frame")
 
-        if not prefix.lower().startswith("maya/<scene>") and \
-                renderer != "renderman":
+        if not prefix.lower().startswith(required_prefix):
             invalid = True
             cls.log.error("Wrong image prefix [ {} ] - "
-                          "doesn't start with: 'maya/<scene>'".format(prefix))
+                          "doesn't start with: '{}'".format(
+                prefix, required_prefix))
 
         if not re.search(cls.R_LAYER_TOKEN, prefix):
             invalid = True

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -69,14 +69,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
     redshift_AOV_prefix = "<BeautyPath>/<BeautyFile>{aov_separator}<RenderPass>"  # noqa: E501
 
-    # WARNING: There is bug? in renderman, translating <scene> token
-    # to something left behind mayas default image prefix. So instead
-    # `SceneName_v01` it translates to:
-    # `SceneName_v01/<RenderLayer>/<RenderLayers_<RenderPass>` that means
-    # for example:
-    # `SceneName_v01/Main/Main_<RenderPass>`. Possible solution is to define
-    # custom token like <scene_name> to point to determined scene name.
-    RendermanDirPrefix = "<ws>/renders/maya/<scene>/<layer>"
+    renderman_dir_prefix = "maya/<scene>/<layer>"
 
     R_AOV_TOKEN = re.compile(
         r'%a|<aov>|<renderpass>', re.IGNORECASE)
@@ -119,21 +112,18 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
         required_prefix = "maya/<scene>"
 
-        if renderer == "renderman":
-            # renderman has prefix set differently
-            required_prefix = "<ws>/renders/{}".format(required_prefix)
-
         if not anim_override:
             invalid = True
             cls.log.error("Animation needs to be enabled. Use the same "
                           "frame for start and end to render single frame")
 
-        if not prefix.lower().startswith(required_prefix):
-            invalid = True
-            cls.log.error(
-                "Wrong image prefix [ {} ] - doesn't start with: '{}'".format(
-                    prefix, required_prefix)
-            )
+        if renderer != "renderman":
+            if not prefix.lower().startswith(required_prefix):
+                invalid = True
+                cls.log.error(
+                    "Wrong image prefix [ {} ] - doesn't start with: '{}'".format(
+                        prefix, required_prefix)
+                )
 
         if not re.search(cls.R_LAYER_TOKEN, prefix):
             invalid = True
@@ -207,7 +197,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 invalid = True
                 cls.log.error("Wrong image prefix [ {} ]".format(file_prefix))
 
-            if dir_prefix.lower() != cls.RendermanDirPrefix.lower():
+            if dir_prefix.lower() != cls.renderman_dir_prefix.lower():
                 invalid = True
                 cls.log.error("Wrong directory prefix [ {} ]".format(
                     dir_prefix))
@@ -313,7 +303,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                              default_prefix,
                              type="string")
                 cmds.setAttr("rmanGlobals.imageOutputDir",
-                             cls.RendermanDirPrefix,
+                             cls.renderman_dir_prefix,
                              type="string")
 
             if renderer == "vray":

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -121,7 +121,8 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             cls.log.error("Animation needs to be enabled. Use the same "
                           "frame for start and end to render single frame")
 
-        if not prefix.lower().startswith("maya/<scene>"):
+        if not prefix.lower().startswith("maya/<scene>") and \
+                renderer != "renderman":
             invalid = True
             cls.log.error("Wrong image prefix [ {} ] - "
                           "doesn't start with: 'maya/<scene>'".format(prefix))

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -227,7 +227,6 @@ def get_renderer_variables(renderlayer, root):
             "d_it": None,
             "d_null": None,
             "d_openexr": "exr",
-            "d_openexr3": "exr",
             "d_png": "png",
             "d_pointcloud": "ptc",
             "d_targa": "tga",
@@ -236,8 +235,9 @@ def get_renderer_variables(renderlayer, root):
         }
 
         extension = display_types.get(
-            cmds.listConnections("rmanDefaultDisplay.displayType")[0]
-        )
+            cmds.listConnections("rmanDefaultDisplay.displayType")[0],
+            "exr"
+        ) or "exr"
 
         filename_prefix = "{}/{}".format(
             cmds.getAttr("rmanGlobals.imageOutputDir"),

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -858,7 +858,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             }
 
         renderer = self._instance.data["renderer"]
-        
+
         # This hack is here because of how Deadline handles Renderman version.
         # it considers everything with `renderman` set as version older than
         # Renderman 22, and so if we are using renderman > 21 we need to set

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -215,6 +215,24 @@ def get_renderer_variables(renderlayer, root):
         filename_0 = os.path.normpath(os.path.join(root, filename_0))
     elif renderer == "renderman":
         prefix_attr = "rmanGlobals.imageFileFormat"
+        # NOTE: This is guessing extensions from renderman display types.
+        #       Some of them are just framebuffers, d_texture format can be
+        #       set in display setting. We set those now to None, but it
+        #       should be handled more gracefully.
+        display_types = {
+            "d_deepexr": "exr",
+            "d_it": None,
+            "d_null": None,
+            "d_openexr": "exr",
+            "d_png": "png",
+            "d_pointcloud": "ptc",
+            "d_targa": "tga",
+            "d_texture": None,
+            "d_tiff": "tif"
+        }
+        extension = display_types.get(
+            cmds.listConnections("rmanDefaultDisplay.displayType")[0]
+        )
     elif renderer == "redshift":
         # mapping redshift extension dropdown values to strings
         ext_mapping = ["iff", "exr", "tif", "png", "tga", "jpg"]

--- a/openpype/settings/defaults/system_settings/tools.json
+++ b/openpype/settings/defaults/system_settings/tools.json
@@ -83,7 +83,7 @@
         "__dynamic_keys_labels__": {
             "mtoa": "Autodesk Arnold",
             "vray": "Chaos Group Vray",
-            "yeti": "Pergrine Labs Yeti",
+            "yeti": "Peregrine Labs Yeti",
             "renderman": "Pixar Renderman"
         }
     }

--- a/openpype/settings/defaults/system_settings/tools.json
+++ b/openpype/settings/defaults/system_settings/tools.json
@@ -52,10 +52,39 @@
             "environment": {},
             "variants": {}
         },
+        "renderman": {
+            "environment": {},
+            "variants": {
+                "24-3-maya": {
+                    "host_names": [
+                        "maya"
+                    ],
+                    "app_variants": [
+                        "maya/2022"
+                    ],
+                    "environment": {
+                        "RFMTREE": {
+                            "windows": "C:\\Program Files\\Pixar\\RenderManForMaya-24.3",
+                            "darwin": "/Applications/Pixar/RenderManForMaya-24.3",
+                            "linux": "/opt/pixar/RenderManForMaya-24.3"
+                        },
+                        "RMANTREE": {
+                            "windows": "C:\\Program Files\\Pixar\\RenderManProServer-24.3",
+                            "darwin": "/Applications/Pixar/RenderManProServer-24.3",
+                            "linux": "/opt/pixar/RenderManProServer-24.3"
+                        }
+                    }
+                },
+                "__dynamic_keys_labels__": {
+                    "24-3-maya": "24.3 RFM"
+                }
+            }
+        },
         "__dynamic_keys_labels__": {
             "mtoa": "Autodesk Arnold",
             "vray": "Chaos Group Vray",
-            "yeti": "Pergrine Labs Yeti"
+            "yeti": "Pergrine Labs Yeti",
+            "renderman": "Pixar Renderman"
         }
     }
 }


### PR DESCRIPTION
## Fix

This is restoring basic support for Renderman in Maya and OpenPype. It is still very basic and has no support for more advanced features like light groups, and so on.

### Testing

Install Renderman for Maya, create simple scene, create render instance, submit to farm.