### PR TITLE
Project Manager: Remove parent info in AssetItem's doc generation

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1925,7 +1925,6 @@ class AssetItem(BaseItem):
                 tasks.update(item.to_doc_data())
 
         doc_data = {
-            "parents": self.parent().child_parents(),
             "visualParent": self.parent().asset_id,
             "tasks": tasks
         }
@@ -1939,7 +1938,6 @@ class AssetItem(BaseItem):
             "type": self.data(QtCore.Qt.EditRole, "type"),
             "schema": schema_name,
             "data": doc_data,
-            "parent": self.project_id
         }
         if self.mongo_id:
             doc["_id"] = self.mongo_id


### PR DESCRIPTION
Remove fields about parents in `AssetItem.to_doc( )`, so the comparison for update info doesn't identify AssetItems as needing update due to mismatching fields. 
 
While trying to device some Python way to programmatically create new tasks, I noticed the update data Program manager was writing to Mongo seems a bit excessive. Digging into it, it seems in `AssetItem.update_data()`,  always identify the item to be updated because of the additional field 'parent' in doc and 'parents' in data. 

Here's some debugging printouts for the two doc objects compared for update info, only with some reformatting for easier comparison.
```
[DEBUG] current item doc: 
{
	'_id': ObjectId('617c63c9797e4a6b9d76c208'),
	'name': 'assets',
	'type': 'asset',
	'schema': 'openpype:asset-3.0', 
	'data': {
		'parents': [], 'visualParent': None, 'tasks': {}, 'pixelAspect': 1.0, 'frameStart': 1001, 'handleEnd': 0, 'handleStart': 0, 'fps': 24.0, 'clipIn': 1, 'clipOut': 1, 'tools_env': [], 'resolutionHeight': 1188, 'frameEnd': 1100, 'resolutionWidth': 2112
	}, 
	'parent': ObjectId('617c367c797e4a6b9d76c207'), 

}

[DEBUG] original item doc:
{
	'_id': ObjectId('617c63c9797e4a6b9d76c208'),
	'name': 'assets',
	'type': 'asset',
	'schema': 'openpype:asset-3.0', 
	'data': {
		'visualParent': None, 'tasks': {}, 'resolutionHeight': 1188, 'handleEnd': 0, 'resolutionWidth': 2112, 'tools_env': [], 'clipIn': 1, 'frameStart': 1001, 'handleStart': 0, 'clipOut': 1, 'fps': 24.0, 'frameEnd': 1100, 'pixelAspect': 1.0
	}
}
```
Then the false positive 'update' info generated for bulk-write: 

```
[INFO] bulk writes: [
UpdateOne({'_id': ObjectId('617c63c9797e4a6b9d76c208')}, {'$set': {'parent': ObjectId('617c367c797e4a6b9d76c207'), 'data.parents': []}}, False, None, None, None), 
...
...

```

Removing them in the doc generation let the update comparison only find the AssetItems actually changed. 


## Testing notes:
Use cases tested: 
- Add a task
- Add an asset
- rename a task
- copy tasks from one asset to another

And after shutting down OP and restart, the changes above were persisted. 
