### PR TITLE
Unreal: Creator import fixes

### DIFF
--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -4,7 +4,6 @@ import logging
 from typing import List
 
 import pyblish.api
-from avalon import api
 
 from openpype.pipeline import (
     register_loader_plugin_path,
@@ -74,30 +73,6 @@ def _register_events():
     TODO: Implement callbacks if supported by UE4
     """
     pass
-
-
-class Creator(LegacyCreator):
-    hosts = ["unreal"]
-    asset_types = []
-
-    def process(self):
-        nodes = list()
-
-        with unreal.ScopedEditorTransaction("OpenPype Creating Instance"):
-            if (self.options or {}).get("useSelection"):
-                self.log.info("setting ...")
-                print("settings ...")
-                nodes = unreal.EditorUtilityLibrary.get_selected_assets()
-
-                asset_paths = [a.get_path_name() for a in nodes]
-                self.name = move_assets_to_path(
-                    "/Game", self.name, asset_paths
-                )
-
-            instance = create_publish_instance("/Game", self.name)
-            imprint(instance, self.data)
-
-        return instance
 
 
 def ls():

--- a/openpype/hosts/unreal/plugins/create/create_camera.py
+++ b/openpype/hosts/unreal/plugins/create/create_camera.py
@@ -2,13 +2,11 @@ import unreal
 from unreal import EditorAssetLibrary as eal
 from unreal import EditorLevelLibrary as ell
 
-from openpype.hosts.unreal.api.plugin import Creator
-from avalon.unreal import (
-    instantiate,
-)
+from openpype.hosts.unreal.api import plugin
+from openpype.hosts.unreal.api.pipeline import instantiate
 
 
-class CreateCamera(Creator):
+class CreateCamera(plugin.Creator):
     """Layout output for character rigs"""
 
     name = "layoutMain"

--- a/openpype/hosts/unreal/plugins/create/create_layout.py
+++ b/openpype/hosts/unreal/plugins/create/create_layout.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 from unreal import EditorLevelLibrary as ell
-from openpype.hosts.unreal.api.plugin import Creator
-from avalon.unreal import (
-    instantiate,
-)
+from openpype.hosts.unreal.api import plugin
+from openpype.hosts.unreal.api.pipeline import instantiate
 
 
-class CreateLayout(Creator):
+class CreateLayout(plugin.Creator):
     """Layout output for character rigs."""
 
     name = "layoutMain"

--- a/openpype/hosts/unreal/plugins/create/create_look.py
+++ b/openpype/hosts/unreal/plugins/create/create_look.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 """Create look in Unreal."""
 import unreal  # noqa
-from openpype.hosts.unreal.api.plugin import Creator
-from openpype.hosts.unreal.api import pipeline
+from openpype.hosts.unreal.api import pipeline, plugin
 
 
-class CreateLook(Creator):
+class CreateLook(plugin.Creator):
     """Shader connections defining shape look."""
 
     name = "unrealLook"

--- a/openpype/hosts/unreal/plugins/create/create_staticmeshfbx.py
+++ b/openpype/hosts/unreal/plugins/create/create_staticmeshfbx.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Create Static Meshes as FBX geometry."""
 import unreal  # noqa
-from openpype.hosts.unreal.api.plugin import Creator
+from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     instantiate,
 )
 
 
-class CreateStaticMeshFBX(Creator):
+class CreateStaticMeshFBX(plugin.Creator):
     """Static FBX geometry."""
 
     name = "unrealStaticMeshMain"


### PR DESCRIPTION
## Brief description
Creators in unreal are using function from avalon which are not avaialbe anymore and were importing `Creator` directly which caused that the base of Unreal Creator was visible in Creator tool.

## Description
Change imports to use function from OpenPype and base `Creator` plugin is not part in globals of plugin files.

## Testing notes:
1. Open unreal using openpype
2. All should work
3. Creator tool should show all 4 current creators and not should default one