### PR TITLE
Nuke: Add aov matching even for remainder and prerender

### DIFF
--- a/openpype/lib/profiles_filtering.py
+++ b/openpype/lib/profiles_filtering.py
@@ -44,12 +44,6 @@ def _profile_exclusion(matching_profiles, logger):
     Returns:
         dict: Most matching profile.
     """
-
-    logger.info(
-        "Search for first most matching profile in match order:"
-        " Host name -> Task name -> Family."
-    )
-
     if not matching_profiles:
         return None
 
@@ -168,6 +162,15 @@ def filter_profiles(profiles_data, key_values, keys_order=None, logger=None):
                 _keys_order.append(key)
         keys_order = tuple(_keys_order)
 
+    log_parts = " | ".join([
+        "{}: \"{}\"".format(*item)
+        for item in key_values.items()
+    ])
+
+    logger.info(
+        "Looking for matching profile for: {}".format(log_parts)
+    )
+
     matching_profiles = None
     highest_profile_points = -1
     # Each profile get 1 point for each matching filter. Profile with most
@@ -205,11 +208,6 @@ def filter_profiles(profiles_data, key_values, keys_order=None, logger=None):
         if profile_points == highest_profile_points:
             matching_profiles.append((profile, profile_scores))
 
-    log_parts = " | ".join([
-        "{}: \"{}\"".format(*item)
-        for item in key_values.items()
-    ])
-
     if not matching_profiles:
         logger.info(
             "None of profiles match your setup. {}".format(log_parts)
@@ -221,4 +219,9 @@ def filter_profiles(profiles_data, key_values, keys_order=None, logger=None):
             "More than one profile match your setup. {}".format(log_parts)
         )
 
-    return _profile_exclusion(matching_profiles, logger)
+    profile = _profile_exclusion(matching_profiles, logger)
+    if profile:
+        logger.info(
+            "Profile selected: {}".format(profile)
+        )
+    return profile

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -619,7 +619,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                     "fps": instance.get("fps"),
                     "tags": ["review"]
                 })
-            self._solve_families(instance, True)
+            self._solve_families(instance, preview)
 
             already_there = False
             for repre in instance.get("representations", []):

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -524,6 +524,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
         """
         representations = []
+        host_name = os.environ.get("AVALON_APP", "")
         collections, remainders = clique.assemble(exp_files)
 
         # create representation for every collected sequento ce
@@ -541,7 +542,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                     preview = True
                 else:
                     render_file_name = list(collection)[0]
-                    host_name = os.environ.get("AVALON_APP", "")
                     # if filtered aov name is found in filename, toggle it for
                     # preview video rendering
                     preview = match_aov_pattern(
@@ -610,7 +610,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 "files": os.path.basename(remainder),
                 "stagingDir": os.path.dirname(remainder),
             }
-            if "render" in instance.get("families"):
+
+            preview = match_aov_pattern(
+                host_name, self.aov_filter, remainder
+            )
+            if preview:
                 rep.update({
                     "fps": instance.get("fps"),
                     "tags": ["review"]

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -34,6 +34,7 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
             self.log.warning("No profiles present for adding Ftrack family")
             return
 
+        add_ftrack_family = False
         task_name = instance.data.get("task",
                                       avalon.api.Session["AVALON_TASK"])
         host_name = avalon.api.Session["AVALON_APP"]
@@ -68,6 +69,13 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
                         instance.data["families"].append("ftrack")
                 else:
                     instance.data["families"] = ["ftrack"]
+
+        result_str = "Adding"
+        if not add_ftrack_family:
+            result_str = "Not adding"
+        self.log.info("{} 'ftrack' family for instance with '{}'".format(
+            result_str, family
+        ))
 
     def _get_add_ftrack_f_from_addit_filters(self,
                                              additional_filters,

--- a/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_ftrack_family.py
@@ -54,6 +54,8 @@ class CollectFtrackFamily(pyblish.api.InstancePlugin):
 
             additional_filters = profile.get("advanced_filtering")
             if additional_filters:
+                self.log.info("'{}' families used for additional filtering".
+                              format(families))
                 add_ftrack_family = self._get_add_ftrack_f_from_addit_filters(
                     additional_filters,
                     families,


### PR DESCRIPTION
## Brief description
Previously filtering used only for collections and 'render' family.

## Description
This should allow more control when to add 'review' tag to representation.


## Testing notes:
1. Create `prerender` write node in Nuke
2. configure `project_settings/deadline/publish/ProcessSubmittedJobOnFarm/aov_filter`
2a. configure that pattern matches created subset name
2b. configure that pattern doesn't match created subset name
4. publish
5. check Ftrack