### PR TITLE
Loader UI: Speed issues of loader with sync server

### DIFF
--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -921,11 +921,17 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         if self.enabled:
             for project in self.connection.projects(projection={"name": 1}):
                 project_name = project["name"]
-                project_settings = self.get_sync_project_setting(project_name)
-                if project_settings and project_settings.get("enabled"):
+                if self.is_project_enabled(project_name):
                     enabled_projects.append(project_name)
 
         return enabled_projects
+
+    def is_project_enabled(self, project_name):
+        if self.enabled:
+            project_settings = self.get_sync_project_setting(project_name)
+            if project_settings and project_settings.get("enabled"):
+                return True
+        return False
 
     def handle_alternate_site(self, collection, representation, processed_site,
                               file_id, synced_file_id):


### PR DESCRIPTION
## Brief description
A little bit enhanced loader UI speec when sync server is enabled.

## Description
Cache sync server related information for some time to avoid refresh of sync server on each selection change.

## Additional info
Loader was refreshing sync server module, it's setting for all projects on each change of context in loader UI which is also happening separatelly for subset widget and representation widget.

This is a "quick" change, full fix would require to modify some logic in sync server and partially rewrite how loader UI logic works.

## Testing notes:
Loader didn't change but should be faster when sync server is enabled.