### PR TITLE
General: Fix import after movements

### DIFF
--- a/openpype/hosts/tvpaint/plugins/load/load_reference_image.py
+++ b/openpype/hosts/tvpaint/plugins/load/load_reference_image.py
@@ -1,6 +1,6 @@
 import collections
 import qargparse
-from avalon.pipeline import get_representation_context
+from openpype.pipeline import get_representation_context
 from openpype.hosts.tvpaint.api import lib, pipeline, plugin
 
 

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -41,6 +41,7 @@ from .load import (
 
     loaders_from_representation,
     get_representation_path,
+    get_representation_context,
     get_repres_contexts,
 )
 
@@ -113,6 +114,7 @@ __all__ = (
 
     "loaders_from_representation",
     "get_representation_path",
+    "get_representation_context",
     "get_repres_contexts",
 
     # --- Publish ---


### PR DESCRIPTION
## Brief description
One of refactor PRs broke import of `get_representation_context`.

## Description
Added `get_representation_context` to `openpype.pipeline` import level and changed import in TVPaint load plugin.

## Testing notes:
1. TVPaint loader should be visible
2. Maya loader `ImportModelRender` should work