### PR TITLE
nuke: adding extract thumbnail settings

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
@@ -42,11 +42,17 @@ class ExtractThumbnail(openpype.api.Extractor):
             self.render_thumbnail(instance)
 
     def render_thumbnail(self, instance):
+        first_frame = instance.data["frameStartHandle"]
+        last_frame = instance.data["frameEndHandle"]
+
+        # find frame range and define middle thumb frame
+        mid_frame = int((last_frame - first_frame) / 2)
+
         node = instance[0]  # group node
         self.log.info("Creating staging dir...")
 
         if "representations" not in instance.data:
-            instance.data["representations"] = list()
+            instance.data["representations"] = []
 
         staging_dir = os.path.normpath(
             os.path.dirname(instance.data['path']))
@@ -69,21 +75,19 @@ class ExtractThumbnail(openpype.api.Extractor):
                     "{head}{padding}{tail}"))
                 fhead = collection.format("{head}")
 
-                # get first and last frame
-                first_frame = min(collection.indexes)
-                last_frame = max(collection.indexes)
+                thumb_fname = list(collection)[mid_frame]
             else:
-                fname = os.path.basename(instance.data.get("path", None))
+                fname = thumb_fname = os.path.basename(
+                    instance.data.get("path", None))
                 fhead = os.path.splitext(fname)[0] + "."
-                first_frame = instance.data.get("frameStart", None)
-                last_frame = instance.data.get("frameEnd", None)
 
             self.log.debug("__ fhead: `{}`".format(fhead))
 
             if "#" in fhead:
                 fhead = fhead.replace("#", "")[:-1]
 
-            path_render = os.path.join(staging_dir, fname).replace("\\", "/")
+            path_render = os.path.join(
+                staging_dir, thumb_fname).replace("\\", "/")
             self.log.debug("__ path_render: `{}`".format(path_render))
 
             # check if file exist otherwise connect to write node
@@ -92,10 +96,13 @@ class ExtractThumbnail(openpype.api.Extractor):
 
                 rnode["file"].setValue(path_render)
 
-                rnode["first"].setValue(first_frame)
-                rnode["origfirst"].setValue(first_frame)
-                rnode["last"].setValue(last_frame)
-                rnode["origlast"].setValue(last_frame)
+                # turn it raw if none of baking is ON
+                if all([
+                    not self.bake_viewer_input_process,
+                    not self.bake_viewer_process
+                ]):
+                    rnode["raw"].setValue(True)
+
                 temporary_nodes.append(rnode)
                 previous_node = rnode
             else:
@@ -144,26 +151,18 @@ class ExtractThumbnail(openpype.api.Extractor):
         temporary_nodes.append(write_node)
         tags = ["thumbnail", "publish_on_farm"]
 
-        # retime for
-        mid_frame = int((int(last_frame) - int(first_frame)) / 2) \
-            + int(first_frame)
-        first_frame = int(last_frame) / 2
-        last_frame = int(last_frame) / 2
-
         repre = {
             'name': name,
             'ext': "jpg",
             "outputName": "thumb",
             'files': file,
             "stagingDir": staging_dir,
-            "frameStart": first_frame,
-            "frameEnd": last_frame,
             "tags": tags
         }
         instance.data["representations"].append(repre)
 
         # Render frames
-        nuke.execute(write_node.name(), int(mid_frame), int(mid_frame))
+        nuke.execute(write_node.name(), mid_frame, mid_frame)
 
         self.log.debug(
             "representations: {}".format(instance.data["representations"]))

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -81,6 +81,9 @@
         },
         "ExtractThumbnail": {
             "enabled": true,
+            "use_rendered": true,
+            "bake_viewer_process": true,
+            "bake_viewer_input_process": true,
             "nodes": {
                 "Reformat": [
                     [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -132,9 +132,31 @@
                     "label": "Enabled"
                 },
                 {
-                    "type": "raw-json",
-                    "key": "nodes",
-                    "label": "Nodes"
+                    "type": "boolean",
+                    "key": "use_rendered",
+                    "label": "Use rendered images"
+                },
+                {
+                    "type": "boolean",
+                    "key": "bake_viewer_process",
+                    "label": "Bake viewer process"
+                },
+                {
+                    "type": "boolean",
+                    "key": "bake_viewer_input_process",
+                    "label": "Bake viewer input process"
+                },
+                {
+                    "type": "collapsible-wrap",
+                    "label": "Nodes",
+                    "collapsible": true,
+                    "children": [
+                        {
+                            "type": "raw-json",
+                            "key": "nodes",
+                            "label": "Nodes"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Brief description
Thumbnail can be passed from rendered with bypassed baking

## Description
Thumbnail was not correctly identifying existing path. It was pushing the process to re-render thumbnail from node tree instead of getting rendered frame. Also we didn't have toggles for baking process, so those were included now too.

## Testing notes:
1. open testing workfile on testing project
2. go to settings on your project `project_settings/nuke/publish/ExtractThumbnail/bake_viewer_process`
3. set toggles as shown on picture
![image](https://user-images.githubusercontent.com/40640033/167009172-d1378f1a-152a-4605-bfc6-3110907d58be.png)
4. publish as `local` or `use rendered images`
5. see that thumbnail plugin will create read node (it is very quick process so be mindfull :D)
6. check rendered thumnail in ftrack and notice that gamma is dark (in case your render was set to linear space) 