### PR TITLE
Webpublisher: replace space by underscore in subset names

### DIFF
--- a/openpype/hosts/photoshop/api/ws_stub.py
+++ b/openpype/hosts/photoshop/api/ws_stub.py
@@ -29,6 +29,16 @@ class PSItem(object):
     color_code = attr.ib(default=None)  # color code of layer
     instance_id = attr.ib(default=None)
 
+    @property
+    def clean_name(self):
+        """Returns layer name without publish icon highlight
+
+        Returns:
+            (str)
+        """
+        return (self.name.replace(PhotoshopServerStub.PUBLISH_ICON, '')
+                         .replace(PhotoshopServerStub.LOADED_ICON, ''))
+
 
 class PhotoshopServerStub:
     """

--- a/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
@@ -151,6 +151,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
         instance.data["task"] = task_name
         instance.data["subset"] = subset
         instance.data["layer"] = layer
+        instance.data["families"] = []
 
         return instance
 

--- a/openpype/hosts/photoshop/plugins/publish/validate_naming.py
+++ b/openpype/hosts/photoshop/plugins/publish/validate_naming.py
@@ -42,7 +42,8 @@ class ValidateNamingRepair(pyblish.api.Action):
 
             layer_name = re.sub(invalid_chars,
                                 replace_char,
-                                current_layer_state.name)
+                                current_layer_state.clean_name)
+            layer_name = stub.PUBLISH_ICON + layer_name
 
             stub.rename_layer(current_layer_state.id, layer_name)
 
@@ -73,13 +74,17 @@ class ValidateNaming(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         help_msg = ' Use Repair action (A) in Pyblish to fix it.'
-        msg = "Name \"{}\" is not allowed.{}".format(instance.data["name"],
-                                                     help_msg)
 
-        formatting_data = {"msg": msg}
-        if re.search(self.invalid_chars, instance.data["name"]):
-            raise PublishXmlValidationError(self, msg,
-                                            formatting_data=formatting_data)
+        layer = instance.data.get("layer")
+        if layer:
+            msg = "Name \"{}\" is not allowed.{}".format(layer.clean_name,
+                                                         help_msg)
+
+            formatting_data = {"msg": msg}
+            if re.search(self.invalid_chars, layer.clean_name):
+                raise PublishXmlValidationError(self, msg,
+                                                formatting_data=formatting_data
+                                                )
 
         msg = "Subset \"{}\" is not allowed.{}".format(instance.data["subset"],
                                                        help_msg)


### PR DESCRIPTION
## Brief description
Invalid character(s) (as a underscore) triggered error in ValidateNaming plugin.

## Description
Plugin which creates instances from color coded layers uses `ValidateNaming` Settings to clean subset and layer name

Develop version of https://github.com/pypeclub/OpenPype/pull/3159

## Testing notes:
1. Prepare .pds with names like "Layer 1" or "Layer ;/ 1" with proper color coding by configured values in `project_settings/photoshop/publish/CollectColorCodedInstances`
2. Publish via Webpublisher and studio processing
3. It shouldn't fail