### PR TITLE
Nuke: fixing default settings for workfile builder loaders

### DIFF
--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -220,11 +220,12 @@
                         "repre_names": [
                             "exr",
                             "dpx",
-                            "mov"
+                            "mov",
+                            "mp4",
+                            "h264"
                         ],
                         "loaders": [
-                            "LoadSequence",
-                            "LoadMov"
+                            "LoadClip"
                         ]
                     }
                 ],


### PR DESCRIPTION
## Brief description
Default settings are set to the new `LoadClip` plugin

## Description
Settings were holding obsolete plugins

## Testing notes:
1. start nuke in testing task workfile
2. make sure no project overrides are in `project_settings/nuke/workfile_builder/profiles/0/current_context/0/loaders`
3. go to nuke menu Openpype/Build Workfile
4. It should load available subset version. 