### PR TITLE
General: Add 'dataclasses' to required python modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ install_requires = [
     "dns",
     # Python defaults (cx_Freeze skip them by default)
     "dbm",
-    "sqlite3"
+    "sqlite3",
+    "dataclasses"
 ]
 
 includes = []


### PR DESCRIPTION
## Brief description
Python module 'dataclasses' was added to required module in build.

## Description
The module is Python builtin module which is not copied to build because is not used in OP but can be used in addons.

## Testing notes:
1. Only difference is that build will contain dataclasses module