### PR TITLE
Maya: fix image plane loader

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -175,10 +175,18 @@ class ImagePlaneLoader(load.LoaderPlugin):
                 QtWidgets.QMessageBox.Cancel
             )
             if reply == QtWidgets.QMessageBox.Ok:
-                pm.delete(
-                    image_plane_shape.listConnections(type="expression")[0]
-                )
-                image_plane_shape.frameExtension.set(start_frame)
+                try:
+                    pm.delete(
+                        image_plane_shape.listConnections(type="expression")[0]
+                    )
+                except IndexError:
+                    # happens where there's no expression
+                    pass
+                try:
+                    image_plane_shape.frameExtension.set(start_frame)
+                except RuntimeError:
+                    # happens when frame extension is locked
+                    pass
 
         new_nodes.extend(
             [


### PR DESCRIPTION
## Fix

This is fixing some error when trying to load exr sequence as image plane in Maya.

### Testing:

1) OpenPype -> Load and select exr sequence
2) RMB and load as image plane
3) Create new camera
4) It should load without errors

Not sure why these error popped up, but I've tested it in Maya 2020 and 2022. This fixes them by sort of ignoring. 