### PR TITLE
Nuke: render instance with subset name filtered overrides

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -560,7 +560,13 @@ def get_created_node_imageio_setting(**kwarg):
                         "_ overriding knob: `{}` > `{}`".format(
                             knob, oknob
                         ))
-                    knob["value"] = oknob["value"]
+                    if not oknob["value"]:
+                        # remove original knob if no value found in oknob
+                        imageio_node["knobs"].remove(knob)
+                    else:
+                        # override knob value with oknob's
+                        knob["value"] = oknob["value"]
+
                 # add missing knobs into imageio_node
                 if oknob["name"] not in knob_names:
                     log.debug(

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -541,7 +541,7 @@ def get_imageio_input_colorspace(filename):
 def on_script_load():
     ''' Callback for ffmpeg support
     '''
-    if nuke.env['LINUX']:
+    if nuke.env["LINUX"]:
         nuke.tcl('load ffmpegReader')
         nuke.tcl('load ffmpegWriter')
     else:
@@ -592,7 +592,7 @@ def check_inventory_versions():
             versions = legacy_io.find({
                 "type": "version",
                 "parent": version["parent"]
-            }).distinct('name')
+            }).distinct("name")
 
             max_version = max(versions)
 
@@ -625,17 +625,17 @@ def writes_version_sync():
         avalon_knob_data = read_avalon_data(each)
 
         try:
-            if avalon_knob_data['families'] not in ["render"]:
-                log.debug(avalon_knob_data['families'])
+            if avalon_knob_data["families"] not in ["render"]:
+                log.debug(avalon_knob_data["families"])
                 continue
 
-            node_file = each['file'].value()
+            node_file = each["file"].value()
 
             node_version = "v" + get_version_from_path(node_file)
             log.debug("node_version: {}".format(node_version))
 
             node_new_file = node_file.replace(node_version, new_version)
-            each['file'].setValue(node_new_file)
+            each["file"].setValue(node_new_file)
             if not os.path.isdir(os.path.dirname(node_new_file)):
                 log.warning("Path does not exist! I am creating it.")
                 os.makedirs(os.path.dirname(node_new_file))
@@ -673,9 +673,9 @@ def get_render_path(node):
     '''
     data = {'avalon': read_avalon_data(node)}
     data_preset = {
-        "nodeclass": data['avalon']['family'],
-        "families": [data['avalon']['families']],
-        "creator": data['avalon']['creator']
+        "nodeclass": data["avalon"]["family"],
+        "families": [data["avalon"]["families"]],
+        "creator": data["avalon"]["creator"],
     }
 
     nuke_imageio_writes = get_created_node_imageio_setting(**data_preset)
@@ -748,7 +748,7 @@ def format_anatomy(data):
 def script_name():
     ''' Returns nuke script path
     '''
-    return nuke.root().knob('name').value()
+    return nuke.root().knob("name").value()
 
 
 def add_button_write_to_read(node):
@@ -843,7 +843,7 @@ def create_write_node(name, data, input=None, prenodes=None,
     # adding dataflow template
     log.debug("imageio_writes: `{}`".format(imageio_writes))
     for knob in imageio_writes["knobs"]:
-        _data.update({knob["name"]: knob["value"]})
+        _data[knob["name"]] = knob["value"]
 
     _data = fix_data_for_node_create(_data)
 
@@ -1192,15 +1192,19 @@ class WorkfileSettings(object):
 
         erased_viewers = []
         for v in nuke.allNodes(filter="Viewer"):
-            v['viewerProcess'].setValue(str(viewer_dict["viewerProcess"]))
+            # set viewProcess to preset from settings
+            v["viewerProcess"].setValue(
+                str(viewer_dict["viewerProcess"])
+            )
+
             if str(viewer_dict["viewerProcess"]) \
-                    not in v['viewerProcess'].value():
+                    not in v["viewerProcess"].value():
                 copy_inputs = v.dependencies()
                 copy_knobs = {k: v[k].value() for k in v.knobs()
                               if k not in filter_knobs}
 
                 # delete viewer with wrong settings
-                erased_viewers.append(v['name'].value())
+                erased_viewers.append(v["name"].value())
                 nuke.delete(v)
 
                 # create new viewer
@@ -1216,7 +1220,7 @@ class WorkfileSettings(object):
                     nv[k].setValue(v)
 
                 # set viewerProcess
-                nv['viewerProcess'].setValue(str(viewer_dict["viewerProcess"]))
+                nv["viewerProcess"].setValue(str(viewer_dict["viewerProcess"]))
 
         if erased_viewers:
             log.warning(
@@ -1308,7 +1312,7 @@ class WorkfileSettings(object):
             data_preset = {
                 "nodeclass": avalon_knob_data["family"],
                 "families": families,
-                "creator": avalon_knob_data['creator']
+                "creator": avalon_knob_data["creator"],
             }
 
             nuke_imageio_writes = get_created_node_imageio_setting(
@@ -1366,17 +1370,16 @@ class WorkfileSettings(object):
                 current = n["colorspace"].value()
                 future = str(preset_clrsp)
                 if current != future:
-                    changes.update({
-                        n.name(): {
-                            "from": current,
-                            "to": future
-                        }
-                    })
+                    changes[n.name()] = {
+                        "from": current,
+                        "to": future
+                    }
+
         log.debug(changes)
         if changes:
             msg = "Read nodes are not set to correct colospace:\n\n"
             for nname, knobs in changes.items():
-                msg += str(
+                msg += (
                     " - node: '{0}' is now '{1}' but should be '{2}'\n"
                 ).format(nname, knobs["from"], knobs["to"])
 
@@ -1608,17 +1611,17 @@ def get_hierarchical_attr(entity, attr, default=None):
         if not value:
             break
 
-    if value or entity['type'].lower() == 'project':
+    if value or entity["type"].lower() == "project":
         return value
 
-    parent_id = entity['parent']
+    parent_id = entity["parent"]
     if (
-        entity['type'].lower() == 'asset'
-        and entity.get('data', {}).get('visualParent')
+        entity["type"].lower() == "asset"
+        and entity.get("data", {}).get("visualParent")
     ):
-        parent_id = entity['data']['visualParent']
+        parent_id = entity["data"]["visualParent"]
 
-    parent = legacy_io.find_one({'_id': parent_id})
+    parent = legacy_io.find_one({"_id": parent_id})
 
     return get_hierarchical_attr(parent, attr)
 
@@ -1631,9 +1634,9 @@ def get_write_node_template_attr(node):
     data = {"avalon": read_avalon_data(node)}
 
     data_preset = {
-        "nodeclass": data['avalon']['family'],
-        "families": [data['avalon']['families']],
-        "creator": data['avalon']['creator']
+        "nodeclass": data["avalon"]["family"],
+        "families": [data["avalon"]["families"]],
+        "creator": data["avalon"]["creator"],
     }
 
     # get template data
@@ -1644,10 +1647,11 @@ def get_write_node_template_attr(node):
         "file": get_render_path(node)
     })
 
-    # adding imageio template
-    {correct_data.update({k: v})
-     for k, v in nuke_imageio_writes.items()
-     if k not in ["_id", "_previous"]}
+    # adding imageio knob presets
+    for k, v in nuke_imageio_writes.items():
+        if k in ["_id", "_previous"]:
+            continue
+        correct_data[k] = v
 
     # fix badly encoded data
     return fix_data_for_node_create(correct_data)
@@ -1763,8 +1767,8 @@ def maintained_selection():
 
     Example:
         >>> with maintained_selection():
-        ...     node['selected'].setValue(True)
-        >>> print(node['selected'].value())
+        ...     node["selected"].setValue(True)
+        >>> print(node["selected"].value())
         False
     """
     previous_selection = nuke.selectedNodes()
@@ -1772,11 +1776,11 @@ def maintained_selection():
         yield
     finally:
         # unselect all selection in case there is some
-        current_seletion = nuke.selectedNodes()
-        [n['selected'].setValue(False) for n in current_seletion]
+        reset_selection()
+
         # and select all previously selected nodes
         if previous_selection:
-            [n['selected'].setValue(True) for n in previous_selection]
+            select_nodes(previous_selection)
 
 
 def reset_selection():

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -32,7 +32,7 @@ from .lib import (
     launch_workfiles_app,
     check_inventory_versions,
     set_avalon_knob_data,
-    read,
+    read_avalon_data,
     Context
 )
 
@@ -359,7 +359,7 @@ def parse_container(node):
         dict: The container schema data for this container node.
 
     """
-    data = read(node)
+    data = read_avalon_data(node)
 
     # (TODO) Remove key validation when `ls` has re-implemented.
     #

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -260,8 +260,6 @@ class ExporterReview(object):
             return nuke_imageio["viewer"]["viewerProcess"]
 
 
-
-
 class ExporterReviewLut(ExporterReview):
     """
     Generator object for review lut from Nuke

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -671,7 +671,8 @@ class AbstractWriteRender(OpenPypeCreator):
         write_data = {
             "nodeclass": self.n_class,
             "families": [self.family],
-            "avalon": self.data
+            "avalon": self.data,
+            "subset": self.data["subset"]
         }
 
         # add creator data

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -52,7 +52,7 @@ class ExtractReviewDataMov(openpype.api.Extractor):
             for o_name, o_data in self.outputs.items():
                 f_families = o_data["filter"]["families"]
                 f_task_types = o_data["filter"]["task_types"]
-                f_subsets = o_data["filter"]["sebsets"]
+                f_subsets = o_data["filter"]["subsets"]
 
                 self.log.debug(
                     "f_families `{}` > families: {}".format(

--- a/openpype/settings/defaults/project_anatomy/imageio.json
+++ b/openpype/settings/defaults/project_anatomy/imageio.json
@@ -165,7 +165,7 @@
                     ]
                 }
             ],
-            "customNodes": []
+            "overrideNodes": []
         },
         "regexInputs": {
             "inputs": [

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -120,7 +120,7 @@
                     "filter": {
                         "task_types": [],
                         "families": [],
-                        "sebsets": []
+                        "subsets": []
                     },
                     "read_raw": false,
                     "viewer_process_override": "",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -253,7 +253,7 @@
                         {
                             "key": "requiredNodes",
                             "type": "list",
-                            "label": "Required Nodes",
+                            "label": "Plugin required",
                             "object_type": {
                                 "type": "dict",
                                 "children": [
@@ -272,35 +272,43 @@
                                         "label": "Nuke Node Class"
                                     },
                                     {
-                                        "type": "splitter"
-                                    },
-                                    {
-                                        "key": "knobs",
+                                        "type": "collapsible-wrap",
                                         "label": "Knobs",
-                                        "type": "list",
-                                        "object_type": {
-                                            "type": "dict",
-                                            "children": [
-                                                {
-                                                    "type": "text",
-                                                    "key": "name",
-                                                    "label": "Name"
-                                                },
-                                                {
-                                                    "type": "text",
-                                                    "key": "value",
-                                                    "label": "Value"
+                                        "collapsible": true,
+                                        "collapsed": true,
+                                        "children": [
+                                            {
+                                                "key": "knobs",
+                                                "type": "list",
+                                                "object_type": {
+                                                    "type": "dict",
+                                                    "children": [
+                                                        {
+                                                            "type": "text",
+                                                            "key": "name",
+                                                            "label": "Name"
+                                                        },
+                                                        {
+                                                            "type": "text",
+                                                            "key": "value",
+                                                            "label": "Value"
+                                                        }
+                                                    ]
                                                 }
-                                            ]
-                                        }
+                                            }
+                                        ]
                                     }
+
                                 ]
                             }
                         },
                         {
+                            "type": "splitter"
+                        },
+                        {
                             "type": "list",
-                            "key": "customNodes",
-                            "label": "Custom Nodes",
+                            "key": "overrideNodes",
+                            "label": "Plugin's node overrides",
                             "object_type": {
                                 "type": "dict",
                                 "children": [
@@ -319,27 +327,37 @@
                                         "label": "Nuke Node Class"
                                     },
                                     {
-                                        "type": "splitter"
+                                        "key": "sebsets",
+                                        "label": "Subsets",
+                                        "type": "list",
+                                        "object_type": "text"
                                     },
                                     {
-                                        "key": "knobs",
+                                        "type": "collapsible-wrap",
                                         "label": "Knobs",
-                                        "type": "list",
-                                        "object_type": {
-                                            "type": "dict",
-                                            "children": [
-                                                {
-                                                    "type": "text",
-                                                    "key": "name",
-                                                    "label": "Name"
-                                                },
-                                                {
-                                                    "type": "text",
-                                                    "key": "value",
-                                                    "label": "Value"
+                                        "collapsible": true,
+                                        "collapsed": true,
+                                        "children": [
+                                            {
+                                                "key": "knobs",
+                                                "type": "list",
+                                                "object_type": {
+                                                    "type": "dict",
+                                                    "children": [
+                                                        {
+                                                            "type": "text",
+                                                            "key": "name",
+                                                            "label": "Name"
+                                                        },
+                                                        {
+                                                            "type": "text",
+                                                            "key": "value",
+                                                            "label": "Value"
+                                                        }
+                                                    ]
                                                 }
-                                            ]
-                                        }
+                                            }
+                                        ]
                                     }
                                 ]
                             }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -327,7 +327,7 @@
                                         "label": "Nuke Node Class"
                                     },
                                     {
-                                        "key": "sebsets",
+                                        "key": "subsets",
                                         "label": "Subsets",
                                         "type": "list",
                                         "object_type": "text"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -334,7 +334,7 @@
                                     },
                                     {
                                         "type": "collapsible-wrap",
-                                        "label": "Knobs",
+                                        "label": "Knobs overrides",
                                         "collapsible": true,
                                         "collapsed": true,
                                         "children": [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -212,7 +212,7 @@
                                         "object_type": "text"
                                     },
                                     {
-                                        "key": "sebsets",
+                                        "key": "subsets",
                                         "label": "Subsets",
                                         "type": "list",
                                         "object_type": "text"


### PR DESCRIPTION
## Brief description
Adding ability to override Anatomy imagio required nodes with subset filtering.

## Description
Some studios were requesting overriding per subset name regex filtering. This will allow to have different colorspace on subset `renderCompMain` then on `renderCompMask` for example. Overrides and also adding missing knob values if they are not found in the original Required Plugin nodes. 

## Additional info
- if override knob is having the same name but different value, value is overriten
- if override knob is not having its equivalent in original knobs, it is added
- if override knob is having matching equivalent in original knobs and having empty value, it is removed from original knobs.

## Testing notes:
1. Start testing workfile in nuke
2. go to Studio settings `project_anatomy/imageio/nuke/nodes/overrideNodes` at your project
3. configure new override similary to the image, and save settings
![image](https://user-images.githubusercontent.com/40640033/165826109-d68b5e46-b40e-481f-8aac-abaecd111db0.png)
4. in nuke go to openpype/create/Create Write Render, set Subset to `Boho` and Create
5. Select the node and CTRL+Enter to see content of render group. Double click at write node and see properties bin. It should look similar to following image, if your colorspace was originaly defined as ACES
![image](https://user-images.githubusercontent.com/40640033/165826581-fb0b3602-e5f0-4117-ab8a-72247577fad7.png)
6. now try to create again but Subset name as `Main` and repeate step 5 and look to `project_anatomy/imageio/nuke/nodes/requiredNodes/0/knobs` and compare. It shold be set exactly as it is in settings.