### PR TITLE
Deadline: Fixed default value of use sequence for review

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -531,10 +531,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             #   expected files contains more explicitly and from what
             #   should be review made.
             # - "review" tag is never added when is set to 'False'
-            use_sequence_for_review = instance.get(
-                "useSequenceForReview", True
-            )
-            if use_sequence_for_review:
+            if instance["useSequenceForReview"]:
                 # if filtered aov name is found in filename, toggle it for
                 # preview video rendering
                 for app in self.aov_filter.keys():
@@ -737,7 +734,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "resolutionHeight": data.get("resolutionHeight", 1080),
             "multipartExr": data.get("multipartExr", False),
             "jobBatchName": data.get("jobBatchName", ""),
-            "useSequenceForReview": data.get("useSequenceForReview")
+            "useSequenceForReview": data.get("useSequenceForReview", True)
         }
 
         if "prerender" in instance.data["families"]:


### PR DESCRIPTION
## Brief description
The default value of `useSequenceForReview` was not used because the key was always available with value `None`.

## Description
Moved default value to place where the key is assigned to instance data. Issue caused by [this PR](https://github.com/pypeclub/OpenPype/pull/3015).

## Testing notes:
1. Publish using deadline
2. The review should be created in all matching aov cases