### PR TITLE
SiteSync: fix transitive alternate sites, fix dropdown in Local Settings

### DIFF
--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -850,7 +850,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         active_site = sync_settings["config"]["active_site"]
         # for Tray running background process
-        if active_site == get_local_site_id() and active_site not in sites:
+        if active_site not in sites and active_site == get_local_site_id():
             sites.append(active_site)
 
         return sites

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -848,6 +848,11 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         if self.enabled and sync_settings.get('enabled'):
             sites.append(self.LOCAL_SITE)
 
+        active_site = sync_settings["config"]["active_site"]
+        # for Tray running background process
+        if active_site == get_local_site_id() and active_site not in sites:
+            sites.append(active_site)
+
         return sites
 
     def tray_init(self):

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -8,6 +8,7 @@ import errno
 import six
 import re
 import shutil
+from collections import deque
 
 from bson.objectid import ObjectId
 from pymongo import DeleteOne, InsertOne
@@ -1199,21 +1200,23 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
         # transitive relationship, eg site is alternative to another which is
         # alternative to nex site
-        loop = True
-        while loop:
-            loop = False
-            for site_name, alt_sites in alt_site_pairs.items():
-                for alt_site in alt_sites:
-                    # safety against wrong config
-                    # {"SFTP": {"alternative_site": "SFTP"}
-                    if alt_site == site_name:
-                        continue
+        for site_name, alt_sites in alt_site_pairs.items():
+            sites_queue = deque(alt_sites)
+            while sites_queue:
+                alt_site = sites_queue.popleft()
 
-                    for alt_alt_site in alt_site_pairs.get(alt_site, []):
-                        if (    alt_alt_site != site_name
-                                and alt_alt_site not in alt_sites):
-                            alt_site_pairs[site_name].append(alt_alt_site)
-                            loop = True
+                # safety against wrong config
+                # {"SFTP": {"alternative_site": "SFTP"}
+                if alt_site == site_name or alt_site not in alt_site_pairs:
+                    continue
+
+                for alt_alt_site in alt_site_pairs[alt_site]:
+                    if (
+                            alt_alt_site != site_name
+                            and alt_alt_site not in alt_sites
+                    ):
+                        alt_sites.append(alt_alt_site)
+                        sites_queue.append(alt_alt_site)
 
         return alt_site_pairs
 

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -8,7 +8,7 @@ import errno
 import six
 import re
 import shutil
-from collections import deque
+from collections import deque, defaultdict
 
 from bson.objectid import ObjectId
 from pymongo import DeleteOne, InsertOne
@@ -1185,21 +1185,14 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         Returns:
             (dict): {'site': [alternative sites]...}
         """
-        alt_site_pairs = {}
+        alt_site_pairs = defaultdict(list)
         for site_name, site_info in conf_sites.items():
             alt_sites = set(site_info.get("alternative_sites", []))
-            if not alt_site_pairs.get(site_name):
-                alt_site_pairs[site_name] = []
-
             alt_site_pairs[site_name].extend(alt_sites)
 
             for alt_site in alt_sites:
-                if not alt_site_pairs.get(alt_site):
-                    alt_site_pairs[alt_site] = []
-                alt_site_pairs[alt_site].extend([site_name])
+                alt_site_pairs[alt_site].append(site_name)
 
-        # transitive relationship, eg site is alternative to another which is
-        # alternative to nex site
         for site_name, alt_sites in alt_site_pairs.items():
             sites_queue = deque(alt_sites)
             while sites_queue:


### PR DESCRIPTION
## Brief description
Based on specific use case for a customer where separate site is used for specific project.

## Description
'studio2' site was created to separate synchronization for specific project, previous implementation didn't handle setting this site as an alternative site to `studio`.


## Testing notes:
1. this PR will be tested by customer on their specific configuration
2. It should be tested on regular configuration if it didn't break anything (just pulled and start OP and try to publish something if it behaves same way as before)