### PR TITLE
General: default workfile subset name for workfile

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -245,6 +245,15 @@
                 },
                 {
                     "families": [
+                        "workfile"
+                    ],
+                    "hosts": [],
+                    "task_types": [],
+                    "tasks": [],
+                    "template": "{family}{Task}"
+                },
+                {
+                    "families": [
                         "render"
                     ],
                     "hosts": [],

--- a/tests/lib/assert_classes.py
+++ b/tests/lib/assert_classes.py
@@ -24,16 +24,18 @@ class DBAssert:
             else:
                 args[key] = val
 
-        msg = None
-        no_of_docs = dbcon.count_documents(args)
-        if expected != no_of_docs:
-            msg = "Not expected no of versions. "\
-                  "Expected {}, found {}".format(expected, no_of_docs)
-
         args.pop("type")
         detail_str = " "
         if args:
-            detail_str = " with {}".format(args)
+            detail_str = " with '{}'".format(args)
+
+        msg = None
+        no_of_docs = dbcon.count_documents(args)
+        if expected != no_of_docs:
+            msg = "Not expected no of '{}'{}."\
+                  "Expected {}, found {}".format(queried_type,
+                                                 detail_str,
+                                                 expected, no_of_docs)
 
         status = "successful"
         if msg:
@@ -42,7 +44,5 @@ class DBAssert:
         print("Comparing count of {}{} {}".format(queried_type,
                                                   detail_str,
                                                   status))
-        if msg:
-            print(msg)
 
         return msg


### PR DESCRIPTION
## Brief description
Added default template for subset workfile to '{family}{Task}'. (eg. for TestTask subset would be `workfileTestTask`)

## Description
Standard method `get_subset_name` might not be used for workfiles on all places (it should), but it seems when it will be used, 
it should translate into workfileTaskname format.
