### PR TITLE
Update collect_render.py

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -211,7 +211,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                     })
 
             assert render_cameras, "No render cameras found."
-                
+
             self.log.info("multipart: {}".format(
                 multipart))
             assert exp_files, "no file names were generated, this is bug"

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -194,11 +194,13 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             assert render_products, "no render products generated"
             exp_files = []
             multipart = False
+            render_cameras = []
             for product in render_products:
                 if product.multipart:
                     multipart = True
                 product_name = product.productName
                 if product.camera and layer_render_products.has_camera_token():
+                    render_cameras.append(product.camera)
                     product_name = "{}{}".format(
                         product.camera,
                         "_" + product_name if product_name else "")
@@ -208,6 +210,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                             product)
                     })
 
+            assert render_cameras, "No render cameras found."
+                
             self.log.info("multipart: {}".format(
                 multipart))
             assert exp_files, "no file names were generated, this is bug"


### PR DESCRIPTION
Better error message for non selected render camera edge case.

![Capture](https://user-images.githubusercontent.com/1860085/163013715-5d7697ba-c17c-45e2-9212-26b6dbfc62e2.PNG)

Previously error message would read `no file names were generated, this is bug`, which does not help fix the issue.