### PR TITLE
Nuke: Typos in imports from Nuke implementation

### DIFF
--- a/openpype/hosts/nuke/plugins/inventory/select_containers.py
+++ b/openpype/hosts/nuke/plugins/inventory/select_containers.py
@@ -1,5 +1,5 @@
 from openpype.pipeline import InventoryAction
-from openpype.hosts.nuke.api.commands import viewer_update_and_undo_stop
+from openpype.hosts.nuke.api.command import viewer_update_and_undo_stop
 
 
 class SelectContainers(InventoryAction):

--- a/openpype/hosts/nuke/plugins/load/load_backdrop.py
+++ b/openpype/hosts/nuke/plugins/load/load_backdrop.py
@@ -14,7 +14,7 @@ from openpype.hosts.nuke.api.lib import (
     get_avalon_knob_data,
     set_avalon_knob_data
 )
-from openpype.hosts.nuke.api.commands import viewer_update_and_undo_stop
+from openpype.hosts.nuke.api.command import viewer_update_and_undo_stop
 from openpype.hosts.nuke.api import containerise, update_container
 
 


### PR DESCRIPTION
## Brief description
Import of `openpype.hosts.nuke.api.command` has typos in 2 plugins loader `LoadBackdropNodes` and inventory action `SelectContainers`.

## Description
Fixed the imports from `openpype.hosts.nuke.api.commands` to `openpype.hosts.nuke.api.command`.

## Testing notes:
1. Load backdrop and Select containers should work