### PR TITLE
AfterEffects: Added creating subset name for workfile from template

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -1,6 +1,7 @@
 import os
 from avalon import api
 import pyblish.api
+from openpype.lib import get_subset_name_with_asset_doc
 
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
@@ -38,7 +39,14 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
 
         # workfile instance
         family = "workfile"
-        subset = family + task.capitalize()
+        subset = get_subset_name_with_asset_doc(
+            family,
+            "",
+            context.data["anatomyData"]["task"]["name"],
+            context.data["assetEntity"],
+            context.data["anatomyData"]["project"]["name"],
+            host_name=context.data["hostName"]
+        )
         # Create instance
         instance = context.create_instance(subset)
 


### PR DESCRIPTION
## Brief description
Subset name (folder and subset part of published workfile) was previously hardcoded as `workfileTASKNAME`.

## Description
Now it uses template in `project_settings/global/tools/creator/subset_name_profiles` -

## Testing notes:
1. modify template in `project_settings/global/tools/creator/subset_name_profiles`
2. publish workfile in AE, check name of published folder and name of published workfile if it matches to template