### PR TITLE
Hotfix: fixing deadline job publishing

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -540,7 +540,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 if instance.get("multipartExr", False):
                     preview = True
                 else:
-                    render_file_name = list(collection[0])
+                    render_file_name = list(collection)[0]
                     host_name = os.environ.get("AVALON_APP", "")
                     # if filtered aov name is found in filename, toggle it for
                     # preview video rendering


### PR DESCRIPTION
## Hotfix

This is fixing invalid module definition that was breaking importing of `submit_job_deadline`. Also it is fixing collection indexing bug.