### PR TITLE
Project manager: Sped up project load

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -264,6 +264,8 @@ class HierarchyModel(QtCore.QAbstractItemModel):
         if not project_doc:
             return
 
+        self.blockSignals(True)
+
         # Create project item
         project_item = ProjectItem(project_doc)
         self.add_item(project_item)
@@ -376,6 +378,8 @@ class HierarchyModel(QtCore.QAbstractItemModel):
                 task_items.append(task_item)
 
             self.add_items(task_items, asset_item)
+
+        self.blockSignals(False)
 
         # Emit that project was successfully changed
         self.project_changed.emit()

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -195,13 +195,13 @@ class HierarchyView(QtWidgets.QTreeView):
         for idx, width in widths_by_idx.items():
             self.setColumnWidth(idx, width)
 
-    def set_project(self, project_name):
+    def set_project(self, project_name, force=False):
         # Trigger helpers first
         self._project_doc_cache.set_project(project_name)
         self._tools_cache.refresh()
 
         # Trigger update of model after all data for delegates are filled
-        self._source_model.set_project(project_name)
+        self._source_model.set_project(project_name, force)
 
     def _on_project_reset(self):
         self.header_init()

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -191,7 +191,7 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self._add_task_btn.setEnabled(project_name is not None)
         self._save_btn.setEnabled(project_name is not None)
         self._project_proxy_model.set_filter_default(project_name is not None)
-        self.hierarchy_view.set_project(project_name)
+        self.hierarchy_view.set_project(project_name, True)
 
     def _current_project(self):
         row = self._project_combobox.currentIndex()


### PR DESCRIPTION
## Brief description
Speed of project loading was enhanced by ignoring signals during initial project item creation.

## Description
Blocking of signals during that time cause that filtering and repaint of view is not triggered which makes everything much smoother. Also refresh button forces to refresh current project.

## Testing notes:
1. Open project manager
2. Select project
3. Load of project entities should be 3x faster