### PR TITLE
General: Avoid creating multiple thumbnails

### DIFF
--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -49,6 +49,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             return
 
         filtered_repres = self._get_filtered_repres(instance)
+        name_counter = 0
         for repre in filtered_repres:
             repre_files = repre["files"]
             if not isinstance(repre_files, (list, tuple)):
@@ -134,8 +135,12 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
                 self.log.warning("Conversion crashed", exc_info=True)
                 raise
 
+            repre_name = "thumbnail"
+            if name_counter > 0:
+                repre_name += str(name_counter)
+            name_counter += 1
             new_repre = {
-                "name": "thumbnail",
+                "name": repre_name,
                 "ext": "jpg",
                 "files": jpeg_file,
                 "stagingDir": stagingdir,

--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -49,7 +49,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             return
 
         filtered_repres = self._get_filtered_repres(instance)
-        name_counter = 0
+
         for repre in filtered_repres:
             repre_files = repre["files"]
             if not isinstance(repre_files, (list, tuple)):
@@ -135,12 +135,8 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
                 self.log.warning("Conversion crashed", exc_info=True)
                 raise
 
-            repre_name = "thumbnail"
-            if name_counter > 0:
-                repre_name += str(name_counter)
-            name_counter += 1
             new_repre = {
-                "name": repre_name,
+                "name": "thumbnail",
                 "ext": "jpg",
                 "files": jpeg_file,
                 "stagingDir": stagingdir,
@@ -155,6 +151,11 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             # Cleanup temp folder
             if convert_dir is not None and os.path.exists(convert_dir):
                 shutil.rmtree(convert_dir)
+
+            # Create only one representation with name 'thumbnail'
+            # TODO maybe handle way how to decide from which representation
+            #   will be thumbnail created
+            break
 
     def _get_filtered_repres(self, instance):
         filtered_repres = []


### PR DESCRIPTION
## Brief description
Extract jpeg exr does not create multiple representation names with "thumbnail" name but skip others after first.

## Description
There is no way how to define which representation will be source but that is for future PRs.

## Testing notes:
1. Publish on farm instance with more outputs from which thumbnail can be created (I don't know how)
2. It should not crash during integration