### PR TITLE
LibraryLoader: Use current project for asset query in families filter

### DIFF
--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -409,6 +409,7 @@ class FamilyConfigCache:
         project_name = os.environ.get("AVALON_PROJECT")
         asset_name = os.environ.get("AVALON_ASSET")
         task_name = os.environ.get("AVALON_TASK")
+        host_name = os.environ.get("AVALON_APP")
         if not all((project_name, asset_name, task_name)):
             return
 
@@ -422,15 +423,18 @@ class FamilyConfigCache:
             ["family_filter_profiles"]
         )
         if profiles:
-            asset_doc = self.dbcon.find_one(
+            # Make sure connection is installed
+            # - accessing attribute which does not have auto-install
+            self.dbcon.install()
+            asset_doc = self.dbcon.database[project_name].find_one(
                 {"type": "asset", "name": asset_name},
                 {"data.tasks": True}
-            )
+            ) or {}
             tasks_info = asset_doc.get("data", {}).get("tasks") or {}
             task_type = tasks_info.get(task_name, {}).get("type")
             profiles_filter = {
                 "task_types": task_type,
-                "hosts": os.environ["AVALON_APP"]
+                "hosts": host_name
             }
             matching_item = filter_profiles(profiles, profiles_filter)
 


### PR DESCRIPTION
## Brief description
Family filter now query asset from current project instead of project selected in library loader.

## Description
Library loader queried asset document which defines family filters from the project defined in library loader instead of from current project which caused missing asset document bug.

## Testing notes:
1. You have to have at least one library project
2. Open host in other project
3. Open Library loader in the host
4. Select a library project
5. Tool should not crash due to missing asset document

### Source traceback
```
# Traceback (most recent call last):
#   File ".\openpype\openpype-v3.9.1\openpype\tools\libraryloader\app.py", line 278, in on_project_change
#     self._refresh_assets()
#   File ".\openpype\openpype-v3.9.1\openpype\tools\libraryloader\app.py", line 343, in _refresh_assets
#     self._families_filter_view.refresh()
#   File ".\openpype\openpype-v3.9.1\openpype\tools\loader\widgets.py", line 1047, in refresh
#     self._family_model.refresh()
#   File ".\openpype\openpype-v3.9.1\openpype\tools\loader\widgets.py", line 943, in refresh
#     family_config = self.family_config_cache.family_config(family)
#   File ".\openpype\openpype-v3.9.1\openpype\tools\utils\lib.py", line 354, in family_config
#     self._refresh()
#   File ".\openpype\openpype-v3.9.1\openpype\tools\utils\lib.py", line 417, in _refresh
#     tasks_info = asset_doc.get("data", {}).get("tasks") or {}
# AttributeError: 'NoneType' object has no attribute 'get'
```