### PR TITLE
Harmony: fixed missing task name in render instance

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
+++ b/openpype/hosts/harmony/plugins/publish/collect_farm_render.py
@@ -144,6 +144,7 @@ class CollectFarmRender(openpype.lib.abstract_collect_render.
                 label=node.split("/")[1],
                 subset=subset_name,
                 asset=legacy_io.Session["AVALON_ASSET"],
+                task=task_name,
                 attachTo=False,
                 setMembers=[node],
                 publish=info[4],


### PR DESCRIPTION
## Brief description
Render instance was missing filled task


## Testing notes:
1.Try to publish from Harmony to Deadline