### PR TITLE
Standalone publisher: Fix plugins install

### DIFF
--- a/openpype/tools/standalonepublish/publish.py
+++ b/openpype/tools/standalonepublish/publish.py
@@ -1,14 +1,14 @@
 import os
 import sys
 
-import openpype
 import pyblish.api
+from openpype.pipeline import install_openpype_plugins
 from openpype.tools.utils.host_tools import show_publish
 
 
 def main(env):
     # Registers pype's Global pyblish plugins
-    openpype.install()
+    install_openpype_plugins()
 
     # Register additional paths
     addition_paths_str = env.get("PUBLISH_PATHS") or ""


### PR DESCRIPTION
## Brief description
Install openpype plugins properly. Bug caused by [PR](https://github.com/pypeclub/OpenPype/pull/3009).

## Description
Changed deprecated `openpype.install()` to `install_openpype_plugins()`.

## Testing notes:
1. Open standalone publisher
2. Run publish