### PR TITLE
GitHub: Updated push-protected action in github workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -80,7 +80,7 @@ jobs:
         git tag -a $tag_name -m "nightly build"
     
     - name: Push to protected main branch
-      uses: CasperWA/push-protected@v2
+      uses: CasperWA/push-protected@v2.10.0
       with:
         token: ${{ secrets.ADMIN_TOKEN }}
         branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: 🔏 Push to protected main branch
       if: steps.version.outputs.release_tag != 'skip'
-      uses: CasperWA/push-protected@v2
+      uses: CasperWA/push-protected@v2.10.0
       with:
         token: ${{ secrets.ADMIN_TOKEN }}
         branch: main


### PR DESCRIPTION
## Brief description
Updated github workflow action.

## Description
Due to fix of [security issue](https://github.blog/2022-04-12-git-security-vulnerability-announced/) workflow action, pushing to protected branch `main`, stopped to work. The action was [recently fixed](https://github.com/CasperWA/push-protected/pull/115) so the action version which should be used was changed.