### PR TITLE
Ftrack: multiple  reviewable componets

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -729,7 +729,9 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "resolutionWidth": data.get("resolutionWidth", 1920),
             "resolutionHeight": data.get("resolutionHeight", 1080),
             "multipartExr": data.get("multipartExr", False),
-            "jobBatchName": data.get("jobBatchName", "")
+            "jobBatchName": data.get("jobBatchName", ""),
+            "hasReviewableRepresentations": data.get(
+                "hasReviewableRepresentations")
         }
 
         if "prerender" in instance.data["families"]:

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -175,33 +175,40 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             # Create copy of base comp item and append it
             review_item = copy.deepcopy(base_component_item)
 
-            # condition for multiple reviewable representations
-            # expand name to better label componenst
+            # get asset name and define extended name variant
+            asset_name = review_item["asset_data"]["name"]
+            extended_asset_name = "_".join(
+                (asset_name, repre["name"])
+            )
+
+            # reset extended if no need for extended asset name
             if (
-                not self.keep_first_subset_name_for_review
-                and multiple_reviewable
+                self.keep_first_subset_name_for_review
+                and is_first_review_repre
             ):
-                asset_name = review_item["asset_data"]["name"]
-                # define new extended name
-                extended_asset_name = "_".join(
-                    (asset_name, repre["name"])
-                )
-                review_item["asset_data"]["name"] = extended_asset_name
+                extended_asset_name = ""
+            else:
+                # only rename if multiple reviewable
+                if multiple_reviewable:
+                    review_item["asset_data"]["name"] = extended_asset_name
+                else:
+                    extended_asset_name = ""
 
-                # rename asset name only if multiple reviewable repre
-                if is_first_review_repre:
-                    # and rename all already created components
-                    for _ci in component_list:
-                        _ci["asset_data"]["name"] = extended_asset_name
+            # rename all already created components
+            # only if first repre and extended name available
+            if is_first_review_repre and extended_asset_name:
+                # and rename all already created components
+                for _ci in component_list:
+                    _ci["asset_data"]["name"] = extended_asset_name
 
-                    # and rename all already created src components
-                    for _sci in src_components_to_add:
-                        _sci["asset_data"]["name"] = extended_asset_name
+                # and rename all already created src components
+                for _sci in src_components_to_add:
+                    _sci["asset_data"]["name"] = extended_asset_name
 
-                    # rename also first thumbnail component if any
-                    if first_thumbnail_component is not None:
-                        first_thumbnail_component[
-                            "asset_data"]["name"] = extended_asset_name
+                # rename also first thumbnail component if any
+                if first_thumbnail_component is not None:
+                    first_thumbnail_component[
+                        "asset_data"]["name"] = extended_asset_name
 
             frame_start = repre.get("frameStartFtrack")
             frame_end = repre.get("frameEndFtrack")
@@ -236,6 +243,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             if is_first_review_repre:
                 is_first_review_repre = False
             else:
+                # later detection for thumbnail duplication
                 not_first_components.append(review_item)
 
             # Create copy of item before setting location
@@ -280,7 +288,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             other_item = copy.deepcopy(base_component_item)
 
             # add extended name if any
-            if extended_asset_name:
+            if (
+                not self.keep_first_subset_name_for_review
+                and extended_asset_name
+            ):
                 other_item["asset_data"]["name"] = extended_asset_name
 
             other_item["component_data"] = {


### PR DESCRIPTION
## Brief description
Names were not correctly distributing

## Description
Previous PR https://github.com/pypeclub/OpenPype/pull/2996 was merged with broken logic and didn't distribute correctly extended names. 

## Testing notes:
1. Nuke Single baking preset with `project_settings/ftrack/publish/IntegrateFtrackInstance/keep_first_subset_name_for_review` ON should create ftrack asset name equal to `{subset_name}`
2. Nuke Single baking preset with `project_settings/ftrack/publish/IntegrateFtrackInstance/keep_first_subset_name_for_review` OFF should create ftrack asset name equal to `{subset_name}`
3. Nuke Multiple baking preset with `project_settings/ftrack/publish/IntegrateFtrackInstance/keep_first_subset_name_for_review` ON should create ftrack asset name equal to `{subset_name}_{repre_name}` but __first__ asset name should equal to `{subset_name}`
4. Nuke Multiple baking preset with `project_settings/ftrack/publish/IntegrateFtrackInstance/keep_first_subset_name_for_review` OFF should create all ftrack asset names equal to `{subset_name}_{repre_name}`