### PR TITLE
General: OpenPype modules publish plugins are registered in host

### DIFF
--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -119,7 +119,7 @@ def install_openpype_plugins(project_name=None, host_name=None):
     modules_manager = ModulesManager()
     publish_plugin_dirs = modules_manager.collect_plugin_paths()["publish"]
     for path in publish_plugin_dirs:
-        pyblish.api.register_plugin_path(PUBLISH_PATH)
+        pyblish.api.register_plugin_path(path)
 
     if host_name is None:
         host_name = os.environ.get("AVALON_APP")

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -116,10 +116,14 @@ def install_openpype_plugins(project_name=None, host_name=None):
     pyblish.api.register_discovery_filter(filter_pyblish_plugins)
     register_loader_plugin_path(LOAD_PATH)
 
+    modules_manager = ModulesManager()
+    publish_plugin_dirs = modules_manager.collect_plugin_paths()["publish"]
+    for path in publish_plugin_dirs:
+        pyblish.api.register_plugin_path(PUBLISH_PATH)
+
     if host_name is None:
         host_name = os.environ.get("AVALON_APP")
 
-    modules_manager = ModulesManager()
     creator_paths = modules_manager.collect_creator_plugin_paths(host_name)
     for creator_path in creator_paths:
         register_creator_plugin_path(creator_path)

--- a/start.py
+++ b/start.py
@@ -386,18 +386,6 @@ def set_modules_environments():
     modules_manager = ModulesManager()
 
     module_envs = modules_manager.collect_global_environments()
-    publish_plugin_dirs = modules_manager.collect_plugin_paths()["publish"]
-
-    # Set pyblish plugins paths if any module want to register them
-    if publish_plugin_dirs:
-        publish_paths_str = os.environ.get("PYBLISHPLUGINPATH") or ""
-        publish_paths = publish_paths_str.split(os.pathsep)
-        _publish_paths = {
-            os.path.normpath(path) for path in publish_paths if path
-        }
-        for path in publish_plugin_dirs:
-            _publish_paths.add(os.path.normpath(path))
-        module_envs["PYBLISHPLUGINPATH"] = os.pathsep.join(_publish_paths)
 
     # Merge environments with current environments and update values
     if module_envs:


### PR DESCRIPTION
## Brief description
Module's publish plugin paths are registered during installation of OpenPype plugins.

## Description
Changed how module plugin paths are registered. Instead of using environment variables are plugin paths registered during installation of OpenPype plugins which is more suitable and possible dynamic.

## Additional info
This approach gives more dynamic approach of registering publish plugins (e.g. does not require restart of tray when module change state). Can be extended in future to install plugin paths per project and more dynamically, which is not as easy now because modules' plugin paths are there from moment when openpype starts.

PR is based on https://github.com/pypeclub/OpenPype/pull/3179 where creator plugins are installed same way. I wanted to separate the PRs as this change should be fully tested.

## Testing notes:
1. All modules should register their publish plugins in all hosts
2. The same must work for farm publishing, standalone publishing and webpublisher