### PR TITLE
Ftrack: AssetVersion status on publish

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -24,48 +24,6 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
     label = "Integrate Ftrack Api"
     families = ["ftrack"]
 
-    def query(self, entitytype, data):
-        """ Generate a query expression from data supplied.
-
-        If a value is not a string, we'll add the id of the entity to the
-        query.
-
-        Args:
-            entitytype (str): The type of entity to query.
-            data (dict): The data to identify the entity.
-            exclusions (list): All keys to exclude from the query.
-
-        Returns:
-            str: String query to use with "session.query"
-        """
-        queries = []
-        if sys.version_info[0] < 3:
-            for key, value in data.iteritems():
-                if not isinstance(value, (basestring, int)):
-                    self.log.info("value: {}".format(value))
-                    if "id" in value.keys():
-                        queries.append(
-                            "{0}.id is \"{1}\"".format(key, value["id"])
-                        )
-                else:
-                    queries.append("{0} is \"{1}\"".format(key, value))
-        else:
-            for key, value in data.items():
-                if not isinstance(value, (str, int)):
-                    self.log.info("value: {}".format(value))
-                    if "id" in value.keys():
-                        queries.append(
-                            "{0}.id is \"{1}\"".format(key, value["id"])
-                        )
-                else:
-                    queries.append("{0} is \"{1}\"".format(key, value))
-
-        query = (
-            "select id from " + entitytype + " where " + " and ".join(queries)
-        )
-        self.log.debug(query)
-        return query
-
     def process(self, instance):
         session = instance.context.data["ftrackSession"]
         context = instance.context

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -406,7 +406,8 @@
                 "redshiftproxy": "cache",
                 "usd": "usd"
             },
-            "keep_first_subset_name_for_review": true
+            "keep_first_subset_name_for_review": true,
+            "asset_versions_status_profiles": []
         }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -858,6 +858,43 @@
                             "key": "keep_first_subset_name_for_review",
                             "label": "Make subset name as first asset name",
                             "default": true
+                        },
+                        {
+                            "type": "list",
+                            "collapsible": true,
+                            "key": "asset_versions_status_profiles",
+                            "label": "AssetVersion status on publish",
+                            "use_label_wrap": true,
+                            "object_type": {
+                                "type": "dict",
+                                "children": [
+                                    {
+                                        "key": "hosts",
+                                        "label": "Host names",
+                                        "type": "hosts-enum",
+                                        "multiselection": true
+                                    },
+                                    {
+                                        "key": "task_types",
+                                        "label": "Task types",
+                                        "type": "task-types-enum"
+                                    },
+                                    {
+                                        "key": "family",
+                                        "label": "Family",
+                                        "type": "list",
+                                        "object_type": "text"
+                                    },
+                                    {
+                                        "type": "separator"
+                                    },
+                                    {
+                                        "key": "status",
+                                        "label": "Status name",
+                                        "type": "text"
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
## Brief description
Give ability to set status of AssetVersion on publish.

## Description
Added new settings `project_settings/ftrack/publish/IntegrateFtrackInstance/asset_versions_status_profiles` where is possible to define which status will have asset version on publish. By default is empty.

## Testing notes:
1. Add new profile in the settings
2. Set to the result of profile different then default status from ftrack
3. Publish
4. Check if AssetVersion in ftrack has the status

Older release variant of [PR](https://github.com/pypeclub/OpenPype/pull/3108)