### PR TITLE
Maya: Redshift Volume Loader Implement update, remove, switch + fix vdb sequence support

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_vdb_to_redshift.py
+++ b/openpype/hosts/maya/plugins/load/load_vdb_to_redshift.py
@@ -1,11 +1,21 @@
 import os
 
 from openpype.api import get_project_settings
-from openpype.pipeline import load
+from openpype.pipeline import (
+    load,
+    get_representation_path
+)
 
 
 class LoadVDBtoRedShift(load.LoaderPlugin):
-    """Load OpenVDB in a Redshift Volume Shape"""
+    """Load OpenVDB in a Redshift Volume Shape
+
+    Note that the RedshiftVolumeShape is created without a RedshiftVolume
+    shader assigned. To get the Redshift volume to render correctly assign
+    a RedshiftVolume shader (in the Hypershade) and set the density, scatter
+    and emission channels to the channel names of the volumes in the VDB file.
+
+    """
 
     families = ["vdbcache"]
     representations = ["vdb"]
@@ -55,7 +65,7 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
 
         # Root group
         label = "{}:{}".format(namespace, name)
-        root = cmds.group(name=label, empty=True)
+        root = cmds.createNode("transform", name=label)
 
         settings = get_project_settings(os.environ['AVALON_PROJECT'])
         colors = settings['maya']['load']['colors']
@@ -74,9 +84,7 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
                                       name="{}RVSShape".format(label),
                                       parent=root)
 
-        cmds.setAttr("{}.fileName".format(volume_node),
-                     self.fname,
-                     type="string")
+        self._apply_settings(volume_node, path=self.fname)
 
         nodes = [root, volume_node]
         self[:] = nodes
@@ -87,3 +95,70 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
             nodes=nodes,
             context=context,
             loader=self.__class__.__name__)
+
+    def _apply_settings(self,
+                        grid_node,
+                        path):
+        """Apply the settings for the VDB path to the VRayVolumeGrid"""
+        from maya import cmds
+
+        # The path points to a single file. However the vdb files could be
+        # either just that single file or a sequence in a folder so we check
+        # whether it's a sequence
+        folder = os.path.dirname(path)
+        files = os.listdir(folder)
+        is_single_file = len(files) == 1
+        if is_single_file:
+            filename = path
+        else:
+            # The path points to the publish .vdb sequence filepath so we
+            # find the first file in there that ends with .vdb
+            files = sorted(files)
+            first = next((x for x in files if x.endswith(".vdb")), None)
+            if first is None:
+                raise RuntimeError("Couldn't find first .vdb file of "
+                                   "sequence in: %s" % path)
+            filename = os.path.join(path, first)
+
+        # Tell Redshift whether it should load as sequence or single file
+        cmds.setAttr(grid_node + ".useFrameExtension", not is_single_file)
+
+        # Set file path
+        cmds.setAttr(grid_node + ".fileName", filename, type="string")
+
+    def update(self, container, representation):
+        from maya import cmds
+
+        path = get_representation_path(representation)
+
+        # Find VRayVolumeGrid
+        members = cmds.sets(container['objectName'], query=True)
+        grid_nodes = cmds.ls(members, type="RedshiftVolumeShape", long=True)
+        assert len(grid_nodes) == 1, "This is a bug"
+
+        # Update the VRayVolumeGrid
+        self._apply_settings(grid_nodes[0], path=path)
+
+        # Update container representation
+        cmds.setAttr(container["objectName"] + ".representation",
+                     str(representation["_id"]),
+                     type="string")
+
+    def remove(self, container):
+        from maya import cmds
+
+        # Get all members of the avalon container, ensure they are unlocked
+        # and delete everything
+        members = cmds.sets(container['objectName'], query=True)
+        cmds.lockNode(members, lock=False)
+        cmds.delete([container['objectName']] + members)
+
+        # Clean up the namespace
+        try:
+            cmds.namespace(removeNamespace=container['namespace'],
+                           deleteNamespaceContent=True)
+        except RuntimeError:
+            pass
+
+    def switch(self, container, representation):
+        self.update(container, representation)


### PR DESCRIPTION
## Brief description

Improves Redshift Volume VDB loader to actually support updating and removing + also support single file or multiple frames in a sequence

## Additional info

The Loader still loads the volume **without!** a material assigned by default. I was thinking of potentially auto-assigning a simple Volume Material but wasn't sure whether we wanted that in the same namespace + actually auto-remove that material when removing the volume as well.

For now you'll need to just manually assign the shader you'll want to render it with after loading the volume.

## Testing notes:
1. Load a VDB volume into Maya

---

Tested with Maya 2022 + Redshift 3.0.67