### PR TITLE
Standalone Publisher: Always create new representation for thumbnail

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -5,6 +5,7 @@ import openpype.api
 from openpype.lib import (
     get_ffmpeg_tool_path,
     get_ffprobe_streams,
+    path_to_subprocess_arg,
 )
 
 
@@ -37,82 +38,69 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
         if not thumbnail_repre:
             return
 
+        thumbnail_repre.pop("thumbnail")
         files = thumbnail_repre.get("files")
         if not files:
             return
 
         if isinstance(files, list):
-            files_len = len(files)
-            file = str(files[0])
+            first_filename = str(files[0])
         else:
-            files_len = 1
-            file = files
+            first_filename = files
 
         staging_dir = None
-        is_jpeg = False
-        if file.endswith(".jpeg") or file.endswith(".jpg"):
-            is_jpeg = True
 
-        if is_jpeg and files_len == 1:
-            # skip if already is single jpeg file
-            return
+        # Convert to jpeg if not yet
+        full_input_path = os.path.join(
+            thumbnail_repre["stagingDir"], first_filename
+        )
+        self.log.info("input {}".format(full_input_path))
+        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp:
+            full_thumbnail_path = tmp.name
 
-        elif is_jpeg:
-            # use first frame as thumbnail if is sequence of jpegs
-            full_thumbnail_path = os.path.join(
-                thumbnail_repre["stagingDir"], file
-            )
-            self.log.info(
-                "For thumbnail is used file: {}".format(full_thumbnail_path)
-            )
+        self.log.info("output {}".format(full_thumbnail_path))
 
-        else:
-            # Convert to jpeg if not yet
-            full_input_path = os.path.join(thumbnail_repre["stagingDir"], file)
-            self.log.info("input {}".format(full_input_path))
+        instance.context.data["cleanupFullPaths"].append(full_thumbnail_path)
 
-            full_thumbnail_path = tempfile.mkstemp(suffix=".jpg")[1]
-            self.log.info("output {}".format(full_thumbnail_path))
+        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
-            ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_args = self.ffmpeg_args or {}
 
-            ffmpeg_args = self.ffmpeg_args or {}
+        jpeg_items = [
+            path_to_subprocess_arg(ffmpeg_path),
+            # override file if already exists
+            "-y"
+        ]
 
-            jpeg_items = [
-                "\"{}\"".format(ffmpeg_path),
-                # override file if already exists
-                "-y"
-            ]
-
-            # add input filters from peresets
-            jpeg_items.extend(ffmpeg_args.get("input") or [])
-            # input file
-            jpeg_items.append("-i \"{}\"".format(full_input_path))
+        # add input filters from peresets
+        jpeg_items.extend(ffmpeg_args.get("input") or [])
+        # input file
+        jpeg_items.extend([
+            "-i", path_to_subprocess_arg(full_input_path),
             # extract only single file
-            jpeg_items.append("-frames:v 1")
+            "-frames:v", "1",
             # Add black background for transparent images
-            jpeg_items.append((
-                "-filter_complex"
-                " \"color=black,format=rgb24[c]"
+            "-filter_complex", (
+                "\"color=black,format=rgb24[c]"
                 ";[c][0]scale2ref[c][i]"
                 ";[c][i]overlay=format=auto:shortest=1,setsar=1\""
-            ))
+            ),
+        ])
 
-            jpeg_items.extend(ffmpeg_args.get("output") or [])
+        jpeg_items.extend(ffmpeg_args.get("output") or [])
 
-            # output file
-            jpeg_items.append("\"{}\"".format(full_thumbnail_path))
+        # output file
+        jpeg_items.append(path_to_subprocess_arg(full_thumbnail_path))
 
-            subprocess_jpeg = " ".join(jpeg_items)
+        subprocess_jpeg = " ".join(jpeg_items)
 
-            # run subprocess
-            self.log.debug("Executing: {}".format(subprocess_jpeg))
-            openpype.api.run_subprocess(
-                subprocess_jpeg, shell=True, logger=self.log
-            )
+        # run subprocess
+        self.log.debug("Executing: {}".format(subprocess_jpeg))
+        openpype.api.run_subprocess(
+            subprocess_jpeg, shell=True, logger=self.log
+        )
 
         # remove thumbnail key from origin repre
-        thumbnail_repre.pop("thumbnail")
         streams = get_ffprobe_streams(full_thumbnail_path)
         width = height = None
         for stream in streams:
@@ -121,8 +109,7 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
                 height = stream["height"]
                 break
 
-        filename = os.path.basename(full_thumbnail_path)
-        staging_dir = staging_dir or os.path.dirname(full_thumbnail_path)
+        staging_dir, filename = os.path.split(full_thumbnail_path)
 
         # create new thumbnail representation
         representation = {
@@ -130,15 +117,11 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
             'ext': 'jpg',
             'files': filename,
             "stagingDir": staging_dir,
-            "tags": ["thumbnail"],
+            "tags": ["thumbnail", "delete"],
         }
         if width and height:
             representation["width"] = width
             representation["height"] = height
-
-        # # add Delete tag when temp file was rendered
-        if not is_jpeg:
-            representation["tags"].append("delete")
 
         self.log.info(f"New representation {representation}")
         instance.data["representations"].append(representation)

--- a/openpype/tools/standalonepublish/widgets/widget_components.py
+++ b/openpype/tools/standalonepublish/widgets/widget_components.py
@@ -202,6 +202,7 @@ def cli_publish(data, publish_paths, gui=True):
     if os.path.exists(json_data_path):
         with open(json_data_path, "r") as f:
             result = json.load(f)
+        os.remove(json_data_path)
 
     log.info(f"Publish result: {result}")
 


### PR DESCRIPTION
## Brief description
Standalone publisher thumbnail extractor create new representation for thumbnail even if source file has `jpg` extension.

## Description
The missing representation caused few issues the major is that ftrack did not integrate the published path of the source image. Also temp files from standalone publisher are cleaned up when publishing finish.

## Testing notes:
1. Publish jpg file marked as thumbnail, using standalone publisher (and using ftrack module)
2. Check if ftrack AssetVersion contains both `thumbnail` and `jpg` components where `jpg` component contains published path