### PR TITLE
Maya: Fix Yeti errors on Create, Publish and Load

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/create/create_yeti_cache.py
@@ -22,7 +22,8 @@ class CreateYetiCache(plugin.Creator):
         # Add animation data without step and handles
         anim_data = lib.collect_animation_data()
         anim_data.pop("step")
-        anim_data.pop("handles")
+        anim_data.pop("handleStart")
+        anim_data.pop("handleEnd")
         self.data.update(anim_data)
 
         # Add samples

--- a/openpype/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_cache.py
@@ -269,15 +269,8 @@ class YetiCacheLoader(load.LoaderPlugin):
         assert len(collections) == 1, "This is a bug"
         collection = collections[0]
 
-        # Assume padding from the first frame since clique returns 0 if the
-        # sequence contains no files padded with a zero at the start (e.g.
-        # a sequence starting at 1001)
-        padding = len(str(collection.indexes[0]))
-
-        fname = "{head}%0{padding}d{tail}".format(collection.head,
-                                                  padding,
-                                                  collection.tail)
-
+        # Formats name as {head}%d{tail} like cache.%04d.fur
+        fname = collection.format("{head}{padding}{tail}")
         return os.path.join(root, fname)
 
     def create_node(self, namespace, node_settings):

--- a/openpype/hosts/maya/plugins/publish/collect_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/collect_yeti_rig.py
@@ -43,11 +43,12 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
 
         instance.data["resources"] = yeti_resources
 
-        # Force frame range for export
-        instance.data["frameStart"] = cmds.playbackOptions(
-                                        query=True, animationStartTime=True)
-        instance.data["frameEnd"] = cmds.playbackOptions(
-                                        query=True, animationStartTime=True)
+        # Force frame range for yeti cache export for the rig
+        start = cmds.playbackOptions(query=True, animationStartTime=True)
+        for key in ["frameStart", "frameEnd",
+                    "frameStartHandle", "frameEndHandle"]:
+            instance.data[key] = start
+        instance.data["preroll"] = 0
 
     def collect_input_connections(self, instance):
         """Collect the inputs for all nodes in the input_SET"""

--- a/openpype/hosts/maya/plugins/publish/extract_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_yeti_cache.py
@@ -29,9 +29,9 @@ class ExtractYetiCache(openpype.api.Extractor):
         data_file = os.path.join(dirname, "yeti.fursettings")
 
         # Collect information for writing cache
-        start_frame = instance.data.get("frameStartHandle")
-        end_frame = instance.data.get("frameEndHandle")
-        preroll = instance.data.get("preroll")
+        start_frame = instance.data["frameStartHandle"]
+        end_frame = instance.data["frameEndHandle"]
+        preroll = instance.data["preroll"]
         if preroll > 0:
             start_frame -= preroll
 

--- a/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
@@ -167,7 +167,7 @@ class ExtractYetiRig(openpype.api.Extractor):
         resources = instance.data.get("resources", {})
         with disconnect_plugs(settings, members):
             with yetigraph_attribute_values(resources_dir, resources):
-                with maya.attribute_values(attr_value):
+                with lib.attribute_values(attr_value):
                     cmds.select(nodes, noExpand=True)
                     cmds.file(maya_path,
                               force=True,

--- a/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
@@ -157,7 +157,7 @@ class ExtractYetiRig(openpype.api.Extractor):
         input_set = next(i for i in instance if i == "input_SET")
 
         # Get all items
-        set_members = cmds.sets(input_set, query=True)
+        set_members = cmds.sets(input_set, query=True) or []
         set_members += cmds.listRelatives(set_members,
                                           allDescendents=True,
                                           fullPath=True) or []

--- a/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/publish/extract_yeti_rig.py
@@ -124,8 +124,8 @@ class ExtractYetiRig(openpype.api.Extractor):
         settings_path = os.path.join(dirname, "yeti.rigsettings")
 
         # Yeti related staging dirs
-        maya_path = os.path.join(
-            dirname, "yeti_rig.{}".format(self.scene_type))
+        maya_path = os.path.join(dirname,
+                                 "yeti_rig.{}".format(self.scene_type))
 
         self.log.info("Writing metadata file")
 


### PR DESCRIPTION
## Brief description

I was unable to create a Yeti rig publish and load it correctly so I started working on fixing the implementation.

**This is still a draft WIP - not fully tested.**

Current status:

-  [x] Creators work
-  [x] Extractors work
-  [x] Loaders work

### Questions


Currently the Yeti Rig publish will also try to create a single frame Yeti Cache alongside the rig publish - which as far as I know isn't required for a Yeti Rig to work. Would it make sense to remove that logic and if one would ever want both a "rig" and a "cache" from that same file they would just create two publish instances, one `yetiRig` family and one `yetiCache` family.

---

The way it's currently broken it seems like this has hardly ever been tested - or maybe has seen numerous changes in other areas of OpenPype but hasn't been tested in quite some time and thus has been unused too.

Would it be worth maybe refactoring the family name `yeticache` to `yetiCache` for readability?

## Additional info

I'm currently testing with Maya 2022 + Yeti 4.1.4

## Testing notes:
1. Create a Yeti Rig and Yeti Cache
2. Publish it.
3. Load it.

Preferably also test cases that uses textures/files in the Yeti Graph since those should be published along similar to Lookdev publishes.