### PR TITLE
Deadline: reworked pools assignment

### DIFF
--- a/openpype/hosts/aftereffects/plugins/publish/collect_render.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_render.py
@@ -25,7 +25,7 @@ class AERenderInstance(RenderInstance):
 
 class CollectAERender(abstract_collect_render.AbstractCollectRender):
 
-    order = pyblish.api.CollectorOrder + 0.498
+    order = pyblish.api.CollectorOrder + 0.400
     label = "Collect After Effects Render Layers"
     hosts = ["aftereffects"]
 

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -4,8 +4,6 @@ import os
 import json
 import appdirs
 import requests
-import six
-import sys
 
 from maya import cmds
 import maya.app.renderSetup.model.renderSetup as renderSetup
@@ -14,6 +12,7 @@ from openpype.hosts.maya.api import (
     lib,
     plugin
 )
+from openpype.lib import requests_get
 from openpype.api import (
     get_system_settings,
     get_project_settings,
@@ -117,6 +116,8 @@ class CreateRender(plugin.Creator):
         except KeyError:
             self.aov_separator = "_"
 
+        manager = ModulesManager()
+        self.deadline_module = manager.modules_by_name["deadline"]
         try:
             default_servers = deadline_settings["deadline_urls"]
             project_servers = (
@@ -133,10 +134,8 @@ class CreateRender(plugin.Creator):
 
         except AttributeError:
             # Handle situation were we had only one url for deadline.
-            manager = ModulesManager()
-            deadline_module = manager.modules_by_name["deadline"]
             # get default deadline webservice url from deadline module
-            self.deadline_servers = deadline_module.deadline_urls
+            self.deadline_servers = self.deadline_module.deadline_urls
 
     def process(self):
         """Entry point."""
@@ -211,7 +210,7 @@ class CreateRender(plugin.Creator):
                 cmds.getAttr("{}.deadlineServers".format(self.instance))
             ]
         ]
-        pools = self._get_deadline_pools(webservice)
+        pools = self.deadline_module.get_deadline_pools(webservice, self.log)
         cmds.deleteAttr("{}.primaryPool".format(self.instance))
         cmds.deleteAttr("{}.secondaryPool".format(self.instance))
         cmds.addAttr(self.instance, longName="primaryPool",
@@ -220,33 +219,6 @@ class CreateRender(plugin.Creator):
         cmds.addAttr(self.instance, longName="secondaryPool",
                      attributeType="enum",
                      enumName=":".join(["-"] + pools))
-
-    def _get_deadline_pools(self, webservice):
-        # type: (str) -> list
-        """Get pools from Deadline.
-        Args:
-            webservice (str): Server url.
-        Returns:
-            list: Pools.
-        Throws:
-            RuntimeError: If deadline webservice is unreachable.
-
-        """
-        argument = "{}/api/pools?NamesOnly=true".format(webservice)
-        try:
-            response = self._requests_get(argument)
-        except requests.exceptions.ConnectionError as exc:
-            msg = 'Cannot connect to deadline web service'
-            self.log.error(msg)
-            six.reraise(
-                RuntimeError,
-                RuntimeError('{} - {}'.format(msg, exc)),
-                sys.exc_info()[2])
-        if not response.ok:
-            self.log.warning("No pools retrieved")
-            return []
-
-        return response.json()
 
     def _create_render_settings(self):
         """Create instance settings."""
@@ -295,7 +267,8 @@ class CreateRender(plugin.Creator):
                 # use first one for initial list of pools.
                 deadline_url = next(iter(self.deadline_servers.values()))
 
-            pool_names = self._get_deadline_pools(deadline_url)
+            pool_names = self.deadline_module.get_deadline_pools(deadline_url,
+                                                                 self.log)
             maya_submit_dl = self._project_settings.get(
                 "deadline", {}).get(
                 "publish", {}).get(
@@ -366,7 +339,7 @@ class CreateRender(plugin.Creator):
         """
         params = {"authToken": self._token}
         api_entry = "/api/pools/list"
-        response = self._requests_get(self.MUSTER_REST_URL + api_entry,
+        response = requests_get(self.MUSTER_REST_URL + api_entry,
                                       params=params)
         if response.status_code != 200:
             if response.status_code == 401:
@@ -392,44 +365,10 @@ class CreateRender(plugin.Creator):
         api_url = "{}/muster/show_login".format(
             os.environ["OPENPYPE_WEBSERVER_URL"])
         self.log.debug(api_url)
-        login_response = self._requests_get(api_url, timeout=1)
+        login_response = requests_get(api_url, timeout=1)
         if login_response.status_code != 200:
             self.log.error("Cannot show login form to Muster")
             raise Exception("Cannot show login form to Muster")
-
-    def _requests_post(self, *args, **kwargs):
-        """Wrap request post method.
-
-        Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
-        variable is found. This is useful when Deadline or Muster server are
-        running with self-signed certificates and their certificate is not
-        added to trusted certificates on client machines.
-
-        Warning:
-            Disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-
-        """
-        if "verify" not in kwargs:
-            kwargs["verify"] = not os.getenv("OPENPYPE_DONT_VERIFY_SSL", True)
-        return requests.post(*args, **kwargs)
-
-    def _requests_get(self, *args, **kwargs):
-        """Wrap request get method.
-
-        Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
-        variable is found. This is useful when Deadline or Muster server are
-        running with self-signed certificates and their certificate is not
-        added to trusted certificates on client machines.
-
-        Warning:
-            Disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-
-        """
-        if "verify" not in kwargs:
-            kwargs["verify"] = not os.getenv("OPENPYPE_DONT_VERIFY_SSL", True)
-        return requests.get(*args, **kwargs)
 
     def _set_default_renderer_settings(self, renderer):
         """Set basic settings based on renderer.

--- a/openpype/hosts/maya/plugins/create/create_vrayscene.py
+++ b/openpype/hosts/maya/plugins/create/create_vrayscene.py
@@ -4,8 +4,6 @@ import os
 import json
 import appdirs
 import requests
-import six
-import sys
 
 from maya import cmds
 import maya.app.renderSetup.model.renderSetup as renderSetup
@@ -19,6 +17,7 @@ from openpype.api import (
     get_project_settings
 )
 
+from openpype.lib import requests_get
 from openpype.pipeline import CreatorError
 from openpype.modules import ModulesManager
 
@@ -40,6 +39,10 @@ class CreateVRayScene(plugin.Creator):
         self._rs = renderSetup.instance()
         self.data["exportOnFarm"] = False
         deadline_settings = get_system_settings()["modules"]["deadline"]
+
+        manager = ModulesManager()
+        self.deadline_module = manager.modules_by_name["deadline"]
+
         if not deadline_settings["enabled"]:
             self.deadline_servers = {}
             return
@@ -62,10 +65,8 @@ class CreateVRayScene(plugin.Creator):
 
         except AttributeError:
             # Handle situation were we had only one url for deadline.
-            manager = ModulesManager()
-            deadline_module = manager.modules_by_name["deadline"]
             # get default deadline webservice url from deadline module
-            self.deadline_servers = deadline_module.deadline_urls
+            self.deadline_servers = self.deadline_module.deadline_urls
 
     def process(self):
         """Entry point."""
@@ -128,7 +129,7 @@ class CreateVRayScene(plugin.Creator):
                 cmds.getAttr("{}.deadlineServers".format(self.instance))
             ]
         ]
-        pools = self._get_deadline_pools(webservice)
+        pools = self.deadline_module.get_deadline_pools(webservice)
         cmds.deleteAttr("{}.primaryPool".format(self.instance))
         cmds.deleteAttr("{}.secondaryPool".format(self.instance))
         cmds.addAttr(self.instance, longName="primaryPool",
@@ -137,33 +138,6 @@ class CreateVRayScene(plugin.Creator):
         cmds.addAttr(self.instance, longName="secondaryPool",
                      attributeType="enum",
                      enumName=":".join(["-"] + pools))
-
-    def _get_deadline_pools(self, webservice):
-        # type: (str) -> list
-        """Get pools from Deadline.
-        Args:
-            webservice (str): Server url.
-        Returns:
-            list: Pools.
-        Throws:
-            RuntimeError: If deadline webservice is unreachable.
-
-        """
-        argument = "{}/api/pools?NamesOnly=true".format(webservice)
-        try:
-            response = self._requests_get(argument)
-        except requests.exceptions.ConnectionError as exc:
-            msg = 'Cannot connect to deadline web service'
-            self.log.error(msg)
-            six.reraise(
-                CreatorError,
-                CreatorError('{} - {}'.format(msg, exc)),
-                sys.exc_info()[2])
-        if not response.ok:
-            self.log.warning("No pools retrieved")
-            return []
-
-        return response.json()
 
     def _create_vray_instance_settings(self):
         # get pools
@@ -195,7 +169,7 @@ class CreateVRayScene(plugin.Creator):
                     for k in self.deadline_servers.keys()
                 ][0]
 
-            pool_names = self._get_deadline_pools(deadline_url)
+            pool_names = self.deadline_module.get_deadline_pools(deadline_url)
 
         if muster_enabled:
             self.log.info(">>> Loading Muster credentials ...")
@@ -259,8 +233,8 @@ class CreateVRayScene(plugin.Creator):
         """
         params = {"authToken": self._token}
         api_entry = "/api/pools/list"
-        response = self._requests_get(self.MUSTER_REST_URL + api_entry,
-                                      params=params)
+        response = requests_get(self.MUSTER_REST_URL + api_entry,
+                                params=params)
         if response.status_code != 200:
             if response.status_code == 401:
                 self.log.warning("Authentication token expired.")
@@ -285,45 +259,7 @@ class CreateVRayScene(plugin.Creator):
         api_url = "{}/muster/show_login".format(
             os.environ["OPENPYPE_WEBSERVER_URL"])
         self.log.debug(api_url)
-        login_response = self._requests_get(api_url, timeout=1)
+        login_response = requests_get(api_url, timeout=1)
         if login_response.status_code != 200:
             self.log.error("Cannot show login form to Muster")
             raise CreatorError("Cannot show login form to Muster")
-
-    def _requests_post(self, *args, **kwargs):
-        """Wrap request post method.
-
-        Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
-        variable is found. This is useful when Deadline or Muster server are
-        running with self-signed certificates and their certificate is not
-        added to trusted certificates on client machines.
-
-        Warning:
-            Disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-
-        """
-        if "verify" not in kwargs:
-            kwargs["verify"] = (
-                False if os.getenv("OPENPYPE_DONT_VERIFY_SSL", True) else True
-            )  # noqa
-        return requests.post(*args, **kwargs)
-
-    def _requests_get(self, *args, **kwargs):
-        """Wrap request get method.
-
-        Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
-        variable is found. This is useful when Deadline or Muster server are
-        running with self-signed certificates and their certificate is not
-        added to trusted certificates on client machines.
-
-        Warning:
-            Disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-
-        """
-        if "verify" not in kwargs:
-            kwargs["verify"] = (
-                False if os.getenv("OPENPYPE_DONT_VERIFY_SSL", True) else True
-            )  # noqa
-        return requests.get(*args, **kwargs)

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -388,7 +388,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
 
             # get string values for pools
             primary_pool = overrides["renderGlobals"]["Pool"]
-            secondary_pool = overrides["renderGlobals"]["SecondaryPool"]
+            secondary_pool = overrides["renderGlobals"].get("SecondaryPool")
             data["primaryPool"] = primary_pool
             data["secondaryPool"] = secondary_pool
 

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -342,8 +342,6 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "tileRendering": render_instance.data.get("tileRendering") or False,  # noqa: E501
                 "tilesX": render_instance.data.get("tilesX") or 2,
                 "tilesY": render_instance.data.get("tilesY") or 2,
-                "primaryPool": render_instance.data.get("primaryPool"),
-                "secondaryPool": render_instance.data.get("secondaryPool"),
                 "priority": render_instance.data.get("priority"),
                 "convertToScanline": render_instance.data.get(
                     "convertToScanline") or False,
@@ -387,6 +385,12 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             # Get global overrides and translate to Deadline values
             overrides = self.parse_options(str(render_globals))
             data.update(**overrides)
+
+            # get string values for pools
+            primary_pool = overrides["renderGlobals"]["Pool"]
+            secondary_pool = overrides["renderGlobals"]["SecondaryPool"]
+            data["primaryPool"] = primary_pool
+            data["secondaryPool"] = secondary_pool
 
             # Define nice label
             label = "{0} ({1})".format(expected_layer_name, data["asset"])

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -342,6 +342,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "tileRendering": render_instance.data.get("tileRendering") or False,  # noqa: E501
                 "tilesX": render_instance.data.get("tilesX") or 2,
                 "tilesY": render_instance.data.get("tilesY") or 2,
+                "primaryPool": render_instance.data.get("primaryPool"),
+                "secondaryPool": render_instance.data.get("secondaryPool"),
                 "priority": render_instance.data.get("priority"),
                 "convertToScanline": render_instance.data.get(
                     "convertToScanline") or False,

--- a/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
+++ b/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
@@ -4,13 +4,13 @@ import getpass
 import platform
 
 import appdirs
-import requests
 
 from maya import cmds
 
 from avalon import api
 
 import pyblish.api
+from openpype.lib import requests_post
 from openpype.hosts.maya.api import lib
 from openpype.api import get_system_settings
 
@@ -184,7 +184,7 @@ class MayaSubmitMuster(pyblish.api.InstancePlugin):
             "select": "name"
         }
         api_entry = '/api/templates/list'
-        response = self._requests_post(
+        response = requests_post(
             self.MUSTER_REST_URL + api_entry, params=params)
         if response.status_code != 200:
             self.log.error(
@@ -235,7 +235,7 @@ class MayaSubmitMuster(pyblish.api.InstancePlugin):
             "name": "submit"
         }
         api_entry = '/api/queue/actions'
-        response = self._requests_post(
+        response = requests_post(
             self.MUSTER_REST_URL + api_entry, params=params, json=payload)
 
         if response.status_code != 200:
@@ -549,16 +549,3 @@ class MayaSubmitMuster(pyblish.api.InstancePlugin):
                 % (value, int(value))
             )
 
-    def _requests_post(self, *args, **kwargs):
-        """ Wrapper for requests, disabling SSL certificate validation if
-            DONT_VERIFY_SSL environment variable is found. This is useful when
-            Deadline or Muster server are running with self-signed certificates
-            and their certificate is not added to trusted certificates on
-            client machines.
-
-            WARNING: disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-        """
-        if 'verify' not in kwargs:
-            kwargs['verify'] = False if os.getenv("OPENPYPE_DONT_VERIFY_SSL", True) else True  # noqa
-        return requests.post(*args, **kwargs)

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -221,6 +221,12 @@ from .openpype_version import (
     is_current_version_higher_than_expected
 )
 
+
+from .connections import (
+    requests_get,
+    requests_post
+)
+
 terminal = Terminal
 
 __all__ = [
@@ -390,4 +396,7 @@ __all__ = [
     "is_running_from_build",
     "is_running_staging",
     "is_current_version_studio_latest",
+
+    "requests_get",
+    "requests_post"
 ]

--- a/openpype/lib/connections.py
+++ b/openpype/lib/connections.py
@@ -1,0 +1,38 @@
+import requests
+import os
+
+
+def requests_post(*args, **kwargs):
+    """Wrap request post method.
+
+    Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
+    variable is found. This is useful when Deadline or Muster server are
+    running with self-signed certificates and their certificate is not
+    added to trusted certificates on client machines.
+
+    Warning:
+        Disabling SSL certificate validation is defeating one line
+        of defense SSL is providing and it is not recommended.
+
+    """
+    if "verify" not in kwargs:
+        kwargs["verify"] = not os.getenv("OPENPYPE_DONT_VERIFY_SSL", True)
+    return requests.post(*args, **kwargs)
+
+
+def requests_get(*args, **kwargs):
+    """Wrap request get method.
+
+    Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
+    variable is found. This is useful when Deadline or Muster server are
+    running with self-signed certificates and their certificate is not
+    added to trusted certificates on client machines.
+
+    Warning:
+        Disabling SSL certificate validation is defeating one line
+        of defense SSL is providing and it is not recommended.
+
+    """
+    if "verify" not in kwargs:
+        kwargs["verify"] = not os.getenv("OPENPYPE_DONT_VERIFY_SSL", True)
+    return requests.get(*args, **kwargs)

--- a/openpype/modules/deadline/deadline_module.py
+++ b/openpype/modules/deadline/deadline_module.py
@@ -3,8 +3,7 @@ import requests
 import six
 import sys
 
-
-from openpype.lib import requests_get
+from openpype.lib import requests_get, PypeLogger
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import IPluginPaths
 
@@ -59,9 +58,7 @@ class DeadlineModule(OpenPypeModule, IPluginPaths):
 
         """
         if not log:
-            from openpype.lib import PypeLogger
-
-            log = PypeLogger().get_logger(__name__)
+            log = PypeLogger.get_logger(__name__)
 
         argument = "{}/api/pools?NamesOnly=true".format(webservice)
         try:

--- a/openpype/modules/deadline/deadline_module.py
+++ b/openpype/modules/deadline/deadline_module.py
@@ -1,6 +1,18 @@
 import os
+import requests
+import six
+import sys
+
+
+from openpype.lib import requests_get
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import IPluginPaths
+
+
+class DeadlineWebserviceError(Exception):
+    """
+    Exception to throw when connection to Deadline server fails.
+    """
 
 
 class DeadlineModule(OpenPypeModule, IPluginPaths):
@@ -32,3 +44,37 @@ class DeadlineModule(OpenPypeModule, IPluginPaths):
         return {
             "publish": [os.path.join(current_dir, "plugins", "publish")]
         }
+
+    @staticmethod
+    def get_deadline_pools(webservice, log=None):
+        # type: (str) -> list
+        """Get pools from Deadline.
+        Args:
+            webservice (str): Server url.
+            log (Logger)
+        Returns:
+            list: Pools.
+        Throws:
+            RuntimeError: If deadline webservice is unreachable.
+
+        """
+        if not log:
+            from openpype.lib import PypeLogger
+
+            log = PypeLogger().get_logger(__name__)
+
+        argument = "{}/api/pools?NamesOnly=true".format(webservice)
+        try:
+            response = requests_get(argument)
+        except requests.exceptions.ConnectionError as exc:
+            msg = 'Cannot connect to DL web service {}'.format(webservice)
+            log.error(msg)
+            six.reraise(
+                DeadlineWebserviceError,
+                DeadlineWebserviceError('{} - {}'.format(msg, exc)),
+                sys.exc_info()[2])
+        if not response.ok:
+            log.warning("No pools retrieved")
+            return []
+
+        return response.json()

--- a/openpype/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
+++ b/openpype/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
@@ -11,7 +11,7 @@ import pyblish.api
 class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
     """Collect Deadline Webservice URL from instance."""
 
-    order = pyblish.api.CollectorOrder + 0.02
+    order = pyblish.api.CollectorOrder + 0.415
     label = "Deadline Webservice from the Instance"
     families = ["rendering"]
 

--- a/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
+++ b/openpype/modules/deadline/plugins/publish/collect_default_deadline_server.py
@@ -6,7 +6,7 @@ import pyblish.api
 class CollectDefaultDeadlineServer(pyblish.api.ContextPlugin):
     """Collect default Deadline Webservice URL."""
 
-    order = pyblish.api.CollectorOrder + 0.01
+    order = pyblish.api.CollectorOrder + 0.410
     label = "Default Deadline Webservice"
 
     pass_mongo_url = False

--- a/openpype/modules/deadline/plugins/publish/collect_pools.py
+++ b/openpype/modules/deadline/plugins/publish/collect_pools.py
@@ -6,19 +6,18 @@ import pyblish.api
 
 
 class CollectDeadlinePools(pyblish.api.InstancePlugin):
-    """Collect pools from Deadline, if set on instance use these."""
+    """Collect pools from instance if present, from Setting otherwise."""
 
-    order = pyblish.api.CollectorOrder + 0.04
-    label = "Deadline Webservice from the Instance"
-    families = ["rendering", "render.farm", "renderFarm"]
+    order = pyblish.api.CollectorOrder + 0.420
+    label = "Collect Deadline Pools"
+    families = ["rendering", "render.farm", "renderFarm", "renderlayer"]
 
     primary_pool = None
     secondary_pool = None
 
     def process(self, instance):
-
         if not instance.data.get("primaryPool"):
-            self.instance.data["primaryPool"] = self.primary_pool
+            instance.data["primaryPool"] = self.primary_pool or "none"
 
         if not instance.data.get("secondaryPool"):
-            self.instance.data["secondaryPool"] = self.secondary_pool
+            instance.data["secondaryPool"] = self.secondary_pool or "none"

--- a/openpype/modules/deadline/plugins/publish/collect_pools.py
+++ b/openpype/modules/deadline/plugins/publish/collect_pools.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Collect Deadline pools. Choose default one from Settings
+
+"""
+import pyblish.api
+
+
+class CollectDeadlinePools(pyblish.api.InstancePlugin):
+    """Collect pools from Deadline, if set on instance use these."""
+
+    order = pyblish.api.CollectorOrder + 0.04
+    label = "Deadline Webservice from the Instance"
+    families = ["rendering", "render.farm", "renderFarm"]
+
+    primary_pool = None
+    secondary_pool = None
+
+    def process(self, instance):
+
+        if not instance.data.get("primaryPool"):
+            self.instance.data["primaryPool"] = self.primary_pool
+
+        if not instance.data.get("secondaryPool"):
+            self.instance.data["secondaryPool"] = self.secondary_pool

--- a/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
+++ b/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
-<error id="main">
-<title>Scene setting</title>
-<description>
-## Invalid Deadline pools found
+    <error id="main">
+        <title>Scene setting</title>
+        <description>
+            ## Invalid Deadline pools found
 
-Configured pools don't match what is set in Deadline.
+            Configured pools don't match what is set in Deadline.
 
-{invalid_setting_str}
+            {invalid_value_str}
 
-### How to repair?
+            ### How to repair?
 
-    If your instance had deadline pools set on creation, remove or change them.</br>
-In other cases inform admin to change them in Settings.
+            If your instance had deadline pools set on creation, remove or
+            change them.
 
-    Available deadline pools {pools_str}.
-<detail>
-### __Detailed Info__
+        In other cases inform admin to change them in Settings.
 
-This error is shown when deadline pool is not on Deadline anymore. It could happen in case of republish old workfile which was created with previous deadline pools,
-    or someone changed pools on Deadline side, but didn't modify Openpype Settings.
-</detail>
+        Available deadline pools {pools_str}.
+        </description>
+        <detail>
+            ### __Detailed Info__
+
+            This error is shown when deadline pool is not on Deadline anymore. It
+            could happen in case of republish old workfile which was created with
+            previous deadline pools,
+            or someone changed pools on Deadline side, but didn't modify Openpype
+            Settings.
+        </detail>
+    </error>
 </root>

--- a/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
+++ b/openpype/modules/deadline/plugins/publish/help/validate_deadline_pools.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Scene setting</title>
+<description>
+## Invalid Deadline pools found
+
+Configured pools don't match what is set in Deadline.
+
+{invalid_setting_str}
+
+### How to repair?
+
+    If your instance had deadline pools set on creation, remove or change them.</br>
+In other cases inform admin to change them in Settings.
+
+    Available deadline pools {pools_str}.
+<detail>
+### __Detailed Info__
+
+This error is shown when deadline pool is not on Deadline anymore. It could happen in case of republish old workfile which was created with previous deadline pools,
+    or someone changed pools on Deadline side, but didn't modify Openpype Settings.
+</detail>
+</root>

--- a/openpype/modules/deadline/plugins/publish/submit_aftereffects_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_aftereffects_deadline.py
@@ -37,8 +37,6 @@ class AfterEffectsSubmitDeadline(
 
     priority = 50
     chunk_size = 1000000
-    primary_pool = None
-    secondary_pool = None
     group = None
     department = None
     multiprocess = True
@@ -62,8 +60,8 @@ class AfterEffectsSubmitDeadline(
             dln_job_info.Frames = frame_range
 
         dln_job_info.Priority = self.priority
-        dln_job_info.Pool = self.primary_pool
-        dln_job_info.SecondaryPool = self.secondary_pool
+        dln_job_info.Pool = self._instance.data.get("primaryPool")
+        dln_job_info.SecondaryPool = self._instance.data.get("secondaryPool")
         dln_job_info.Group = self.group
         dln_job_info.Department = self.department
         dln_job_info.ChunkSize = self.chunk_size

--- a/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -241,8 +241,6 @@ class HarmonySubmitDeadline(
 
     optional = True
     use_published = False
-    primary_pool = ""
-    secondary_pool = ""
     priority = 50
     chunk_size = 1000000
     group = "none"
@@ -259,8 +257,8 @@ class HarmonySubmitDeadline(
         # for now, get those from presets. Later on it should be
         # configurable in Harmony UI directly.
         job_info.Priority = self.priority
-        job_info.Pool = self.primary_pool
-        job_info.SecondaryPool = self.secondary_pool
+        job_info.Pool = self._instance.data.get("primaryPool")
+        job_info.SecondaryPool = self._instance.data.get("secondaryPool")
         job_info.ChunkSize = self.chunk_size
         job_info.BatchName = os.path.basename(self._instance.data["source"])
         job_info.Department = self.department

--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -7,7 +7,7 @@ from avalon import api
 
 import pyblish.api
 
-import hou
+# import hou  ???
 
 
 class HoudiniSubmitRenderDeadline(pyblish.api.InstancePlugin):
@@ -71,7 +71,8 @@ class HoudiniSubmitRenderDeadline(pyblish.api.InstancePlugin):
                 "UserName": deadline_user,
 
                 "Plugin": "Houdini",
-                "Pool": "houdini_redshift",  # todo: remove hardcoded pool
+                "Pool": instance.data.get("primaryPool"),
+                "secondaryPool": instance.data.get("secondaryPool"),
                 "Frames": frames,
 
                 "ChunkSize": instance.data.get("chunkSize", 10),

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -28,8 +28,6 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
     priority = 50
     chunk_size = 1
     concurrent_tasks = 1
-    primary_pool = ""
-    secondary_pool = ""
     group = ""
     department = ""
     limit_groups = {}
@@ -187,8 +185,8 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
 
                 "Department": self.department,
 
-                "Pool": self.primary_pool,
-                "SecondaryPool": self.secondary_pool,
+                "Pool": instance.data.get("primaryPool"),
+                "SecondaryPool": instance.data.get("secondaryPool"),
                 "Group": self.group,
 
                 "Plugin": "Nuke",

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -259,8 +259,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 "Priority": priority,
 
                 "Group": self.deadline_group,
-                "Pool": self.deadline_pool,
-                "SecondaryPool": self.deadline_pool_secondary,
+                "Pool": instance.data.get("primaryPool"),
+                "SecondaryPool": instance.data.get("secondaryPool"),
 
                 "OutputDirectory0": output_dir
             },

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -1,0 +1,47 @@
+import pyblish.api
+
+from openpype.pipeline import (
+    PublishXmlValidationError,
+    OptionalPyblishPluginMixin
+)
+from openpype.modules.deadline.deadline_module import DeadlineModule
+
+
+class ValidateDeadlinePools(OptionalPyblishPluginMixin,
+                            pyblish.api.InstancePlugin):
+    """Validate primaryPool and secondaryPool on instance.
+
+    Values are on instance based on value insertion when Creating instance or
+    by Settings in CollectDeadlinePools.
+    """
+
+    label = "Validate Deadline Web Service"
+    order = pyblish.api.ValidatorOrder
+    families = ["rendering", "render.farm", "renderFarm"]
+    optional = True
+
+    def process(self, instance):
+        # get default deadline webservice url from deadline module
+        deadline_url = instance.context.data["defaultDeadline"]
+        self.log.info("deadline_url::{}".format(deadline_url))
+        pools = DeadlineModule.get_deadline_pools(deadline_url, log=self.log)
+        self.log.info("pools::{}".format(pools))
+
+        formatting_data = {
+            "pools_str": ",".join(pools)
+        }
+
+        primary_pool = instance.data.get("primaryPool")
+        if primary_pool and primary_pool not in pools:
+            msg = "Configured primary '{}' not present on Deadline".format(
+                    instance.data["primaryPool"])
+
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)
+
+        secondary_pool = instance.data.get("secondaryPool")
+        if secondary_pool and secondary_pool not in pools:
+            msg = "Configured secondary '{}' not present on Deadline".format(
+                    instance.data["secondaryPool"])
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -15,9 +15,9 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
     by Settings in CollectDeadlinePools.
     """
 
-    label = "Validate Deadline Web Service"
+    label = "Validate Deadline Pools"
     order = pyblish.api.ValidatorOrder
-    families = ["rendering", "render.farm", "renderFarm"]
+    families = ["rendering", "render.farm", "renderFarm", "renderlayer"]
     optional = True
 
     def process(self, instance):
@@ -35,7 +35,7 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
         if primary_pool and primary_pool not in pools:
             msg = "Configured primary '{}' not present on Deadline".format(
                     instance.data["primaryPool"])
-
+            formatting_data["invalid_value_str"] = msg
             raise PublishXmlValidationError(self, msg,
                                             formatting_data=formatting_data)
 
@@ -43,5 +43,6 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
         if secondary_pool and secondary_pool not in pools:
             msg = "Configured secondary '{}' not present on Deadline".format(
                     instance.data["secondaryPool"])
+            formatting_data["invalid_value_str"] = msg
             raise PublishXmlValidationError(self, msg,
                                             formatting_data=formatting_data)

--- a/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
+++ b/openpype/modules/deadline/plugins/publish/validate_deadline_pools.py
@@ -34,7 +34,7 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
         primary_pool = instance.data.get("primaryPool")
         if primary_pool and primary_pool not in pools:
             msg = "Configured primary '{}' not present on Deadline".format(
-                    instance.data["primaryPool"])
+                instance.data["primaryPool"])
             formatting_data["invalid_value_str"] = msg
             raise PublishXmlValidationError(self, msg,
                                             formatting_data=formatting_data)
@@ -42,7 +42,7 @@ class ValidateDeadlinePools(OptionalPyblishPluginMixin,
         secondary_pool = instance.data.get("secondaryPool")
         if secondary_pool and secondary_pool not in pools:
             msg = "Configured secondary '{}' not present on Deadline".format(
-                    instance.data["secondaryPool"])
+                instance.data["secondaryPool"])
             formatting_data["invalid_value_str"] = msg
             raise PublishXmlValidationError(self, msg,
                                             formatting_data=formatting_data)

--- a/openpype/settings/defaults/project_settings/deadline.json
+++ b/openpype/settings/defaults/project_settings/deadline.json
@@ -4,6 +4,10 @@
         "CollectDefaultDeadlineServer": {
             "pass_mongo_url": false
         },
+        "CollectDeadlinePools": {
+            "primary_pool": "",
+            "secondary_pool": ""
+        },
         "ValidateExpectedFiles": {
             "enabled": true,
             "active": true,
@@ -38,8 +42,6 @@
             "priority": 50,
             "chunk_size": 10,
             "concurrent_tasks": 1,
-            "primary_pool": "",
-            "secondary_pool": "",
             "group": "",
             "department": "",
             "use_gpu": true,
@@ -54,8 +56,6 @@
             "use_published": true,
             "priority": 50,
             "chunk_size": 10000,
-            "primary_pool": "",
-            "secondary_pool": "",
             "group": "",
             "department": ""
         },
@@ -66,8 +66,6 @@
             "use_published": true,
             "priority": 50,
             "chunk_size": 10000,
-            "primary_pool": "",
-            "secondary_pool": "",
             "group": "",
             "department": "",
             "multiprocess": true

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -33,6 +33,24 @@
                 {
                     "type": "dict",
                     "collapsible": true,
+                    "key": "CollectDeadlinePools",
+                    "label": "Default Deadline Pools",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "primary_pool",
+                            "label": "Primary Pool"
+                        },
+                        {
+                            "type": "text",
+                            "key": "secondary_pool",
+                            "label": "Secondary Pool"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
                     "key": "ValidateExpectedFiles",
                     "label": "Validate Expected Files",
                     "checkbox_key": "enabled",
@@ -225,16 +243,6 @@
                         },
                         {
                             "type": "text",
-                            "key": "primary_pool",
-                            "label": "Primary Pool"
-                        },
-                        {
-                            "type": "text",
-                            "key": "secondary_pool",
-                            "label": "Secondary Pool"
-                        },
-                        {
-                            "type": "text",
                             "key": "group",
                             "label": "Group"
                         },
@@ -315,16 +323,6 @@
                         },
                         {
                             "type": "text",
-                            "key": "primary_pool",
-                            "label": "Primary Pool"
-                        },
-                        {
-                            "type": "text",
-                            "key": "secondary_pool",
-                            "label": "Secondary Pool"
-                        },
-                        {
-                            "type": "text",
                             "key": "group",
                             "label": "Group"
                         },
@@ -371,16 +369,6 @@
                             "type": "number",
                             "key": "chunk_size",
                             "label": "Chunk Size"
-                        },
-                        {
-                            "type": "text",
-                            "key": "primary_pool",
-                            "label": "Primary Pool"
-                        },
-                        {
-                            "type": "text",
-                            "key": "secondary_pool",
-                            "label": "Secondary Pool"
                         },
                         {
                             "type": "text",


### PR DESCRIPTION
## Brief description
Previous solution was nonconsistent, expected values for pools in multiple places in Setting.

## Description
New collector and validator was introduced. Collector adds pool names from Setting (merged and removed separate pool settings in hosts sections) if not already present on a instance (as Maya has it, potentially others with New Publisher).

Validator checks if name of pools on the instances matches to current values on DL (does a query of DL).

## Additional info
Refactored `_requests_get` and `requests_post` wrappers into `openpype.lib.connections` - name up for commenting/changing.


## Testing notes:
1. configure `project_settings/deadline/publish/CollectDeadlinePools`
1.a - insert non existent values
1.b - insert values matching situation on DL
3. publish on DL and check pools