### PR TITLE
Resolve environment variable in google drive credential path 

### DIFF
--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -3,7 +3,7 @@ import os.path
 import time
 import sys
 import six
-import platform
+import acre
 
 from openpype.api import Logger
 from openpype.api import get_system_settings
@@ -73,8 +73,13 @@ class GDriveHandler(AbstractProvider):
                      format(site_name))
             return
 
-        cred_path = self.presets.get("credentials_url", {}).\
-            get(platform.system().lower()) or ''
+        cred_data = {
+            'cred_path': self.presets.get("credentials_url", {})
+        }
+        cred_data = acre.parse(cred_data)
+        cred_data = acre.merge(cred_data, current_env=os.environ)
+        cred_path = cred_data['cred_path']
+
         if not os.path.exists(cred_path):
             msg = "Sync Server: No credentials for gdrive provider " + \
                   "for '{}' on path '{}'!".format(site_name, cred_path)

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -86,8 +86,8 @@ class GDriveHandler(AbstractProvider):
         try:
             cred_path = cred_path.format(**os.environ)
         except KeyError as e:
-            log.info("The key(s) {} does not exist in the environment "
-                     "variables".format(" ".join(e.args)))
+            log.info("Sync Server: The key(s) {} does not exist in the "
+                     "environment variables".format(" ".join(e.args)))
             return
 
         if not os.path.exists(cred_path):

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -3,7 +3,7 @@ import os.path
 import time
 import sys
 import six
-import acre
+import platform
 
 from openpype.api import Logger
 from openpype.api import get_system_settings
@@ -73,12 +73,22 @@ class GDriveHandler(AbstractProvider):
                      format(site_name))
             return
 
-        cred_data = {
-            'cred_path': self.presets.get("credentials_url", {})
-        }
-        cred_data = acre.parse(cred_data)
-        cred_data = acre.merge(cred_data, current_env=os.environ)
-        cred_path = cred_data['cred_path']
+        current_platform = platform.system().lower()
+        cred_path = self.presets.get("credentials_url", {}). \
+            get(current_platform) or ''
+
+        if not cred_path:
+            msg = "Sync Server: Please, fill the credentials for gdrive "\
+                  "provider for platform '{}' !".format(current_platform)
+            log.info(msg)
+            return
+
+        try:
+            cred_path = cred_path.format(**os.environ)
+        except KeyError as e:
+            log.info("the key(s) {} does not exist in the environment "
+                     "variables".format(" ".join(e.args)))
+            return
 
         if not os.path.exists(cred_path):
             msg = "Sync Server: No credentials for gdrive provider " + \

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -86,7 +86,7 @@ class GDriveHandler(AbstractProvider):
         try:
             cred_path = cred_path.format(**os.environ)
         except KeyError as e:
-            log.info("the key(s) {} does not exist in the environment "
+            log.info("The key(s) {} does not exist in the environment "
                      "variables".format(" ".join(e.args)))
             return
 


### PR DESCRIPTION
## Brief description
Allow resolving a path with an environment variable in gdrive credentials.
For example:
 if OpenPype is installed in `path/to/OP` and setting `project_settings/global/sync_server/sites/gdrive/credentials_url` is `{OPENPYPE_ROOT}/path/to/cred_file.json` will give `/path/to/OP/path/to/cred_file.json`