### PR TITLE
Harmony: Added creating subset name for workfile from template

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_workfile.py
@@ -3,6 +3,8 @@
 import pyblish.api
 import os
 
+from openpype.lib import get_subset_name_with_asset_doc
+
 
 class CollectWorkfile(pyblish.api.ContextPlugin):
     """Collect current script for publish."""
@@ -14,10 +16,15 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
     def process(self, context):
         """Plugin entry point."""
         family = "workfile"
-        task = os.getenv("AVALON_TASK", None)
-        sanitized_task_name = task[0].upper() + task[1:]
         basename = os.path.basename(context.data["currentFile"])
-        subset = "{}{}".format(family, sanitized_task_name)
+        subset = get_subset_name_with_asset_doc(
+            family,
+            "",
+            context.data["anatomyData"]["task"]["name"],
+            context.data["assetEntity"],
+            context.data["anatomyData"]["project"]["name"],
+            host_name=context.data["hostName"]
+        )
 
         # Create instance
         instance = context.create_instance(subset)


### PR DESCRIPTION
## Brief description
Subset name (folder and subset part of published workfile) was previously hardcoded as `workfileTASKNAME`.

## Description
Now it uses template in `project_settings/global/tools/creator/subset_name_profiles` -

## Testing notes:
1. modify template in `project_settings/global/tools/creator/subset_name_profiles`
2. publish workfile in Harmony, check name of published folder and name of published workfile if it matches to template