### PR TITLE
Maya: added clean_import option to Import loader

### DIFF
--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -1,7 +1,7 @@
 """A module containing generic loader actions that will display in the Loader.
 
 """
-
+import qargparse
 from openpype.pipeline import load
 from openpype.hosts.maya.api.lib import (
     maintained_selection,
@@ -98,12 +98,23 @@ class ImportMayaLoader(load.LoaderPlugin):
     icon = "arrow-circle-down"
     color = "#775555"
 
+    options = [
+        qargparse.Boolean(
+            "clean_import",
+            label="Clean import",
+            default=False,
+            help="Should all occurences of cbId be purged?"
+        )
+    ]
+
     def load(self, context, name=None, namespace=None, data=None):
         import maya.cmds as cmds
 
         choice = self.display_warning()
         if choice is False:
             return
+
+        clean_import = data.get("clean_import", False)
 
         asset = context['asset']
 
@@ -114,13 +125,21 @@ class ImportMayaLoader(load.LoaderPlugin):
         )
 
         with maintained_selection():
-            cmds.file(self.fname,
-                      i=True,
-                      preserveReferences=True,
-                      namespace=namespace,
-                      returnNewNodes=True,
-                      groupReference=True,
-                      groupName="{}:{}".format(namespace, name))
+            nodes = cmds.file(self.fname,
+                              i=True,
+                              preserveReferences=True,
+                              namespace=namespace,
+                              returnNewNodes=True,
+                              groupReference=True,
+                              groupName="{}:{}".format(namespace, name))
+
+            if clean_import:
+                shapes = cmds.ls(nodes, shapes=True, long=True)
+                for shape in shapes:
+                    meshes = cmds.ls('{}.cbId'.format(shape))
+                    for mesh in meshes:
+                        print("Removing ... " + (mesh))
+                        cmds.deleteAttr(mesh)
 
         # We do not containerize imported content, it remains unmanaged
         return

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -114,8 +114,6 @@ class ImportMayaLoader(load.LoaderPlugin):
         if choice is False:
             return
 
-        clean_import = data.get("clean_import", False)
-
         asset = context['asset']
 
         namespace = namespace or unique_namespace(
@@ -133,13 +131,14 @@ class ImportMayaLoader(load.LoaderPlugin):
                               groupReference=True,
                               groupName="{}:{}".format(namespace, name))
 
-            if clean_import:
-                shapes = cmds.ls(nodes, shapes=True, long=True)
-                for shape in shapes:
-                    meshes = cmds.ls('{}.cbId'.format(shape))
-                    for mesh in meshes:
-                        print("Removing ... " + (mesh))
-                        cmds.deleteAttr(mesh)
+            if data.get("clean_import", False):
+                remove_attributes = ["cbId"]
+                for node in nodes:
+                    for attr in remove_attributes:
+                        if cmds.attributeQuery(attr, node=node, exists=True):
+                            full_attr = "{}.{}".format(node, attr)
+                            print("Removing {}".format(full_attr))
+                            cmds.deleteAttr(full_attr)
 
         # We do not containerize imported content, it remains unmanaged
         return


### PR DESCRIPTION
## Brief description
By selecting this option all occurrences of cbId of imported nodes will be removed.

## Description
Usable for sharing assets between projects.

## Testing notes:
1. Load model via `Import` loader - set `Clean import` option (rectangle after Import label)
2.`cbId` in `Extra Attributes` should be removed (also check log for 'Removing ..' in Script Editor)