### PR TITLE
Maya: Collect Render fix any render cameras check

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -194,13 +194,11 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             assert render_products, "no render products generated"
             exp_files = []
             multipart = False
-            render_cameras = []
             for product in render_products:
                 if product.multipart:
                     multipart = True
                 product_name = product.productName
                 if product.camera and layer_render_products.has_camera_token():
-                    render_cameras.append(product.camera)
                     product_name = "{}{}".format(
                         product.camera,
                         "_" + product_name if product_name else "")
@@ -210,7 +208,8 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                             product)
                     })
 
-            assert render_cameras, "No render cameras found."
+            has_cameras = any(product.camera for product in render_products)
+            assert has_cameras, "No render cameras found."
 
             self.log.info("multipart: {}".format(
                 multipart))


### PR DESCRIPTION
## Brief description

This fixes the bug mentioned [here](https://github.com/pypeclub/OpenPype/pull/3055#issuecomment-1106235644)

## Description

With this fix a simple renderlayer with a single camera without <camera> in the render tokens now has render cameras checked correctly. 

## Testing notes:
1. Open a lighting scene without `<camera>` render token and check if you can collect `CreateRender` correctly