### PR TITLE
Nuke: Expose write attributes to settings

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -858,6 +858,7 @@ def create_write_node(name, data, input=None, prenodes=None,
     Return:
         node (obj): group node with avalon data as Knobs
     '''
+    knob_overrides = data.get("knobs", [])
 
     imageio_writes = get_created_node_imageio_setting(**data)
     for knob in imageio_writes["knobs"]:
@@ -1060,6 +1061,30 @@ def create_write_node(name, data, input=None, prenodes=None,
     # set tile color
     tile_color = _data.get("tile_color", "0xff0000ff")
     GN["tile_color"].setValue(tile_color)
+
+    # overrie knob values from settings
+    for knob in knob_overrides:
+        knob_type = knob["type"]
+        knob_name = knob["name"]
+        knob_value = knob["value"]
+        if knob_name not in GN.knobs():
+            continue
+        if not knob_value:
+            continue
+
+        # set correctly knob types
+        if knob_type == "string":
+            knob_value = str(knob_value)
+        if knob_type == "number":
+            knob_value = int(knob_value)
+        if knob_type == "decimal_number":
+            knob_value = float(knob_value)
+        if knob_type == "bool":
+            knob_value = bool(knob_value)
+        if knob_type in ["2d_vector", "3d_vector"]:
+            knob_value = list(knob_value)
+
+        GN[knob_name].setValue(knob_value)
 
     return GN
 

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -605,6 +605,7 @@ class AbstractWriteRender(OpenPypeCreator):
     family = "render"
     icon = "sign-out"
     defaults = ["Main", "Mask"]
+    knobs = []
 
     def __init__(self, *args, **kwargs):
         super(AbstractWriteRender, self).__init__(*args, **kwargs)
@@ -672,7 +673,8 @@ class AbstractWriteRender(OpenPypeCreator):
             "nodeclass": self.n_class,
             "families": [self.family],
             "avalon": self.data,
-            "subset": self.data["subset"]
+            "subset": self.data["subset"],
+            "knobs": self.knobs
         }
 
         # add creator data

--- a/openpype/hosts/nuke/plugins/create/create_write_render.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_render.py
@@ -13,6 +13,7 @@ class CreateWriteRender(plugin.AbstractWriteRender):
     family = "render"
     icon = "sign-out"
     defaults = ["Main", "Mask"]
+    knobs = []
 
     def __init__(self, *args, **kwargs):
         super(CreateWriteRender, self).__init__(*args, **kwargs)
@@ -38,13 +39,12 @@ class CreateWriteRender(plugin.AbstractWriteRender):
             }
         ]
 
-        write_node = create_write_node(
+        return create_write_node(
             self.data["subset"],
             write_data,
             input=selected_node,
-            prenodes=_prenodes)
-
-        return write_node
+            prenodes=_prenodes
+        )
 
     def _modify_write_node(self, write_node):
         return write_node

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -21,7 +21,8 @@
             "defaults": [
                 "Main",
                 "Mask"
-            ]
+            ],
+            "knobs": []
         },
         "CreateWritePrerender": {
             "fpath_template": "{work}/prerenders/nuke/{subset}/{subset}.{frame}.{ext}",
@@ -33,7 +34,8 @@
                 "Branch01",
                 "Part01"
             ],
-            "reviewable": false
+            "reviewable": false,
+            "knobs": []
         }
     },
     "publish": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
@@ -87,7 +87,7 @@
             "children": [
                 {
                     "type": "dict",
-                    "collapsible": false,
+                    "collapsible": true,
                     "key": "CreateWriteRender",
                     "label": "CreateWriteRender",
                     "is_group": true,
@@ -104,12 +104,16 @@
                             "object_type": {
                                 "type": "text"
                             }
+                        },
+                        {
+                            "type": "schema",
+                            "name": "schema_nuke_knob_inputs"
                         }
                     ]
                 },
                 {
                     "type": "dict",
-                    "collapsible": false,
+                    "collapsible": true,
                     "key": "CreateWritePrerender",
                     "label": "CreateWritePrerender",
                     "is_group": true,
@@ -136,6 +140,10 @@
                             "type": "boolean",
                             "key": "reviewable",
                             "label": "Add reviewable toggle"
+                        },
+                        {
+                            "type": "schema",
+                            "name": "schema_nuke_knob_inputs"
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_knob_inputs.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_knob_inputs.json
@@ -1,0 +1,151 @@
+{
+    "type": "collapsible-wrap",
+    "label": "Knob defaults",
+    "collapsible": true,
+    "collapsed": true,
+    "children": [{
+        "type": "list",
+        "key": "knobs",
+        "object_type": {
+            "type": "dict-conditional",
+            "enum_key": "type",
+            "enum_label": "Type",
+            "enum_children": [
+                {
+                    "key": "string",
+                    "label": "String",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "name",
+                            "label": "Name"
+                        },
+                        {
+                            "type": "text",
+                            "key": "value",
+                            "label": "Value"
+                        }
+                    ]
+                },
+                {
+                    "key": "bool",
+                    "label": "Boolean",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "name",
+                            "label": "Name"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "value",
+                            "label": "Value"
+                        }
+                    ]
+                },
+                {
+                    "key": "number",
+                    "label": "Number",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "name",
+                            "label": "Name"
+                        },
+                        {
+                            "type": "number",
+                            "key": "value",
+                            "default": 1,
+                            "decimal": 0
+                        }
+
+                    ]
+                },
+                {
+                    "key": "decimal_number",
+                    "label": "Decimal number",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "name",
+                            "label": "Name"
+                        },
+                        {
+                            "type": "number",
+                            "key": "value",
+                            "default": 1,
+                            "decimal": 4
+                        }
+
+                    ]
+                },
+                {
+                    "key": "2d_vector",
+                    "label": "2D vector",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "name",
+                            "label": "Name"
+                        },
+                        {
+                            "type": "list-strict",
+                            "key": "value",
+                            "label": "Value",
+                            "object_types": [
+                                {
+                                    "type": "number",
+                                    "key": "x",
+                                    "default": 1,
+                                    "decimal": 4
+                                },
+                                {
+                                    "type": "number",
+                                    "key": "y",
+                                    "default": 1,
+                                    "decimal": 4
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "3d_vector",
+                    "label": "3D vector",
+                    "children": [
+                        {
+                            "type": "text",
+                            "key": "name",
+                            "label": "Name"
+                        },
+                        {
+                            "type": "list-strict",
+                            "key": "value",
+                            "label": "Value",
+                            "object_types": [
+                                {
+                                    "type": "number",
+                                    "key": "x",
+                                    "default": 1,
+                                    "decimal": 4
+                                },
+                                {
+                                    "type": "number",
+                                    "key": "y",
+                                    "default": 1,
+                                    "decimal": 4
+                                },
+                                {
+                                    "type": "number",
+                                    "key": "y",
+                                    "default": 1,
+                                    "decimal": 4
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }]
+}


### PR DESCRIPTION
## Brief description
Created node knobs have settings for overrides

## Description
Now we are able to define knob overrides for example for `render` or `deadlinePriority`.

## Additional info
In settings it is important to know knob type to be able to define it correctly - finally no guessing on this.

## Testing notes:
1. open your favorite testing workfile in nuke
2. hover above created node's knob to find out exact name of knob 
![image](https://user-images.githubusercontent.com/40640033/166220398-d06d5aa6-05ee-4624-b840-fa5821d46b79.png)
3. add some knob override to `project_settings/nuke/create/CreateWriteRender/knobs` to your project override and save settings.
4. Create Render node and see that the default value was set. 