### PR TITLE
General: Oiio conversion for ffmpeg checks for invalid characters

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -493,8 +493,9 @@ def convert_for_ffmpeg(
             erase_reason = "has too long value ({} chars).".format(
                 len(attr_value)
             )
+            erase_attribute = True
 
-        if erase_attribute:
+        if not erase_attribute:
             for char in NOT_ALLOWED_FFMPEG_CHARS:
                 if char in attr_value:
                     erase_attribute = True
@@ -623,14 +624,16 @@ def convert_input_paths_for_ffmpeg(
                 erase_reason = "has too long value ({} chars).".format(
                     len(attr_value)
                 )
+                erase_attribute = True
 
-            for char in NOT_ALLOWED_FFMPEG_CHARS:
-                if char in attr_value:
-                    erase_attribute = True
-                    erase_reason = (
-                        "contains unsupported character \"{}\"."
-                    ).format(char)
-                    break
+            if not erase_attribute:
+                for char in NOT_ALLOWED_FFMPEG_CHARS:
+                    if char in attr_value:
+                        erase_attribute = True
+                        erase_reason = (
+                            "contains unsupported character \"{}\"."
+                        ).format(char)
+                        break
 
             if erase_attribute:
                 # Set attribute to empty string

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -624,14 +624,13 @@ def convert_input_paths_for_ffmpeg(
                     len(attr_value)
                 )
 
-            if erase_attribute:
-                for char in NOT_ALLOWED_FFMPEG_CHARS:
-                    if char in attr_value:
-                        erase_attribute = True
-                        erase_reason = (
-                            "contains unsupported character \"{}\"."
-                        ).format(char)
-                        break
+            for char in NOT_ALLOWED_FFMPEG_CHARS:
+                if char in attr_value:
+                    erase_attribute = True
+                    erase_reason = (
+                        "contains unsupported character \"{}\"."
+                    ).format(char)
+                    break
 
             if erase_attribute:
                 # Set attribute to empty string


### PR DESCRIPTION
## Brief description
Fix check for invalid characters in oiio conversion.

## Description
Check for invalid characters never happened because of invalid condition before.

## Testing notes:
1. Create renders with `"` in some metadata attribute but shorted then 8196 characters
2. Make it go through ExtractReview plugin
3. It should not crash on ffmpeg conversion