### PR TITLE
Fix for attaching render to subset

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -468,7 +468,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
             new_instance = copy(instance_data)
             new_instance["subset"] = subset_name
-            new_instance["subsetGroup"] = group_name
+            if not instance_data.get("append"):
+                new_instance["subsetGroup"] = group_name
             if preview:
                 new_instance["review"] = True
 
@@ -883,8 +884,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                     new_i = copy(i)
                     new_i["version"] = at.get("version")
                     new_i["subset"] = at.get("subset")
+                    new_i["family"] = at.get("family")
                     new_i["append"] = True
-                    new_i["families"].append(at.get("family"))
                     new_instances.append(new_i)
                     self.log.info("  - {} / v{}".format(
                         at.get("subset"), at.get("version")))

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -468,8 +468,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
             new_instance = copy(instance_data)
             new_instance["subset"] = subset_name
-            if not instance_data.get("append"):
-                new_instance["subsetGroup"] = group_name
+            new_instance["subsetGroup"] = group_name
             if preview:
                 new_instance["review"] = True
 
@@ -886,6 +885,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                     new_i["subset"] = at.get("subset")
                     new_i["family"] = at.get("family")
                     new_i["append"] = True
+                    # don't set subsetGroup if we are attaching
+                    new_i.pop("subsetGroup")
                     new_instances.append(new_i)
                     self.log.info("  - {} / v{}".format(
                         at.get("subset"), at.get("version")))


### PR DESCRIPTION
## Fix

This is fixing issue when renders couldn't be attached as a review to published subsets.

### Old behaviour:

- Create look
- Create Render
- Drag Look instance under render layer set in Render instance
- Set your render settings as needed
- Publish

Look will be published just fine, job will be submited to farm and when complete, render will be published as render. It will be shown on ftrack as render asset type and you won't find it in Maya Loader.

This is fixing it, render should attach correctly and look subset should be found along others in Loader as usual.

Close #2753