### PR TITLE
nuke: generate publishing nodes inside render group node 

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -407,6 +407,7 @@ class ExporterReviewMov(ExporterReview):
         # deal with now lut defined in viewer lut
         self.viewer_lut_raw = klass.viewer_lut_raw
         self.write_colorspace = instance.data["colorspace"]
+        self.render_group_node = instance[0]
 
         self.name = name or "baked"
         self.ext = ext or "mov"
@@ -428,11 +429,12 @@ class ExporterReviewMov(ExporterReview):
 
     def render(self, render_node_name):
         self.log.info("Rendering...  ")
-        # Render Write node
-        nuke.execute(
-            render_node_name,
-            int(self.first_frame),
-            int(self.last_frame))
+        with self.render_group_node:
+            # Render Write node
+            nuke.execute(
+                render_node_name,
+                int(self.first_frame),
+                int(self.last_frame))
 
         self.log.info("Rendered...")
 
@@ -476,99 +478,100 @@ class ExporterReviewMov(ExporterReview):
         self._temp_nodes[subset] = []
         # ---------- start nodes creation
 
-        # Read node
-        r_node = nuke.createNode("Read")
-        r_node["file"].setValue(self.path_in)
-        r_node["first"].setValue(self.first_frame)
-        r_node["origfirst"].setValue(self.first_frame)
-        r_node["last"].setValue(self.last_frame)
-        r_node["origlast"].setValue(self.last_frame)
-        r_node["colorspace"].setValue(self.write_colorspace)
+        with self.render_group_node:
+            # Read node
+            r_node = nuke.createNode("Read")
+            r_node["file"].setValue(self.path_in)
+            r_node["first"].setValue(self.first_frame)
+            r_node["origfirst"].setValue(self.first_frame)
+            r_node["last"].setValue(self.last_frame)
+            r_node["origlast"].setValue(self.last_frame)
+            r_node["colorspace"].setValue(self.write_colorspace)
 
-        if read_raw:
-            r_node["raw"].setValue(1)
-
-        # connect
-        self._temp_nodes[subset].append(r_node)
-        self.previous_node = r_node
-        self.log.debug("Read...   `{}`".format(self._temp_nodes[subset]))
-
-        # add reformat node
-        if reformat_node_add:
-            # append reformated tag
-            add_tags.append("reformated")
-
-            rf_node = nuke.createNode("Reformat")
-            for kn_conf in reformat_node_config:
-                _type = kn_conf["type"]
-                k_name = str(kn_conf["name"])
-                k_value = kn_conf["value"]
-
-                # to remove unicode as nuke doesn't like it
-                if _type == "string":
-                    k_value = str(kn_conf["value"])
-
-                rf_node[k_name].setValue(k_value)
+            if read_raw:
+                r_node["raw"].setValue(1)
 
             # connect
-            rf_node.setInput(0, self.previous_node)
-            self._temp_nodes[subset].append(rf_node)
-            self.previous_node = rf_node
-            self.log.debug(
-                "Reformat...   `{}`".format(self._temp_nodes[subset]))
+            self._temp_nodes[subset].append(r_node)
+            self.previous_node = r_node
+            self.log.debug("Read...   `{}`".format(self._temp_nodes[subset]))
 
-        # only create colorspace baking if toggled on
-        if bake_viewer_process:
-            if bake_viewer_input_process_node:
-                # View Process node
-                ipn = self.get_view_input_process_node()
-                if ipn is not None:
-                    # connect
-                    ipn.setInput(0, self.previous_node)
-                    self._temp_nodes[subset].append(ipn)
-                    self.previous_node = ipn
-                    self.log.debug(
-                        "ViewProcess...   `{}`".format(
-                            self._temp_nodes[subset]))
+            # add reformat node
+            if reformat_node_add:
+                # append reformated tag
+                add_tags.append("reformated")
 
-            if not self.viewer_lut_raw:
-                # OCIODisplay
-                dag_node = nuke.createNode("OCIODisplay")
-                dag_node["view"].setValue(str(baking_view_profile))
+                rf_node = nuke.createNode("Reformat")
+                for kn_conf in reformat_node_config:
+                    _type = kn_conf["type"]
+                    k_name = str(kn_conf["name"])
+                    k_value = kn_conf["value"]
+
+                    # to remove unicode as nuke doesn't like it
+                    if _type == "string":
+                        k_value = str(kn_conf["value"])
+
+                    rf_node[k_name].setValue(k_value)
 
                 # connect
-                dag_node.setInput(0, self.previous_node)
-                self._temp_nodes[subset].append(dag_node)
-                self.previous_node = dag_node
-                self.log.debug("OCIODisplay...   `{}`".format(
-                    self._temp_nodes[subset]))
+                rf_node.setInput(0, self.previous_node)
+                self._temp_nodes[subset].append(rf_node)
+                self.previous_node = rf_node
+                self.log.debug(
+                    "Reformat...   `{}`".format(self._temp_nodes[subset]))
 
-        # Write node
-        write_node = nuke.createNode("Write")
-        self.log.debug("Path: {}".format(self.path))
-        write_node["file"].setValue(str(self.path))
-        write_node["file_type"].setValue(str(self.ext))
+            # only create colorspace baking if toggled on
+            if bake_viewer_process:
+                if bake_viewer_input_process_node:
+                    # View Process node
+                    ipn = self.get_view_input_process_node()
+                    if ipn is not None:
+                        # connect
+                        ipn.setInput(0, self.previous_node)
+                        self._temp_nodes[subset].append(ipn)
+                        self.previous_node = ipn
+                        self.log.debug(
+                            "ViewProcess...   `{}`".format(
+                                self._temp_nodes[subset]))
 
-        # Knobs `meta_codec` and `mov64_codec` are not available on centos.
-        # TODO shouldn't this come from settings on outputs?
-        try:
-            write_node["meta_codec"].setValue("ap4h")
-        except Exception:
-            self.log.info("`meta_codec` knob was not found")
+                if not self.viewer_lut_raw:
+                    # OCIODisplay
+                    dag_node = nuke.createNode("OCIODisplay")
+                    dag_node["view"].setValue(str(baking_view_profile))
 
-        try:
-            write_node["mov64_codec"].setValue("ap4h")
-            write_node["mov64_fps"].setValue(float(fps))
-        except Exception:
-            self.log.info("`mov64_codec` knob was not found")
+                    # connect
+                    dag_node.setInput(0, self.previous_node)
+                    self._temp_nodes[subset].append(dag_node)
+                    self.previous_node = dag_node
+                    self.log.debug("OCIODisplay...   `{}`".format(
+                        self._temp_nodes[subset]))
 
-        write_node["mov64_write_timecode"].setValue(1)
-        write_node["raw"].setValue(1)
-        # connect
-        write_node.setInput(0, self.previous_node)
-        self._temp_nodes[subset].append(write_node)
-        self.log.debug("Write...   `{}`".format(self._temp_nodes[subset]))
-        # ---------- end nodes creation
+            # Write node
+            write_node = nuke.createNode("Write")
+            self.log.debug("Path: {}".format(self.path))
+            write_node["file"].setValue(str(self.path))
+            write_node["file_type"].setValue(str(self.ext))
+
+            # Knobs `meta_codec` and `mov64_codec` are not available on centos.
+            # TODO shouldn't this come from settings on outputs?
+            try:
+                write_node["meta_codec"].setValue("ap4h")
+            except Exception:
+                self.log.info("`meta_codec` knob was not found")
+
+            try:
+                write_node["mov64_codec"].setValue("ap4h")
+                write_node["mov64_fps"].setValue(float(fps))
+            except Exception:
+                self.log.info("`mov64_codec` knob was not found")
+
+            write_node["mov64_write_timecode"].setValue(1)
+            write_node["raw"].setValue(1)
+            # connect
+            write_node.setInput(0, self.previous_node)
+            self._temp_nodes[subset].append(write_node)
+            self.log.debug("Write...   `{}`".format(self._temp_nodes[subset]))
+            # ---------- end nodes creation
 
         # ---------- render or save to nk
         if self.publish_on_farm:

--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -5,7 +5,6 @@ import openpype
 from openpype.hosts.nuke.api import plugin
 from openpype.hosts.nuke.api.lib import maintained_selection
 
-
 class ExtractReviewDataMov(openpype.api.Extractor):
     """Extracts movie and thumbnail with baked in luts
 
@@ -88,7 +87,7 @@ class ExtractReviewDataMov(openpype.api.Extractor):
                 # check if settings have more then one preset
                 # so we dont need to add outputName to representation
                 # in case there is only one preset
-                multiple_presets = bool(len(self.outputs.keys()) > 1)
+                multiple_presets = len(self.outputs.keys()) > 1
 
                 # create exporter instance
                 exporter = plugin.ExporterReviewMov(

--- a/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_thumbnail.py
@@ -63,92 +63,96 @@ class ExtractThumbnail(openpype.api.Extractor):
             "StagingDir `{0}`...".format(instance.data["stagingDir"]))
 
         temporary_nodes = []
+        with node:
+            # try to connect already rendered images
+            if self.use_rendered:
+                collection = instance.data.get("collection", None)
+                self.log.debug("__ collection: `{}`".format(collection))
 
-        # try to connect already rendered images
-        if self.use_rendered:
-            collection = instance.data.get("collection", None)
-            self.log.debug("__ collection: `{}`".format(collection))
+                if collection:
+                    # get path
+                    fname = os.path.basename(collection.format(
+                        "{head}{padding}{tail}"))
+                    fhead = collection.format("{head}")
 
-            if collection:
-                # get path
-                fname = os.path.basename(collection.format(
-                    "{head}{padding}{tail}"))
-                fhead = collection.format("{head}")
+                    thumb_fname = list(collection)[mid_frame]
+                else:
+                    fname = thumb_fname = os.path.basename(
+                        instance.data.get("path", None))
+                    fhead = os.path.splitext(fname)[0] + "."
 
-                thumb_fname = list(collection)[mid_frame]
-            else:
-                fname = thumb_fname = os.path.basename(
-                    instance.data.get("path", None))
-                fhead = os.path.splitext(fname)[0] + "."
+                self.log.debug("__ fhead: `{}`".format(fhead))
 
-            self.log.debug("__ fhead: `{}`".format(fhead))
+                if "#" in fhead:
+                    fhead = fhead.replace("#", "")[:-1]
 
-            if "#" in fhead:
-                fhead = fhead.replace("#", "")[:-1]
+                path_render = os.path.join(
+                    staging_dir, thumb_fname).replace("\\", "/")
+                self.log.debug("__ path_render: `{}`".format(path_render))
 
-            path_render = os.path.join(
-                staging_dir, thumb_fname).replace("\\", "/")
-            self.log.debug("__ path_render: `{}`".format(path_render))
+                # check if file exist otherwise connect to write node
+                if os.path.isfile(path_render):
+                    rnode = nuke.createNode("Read")
 
-            # check if file exist otherwise connect to write node
-            if os.path.isfile(path_render):
-                rnode = nuke.createNode("Read")
+                    rnode["file"].setValue(path_render)
 
-                rnode["file"].setValue(path_render)
+                    # turn it raw if none of baking is ON
+                    if all([
+                        not self.bake_viewer_input_process,
+                        not self.bake_viewer_process
+                    ]):
+                        rnode["raw"].setValue(True)
 
-                # turn it raw if none of baking is ON
-                if all([
-                    not self.bake_viewer_input_process,
-                    not self.bake_viewer_process
-                ]):
-                    rnode["raw"].setValue(True)
+                    temporary_nodes.append(rnode)
+                    previous_node = rnode
+                else:
+                    previous_node = node
 
-                temporary_nodes.append(rnode)
-                previous_node = rnode
-            else:
-                previous_node = node
+            # bake viewer input look node into thumbnail image
+            if self.bake_viewer_input_process:
+                # get input process and connect it to baking
+                ipn = self.get_view_process_node()
+                if ipn is not None:
+                    ipn.setInput(0, previous_node)
+                    previous_node = ipn
+                    temporary_nodes.append(ipn)
 
-        # bake viewer input look node into thumbnail image
-        if self.bake_viewer_input_process:
-            # get input process and connect it to baking
-            ipn = self.get_view_process_node()
-            if ipn is not None:
-                ipn.setInput(0, previous_node)
-                previous_node = ipn
-                temporary_nodes.append(ipn)
+            reformat_node = nuke.createNode("Reformat")
 
-        reformat_node = nuke.createNode("Reformat")
+            ref_node = self.nodes.get("Reformat", None)
+            if ref_node:
+                for k, v in ref_node:
+                    self.log.debug("k, v: {0}:{1}".format(k, v))
+                    if isinstance(v, unicode):
+                        v = str(v)
+                    reformat_node[k].setValue(v)
 
-        ref_node = self.nodes.get("Reformat", None)
-        if ref_node:
-            for k, v in ref_node:
-                self.log.debug("k, v: {0}:{1}".format(k, v))
-                if isinstance(v, unicode):
-                    v = str(v)
-                reformat_node[k].setValue(v)
+            reformat_node.setInput(0, previous_node)
+            previous_node = reformat_node
+            temporary_nodes.append(reformat_node)
 
-        reformat_node.setInput(0, previous_node)
-        previous_node = reformat_node
-        temporary_nodes.append(reformat_node)
+            # bake viewer colorspace into thumbnail image
+            if self.bake_viewer_process:
+                dag_node = nuke.createNode("OCIODisplay")
+                dag_node.setInput(0, previous_node)
+                previous_node = dag_node
+                temporary_nodes.append(dag_node)
 
-        # bake viewer colorspace into thumbnail image
-        if self.bake_viewer_process:
-            dag_node = nuke.createNode("OCIODisplay")
-            dag_node.setInput(0, previous_node)
-            previous_node = dag_node
-            temporary_nodes.append(dag_node)
+            # create write node
+            write_node = nuke.createNode("Write")
+            file = fhead + "jpg"
+            name = "thumbnail"
+            path = os.path.join(staging_dir, file).replace("\\", "/")
+            instance.data["thumbnail"] = path
+            write_node["file"].setValue(path)
+            write_node["file_type"].setValue("jpg")
+            write_node["raw"].setValue(1)
+            write_node.setInput(0, previous_node)
+            temporary_nodes.append(write_node)
 
-        # create write node
-        write_node = nuke.createNode("Write")
-        file = fhead + "jpg"
-        name = "thumbnail"
-        path = os.path.join(staging_dir, file).replace("\\", "/")
-        instance.data["thumbnail"] = path
-        write_node["file"].setValue(path)
-        write_node["file_type"].setValue("jpg")
-        write_node["raw"].setValue(1)
-        write_node.setInput(0, previous_node)
-        temporary_nodes.append(write_node)
+            # Render frames
+            nuke.execute(write_node.name(), mid_frame, mid_frame)
+
         tags = ["thumbnail", "publish_on_farm"]
 
         repre = {
@@ -161,8 +165,6 @@ class ExtractThumbnail(openpype.api.Extractor):
         }
         instance.data["representations"].append(repre)
 
-        # Render frames
-        nuke.execute(write_node.name(), mid_frame, mid_frame)
 
         self.log.debug(
             "representations: {}".format(instance.data["representations"]))

--- a/openpype/hosts/nuke/plugins/publish/precollect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_writes.py
@@ -23,7 +23,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
 
         node = None
         for x in instance:
-            if x.Class() == "Write":
+            if x.Class() == "Write" and x.name().startswith("inside_"):
                 node = x
 
         if node is None:


### PR DESCRIPTION
## Brief description
Publishing UX are less distracting 

## Description
Once additional publishing nodes created on flight are created inside rendering group node. Publishing seems to be less distracting

## Testing notes:
1. open nuke test script
2. publish render write node
3. notice that during publishing no nodes are created in top tree view.