### PR TITLE
General: Cleanup some Loader docstrings

### DIFF
--- a/openpype/hosts/fusion/plugins/load/actions.py
+++ b/openpype/hosts/fusion/plugins/load/actions.py
@@ -6,7 +6,7 @@ from openpype.pipeline import load
 
 
 class FusionSetFrameRangeLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Set frame range excluding pre- and post-handles"""
 
     families = ["animation",
                 "camera",
@@ -40,7 +40,7 @@ class FusionSetFrameRangeLoader(load.LoaderPlugin):
 
 
 class FusionSetFrameRangeWithHandlesLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Set frame range including pre- and post-handles"""
 
     families = ["animation",
                 "camera",

--- a/openpype/hosts/houdini/plugins/load/actions.py
+++ b/openpype/hosts/houdini/plugins/load/actions.py
@@ -6,7 +6,7 @@ from openpype.pipeline import load
 
 
 class SetFrameRangeLoader(load.LoaderPlugin):
-    """Set Houdini frame range"""
+    """Set frame range excluding pre- and post-handles"""
 
     families = [
         "animation",
@@ -44,7 +44,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
 
 
 class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
-    """Set Maya frame range including pre- and post-handles"""
+    """Set frame range including pre- and post-handles"""
 
     families = [
         "animation",

--- a/openpype/hosts/houdini/plugins/load/load_alembic.py
+++ b/openpype/hosts/houdini/plugins/load/load_alembic.py
@@ -7,7 +7,7 @@ from openpype.hosts.houdini.api import pipeline
 
 
 class AbcLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Load Alembic"""
 
     families = ["model", "animation", "pointcache", "gpuCache"]
     label = "Load Alembic"

--- a/openpype/hosts/houdini/plugins/load/load_camera.py
+++ b/openpype/hosts/houdini/plugins/load/load_camera.py
@@ -78,7 +78,7 @@ def transfer_non_default_values(src, dest, ignore=None):
 
 
 class CameraLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Load camera from an Alembic file"""
 
     families = ["camera"]
     label = "Load Camera (abc)"

--- a/openpype/hosts/houdini/plugins/load/load_image.py
+++ b/openpype/hosts/houdini/plugins/load/load_image.py
@@ -42,9 +42,9 @@ def get_image_avalon_container():
 
 
 class ImageLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Load images into COP2"""
 
-    families = ["colorbleed.imagesequence"]
+    families = ["imagesequence"]
     label = "Load Image (COP2)"
     representations = ["*"]
     order = -10

--- a/openpype/hosts/houdini/plugins/load/load_vdb.py
+++ b/openpype/hosts/houdini/plugins/load/load_vdb.py
@@ -9,7 +9,7 @@ from openpype.hosts.houdini.api import pipeline
 
 
 class VdbLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Load VDB"""
 
     families = ["vdbcache"]
     label = "Load VDB"

--- a/openpype/hosts/maya/plugins/load/_load_animation.py
+++ b/openpype/hosts/maya/plugins/load/_load_animation.py
@@ -2,7 +2,7 @@ import openpype.hosts.maya.api.plugin
 
 
 class AbcLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Loader to reference an Alembic file"""
 
     families = ["animation",
                 "camera",

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -10,7 +10,7 @@ from openpype.hosts.maya.api.lib import (
 
 
 class SetFrameRangeLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Set frame range excluding pre- and post-handles"""
 
     families = ["animation",
                 "camera",
@@ -44,7 +44,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
 
 
 class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Set frame range including pre- and post-handles"""
 
     families = ["animation",
                 "camera",

--- a/openpype/hosts/maya/plugins/load/load_ass.py
+++ b/openpype/hosts/maya/plugins/load/load_ass.py
@@ -16,7 +16,7 @@ from openpype.hosts.maya.api.pipeline import containerise
 
 
 class AssProxyLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
-    """Load the Proxy"""
+    """Load Arnold Proxy as reference"""
 
     families = ["ass"]
     representations = ["ass"]

--- a/openpype/hosts/maya/plugins/load/load_gpucache.py
+++ b/openpype/hosts/maya/plugins/load/load_gpucache.py
@@ -8,7 +8,7 @@ from openpype.api import get_project_settings
 
 
 class GpuCacheLoader(load.LoaderPlugin):
-    """Load model Alembic as gpuCache"""
+    """Load Alembic as gpuCache"""
 
     families = ["model"]
     representations = ["abc"]

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -12,7 +12,7 @@ from openpype.hosts.maya.api.lib import maintained_selection
 
 
 class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
-    """Load the model"""
+    """Reference file"""
 
     families = ["model",
                 "pointcache",

--- a/openpype/hosts/maya/plugins/load/load_vdb_to_vray.py
+++ b/openpype/hosts/maya/plugins/load/load_vdb_to_vray.py
@@ -74,6 +74,7 @@ def _fix_duplicate_vvg_callbacks():
 
 
 class LoadVDBtoVRay(load.LoaderPlugin):
+    """Load OpenVDB in a V-Ray Volume Grid"""
 
     families = ["vdbcache"]
     representations = ["vdb"]

--- a/openpype/hosts/nuke/plugins/load/actions.py
+++ b/openpype/hosts/nuke/plugins/load/actions.py
@@ -9,7 +9,7 @@ log = Logger().get_logger(__name__)
 
 
 class SetFrameRangeLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Set frame range excluding pre- and post-handles"""
 
     families = ["animation",
                 "camera",
@@ -43,7 +43,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
 
 
 class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
-    """Specific loader of Alembic for the avalon.animation family"""
+    """Set frame range including pre- and post-handles"""
 
     families = ["animation",
                 "camera",


### PR DESCRIPTION
## Brief description

Purely cosmetics (except for one!) change to fix some loader docstrings to be more accurate.

## Description

I believe these are also used as tooltip or status tip for the Loaders in the loader context menu so artists might actually see this information too.

## Additional info

It might still be worth looking into doing a more thorough cleanup and unifying of how Loaders are described across all hosts.