### PR TITLE
Tray publisher: Fixes after code movement

### DIFF
--- a/openpype/hosts/traypublisher/api/pipeline.py
+++ b/openpype/hosts/traypublisher/api/pipeline.py
@@ -7,7 +7,7 @@ from avalon import io
 import avalon.api
 import pyblish.api
 
-from openpype.pipeline import BaseCreator
+from openpype.pipeline import register_creator_plugin_path
 
 ROOT_DIR = os.path.dirname(os.path.dirname(
     os.path.abspath(__file__)
@@ -169,7 +169,7 @@ def install():
 
     pyblish.api.register_host("traypublisher")
     pyblish.api.register_plugin_path(PUBLISH_PATH)
-    avalon.api.register_plugin_path(BaseCreator, CREATE_PATH)
+    register_creator_plugin_path(CREATE_PATH)
 
 
 def set_project_name(project_name):

--- a/openpype/hosts/traypublisher/plugins/publish/validate_workfile.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_workfile.py
@@ -14,11 +14,22 @@ class ValidateWorkfilePath(pyblish.api.InstancePlugin):
     def process(self, instance):
         filepath = instance.data["sourceFilepath"]
         if not filepath:
-            raise PublishValidationError((
-                "Filepath of 'workfile' instance \"{}\" is not set"
-            ).format(instance.data["name"]))
+            raise PublishValidationError(
+                (
+                    "Filepath of 'workfile' instance \"{}\" is not set"
+                ).format(instance.data["name"]),
+                "File not filled",
+                "## Missing file\nYou are supposed to fill the path."
+            )
 
         if not os.path.exists(filepath):
-            raise PublishValidationError((
-                "Filepath of 'workfile' instance \"{}\" does not exist: {}"
-            ).format(instance.data["name"], filepath))
+            raise PublishValidationError(
+                (
+                    "Filepath of 'workfile' instance \"{}\" does not exist: {}"
+                ).format(instance.data["name"], filepath),
+                "File not found",
+                (
+                    "## File was not found\nFile \"{}\" was not found."
+                    " Check if the path is still available."
+                ).format(filepath)
+            )


### PR DESCRIPTION
## Brief description
Register of tray publisher creators does not work after [this PR](https://github.com/pypeclub/OpenPype/pull/2935).

## Description
Changed how creators are registered in traypublisher host. And added few more information into validator exceptions.

## Testing notes:
1. Run tray publisher (enabled experimental **New Standalone Publisher** in local settings first)
2. Workfiles creator should be visible