### PR TITLE
Terminal: Tweak coloring of TrayModuleManager logging enabled states

### DIFF
--- a/openpype/lib/terminal.py
+++ b/openpype/lib/terminal.py
@@ -98,7 +98,7 @@ class Terminal:
             r"\*\*\* WRN": _SB + _LY + r"*** WRN" + _RST,
             r"  \- ": _SB + _LY + r"  - " + _RST,
             r"\[ ": _SB + _LG + r"[ " + _RST,
-            r"\]": _SB + _LG + r"]" + _RST,
+            r" \]": _SB + _LG + r" ]" + _RST,
             r"{": _LG + r"{",
             r"}": r"}" + _RST,
             r"\(": _LY + r"(",


### PR DESCRIPTION
## Brief description

This tweaks the regex for colorizing in the terminal to change how the TrayModulesManager logs the enabled states' colors.

## Description

**Before:**

![traymodulemanager_logs](https://user-images.githubusercontent.com/2439881/166333362-d81c49b7-f7df-4c4a-93d0-c541028cf889.JPG)


**After:**

![traymodulemanager_changed](https://user-images.githubusercontent.com/2439881/166333368-13ba3a1c-6280-4faf-8058-b5df5cf3e417.JPG)

## Additional info

I'm not too knowledgeable about this area of the code base so please double check the change.

## Testing notes:

1. Check whether logging messages are colored as intended and messages come out ok.