### PR TITLE
Project Manager: Avoid unnecessary updates of asset documents

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1819,12 +1819,16 @@ class AssetItem(BaseItem):
     }
     query_projection = {
         "_id": 1,
-        "data.tasks": 1,
-        "data.visualParent": 1,
-        "schema": 1,
-
         "name": 1,
+        "schema": 1,
         "type": 1,
+        "parent": 1,
+
+        "data.visualParent": 1,
+        "data.parents": 1,
+
+        "data.tasks": 1,
+
         "data.frameStart": 1,
         "data.frameEnd": 1,
         "data.fps": 1,
@@ -1835,7 +1839,7 @@ class AssetItem(BaseItem):
         "data.clipIn": 1,
         "data.clipOut": 1,
         "data.pixelAspect": 1,
-        "data.tools_env": 1
+        "data.tools_env": 1,
     }
 
     def __init__(self, asset_doc):


### PR DESCRIPTION
## Brief description
Existing asset documents are not updated if nothing has changed.

## Description
Keys `parent` and `data.parents` are always resolved as changed on existing asset items. That is because queried asset documents do not contain them at all. Added `parent` and `data.parents` to query projection so they can be compared. Source issue and [PR](https://github.com/pypeclub/OpenPype/pull/3082).

## Additional info
Best way how to validate this is working is by modifying code in `openpype/tools/project_manager/project_manager/model.py` on line (approximately line 1412 where condition `if bulk_writes:` is) add log/print of `bulk_writes`. Bulk writes contain all updates that happened which should be empty if nothing has changed.

## Testing notes:
Visually nothing changes.
1. Open Project manager
2. Choose any project
3. Hit "Save"
4. Terminal log should say that nothing has changed
5. Modify some values
6. Hit "Save"
7. Terminal log should say how many assets were updated