### PR TITLE
TVPaint: Composite layers in reversed order

### DIFF
--- a/openpype/hosts/tvpaint/lib.py
+++ b/openpype/hosts/tvpaint/lib.py
@@ -573,7 +573,7 @@ def composite_rendered_layers(
         layer_ids_by_position[layer_position] = layer["layer_id"]
 
     # Sort layer positions
-    sorted_positions = tuple(sorted(layer_ids_by_position.keys()))
+    sorted_positions = tuple(reversed(sorted(layer_ids_by_position.keys())))
     # Prepare variable where filepaths without any rendered content
     #   - transparent will be created
     transparent_filepaths = set()


### PR DESCRIPTION
## Brief description
Layers are composited in reversed order.

## Description
Layer were composited from top to bottom layer which is oposite then it should be.

## Testing notes:
1. Publish renderLayer with multiple layers
2. Output images should be in right order

Release variant of [PR](https://github.com/pypeclub/OpenPype/pull/3135)