### PR TITLE
SiteSync: Providers ignore that site is disabled

### DIFF
--- a/openpype/modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/sync_server/providers/dropbox.py
@@ -17,11 +17,17 @@ class DropboxHandler(AbstractProvider):
         self.active = False
         self.site_name = site_name
         self.presets = presets
+        self.dbx = None
 
         if not self.presets:
             log.info(
                 "Sync Server: There are no presets for {}.".format(site_name)
             )
+            return
+
+        if not self.presets["enabled"]:
+            log.debug("Sync Server: Site {} not enabled for {}.".
+                      format(site_name, project_name))
             return
 
         token = self.presets.get("token", "")
@@ -44,16 +50,13 @@ class DropboxHandler(AbstractProvider):
             log.info(msg)
             return
 
-        self.dbx = None
-
-        if self.presets["enabled"]:
-            try:
-                self.dbx = self._get_service(
-                    token, acting_as_member, team_folder_name
-                )
-            except Exception as e:
-                log.info("Could not establish dropbox object: {}".format(e))
-                return
+        try:
+            self.dbx = self._get_service(
+                token, acting_as_member, team_folder_name
+            )
+        except Exception as e:
+            log.info("Could not establish dropbox object: {}".format(e))
+            return
 
         super(AbstractProvider, self).__init__()
 

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -73,6 +73,11 @@ class GDriveHandler(AbstractProvider):
                      format(site_name))
             return
 
+        if not self.presets["enabled"]:
+            log.debug("Sync Server: Site {} not enabled for {}.".
+                      format(site_name, project_name))
+            return
+
         current_platform = platform.system().lower()
         cred_path = self.presets.get("credentials_url", {}). \
             get(current_platform) or ''
@@ -97,11 +102,10 @@ class GDriveHandler(AbstractProvider):
             return
 
         self.service = None
-        if self.presets["enabled"]:
-            self.service = self._get_gd_service(cred_path)
+        self.service = self._get_gd_service(cred_path)
 
-            self._tree = tree
-            self.active = True
+        self._tree = tree
+        self.active = True
 
     def is_active(self):
         """


### PR DESCRIPTION
## Brief description
GDrive site was checking presence of credentials even if it was disabled on a project.

## Description
This caused uncaught exceptions which prevented of synching of totally unrelated sites, which were configured correctly.
Same behavior noticed in Dropbox, SFTP checked also (without this issue).

## Testing notes:
1. Add Gdrive site in System Settings
2. disable it on project settings
3. restart Tray (without this fix, it would complain in the log that Gdrive credentials are missing)