### PR TITLE
Webpublisher - removed wrong hardcoded family

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -209,7 +209,6 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
         msg = "No family found for combination of " +\
               "task_type: {}, is_sequence:{}, extension: {}".format(
                   task_type, is_sequence, extension)
-        found_family = "render"
         assert found_family, msg
 
         return (found_family,


### PR DESCRIPTION
## Brief description
Removed forgotten hardcoded family

## Testing notes:
1. Publish psd or tvp via Webpublisher
2. shouldn't create render family