### PR TITLE
Deadline: Use more suitable name for sequence review logic

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -123,7 +123,7 @@ class ExtractReviewDataMov(openpype.api.Extractor):
         if generated_repres:
             # assign to representations
             instance.data["representations"] += generated_repres
-            instance.data["hasReviewableRepresentations"] = True
+            instance.data["useSequenceForReview"] = False
         else:
             instance.data["families"].remove("review")
             self.log.info((

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -524,26 +524,31 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         for collection in collections:
             ext = collection.tail.lstrip(".")
             preview = False
-            # if filtered aov name is found in filename, toggle it for
-            # preview video rendering
-            for app in self.aov_filter.keys():
-                if os.environ.get("AVALON_APP", "") == app:
-                    # no need to add review if `hasReviewableRepresentations`
-                    if instance.get("hasReviewableRepresentations"):
-                        break
+            # TODO 'useSequenceForReview' is temporary solution which does
+            #   not work for 100% of cases. We must be able to tell what
+            #   expected files contains more explicitly and from what
+            #   should be review made.
+            # - "review" tag is never added when is set to 'False'
+            use_sequence_for_review = instance.get(
+                "useSequenceForReview", True
+            )
+            if use_sequence_for_review:
+                # if filtered aov name is found in filename, toggle it for
+                # preview video rendering
+                for app in self.aov_filter.keys():
+                    if os.environ.get("AVALON_APP", "") == app:
+                        # iteratre all aov filters
+                        for aov in self.aov_filter[app]:
+                            if re.match(
+                                aov,
+                                list(collection)[0]
+                            ):
+                                preview = True
+                                break
 
-                    # iteratre all aov filters
-                    for aov in self.aov_filter[app]:
-                        if re.match(
-                            aov,
-                            list(collection)[0]
-                        ):
-                            preview = True
-                            break
-
-            # toggle preview on if multipart is on
-            if instance.get("multipartExr", False):
-                preview = True
+                # toggle preview on if multipart is on
+                if instance.get("multipartExr", False):
+                    preview = True
 
             staging = os.path.dirname(list(collection)[0])
             success, rootless_staging_dir = (
@@ -730,8 +735,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "resolutionHeight": data.get("resolutionHeight", 1080),
             "multipartExr": data.get("multipartExr", False),
             "jobBatchName": data.get("jobBatchName", ""),
-            "hasReviewableRepresentations": data.get(
-                "hasReviewableRepresentations")
+            "useSequenceForReview": data.get("useSequenceForReview")
         }
 
         if "prerender" in instance.data["families"]:


### PR DESCRIPTION
## Brief description
Changed key `"hasReviewableRepresentations"` -> `"useSequenceForReview"` to make it more clear for future logic.

## Description
The logic for forcing to not create reviewable from sequence was reversed by checking for `"useSequenceForReview"`. The value must be explicitly set to `False` to not add review tag to the representation. Logic result did not change.

## Additional info
This change was made based on discussion. Result of discussion is that we should probably modify logic of expected files in submit publish job which is limited a lot and can't handle few cases properly.

## Testing notes:
1. Farm publishing of baking nuke scripts should work as did before this PR