### PR TITLE
Nuke: fix anatomy imageio regex default

### DIFF
--- a/openpype/settings/defaults/project_anatomy/imageio.json
+++ b/openpype/settings/defaults/project_anatomy/imageio.json
@@ -170,7 +170,7 @@
         "regexInputs": {
             "inputs": [
                 {
-                    "regex": "[^-a-zA-Z0-9]beauty[^-a-zA-Z0-9]",
+                    "regex": "(beauty).*(?=.exr)",
                     "colorspace": "linear"
                 }
             ]


### PR DESCRIPTION
## Brief description
Regex example is correct.

## Description
This redex is in default settings just to inspire users for their own definition, but since it was wrong it was misleading.