### PR TITLE
General: Missing version on headless mode crash properly

### DIFF
--- a/start.py
+++ b/start.py
@@ -1029,6 +1029,9 @@ def boot():
             message = str(exc)
             _print(message)
             if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
+                openpype_versions = bootstrap.find_openpype(
+                    include_zips=True, staging=use_staging
+                )
                 list_versions(openpype_versions, local_version)
             else:
                 igniter.show_message_dialog("Version not found", message)
@@ -1053,6 +1056,9 @@ def boot():
             message = str(exc)
             _print(message)
             if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
+                openpype_versions = bootstrap.find_openpype(
+                    include_zips=True, staging=use_staging
+                )
                 list_versions(openpype_versions, local_version)
             else:
                 igniter.show_message_dialog("Version not found", message)

--- a/start.py
+++ b/start.py
@@ -931,11 +931,11 @@ def _boot_print_versions(use_staging, local_version, openpype_root):
     else:
         _print("--- This will list only staging versions detected.")
         _print("    To see other version, omit --use-staging argument.")
-    _openpype_root = OPENPYPE_ROOT
+
     openpype_versions = bootstrap.find_openpype(include_zips=True,
                                                 staging=use_staging)
     if getattr(sys, 'frozen', False):
-        local_version = bootstrap.get_version(Path(_openpype_root))
+        local_version = bootstrap.get_version(Path(openpype_root))
     else:
         local_version = OpenPypeVersion.get_installed_version_str()
 

--- a/start.py
+++ b/start.py
@@ -942,6 +942,17 @@ def _boot_print_versions(use_staging, local_version, openpype_root):
     list_versions(openpype_versions, local_version)
 
 
+def _boot_handle_missing_version(local_version, use_staging, message):
+    _print(message)
+    if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
+        openpype_versions = bootstrap.find_openpype(
+            include_zips=True, staging=use_staging
+        )
+        list_versions(openpype_versions, local_version)
+    else:
+        igniter.show_message_dialog("Version not found", message)
+
+
 def boot():
     """Bootstrap OpenPype."""
 
@@ -1034,15 +1045,7 @@ def boot():
         try:
             version_path = _find_frozen_openpype(use_version, use_staging)
         except OpenPypeVersionNotFound as exc:
-            message = str(exc)
-            _print(message)
-            if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
-                openpype_versions = bootstrap.find_openpype(
-                    include_zips=True, staging=use_staging
-                )
-                list_versions(openpype_versions, local_version)
-            else:
-                igniter.show_message_dialog("Version not found", message)
+            _boot_handle_missing_version(local_version, use_staging, str(exc))
             sys.exit(1)
 
         except RuntimeError as e:
@@ -1061,15 +1064,7 @@ def boot():
             version_path = _bootstrap_from_code(use_version, use_staging)
 
         except OpenPypeVersionNotFound as exc:
-            message = str(exc)
-            _print(message)
-            if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
-                openpype_versions = bootstrap.find_openpype(
-                    include_zips=True, staging=use_staging
-                )
-                list_versions(openpype_versions, local_version)
-            else:
-                igniter.show_message_dialog("Version not found", message)
+            _boot_handle_missing_version(local_version, use_staging, str(exc))
             sys.exit(1)
 
     # set this to point either to `python` from venv in case of live code

--- a/start.py
+++ b/start.py
@@ -911,17 +911,11 @@ def _boot_validate_versions(use_version, local_version):
         sys.exit(1)
 
     # print result
-    result = bootstrap.validate_openpype_version(
-        bootstrap.get_version_path_from_list(
-            use_version, openpype_versions))
-
-    _print("{}{}".format(
-        ">>> " if result[0] else "!!! ",
-        bootstrap.validate_openpype_version(
-            bootstrap.get_version_path_from_list(
-                use_version, openpype_versions)
-        )[1])
+    version_path = bootstrap.get_version_path_from_list(
+        use_version, openpype_versions
     )
+    valid, message = bootstrap.validate_openpype_version(version_path)
+    _print("{}{}".format(">>> " if valid else "!!! ", message))
 
 
 def _boot_print_versions(use_staging, local_version, openpype_root):


### PR DESCRIPTION
## Brief description
Added missing variable in start.py.

## Description
Usage of missing OP version in headless mode did not crash properly. It crashed because of missing 'openpype_versions' variable. Moved logic of validate versions and print versions from `boot` into separated functions.

## Testing notes:
1. Start of OpenPype should work as did
2. When version which is not available should be used, it should crash properly in headless mode
    - run e.g. `openpype_console --headless --use-version="4.4.4"` or `start.py --headless --use-version="4.4.4"`

## Traceback
```
Requested version "3.11.0" was not found.
Traceback (most recent call last):
  File "C:\Users\JakubTrllo\Desktop\Prace\openpype3_2\start.py", line 1050, in boot
    version_path = _bootstrap_from_code(use_version, use_staging)
  File "C:\Users\JakubTrllo\Desktop\Prace\openpype3_2\start.py", line 830, in _bootstrap_from_code
    use_version
igniter.tools.OpenPypeVersionNotFound: Requested version "3.11.0" was not found.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\JakubTrllo\Desktop\Prace\openpype3_2\start.py", line 1175, in <module>
    boot()
  File "C:\Users\JakubTrllo\Desktop\Prace\openpype3_2\start.py", line 1056, in boot
    list_versions(openpype_versions, local_version)
UnboundLocalError: local variable 'openpype_versions' referenced before assignment
```