### PR TITLE
Photoshop: skip collector when automatic testing

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_batch_data.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_batch_data.py
@@ -39,6 +39,10 @@ class CollectBatchData(pyblish.api.ContextPlugin):
     def process(self, context):
         self.log.info("CollectBatchData")
         batch_dir = os.environ.get("OPENPYPE_PUBLISH_DATA")
+        if (os.environ.get("IS_TEST") and
+                (not batch_dir or not os.path.exists(batch_dir))):
+            self.log.debug("Automatic testing, no batch data, skipping")
+            return
 
         assert batch_dir, (
             "Missing `OPENPYPE_PUBLISH_DATA`")

--- a/openpype/hosts/photoshop/plugins/publish/collect_batch_data.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_batch_data.py
@@ -39,8 +39,7 @@ class CollectBatchData(pyblish.api.ContextPlugin):
     def process(self, context):
         self.log.info("CollectBatchData")
         batch_dir = os.environ.get("OPENPYPE_PUBLISH_DATA")
-        if (os.environ.get("IS_TEST") and
-                (not batch_dir or not os.path.exists(batch_dir))):
+        if os.environ.get("IS_TEST"):
             self.log.debug("Automatic testing, no batch data, skipping")
             return
 


### PR DESCRIPTION
## Brief description
Collector requires presence of json batch file, that is only in case of webpublishes, this collector should be skipped when automatic test is run.
