### PR TITLE
General/Hiero: better clip duration calculation

### DIFF
--- a/openpype/hosts/hiero/api/otio/hiero_export.py
+++ b/openpype/hosts/hiero/api/otio/hiero_export.py
@@ -151,7 +151,7 @@ def create_otio_reference(clip):
     padding = media_source.filenamePadding()
     file_head = media_source.filenameHead()
     is_sequence = not media_source.singleFile()
-    frame_duration = media_source.duration()
+    frame_duration = media_source.duration() - 1
     fps = utils.get_rate(clip) or self.project_fps
     extension = os.path.splitext(path)[-1]
 

--- a/openpype/hosts/hiero/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_instances.py
@@ -296,6 +296,8 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
                 continue
             if otio_clip.name not in track_item.name():
                 continue
+            self.log.debug("__ parent_range: {}".format(parent_range))
+            self.log.debug("__ timeline_range: {}".format(timeline_range))
             if openpype.lib.is_overlapping_otio_ranges(
                     parent_range, timeline_range, strict=True):
 

--- a/openpype/lib/editorial.py
+++ b/openpype/lib/editorial.py
@@ -17,7 +17,7 @@ def otio_range_to_frame_range(otio_range):
     start = _ot.to_frames(
         otio_range.start_time, otio_range.start_time.rate)
     end = start + _ot.to_frames(
-        otio_range.duration, otio_range.duration.rate) - 1
+        otio_range.duration, otio_range.duration.rate)
     return start, end
 
 
@@ -254,7 +254,7 @@ def get_media_range_with_retimes(otio_clip, handle_start, handle_end):
         media_in + source_in + offset_in)
     media_out_trimmed = (
         media_in + source_in + (
-            ((source_range.duration.value - 1) * abs(
+            (source_range.duration.value * abs(
                 time_scalar)) + offset_out))
 
     # calculate available handles


### PR DESCRIPTION
## Brief description
Improving clip duration calculation

## Description
Frame duration should not be excluding one frame as it is disturbing other hosts. Better to fix it in global then hack particular dcc (flame)

## Testing notes:
1. open your testing hiero script
2. publish a clip
3. all should look as expected