### PR TITLE
RoyalRender Control Submission - AVALON_APP_NAME default

### DIFF
--- a/openpype/modules/royalrender/rr_root/plugins/control_job/perjob/m50__openpype_publish_render.py
+++ b/openpype/modules/royalrender/rr_root/plugins/control_job/perjob/m50__openpype_publish_render.py
@@ -119,7 +119,7 @@ class OpenPypeContextSelector:
         # app names and versions, but since app_name is not used
         # currently down the line (but it is required by OP publish command
         # right now).
-        self.context["app_name"] = "maya/2020"
+        self.context["app_name"] = "celaction/local"
         return True
 
     @staticmethod

--- a/openpype/modules/royalrender/rr_root/plugins/control_job/perjob/m50__openpype_publish_render.py
+++ b/openpype/modules/royalrender/rr_root/plugins/control_job/perjob/m50__openpype_publish_render.py
@@ -119,7 +119,7 @@ class OpenPypeContextSelector:
         # app names and versions, but since app_name is not used
         # currently down the line (but it is required by OP publish command
         # right now).
-        self.context["app_name"] = "celaction/local"
+        # self.context["app_name"] = "maya/2022"
         return True
 
     @staticmethod
@@ -139,7 +139,8 @@ class OpenPypeContextSelector:
         env = {"AVALON_PROJECT": str(self.context.get("project")),
                "AVALON_ASSET": str(self.context.get("asset")),
                "AVALON_TASK": str(self.context.get("task")),
-               "AVALON_APP_NAME": str(self.context.get("app_name"))}
+               # "AVALON_APP_NAME": str(self.context.get("app_name"))
+               }
 
         print(">>> setting environment:")
         for k, v in env.items():
@@ -184,7 +185,7 @@ selector = OpenPypeContextSelector()
 selector.context["project"] = os.getenv("AVALON_PROJECT")
 selector.context["asset"] = os.getenv("AVALON_ASSET")
 selector.context["task"] = os.getenv("AVALON_TASK")
-selector.context["app_name"] = os.getenv("AVALON_APP_NAME")
+# selector.context["app_name"] = os.getenv("AVALON_APP_NAME")
 
 # if anything inside is None, scratch the whole thing and
 # ask user for context.

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -125,13 +125,14 @@ class PypeCommands:
         if not any(paths):
             raise RuntimeError("No publish paths specified")
 
-        env = get_app_environments_for_context(
-            os.environ["AVALON_PROJECT"],
-            os.environ["AVALON_ASSET"],
-            os.environ["AVALON_TASK"],
-            os.environ["AVALON_APP_NAME"]
-        )
-        os.environ.update(env)
+        if os.getenv("AVALON_APP_NAME"):
+            env = get_app_environments_for_context(
+                os.environ["AVALON_PROJECT"],
+                os.environ["AVALON_ASSET"],
+                os.environ["AVALON_TASK"],
+                os.environ["AVALON_APP_NAME"]
+            )
+            os.environ.update(env)
 
         pyblish.api.register_host("shell")
 


### PR DESCRIPTION
## Problem

Submission from RoyalRender Control application must set `AVALON_APP_NAME` even if it is not used down the line. This is fixing it by calling necessary functions only if this variable is set.