### PR TITLE
General: Creator plugins from addons can be registered

### DIFF
--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -14,6 +14,7 @@ from .pipeline import (
 
 class TrayPublishCreator(Creator):
     create_allow_context_change = True
+    host_name = "traypublisher"
 
     def collect_instances(self):
         for instance_data in list_instances():

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -702,6 +702,32 @@ class ModulesManager:
             ).format(expected_keys, " | ".join(msg_items)))
         return output
 
+    def collect_creator_plugin_paths(self, host_name):
+        """Helper to collect creator plugin paths from modules.
+
+        Args:
+            host_name (str): For which host are creators meants.
+
+        Returns:
+            list: List of creator plugin paths.
+        """
+        # Output structure
+        from openpype_interfaces import IPluginPaths
+
+        output = []
+        for module in self.get_enabled_modules():
+            # Skip module that do not inherit from `IPluginPaths`
+            if not isinstance(module, IPluginPaths):
+                continue
+
+            paths = module.get_creator_plugin_paths(host_name)
+            if paths:
+                # Convert to list if value is not list
+                if not isinstance(paths, (list, tuple, set)):
+                    paths = [paths]
+                output.extend(paths)
+        return output
+
     def collect_launch_hook_paths(self):
         """Helper to collect hooks from modules inherited ILaunchHookPaths.
 

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 
+import six
+
 from openpype import resources
 
 from openpype.modules import OpenPypeInterface
@@ -14,10 +16,37 @@ class IPluginPaths(OpenPypeInterface):
         "publish": ["path/to/publish_plugins"]
     }
     """
-    # TODO validation of an output
+
     @abstractmethod
     def get_plugin_paths(self):
         pass
+
+    def get_creator_plugin_paths(self, host_name):
+        """Retreive creator plugin paths.
+
+        Give addons ability to add creator plugin paths based on host name.
+
+        NOTES:
+        - Default implementation uses 'get_plugin_paths' and always return
+            all creator plugins.
+        - Host name may help to organize plugins by host, but each creator
+            alsomay have host filtering.
+
+        Args:
+            host_name (str): For which host are the plugins meant.
+        """
+
+        paths = self.get_plugin_paths()
+        if not paths or "create" not in paths:
+            return []
+
+        create_paths = paths["create"]
+        if not create_paths:
+            return []
+
+        if not isinstance(create_paths, (list, tuple, set)):
+            create_paths = [create_paths]
+        return create_paths
 
 
 class ILaunchHookPaths(OpenPypeInterface):

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -1,7 +1,5 @@
 from abc import abstractmethod
 
-import six
-
 from openpype import resources
 
 from openpype.modules import OpenPypeInterface

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -12,7 +12,7 @@ import pyblish.api
 from pyblish.lib import MessageHandler
 
 import openpype
-from openpype.modules import load_modules
+from openpype.modules import load_modules, ModulesManager
 from openpype.settings import get_project_settings
 from openpype.lib import (
     Anatomy,
@@ -107,7 +107,7 @@ def install_host(host):
     install_openpype_plugins()
 
 
-def install_openpype_plugins(project_name=None):
+def install_openpype_plugins(project_name=None, host_name=None):
     # Make sure modules are loaded
     load_modules()
 
@@ -115,6 +115,14 @@ def install_openpype_plugins(project_name=None):
     pyblish.api.register_plugin_path(PUBLISH_PATH)
     pyblish.api.register_discovery_filter(filter_pyblish_plugins)
     register_loader_plugin_path(LOAD_PATH)
+
+    if host_name is None:
+        host_name = os.environ.get("AVALON_APP")
+
+    modules_manager = ModulesManager()
+    creator_paths = modules_manager.collect_creator_plugin_paths(host_name)
+    for creator_path in creator_paths:
+        register_creator_plugin_path(creator_path)
 
     if project_name is None:
         project_name = os.environ.get("AVALON_PROJECT")

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -750,6 +750,10 @@ class CreateContext:
         return self._host_is_valid
 
     @property
+    def host_name(self):
+        return os.environ["AVALON_APP"]
+
+    @property
     def log(self):
         """Dynamic access to logger."""
         if self._log is None:
@@ -861,6 +865,17 @@ class CreateContext:
                     "Using first and skipping following"
                 ))
                 continue
+
+            # Filter by host name
+            if (
+                creator_class.host_name
+                and creator_class.host_name != self.host_name
+            ):
+                self.log.info((
+                    "Creator's host name is not supported for current host {}"
+                ).format(creator_class.host_name, self.host_name))
+                continue
+
             creator = creator_class(
                 self,
                 system_settings,

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -66,7 +66,7 @@ class BaseCreator:
     # Filtering by host name - can be used to be filtered by host name
     # - used on all hosts when set to 'None' for Backwards compatibility
     #   - was added afterwards
-    # QUESTIOn make this required?
+    # QUESTION make this required?
     host_name = None
 
     def __init__(

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -63,6 +63,12 @@ class BaseCreator:
     #       `openpype.pipeline.attribute_definitions`
     instance_attr_defs = []
 
+    # Filtering by host name - can be used to be filtered by host name
+    # - used on all hosts when set to 'None' for Backwards compatibility
+    #   - was added afterwards
+    # QUESTIOn make this required?
+    host_name = None
+
     def __init__(
         self, create_context, system_settings, project_settings, headless=False
     ):


### PR DESCRIPTION
## Brief description
Addons can register creator plugin paths and Creators can have host name filter.

## Description
Creator plugins have host name filtering so e.g. tray publisher creators won't appear in other hosts. Addon can implement new method which return creator plugin paths for specific host name. Default implementation is using `get_plugin_paths` for backwards compatibility. Installation of openpype plugins will also register creators from modules. Creator plugin has also ability to define host name filter.

## Additional information
We wanted to have filtering ability of creator plugins on both addon and creator side so creator plugin has `host_name` attribute which can define on which host is working. This is for backwards compatibility not abstract. But it is a question if it should be required? In most of cases it is only matter of addon implementation where this filter is "required" (It probably won't happen that host on it's own will register plugins for different host). Also at this time are new creators used only in 3 hosts so it could be easy to change it.

## Testing notes:
1. Create addon and add it to addons path
2. Make sure the addon inherit from `IPluginPaths`
3. Create some creator plugin for TrayPublisher inside the addon
4. Make sure addon implement `get_creator_plugin_paths` which returns path to the creator dir
5. Run tray publisher
6. The creator should be visible there

Resolves https://github.com/pypeclub/OpenPype/issues/3165