### PR TITLE
Console Interpreter: Changed how console splitter size are reused on show

### DIFF
--- a/openpype/modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/python_console_interpreter/window/widgets.py
@@ -648,24 +648,8 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
 
         # Skip if number of size items does not match to splitter
         splitters_count = len(self._widgets_splitter.sizes())
-        if len(splitter_size_ratio) != splitters_count:
-            return
-
-        # Don't use absolute sizes but ratio of last stored sizes
-        ratio_sum = sum(splitter_size_ratio)
-        sizes = []
-        max_size = self._widgets_splitter.height()
-        cur_size = 0
-        ratio = max_size / ratio_sum
-        for size in splitter_size_ratio:
-            item_size = int(ratio * size)
-            cur_size += item_size
-            if cur_size > max_size:
-                item_size -= cur_size - max_size
-            if not item_size:
-                item_size = 1
-            sizes.append(item_size)
-        self._widgets_splitter.setSizes(sizes)
+        if len(splitter_size_ratio) == splitters_count:
+            self._widgets_splitter.setSizes(splitter_size_ratio)
 
     def closeEvent(self, event):
         self.save_registry()

--- a/openpype/modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/python_console_interpreter/window/widgets.py
@@ -638,7 +638,7 @@ class PythonInterpreterWidget(QtWidgets.QWidget):
     def _on_first_show(self):
         # Change stylesheet
         self.setStyleSheet(load_stylesheet())
-        # Check if splitter size raio is set
+        # Check if splitter size ratio is set
         # - first store value to local variable and then unset it
         splitter_size_ratio = self._splitter_size_ratio
         self._splitter_size_ratio = None


### PR DESCRIPTION
## Brief description
Use stored splitter sizes as relative ratio rather then absolute size.

## Description
Restored sizes are now set explicitly on initialization but the size of window is not yet known so the bottom part is squeezed and when sizes would be set as absolute size of first show it may cause issues when machine has more displays with different resolution. The best solution seems to be se restore size of window before first show and change splitter sizes after showing up.

## Testing notes:
1. Open tray > Admin > Console
2. Change sizes of window and splitter parts
3. Restart tray
4. Open tray > Admin > Console again
5. Size of window and splitter parts should be the same, or more close then were before this PR