### PR TITLE
Maya: Allow to select invalid camera contents if no cameras found

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
@@ -40,7 +40,14 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
             # list when there are no actual cameras results in
             # still an empty 'invalid' list
             if len(cameras) < 1:
-                raise RuntimeError("No cameras in instance.")
+                if members:
+                    # If there are members in the instance return all of
+                    # them as 'invalid' so the user can still select invalid
+                    cls.log.error("No cameras found in instance "
+                                  "members: {}".format(members))
+                    return members
+
+                raise RuntimeError("No cameras found in empty instance.")
 
         # non-camera shapes
         valid_shapes = cmds.ls(shapes, type=('camera', 'locator'), long=True)


### PR DESCRIPTION
## Brief description

Fixes #3026

## Testing notes:
1. create camera instance with just an empty group in it
2. pyblish -> right click -> select invalid -- should select the contents