### PR TITLE
General: Fix validate asset docs plug-in filename and class name

### DIFF
--- a/openpype/plugins/publish/validate_asset_docs.py
+++ b/openpype/plugins/publish/validate_asset_docs.py
@@ -3,7 +3,7 @@ from openpype.pipeline import PublishValidationError
 
 
 class ValidateAssetDocs(pyblish.api.InstancePlugin):
-    """Validate existence of asset asset documents on instances.
+    """Validate existence of asset documents on instances.
 
     Without asset document it is not possible to publish the instance.
 
@@ -22,10 +22,10 @@ class ValidateAssetDocs(pyblish.api.InstancePlugin):
             return
 
         if instance.data.get("assetEntity"):
-            self.log.info("Instance have set asset document in it's data.")
+            self.log.info("Instance has set asset document in its data.")
 
         else:
             raise PublishValidationError((
-                "Instance \"{}\" don't have set asset"
-                " document which is needed for publishing."
+                "Instance \"{}\" doesn't have asset document "
+                "set which is needed for publishing."
             ).format(instance.data["name"]))

--- a/openpype/plugins/publish/validate_asset_docs.py
+++ b/openpype/plugins/publish/validate_asset_docs.py
@@ -2,7 +2,7 @@ import pyblish.api
 from openpype.pipeline import PublishValidationError
 
 
-class ValidateContainers(pyblish.api.InstancePlugin):
+class ValidateAssetDocs(pyblish.api.InstancePlugin):
     """Validate existence of asset asset documents on instances.
 
     Without asset document it is not possible to publish the instance.


### PR DESCRIPTION
## Brief description
Fix **Validate asset docs** plug-in filename and class name which was invalid [as reported on Discord](https://discord.com/channels/517362899170230292/517382145552154634/961312392711667773).

Plus some minor typos/grammar changes.

This should also avoid a class name conflict with [Validate Containers](https://github.com/pypeclub/OpenPype/blob/2207d3a279a7974d187a43d404861cd68f06c05c/openpype/plugins/publish/validate_containers.py#L17).

## Testing notes:
1. Check whether the plug-in shows up and runs as expected.