### PR TITLE
Ftrack: Action delete old versions formatting works

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_delete_old_versions.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delete_old_versions.py
@@ -569,7 +569,7 @@ class DeleteOldVersions(BaseAction):
                 context["frame"] = self.sequence_splitter
                 sequence_path = os.path.normpath(
                     StringTemplate.format_strict_template(
-                        context, template
+                        template, context
                     )
                 )
 


### PR DESCRIPTION
## Brief description
Fixed formatting of representation path with frames.

## Description
Arguments for `StringTemplate` were swapped which caused a crash.

## Testing notes:
1. Run the action from Ftrack on representation with frames
2. Action should delete files without any issues


### Traceback
```
==============================
<StringTemplate> argument must be a string, not <class 'dict'>.
==============================
Traceback (most recent call last):
  File "/some_root/openpype/modules/ftrack/lib/ftrack_base_handler.py", line 137, in wrapper_launch
    return func(*args, **kwargs)
  File "/some_root/openpype/modules/ftrack/event_handlers_user/action_delete_old_versions.py", line 310, in launch
    file_path, seq_path = self.path_from_represenation(repre, anatomy)
  File "/some_root/openpype/modules/ftrack/event_handlers_user/action_delete_old_versions.py", line 572, in path_from_represenation
    context, template
  File "/some_root/openpype/lib/path_templates.py", line 197, in format_strict_template
    objected_template = cls(template)
  File "/some_root/openpype/lib/path_templates.py", line 93, in __init__
    self.__class__.__name__, str(type(template))
TypeERROR: <StringTemplate> argument must be a string, not <class 'dict'>.

```