### PR TITLE
General: Add example addons to ignored

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -38,6 +38,7 @@ IGNORED_DEFAULT_FILENAMES = (
     "base.py",
     "interfaces.py",
     "example_addons",
+    "default_modules",
 )
 
 
@@ -308,6 +309,9 @@ def _load_modules():
             # Check existence of init fil
             init_path = os.path.join(fullpath, "__init__.py")
             if not os.path.exists(init_path):
+                log.debug((
+                    "Module directory does not contan __init__.py file {}"
+                ).format(fullpath))
                 continue
 
         elif ext not in (".py", ):
@@ -352,6 +356,9 @@ def _load_modules():
                 # Check existence of init fil
                 init_path = os.path.join(fullpath, "__init__.py")
                 if not os.path.exists(init_path):
+                    log.debug((
+                        "Module directory does not contan __init__.py file {}"
+                    ).format(fullpath))
                     continue
 
             elif ext not in (".py", ):

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -304,7 +304,13 @@ def _load_modules():
         fullpath = os.path.join(current_dir, filename)
         basename, ext = os.path.splitext(filename)
 
-        if not os.path.isdir(fullpath) and ext not in (".py", ):
+        if os.path.isdir(fullpath):
+            # Check existence of init fil
+            init_path = os.path.join(fullpath, "__init__.py")
+            if not os.path.exists(init_path):
+                continue
+
+        elif ext not in (".py", ):
             continue
 
         try:
@@ -342,7 +348,13 @@ def _load_modules():
             fullpath = os.path.join(dirpath, filename)
             basename, ext = os.path.splitext(filename)
 
-            if not os.path.isdir(fullpath) and ext not in (".py", ):
+            if os.path.isdir(fullpath):
+                # Check existence of init fil
+                init_path = os.path.join(fullpath, "__init__.py")
+                if not os.path.exists(init_path):
+                    continue
+
+            elif ext not in (".py", ):
                 continue
 
             # TODO add more logic how to define if folder is module or not

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -37,6 +37,7 @@ IGNORED_DEFAULT_FILENAMES = (
     "__init__.py",
     "base.py",
     "interfaces.py",
+    "example_addons",
 )
 
 

--- a/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
@@ -1,11 +1,6 @@
 import os
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
-from avalon import lib as avalonlib
-from openpype.api import (
-    Anatomy,
-    get_project_settings
-)
-from openpype.lib import ApplicationManager
+from openpype.api import Anatomy
 
 
 class CreateFolders(BaseAction):


### PR DESCRIPTION
## Brief description
Example addons folder is not auto-loaded because is not in ignored filenames variable.

## Description
Added `example_addons` and `default_modules` folders into ignored folders. Also added condition to ignore all openpype module folders that don't have `__init__.py` files in. Side change is removement of imports in ftrack action `action_create_folders.py` which were accidentally added back during merge resolving.

## Testing notes:
1. OpenPype modules should be loaded.
2. Example addons must not be added automatically unless their path is explicitly added in settings.
3. Folders of OpenPype modules containing only pycache files should be skipped.