### PR TITLE
Ftrack: Integrate ftrack api fix

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -263,7 +263,9 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
             self.log.info("Creating asset types with short names: {}".format(
                 ", ".join(asset_type_names_by_missing_shorts.keys())
             ))
-            for missing_short, type_name in asset_type_names_by_missing_shorts:
+            for missing_short, type_name in (
+                asset_type_names_by_missing_shorts.items()
+            ):
                 # Use short for name if name is not defined
                 if not type_name:
                     type_name = missing_short


### PR DESCRIPTION
## Brief description
Fixed wrong looping over dictionary object.

## Description
Loop over dictionary did not use `items` method. Bug was added with [this PR](https://github.com/pypeclub/OpenPype/pull/3025).

## Testing notes:
1. Run any publish which will trigger integrate ftrack api and will cause that new asset type will be created
- asset type name can be defined in `project_settings/ftrack/publish/IntegrateFtrackInstance/family_mapping`