### PR TITLE
General: Remove repos related logic

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -668,9 +668,9 @@ class BootstrapRepos:
         self._progress_callback = progress_callback
 
         if getattr(sys, "frozen", False):
-            self.live_repo_dir = Path(sys.executable).parent / "repos"
+            self.live_repo_dir = Path(sys.executable).parent
         else:
-            self.live_repo_dir = Path(Path(__file__).parent / ".." / "repos")
+            self.live_repo_dir = Path(Path(__file__).parent / "..")
 
     @staticmethod
     def get_version_path_from_list(
@@ -756,7 +756,7 @@ class BootstrapRepos:
                 Path(temp_dir) / f"openpype-v{version}.zip"
             self._print(f"creating zip: {temp_zip}")
 
-            self._create_openpype_zip(temp_zip, repo_dir.parent)
+            self._create_openpype_zip(temp_zip, repo_dir)
             if not os.path.exists(temp_zip):
                 self._print("make archive failed.", LOG_ERROR)
                 return None

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -627,8 +627,6 @@ class BootstrapRepos:
 
     Attributes:
         data_dir (Path): local OpenPype installation directory.
-        live_repo_dir (Path): path to repos directory if running live,
-            otherwise `None`.
         registry (OpenPypeSettingsRegistry): OpenPype registry object.
         zip_filter (list): List of files to exclude from zip
         openpype_filter (list): list of top level directories to
@@ -666,11 +664,6 @@ class BootstrapRepos:
         if not progress_callback:
             progress_callback = empty_progress
         self._progress_callback = progress_callback
-
-        if getattr(sys, "frozen", False):
-            self.live_repo_dir = Path(sys.executable).parent
-        else:
-            self.live_repo_dir = Path(Path(__file__).parent / "..")
 
     @staticmethod
     def get_version_path_from_list(
@@ -736,11 +729,16 @@ class BootstrapRepos:
         # if repo dir is not set, we detect local "live" OpenPype repository
         # version and use it as a source. Otherwise repo_dir is user
         # entered location.
-        if not repo_dir:
-            version = OpenPypeVersion.get_installed_version_str()
-            repo_dir = self.live_repo_dir
-        else:
+        if repo_dir:
             version = self.get_version(repo_dir)
+        else:
+            version = OpenPypeVersion.get_installed_version_str()
+            # QUESTION Can we use 'OPENPYPE_ROOT' env variable or it may
+            #   not be defined yet?
+            if getattr(sys, "frozen", False):
+                repo_dir = Path(sys.executable).parent
+            else:
+                repo_dir = Path(Path(__file__).parent / "..")
 
         if not version:
             self._print("OpenPype not found.", LOG_ERROR)

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -654,7 +654,7 @@ class BootstrapRepos:
         self.registry = OpenPypeSettingsRegistry()
         self.zip_filter = [".pyc", "__pycache__"]
         self.openpype_filter = [
-            "openpype", "repos", "schema", "LICENSE"
+            "openpype", "schema", "LICENSE"
         ]
         self._message = message
 

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -1094,24 +1094,8 @@ class BootstrapRepos:
             directory (Path): path to directory.
 
         """
+
         sys.path.insert(0, directory.as_posix())
-        directory /= "repos"
-        if not directory.exists() and not directory.is_dir():
-            return
-
-        roots = []
-        for item in directory.iterdir():
-            if item.is_dir():
-                root = item.as_posix()
-                if root not in roots:
-                    roots.append(root)
-                    sys.path.insert(0, root)
-
-        pythonpath = os.getenv("PYTHONPATH", "")
-        paths = pythonpath.split(os.pathsep)
-        paths += roots
-
-        os.environ["PYTHONPATH"] = os.pathsep.join(paths)
 
     @staticmethod
     def find_openpype_version(version, staging):

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -1405,6 +1405,7 @@ class BootstrapRepos:
             # create destination parent directories even if they don't exist.
             destination.mkdir(parents=True)
 
+        remove_source_file = False
         # version is directory
         if openpype_version.path.is_dir():
             # create zip inside temporary directory.
@@ -1438,6 +1439,8 @@ class BootstrapRepos:
                 self._progress_callback(35)
                 openpype_version.path = self._copy_zip(
                     openpype_version.path, destination)
+                # Mark zip to be deleted when done
+                remove_source_file = True
 
         # extract zip there
         self._print("extracting zip to destination ...")
@@ -1445,6 +1448,10 @@ class BootstrapRepos:
             self._progress_callback(75)
             zip_ref.extractall(destination)
             self._progress_callback(100)
+
+        # Remove zip file copied to local app data
+        if remove_source_file:
+            os.remove(openpype_version.path)
 
         return destination
 

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -732,13 +732,9 @@ class BootstrapRepos:
         if repo_dir:
             version = self.get_version(repo_dir)
         else:
-            version = OpenPypeVersion.get_installed_version_str()
-            # QUESTION Can we use 'OPENPYPE_ROOT' env variable or it may
-            #   not be defined yet?
-            if getattr(sys, "frozen", False):
-                repo_dir = Path(sys.executable).parent
-            else:
-                repo_dir = Path(Path(__file__).parent / "..")
+            installed_version = OpenPypeVersion.get_installed_version()
+            version = str(installed_version)
+            repo_dir = installed_version.path
 
         if not version:
             self._print("OpenPype not found.", LOG_ERROR)

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -1057,27 +1057,11 @@ class BootstrapRepos:
         if not archive.is_file() and not archive.exists():
             raise ValueError("Archive is not file.")
 
-        with ZipFile(archive, "r") as zip_file:
-            name_list = zip_file.namelist()
-
-        roots = []
-        paths = []
-        for item in name_list:
-            if not item.startswith("repos/"):
-                continue
-
-            root = item.split("/")[1]
-
-            if root not in roots:
-                roots.append(root)
-                paths.append(
-                    f"{archive}{os.path.sep}repos{os.path.sep}{root}")
-                sys.path.insert(0, paths[-1])
-
-        sys.path.insert(0, f"{archive}")
+        archive_path = str(archive)
+        sys.path.insert(0, archive_path)
         pythonpath = os.getenv("PYTHONPATH", "")
         python_paths = pythonpath.split(os.pathsep)
-        python_paths += paths
+        python_paths.insert(0, archive_path)
 
         os.environ["PYTHONPATH"] = os.pathsep.join(python_paths)
 

--- a/setup.py
+++ b/setup.py
@@ -128,10 +128,6 @@ include_files = [
     "README.md"
 ]
 
-repos_path = openpype_root / "repos"
-if repos_path.exists():
-    include_files.append("repos")
-
 if IS_WINDOWS:
     install_requires.extend([
         # `pywin32` packages

--- a/start.py
+++ b/start.py
@@ -824,6 +824,7 @@ def _bootstrap_from_code(use_version, use_staging):
         os.environ["OPENPYPE_REPOS_ROOT"] = _openpype_root
 
     # add self to sys.path of current process
+    # NOTE: this seems to be duplicate of 'add_paths_from_directory'
     sys.path.insert(0, _openpype_root)
     # add venv 'site-packages' to PYTHONPATH
     python_path = os.getenv("PYTHONPATH", "")

--- a/start.py
+++ b/start.py
@@ -823,23 +823,14 @@ def _bootstrap_from_code(use_version, use_staging):
         version_path = Path(_openpype_root)
         os.environ["OPENPYPE_REPOS_ROOT"] = _openpype_root
 
-    repos = []
-    # Check for "openpype/repos" directory for sumodules
-    # NOTE: Is not used at this moment but can be re-used in future
-    repos_dir = os.path.join(_openpype_root, "repos")
-    if os.path.exists(repos_dir):
-        for name in os.listdir(repos_dir):
-            repos.append(os.path.join(repos_dir, name))
-
-    # add self to python paths
-    repos.insert(0, _openpype_root)
-    for repo in repos:
-        sys.path.insert(0, repo)
+    # add self to sys.path of current process
+    sys.path.insert(0, _openpype_root)
     # add venv 'site-packages' to PYTHONPATH
     python_path = os.getenv("PYTHONPATH", "")
     split_paths = python_path.split(os.pathsep)
-    # Add repos as first in list
-    split_paths = repos + split_paths
+    # add self to python paths
+    split_paths.insert(0, _openpype_root)
+
     # last one should be venv site-packages
     # this is slightly convoluted as we can get here from frozen code too
     # in case when we are running without any version installed.

--- a/tests/unit/igniter/test_bootstrap_repos.py
+++ b/tests/unit/igniter/test_bootstrap_repos.py
@@ -152,8 +152,6 @@ def test_install_live_repos(fix_bootstrap, printer, monkeypatch, pytestconfig):
     openpype_version = fix_bootstrap.create_version_from_live_code()
     sep = os.path.sep
     expected_paths = [
-        f"{openpype_version.path}{sep}repos{sep}avalon-core",
-        f"{openpype_version.path}{sep}repos{sep}avalon-unreal-integration",
         f"{openpype_version.path}"
     ]
     printer("testing zip creation")


### PR DESCRIPTION
## Brief description
Remove logic related to repos directory in OpenPype which is removed in [PR](https://github.com/pypeclub/OpenPype/pull/3066).

## Description
Repos directory related logic was removed and few places based on repos directory path was modified. Repos directory is not handled at all from this moment. Zip files copied from version repository are removed.

## Additional info
PR is extending [this PR](https://github.com/pypeclub/OpenPype/pull/3066). This change may affect how OpenPype works so it was separated to this PR to see changes better.

## Testing notes:
- Test if OpenPype from code works
- Zip can be created from code
- Build can be created from code
- Build can load zip from openpype repository
    - zip copied to Local App data should be removed when extracted