### PR TITLE
Ftrack: Review image only if there are no mp4 reviews

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -176,7 +176,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             # Add item to component list
             component_list.append(thumbnail_item)
 
-        if first_thumbnail_component is not None:
+        if (
+            not review_representations
+            and first_thumbnail_component is not None
+        ):
             width = first_thumbnail_component_repre.get("width")
             height = first_thumbnail_component_repre.get("height")
             if not width or not height:


### PR DESCRIPTION
## Brief description
Don't create `ftrackreview-image` component if there are mp4 reviews.

## Description
When there are both `ftrackreview-image` and `ftrackreview-mp4` it is not 100% sure that video is used as review source.

## Testing notes:
1. Publish something with review video and thumbnail
2. Only `ftrackreview-mp4` should be created