### PR TITLE
General: Python 2 compatibility in queries

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1532,13 +1532,13 @@ class BuildWorkfile:
 
         subsets = list(legacy_io.find({
             "type": "subset",
-            "parent": {"$in": asset_entity_by_ids.keys()}
+            "parent": {"$in": list(asset_entity_by_ids.keys())}
         }))
         subset_entity_by_ids = {subset["_id"]: subset for subset in subsets}
 
         sorted_versions = list(legacy_io.find({
             "type": "version",
-            "parent": {"$in": subset_entity_by_ids.keys()}
+            "parent": {"$in": list(subset_entity_by_ids.keys())}
         }).sort("name", -1))
 
         subset_id_with_latest_version = []
@@ -1552,7 +1552,7 @@ class BuildWorkfile:
 
         repres = legacy_io.find({
             "type": "representation",
-            "parent": {"$in": last_versions_by_id.keys()}
+            "parent": {"$in": list(last_versions_by_id.keys())}
         })
 
         output = {}


### PR DESCRIPTION
## Brief description
Get last versions in queries works for Py2 hosts.

## Description
There is an issue that dictionary in Py2 returns `dict_keys` when `.keys()` is called which causes crash in mongod queries, so we're making sure that result of `keys()` is converted to list.

## Testing notes:
1. Run build workfile in Python 2 host

Deveop variant of [PR](https://github.com/pypeclub/OpenPype/pull/3111).