### PR TITLE
add silent audio to slate

### DIFF
--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -89,8 +89,8 @@ class ExtractReviewSlate(openpype.api.Extractor):
                         tags = stream.get("tags") or {}
                         input_timecode = tags.get("timecode") or ""
                         if "width" in stream and "height" in stream:
-                            input_width = stream.get("width")
-                            input_height = stream.get("height")
+                            input_width = int(stream.get("width"))
+                            input_height = int(stream.get("height"))
                         if "r_frame_rate" in stream:
                             # get frame rate in a form of
                             # x/y, like 24000/1001 for 23.976
@@ -100,8 +100,6 @@ class ExtractReviewSlate(openpype.api.Extractor):
                             and input_height
                             and input_frame_rate
                         ):
-                            input_width = int(input_width)
-                            input_height = int(input_height)
                             input_frame_rate = str(input_frame_rate)
                             break
             # Raise exception of any stream didn't define input resolution

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -159,7 +159,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
                 "-loop", "1",
                 "-i", openpype.lib.path_to_subprocess_arg(slate_path),
                 "-r", str(input_frame_rate),
-                "-frames:v",  "1",
+                "-frames:v", "1",
             ])
 
             # add timecode from source to the slate, substract one frame

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -334,8 +334,8 @@ class ExtractReviewSlate(openpype.api.Extractor):
                 slate_silent_subprocess_cmd = " ".join(slate_silent_args)
                 # run slate generation subprocess
                 self.log.debug(
-                    "Silent Slate Executing: {}".format(slate_silent_subprocess_cmd)
-                )
+                    "Silent Slate Executing: {}".format(
+                        slate_silent_subprocess_cmd))
                 openpype.api.run_subprocess(
                     slate_silent_subprocess_cmd, shell=True, logger=self.log
                 )


### PR DESCRIPTION
## Brief description
Allows Nuke slate with audio

## Description
Slate is concatenated with review using ffmpeg concat. Concatenation requires same number, type and layout of streams in concatenated files. Adding silence to the slate before concatenation allows to keep the audio in the review.

## Additional info

- Some review files do not support audio. Make sure you use Do not add audio tag to avoid encoding fail.
- It seems that some file formats produce small audio offsets. That might be a limitation of concat.


## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. make sure you have an audio available
2. setup a review with Add Slate Frame tag
3. Publish from Nuke, with slate
4. Check that review file has slate and audio