### PR TITLE
Deadline: fix the output directory

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -266,7 +266,6 @@ def get_renderer_variables(renderlayer, root):
 
     filename_prefix = cmds.getAttr(prefix_attr)
     return {"ext": extension,
-            "renderer": renderer,
             "filename_prefix": filename_prefix,
             "padding": padding,
             "filename_0": filename_0}
@@ -441,7 +440,9 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
 
         output_filename_0 = filename_0
 
-        if render_variables["renderer"] == "renderman":
+        # this is needed because renderman handles directory and file
+        # prefixes separately
+        if self._instance.data["renderer"] == "renderman":
             dirname = os.path.dirname(output_filename_0)
 
         # Create render folder ----------------------------------------------

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -266,6 +266,7 @@ def get_renderer_variables(renderlayer, root):
 
     filename_prefix = cmds.getAttr(prefix_attr)
     return {"ext": extension,
+            "renderer": renderer,
             "filename_prefix": filename_prefix,
             "padding": padding,
             "filename_0": filename_0}
@@ -440,7 +441,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
 
         output_filename_0 = filename_0
 
-        dirname = os.path.dirname(output_filename_0)
+        if render_variables["renderer"] == "renderman":
+            dirname = os.path.dirname(output_filename_0)
 
         # Create render folder ----------------------------------------------
         try:


### PR DESCRIPTION
## Fix

This is fixing bug introduced with renderman support changing output directory in deadline, Because renderman has different prefix for file and folder.

This is quick fix, but I still vote for optimizing the code to have as little as possible of hardcoded renderer specific code.