### PR TITLE
TVPaint: Match renderlayer key with other hosts

### DIFF
--- a/openpype/hosts/tvpaint/plugins/create/create_render_layer.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render_layer.py
@@ -24,7 +24,9 @@ class CreateRenderlayer(plugin.Creator):
         " {clip_id} {group_id} {r} {g} {b} \"{name}\""
     )
 
-    dynamic_subset_keys = ["render_pass", "render_layer", "group"]
+    dynamic_subset_keys = [
+        "renderpass", "renderlayer", "render_pass", "render_layer", "group"
+    ]
 
     @classmethod
     def get_dynamic_data(
@@ -34,11 +36,16 @@ class CreateRenderlayer(plugin.Creator):
             variant, task_name, asset_id, project_name, host_name
         )
         # Use render pass name from creator's plugin
-        dynamic_data["render_pass"] = cls.render_pass
+        dynamic_data["renderpass"] = cls.render_pass
         # Add variant to render layer
-        dynamic_data["render_layer"] = variant
+        dynamic_data["renderlayer"] = variant
         # Change family for subset name fill
         dynamic_data["family"] = "render"
+
+        # TODO remove - Backwards compatibility for old subset name templates
+        # - added 2022/04/28
+        dynamic_data["render_pass"] = dynamic_data["renderpass"]
+        dynamic_data["render_layer"] = dynamic_data["renderlayer"]
 
         return dynamic_data
 

--- a/openpype/hosts/tvpaint/plugins/create/create_render_pass.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render_pass.py
@@ -36,7 +36,7 @@ class CreateRenderPass(plugin.Creator):
 
         # TODO remove - Backwards compatibility for old subset name templates
         # - added 2022/04/28
-        dynamic_data["renderpass"] = dynamic_data["render_pass"]
+        dynamic_data["render_pass"] = dynamic_data["renderpass"]
 
         return dynamic_data
 

--- a/openpype/hosts/tvpaint/plugins/create/create_render_pass.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render_pass.py
@@ -20,7 +20,9 @@ class CreateRenderPass(plugin.Creator):
     icon = "cube"
     defaults = ["Main"]
 
-    dynamic_subset_keys = ["render_pass", "render_layer"]
+    dynamic_subset_keys = [
+        "renderpass", "renderlayer", "render_pass", "render_layer"
+    ]
 
     @classmethod
     def get_dynamic_data(
@@ -29,8 +31,12 @@ class CreateRenderPass(plugin.Creator):
         dynamic_data = super(CreateRenderPass, cls).get_dynamic_data(
             variant, task_name, asset_id, project_name, host_name
         )
-        dynamic_data["render_pass"] = variant
+        dynamic_data["renderpass"] = variant
         dynamic_data["family"] = "render"
+
+        # TODO remove - Backwards compatibility for old subset name templates
+        # - added 2022/04/28
+        dynamic_data["renderpass"] = dynamic_data["render_pass"]
 
         return dynamic_data
 
@@ -115,6 +121,7 @@ class CreateRenderPass(plugin.Creator):
         else:
             render_layer = beauty_instance["variant"]
 
+        subset_name_fill_data["renderlayer"] = render_layer
         subset_name_fill_data["render_layer"] = render_layer
 
         # Format dynamic keys in subset name
@@ -129,7 +136,7 @@ class CreateRenderPass(plugin.Creator):
 
         self.data["group_id"] = group_id
         self.data["pass"] = variant
-        self.data["render_layer"] = render_layer
+        self.data["renderlayer"] = render_layer
 
         # Collect selected layer ids to be stored into instance
         layer_names = [layer["name"] for layer in selected_layers]

--- a/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
@@ -46,6 +46,22 @@ class CollectInstances(pyblish.api.ContextPlugin):
         for instance_data in filtered_instance_data:
             instance_data["fps"] = context.data["sceneFps"]
 
+            # Conversion from older instances
+            # - change 'render_layer' to 'renderlayer'
+            #       and 'render_pass' to 'renderpass'
+
+            if (
+                "renderlayer" not in instance_data
+                and "render_layer" in instance_data
+            ):
+                instance_data["renderlayer"] = instance_data["render_layer"]
+
+            if (
+                "renderpass" not in instance_data
+                and "render_pass" in instance_data
+            ):
+                instance_data["renderpass"] = instance_data["render_pass"]
+
             # Store workfile instance data to instance data
             instance_data["originData"] = copy.deepcopy(instance_data)
             # Global instance data modifications
@@ -192,7 +208,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
             "Creating render pass instance. \"{}\"".format(pass_name)
         )
         # Change label
-        render_layer = instance_data["render_layer"]
+        render_layer = instance_data["renderlayer"]
 
         # Backwards compatibility
         # - subset names were not stored as final subset names during creation

--- a/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
@@ -48,19 +48,18 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             # Conversion from older instances
             # - change 'render_layer' to 'renderlayer'
-            #       and 'render_pass' to 'renderpass'
+            render_layer = instance_data.get("instance_data")
+            if not render_layer:
+                # Render Layer has only variant
+                if instance_data["family"] == "renderLayer":
+                    render_layer = instance_data.get("variant")
 
-            if (
-                "renderlayer" not in instance_data
-                and "render_layer" in instance_data
-            ):
-                instance_data["renderlayer"] = instance_data["render_layer"]
+                # Backwards compatibility for renderPasses
+                elif "render_layer" in instance_data:
+                    render_layer = instance_data["render_layer"]
 
-            if (
-                "renderpass" not in instance_data
-                and "render_pass" in instance_data
-            ):
-                instance_data["renderpass"] = instance_data["render_pass"]
+                if render_layer:
+                    instance_data["renderlayer"] = render_layer
 
             # Store workfile instance data to instance data
             instance_data["originData"] = copy.deepcopy(instance_data)

--- a/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
@@ -69,9 +69,13 @@ class CollectRenderScene(pyblish.api.ContextPlugin):
         # Variant is using render pass name
         variant = self.render_layer
         dynamic_data = {
-            "render_layer": self.render_layer,
-            "render_pass": self.render_pass
+            "renderlayer": self.render_layer,
+            "renderpass": self.render_pass,
         }
+        # TODO remove - Backwards compatibility for old subset name templates
+        # - added 2022/04/28
+        dynamic_data["render_layer"] = dynamic_data["renderlayer"]
+        dynamic_data["render_pass"] = dynamic_data["renderpass"]
 
         task_name = workfile_context["task"]
         subset_name = get_subset_name_with_asset_doc(
@@ -102,6 +106,8 @@ class CollectRenderScene(pyblish.api.ContextPlugin):
             "asset": asset_name,
             "task": task_name
         }
+        # Add 'renderlayer' and 'renderpass' to data
+        instance_data.update(dynamic_data)
 
         instance = context.create_instance(**instance_data)
 

--- a/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_scene_render.py
@@ -104,10 +104,10 @@ class CollectRenderScene(pyblish.api.ContextPlugin):
             "representations": [],
             "layers": copy.deepcopy(context.data["layersData"]),
             "asset": asset_name,
-            "task": task_name
+            "task": task_name,
+            # Add render layer to instance data
+            "renderlayer": self.render_layer
         }
-        # Add 'renderlayer' and 'renderpass' to data
-        instance_data.update(dynamic_data)
 
         instance = context.create_instance(**instance_data)
 

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -307,7 +307,7 @@
                     ],
                     "task_types": [],
                     "tasks": [],
-                    "template": "{family}{Task}_{Render_layer}_{Render_pass}"
+                    "template": "{family}{Task}_{Renderlayer}_{Renderpass}"
                 },
                 {
                     "families": [


### PR DESCRIPTION
## Brief description
Render layer key in TVPaint implementation is without underscode (`render_layer` -> `renderlayer`).

## Description
Add 'renderlayer' to instance.data for TVPaint render instances. Render passes had `render_layer` which was changed to `renderlayer` and layers pass their `variant` as value. This is to match Maya specifically. There is a secondary reason to do so, to match subset group name filtering. Also usage of `render_pass` was modified to use `renderpass` to keep consistency.

## Additional info
For some time there must be bost ways how are keys stored. Release variant of [PR](https://github.com/pypeclub/OpenPype/pull/3110).

## Testing notes:
- New files
1. Open new TVpaint file
2. Create some render layers/passes
3. Publish
4. All should work and if subset group profile is matching, it should be grouped

- Old files
1. Open TVPaint file with instances created before this PR
2. publish
3. All should work and subset groups should match too