### PR TITLE
Webpublisher: replace space by underscore in subset names

### DIFF
--- a/openpype/hosts/photoshop/api/ws_stub.py
+++ b/openpype/hosts/photoshop/api/ws_stub.py
@@ -28,6 +28,16 @@ class PSItem(object):
     long_name = attr.ib(default=None)
     color_code = attr.ib(default=None)  # color code of layer
 
+    @property
+    def clean_name(self):
+        """Returns layer name without publish icon highlight
+
+        Returns:
+            (str)
+        """
+        return (self.name.replace(PhotoshopServerStub.PUBLISH_ICON, '')
+                         .replace(PhotoshopServerStub.LOADED_ICON, ''))
+
 
 class PhotoshopServerStub:
     """

--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -39,7 +39,8 @@ class ValidateNamingRepair(pyblish.api.Action):
                 if layer_data:
                     layer_name = re.sub(invalid_chars,
                                         replace_char,
-                                        layer_data.name)
+                                        layer_data.clean_name)
+                    layer_name = stub.PUBLISH_ICON + layer_name
 
                     stub.rename_layer(instance.data["uuid"], layer_name)
 
@@ -71,9 +72,11 @@ class ValidateNaming(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         help_msg = ' Use Repair action (A) in Pyblish to fix it.'
-        msg = "Name \"{}\" is not allowed.{}".format(instance.data["name"],
-                                                     help_msg)
-        assert not re.search(self.invalid_chars, instance.data["name"]), msg
+        layer = instance.data.get("layer")
+        if layer:
+            msg = "Name \"{}\" is not allowed.{}".format(layer.clean_name,
+                                                         help_msg)
+            assert not re.search(self.invalid_chars, layer.clean_name), msg
 
         msg = "Subset \"{}\" is not allowed.{}".format(instance.data["subset"],
                                                        help_msg)


### PR DESCRIPTION
## Brief description
Invalid character(s) (as a undercore) triggered error in ValidateNaming.

## Description
Plugin which creates instances from color coded layers uses `ValidateNaming` Settings to clean subset and layer name

Version for 3.9.x branch.

## Testing notes:
1. Prepare .pds with names like "Layer 1" or "Layer ;/ 1" with proper color coding by configured values in `project_settings/photoshop/publish/CollectColorCodedInstances`
2. Publish via Webpublisher and studio processing
3. It shouldn't fail