### PR TITLE
General: Add global log verbose arguments

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -20,6 +20,10 @@ from .pype_commands import PypeCommands
                     "to list staging versions."))
 @click.option("--validate-version", expose_value=False,
               help="validate given version integrity")
+@click.option("--debug", is_flag=True, expose_value=False,
+              help=("Enable debug"))
+@click.option("--verbose", expose_value=False,
+              help=("Change OpenPype log level (debug - critical or 0-50)"))
 def main(ctx):
     """Pype is main command serving as entry point to pipeline system.
 
@@ -49,18 +53,13 @@ def traypublisher():
 
 
 @main.command()
-@click.option("-d", "--debug",
-              is_flag=True, help=("Run pype tray in debug mode"))
-def tray(debug=False):
+def tray():
     """Launch pype tray.
 
     Default action of pype command is to launch tray widget to control basic
     aspects of pype. See documentation for more information.
-
-    Running pype with `--debug` will result in lot of information useful for
-    debugging to be shown in console.
     """
-    PypeCommands().launch_tray(debug)
+    PypeCommands().launch_tray()
 
 
 @PypeCommands.add_modules
@@ -75,7 +74,6 @@ def module(ctx):
 
 
 @main.command()
-@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("--ftrack-url", envvar="FTRACK_SERVER",
               help="Ftrack server url")
 @click.option("--ftrack-user", envvar="FTRACK_API_USER",
@@ -88,8 +86,7 @@ def module(ctx):
               help="Clockify API key.")
 @click.option("--clockify-workspace", envvar="CLOCKIFY_WORKSPACE",
               help="Clockify workspace")
-def eventserver(debug,
-                ftrack_url,
+def eventserver(ftrack_url,
                 ftrack_user,
                 ftrack_api_key,
                 legacy,
@@ -100,8 +97,6 @@ def eventserver(debug,
     This should be ideally used by system service (such us systemd or upstart
     on linux and window service).
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
 
     PypeCommands().launch_eventservercli(
         ftrack_url,
@@ -114,12 +109,11 @@ def eventserver(debug,
 
 
 @main.command()
-@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("-h", "--host", help="Host", default=None)
 @click.option("-p", "--port", help="Port", default=None)
 @click.option("-e", "--executable", help="Executable")
 @click.option("-u", "--upload_dir", help="Upload dir")
-def webpublisherwebserver(debug, executable, upload_dir, host=None, port=None):
+def webpublisherwebserver(executable, upload_dir, host=None, port=None):
     """Starts webserver for communication with Webpublish FR via command line
 
         OP must be congigured on a machine, eg. OPENPYPE_MONGO filled AND
@@ -127,8 +121,6 @@ def webpublisherwebserver(debug, executable, upload_dir, host=None, port=None):
 
         Expect "pype.club" user created on Ftrack.
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
 
     PypeCommands().launch_webpublisher_webservercli(
         upload_dir=upload_dir,
@@ -164,38 +156,34 @@ def extractenvironments(output_json_path, project, asset, task, app, envgroup):
 
 @main.command()
 @click.argument("paths", nargs=-1)
-@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("-t", "--targets", help="Targets module", default=None,
               multiple=True)
 @click.option("-g", "--gui", is_flag=True,
               help="Show Publish UI", default=False)
-def publish(debug, paths, targets, gui):
+def publish(paths, targets, gui):
     """Start CLI publishing.
 
     Publish collects json from paths provided as an argument.
     More than one path is allowed.
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
+
     PypeCommands.publish(list(paths), targets, gui)
 
 
 @main.command()
 @click.argument("path")
-@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("-h", "--host", help="Host")
 @click.option("-u", "--user", help="User email address")
 @click.option("-p", "--project", help="Project")
 @click.option("-t", "--targets", help="Targets", default=None,
               multiple=True)
-def remotepublishfromapp(debug, project, path, host, user=None, targets=None):
+def remotepublishfromapp(project, path, host, user=None, targets=None):
     """Start CLI publishing.
 
     Publish collects json from paths provided as an argument.
     More than one path is allowed.
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
+
     PypeCommands.remotepublishfromapp(
         project, path, host, user, targets=targets
     )
@@ -203,24 +191,21 @@ def remotepublishfromapp(debug, project, path, host, user=None, targets=None):
 
 @main.command()
 @click.argument("path")
-@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("-u", "--user", help="User email address")
 @click.option("-p", "--project", help="Project")
 @click.option("-t", "--targets", help="Targets", default=None,
               multiple=True)
-def remotepublish(debug, project, path, user=None, targets=None):
+def remotepublish(project, path, user=None, targets=None):
     """Start CLI publishing.
 
     Publish collects json from paths provided as an argument.
     More than one path is allowed.
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
+
     PypeCommands.remotepublish(project, path, user, targets=targets)
 
 
 @main.command()
-@click.option("-d", "--debug", is_flag=True, help="Print debug messages")
 @click.option("-p", "--project", required=True,
               help="name of project asset is under")
 @click.option("-a", "--asset", required=True,
@@ -228,7 +213,7 @@ def remotepublish(debug, project, path, user=None, targets=None):
 @click.option("--path", required=True,
               help="path where textures are found",
               type=click.Path(exists=True))
-def texturecopy(debug, project, asset, path):
+def texturecopy(project, asset, path):
     """Copy specified textures to provided asset path.
 
     It validates if project and asset exists. Then it will use speedcopy to
@@ -239,8 +224,7 @@ def texturecopy(debug, project, asset, path):
     Result will be copied without directory structure so it will be flat then.
     Nothing is written to database.
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
+
     PypeCommands().texture_copy(project, asset, path)
 
 
@@ -389,11 +373,9 @@ def runtests(folder, mark, pyargs, test_data_folder, persist, app_variant,
 
 
 @main.command()
-@click.option("-d", "--debug",
-              is_flag=True, help=("Run process in debug mode"))
 @click.option("-a", "--active_site", required=True,
               help="Name of active stie")
-def syncserver(debug, active_site):
+def syncserver(active_site):
     """Run sync site server in background.
 
         Some Site Sync use cases need to expose site to another one.
@@ -408,8 +390,7 @@ def syncserver(debug, active_site):
         Settings (configured by starting OP Tray with env
         var OPENPYPE_LOCAL_ID set to 'active_site'.
     """
-    if debug:
-        os.environ["OPENPYPE_DEBUG"] = "1"
+
     PypeCommands().syncserver(active_site)
 
 

--- a/openpype/lib/log.py
+++ b/openpype/lib/log.py
@@ -330,6 +330,9 @@ class PypeLogger:
 
         # Define if should logging to mongo be used
         use_mongo_logging = bool(log4mongo is not None)
+        if use_mongo_logging:
+            use_mongo_logging = os.environ.get("OPENPYPE_LOG_TO_SERVER") == "1"
+
         # Set mongo id for process (ONLY ONCE)
         if use_mongo_logging and cls.mongo_process_id is None:
             try:

--- a/openpype/lib/log.py
+++ b/openpype/lib/log.py
@@ -216,8 +216,8 @@ class PypeLogger:
     # Collection name under database in Mongo
     log_collection_name = "logs"
 
-    # OPENPYPE_DEBUG
-    pype_debug = 0
+    # Logging level - OPENPYPE_LOG_LEVEL
+    log_level = None
 
     # Data same for all record documents
     process_data = None
@@ -231,10 +231,7 @@ class PypeLogger:
 
         logger = logging.getLogger(name or "__main__")
 
-        if cls.pype_debug > 0:
-            logger.setLevel(logging.DEBUG)
-        else:
-            logger.setLevel(logging.INFO)
+        logger.setLevel(cls.log_level)
 
         add_mongo_handler = cls.use_mongo_logging
         add_console_handler = True
@@ -357,8 +354,16 @@ class PypeLogger:
         # Store result to class definition
         cls.use_mongo_logging = use_mongo_logging
 
-        # Define if is in OPENPYPE_DEBUG mode
-        cls.pype_debug = int(os.getenv("OPENPYPE_DEBUG") or "0")
+        # Define what is logging level
+        log_level = os.getenv("OPENPYPE_LOG_LEVEL")
+        if not log_level:
+            # Check OPENPYPE_DEBUG for backwards compatibility
+            op_debug = os.getenv("OPENPYPE_DEBUG")
+            if op_debug and int(op_debug) > 0:
+                log_level = 10
+            else:
+                log_level = 20
+        cls.log_level = int(log_level)
 
         if not os.environ.get("OPENPYPE_MONGO"):
             cls.use_mongo_logging = False

--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -31,10 +31,13 @@ TOPIC_STATUS_SERVER = "openpype.event.server.status"
 TOPIC_STATUS_SERVER_RESULT = "openpype.event.server.status.result"
 
 
-def check_ftrack_url(url, log_errors=True):
+def check_ftrack_url(url, log_errors=True, logger=None):
     """Checks if Ftrack server is responding"""
+    if logger is None:
+        logger = Logger.get_logger(__name__)
+
     if not url:
-        print('ERROR: Ftrack URL is not set!')
+        logger.error("Ftrack URL is not set!")
         return None
 
     url = url.strip('/ ')
@@ -48,15 +51,15 @@ def check_ftrack_url(url, log_errors=True):
         result = requests.get(url, allow_redirects=False)
     except requests.exceptions.RequestException:
         if log_errors:
-            print('ERROR: Entered Ftrack URL is not accesible!')
+            logger.error("Entered Ftrack URL is not accesible!")
         return False
 
     if (result.status_code != 200 or 'FTRACK_VERSION' not in result.headers):
         if log_errors:
-            print('ERROR: Entered Ftrack URL is not accesible!')
+            logger.error("Entered Ftrack URL is not accesible!")
         return False
 
-    print('DEBUG: Ftrack server {} is accessible.'.format(url))
+    logger.debug("Ftrack server {} is accessible.".format(url))
 
     return url
 
@@ -133,7 +136,7 @@ class ProcessEventHub(SocketBaseEventHub):
     hearbeat_msg = b"processor"
 
     is_collection_created = False
-    pypelog = Logger().get_logger("Session Processor")
+    pypelog = Logger.get_logger("Session Processor")
 
     def __init__(self, *args, **kwargs):
         self.mongo_url = None

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -25,7 +25,7 @@ class PypeCommands:
     Most of its methods are called by :mod:`cli` module.
     """
     @staticmethod
-    def launch_tray(debug=False):
+    def launch_tray():
         PypeLogger.set_process_name("Tray")
 
         from openpype.tools import tray

--- a/openpype/settings/defaults/system_settings/general.json
+++ b/openpype/settings/defaults/system_settings/general.json
@@ -7,6 +7,7 @@
             "global": []
         }
     },
+    "log_to_server": true,
     "disk_mapping": {
         "windows": [],
         "linux": [],

--- a/openpype/settings/entities/schemas/system_schema/schema_general.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_general.json
@@ -41,6 +41,11 @@
             "type": "splitter"
         },
         {
+            "type": "boolean",
+            "key": "log_to_server",
+            "label": "Log to mongo"
+        },
+        {
             "type": "dict",
             "key": "disk_mapping",
             "label": "Disk mapping",

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -324,6 +324,7 @@ class MongoSettingsHandler(SettingsHandler):
     global_general_keys = (
         "openpype_path",
         "admin_password",
+        "log_to_server",
         "disk_mapping",
         "production_version",
         "staging_version"

--- a/start.py
+++ b/start.py
@@ -230,6 +230,11 @@ if "--verbose" in sys.argv:
 
     os.environ["OPENPYPE_LOG_LEVEL"] = str(log_level)
 
+# Enable debug mode, may affect log level if log level is not defined
+if "--debug" in sys.argv:
+    sys.argv.remove("--debug")
+    os.environ["OPENPYPE_DEBUG"] = "1"
+
 
 import igniter  # noqa: E402
 from igniter import BootstrapRepos  # noqa: E402

--- a/start.py
+++ b/start.py
@@ -191,6 +191,46 @@ else:
     if os.getenv("OPENPYPE_HEADLESS_MODE") != "1":
         os.environ.pop("OPENPYPE_HEADLESS_MODE", None)
 
+# Enabled logging debug mode when "--debug" is passed
+if "--verbose" in sys.argv:
+    expected_values = (
+        "Expected: notset, debug, info, warning, error, critical"
+        " or integer [0-50]."
+    )
+    idx = sys.argv.index("--verbose")
+    sys.argv.pop(idx)
+    if idx < len(sys.argv):
+        value = sys.argv.pop(idx)
+    else:
+        raise RuntimeError((
+            "Expect value after \"--verbose\" argument. {}"
+        ).format(expected_values))
+
+    log_level = None
+    low_value = value.lower()
+    if low_value.isdigit():
+        log_level = int(low_value)
+    elif low_value == "notset":
+        log_level = 0
+    elif low_value == "debug":
+        log_level = 10
+    elif low_value == "info":
+        log_level = 20
+    elif low_value == "warning":
+        log_level = 30
+    elif low_value == "error":
+        log_level = 40
+    elif low_value == "critical":
+        log_level = 50
+
+    if log_level is None:
+        raise RuntimeError((
+            "Unexpected value after \"--verbose\" argument \"{}\". {}"
+        ).format(value, expected_values))
+
+    os.environ["OPENPYPE_LOG_LEVEL"] = str(log_level)
+
+
 import igniter  # noqa: E402
 from igniter import BootstrapRepos  # noqa: E402
 from igniter.tools import (

--- a/start.py
+++ b/start.py
@@ -972,6 +972,16 @@ def boot():
     _print(">>> run disk mapping command ...")
     run_disk_mapping_commands(global_settings)
 
+    # Logging to server enabled/disabled
+    log_to_server = global_settings.get("log_to_server", True)
+    if log_to_server:
+        os.environ["OPENPYPE_LOG_TO_SERVER"] = "1"
+        log_to_server_msg = "ON"
+    else:
+        os.environ.pop("OPENPYPE_LOG_TO_SERVER", None)
+        log_to_server_msg = "OFF"
+    _print(f">>> Logging to server is turned {log_to_server_msg}")
+
     # Get openpype path from database and set it to environment so openpype can
     # find its versions there and bootstrap them.
     openpype_path = get_openpype_path_from_settings(global_settings)

--- a/website/docs/admin_openpype_commands.md
+++ b/website/docs/admin_openpype_commands.md
@@ -24,7 +24,11 @@ openpype_console --use-version=3.0.0-foo+bar
 
 `--list-versions [--use-staging]` - to list available versions.
 
-`--validate-version` to validate integrity of given version
+`--validate-version` - to validate integrity of given version
+
+`--verbose` `<level>` - change log verbose level of OpenPype loggers
+
+`--debug` - set debug flag affects logging
 
 For more information [see here](admin_use.md#run-openpype).
 
@@ -47,13 +51,9 @@ For more information [see here](admin_use.md#run-openpype).
 
 ---
 ### `tray` arguments {#tray-arguments}
-| Argument | Description |
-| --- | --- |
-| `--debug` | print verbose information useful for debugging (works with `openpype_console`) |
 
-To launch Tray with debugging information:
 ```shell
-openpype_console tray --debug
+openpype_console tray
 ```
 ---
 ### `launch` arguments {#eventserver-arguments}
@@ -62,7 +62,6 @@ option to specify them.
 
 | Argument | Description |
 | --- | --- |
-| `--debug` | print debug info |
 | `--ftrack-url` | URL to ftrack server (can be set with `FTRACK_SERVER`) |
 | `--ftrack-user` |user name to log in to ftrack (can be set with `FTRACK_API_USER`) |
 | `--ftrack-api-key` | ftrack api key (can be set with `FTRACK_API_KEY`) |
@@ -98,12 +97,16 @@ pype launch --app python --project my_project --asset my_asset --task my_task
 ---
 ### `publish` arguments {#publish-arguments}
 
+Run publishing based on metadata passed in json file e.g. on farm.
+
 | Argument | Description |
 | --- | --- |
-| `--debug` | print more verbose information |
+| `--targets` | define publishing targets (e.g. "farm") |
+| `--gui` (`-g`) | Show publishing |
+| Positional argument | Path to metadata json file |
 
 ```shell
-pype publish <PATH_TO_JSON>
+openpype publish <PATH_TO_JSON> --targes farm
 ```
 
 ---

--- a/website/docs/admin_use.md
+++ b/website/docs/admin_use.md
@@ -69,6 +69,22 @@ stored in `checksums` file.
 Add `--headless` to run OpenPype without graphical UI (useful on server or on automated tasks, etc.)
 :::
 
+`--verbose` `<level>` - change log verbose level of OpenPype loggers.
+
+Level value can be integer in range `0-50` or one of enum strings `"notset" (0)`, `"debug" (10)`, `"info" (20)`, `"warning" (30)`, `"error" (40)`, `"ciritcal" (50)`. Value is stored to `OPENPYPE_LOG_LEVEL` environment variable for next processes.
+
+```shell
+openpype_console --verbose debug
+```
+
+`--debug` - set debug flag affects logging
+
+Enable debug flag for OpenPype process. Change value of environment variable `OPENPYPE_DEBUG` to `"1"`. At this moment affects only OpenPype loggers. Argument `--verbose` or environment variable `OPENPYPE_LOG_LEVEL` are used in preference to affect log level.
+
+```shell
+openpype_console --debug
+```
+
 ### Details
 When you run OpenPype from executable, few check are made: 
 


### PR DESCRIPTION
## Brief description
Added ability to turn on/off mongo logging and handle global arguments for verbose and debug.

## Description
Logging to mongo can be tuend on/off in system settings, change is propagated after restart. Added `--verbose` argument expecting verbose level int [0-50] or string matching python log level enum, value is stored in env variable `OPENPYPE_LOG_LEVEL`. With verbose argument seems `--debug` argument deprecated but there are usages for it so it was also added global flag argument `--debug` which affects `OPENPYPE_DEBUG` value.

## Additional info
This is partially fix and partially enhancement. Current usage of `--debug` argument is not propagated in current process because is handled too late.

## Testing notes:
- change logging to mongo in settings and check if is propagated
- use all new global arguments
    - verbose
    - debug

Resolves https://github.com/pypeclub/OpenPype/issues/2961