### PR TITLE
Project Manager: Project Switch speedup - block signals during full project refresh

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -264,6 +264,8 @@ class HierarchyModel(QtCore.QAbstractItemModel):
         if not project_doc:
             return
 
+        self.blockSignals(True)
+
         # Create project item
         project_item = ProjectItem(project_doc)
         self.add_item(project_item)
@@ -376,6 +378,8 @@ class HierarchyModel(QtCore.QAbstractItemModel):
                 task_items.append(task_item)
 
             self.add_items(task_items, asset_item)
+
+        self.blockSignals(False)
 
         # Emit that project was successfully changed
         self.project_changed.emit()


### PR DESCRIPTION
## Brief description

A follow up to #3216 to see if this speeds up more.
This speeds up going into large projects by _a lot_ on my end - but I haven't done thorough testing whether everything still works.

This block signals on the Model during a full project refresh

## Testing notes:
1. please confirm the UI still works as expected.