### PR TITLE
Project Manager: Fix persistent editors on project change

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -264,8 +264,6 @@ class HierarchyModel(QtCore.QAbstractItemModel):
         if not project_doc:
             return
 
-        self.blockSignals(True)
-
         # Create project item
         project_item = ProjectItem(project_doc)
         self.add_item(project_item)
@@ -378,8 +376,6 @@ class HierarchyModel(QtCore.QAbstractItemModel):
                 task_items.append(task_item)
 
             self.add_items(task_items, asset_item)
-
-        self.blockSignals(False)
 
         # Emit that project was successfully changed
         self.project_changed.emit()

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -213,34 +213,6 @@ class HierarchyView(QtWidgets.QTreeView):
             index = self._source_model.index_for_item(project_item)
             self.expand(index)
 
-        self._open_persistent_editors_on_project_refresh()
-
-    def _open_persistent_editors_on_project_refresh(self):
-        model = self._source_model
-        parent_index = QtCore.QModelIndex()
-        persistent_queue = collections.deque()
-        persistent_queue.append((parent_index, model.rowCount()))
-        while persistent_queue:
-            item = persistent_queue.popleft()
-            parent_index, rows = item
-            if not rows:
-                continue
-
-            for row in range(rows):
-                row_index = model.index(row, 0, parent_index)
-                persistent_queue.append(
-                    (row_index, model.rowCount(row_index))
-                )
-                for key, column in self._column_key_to_index.items():
-                    if key not in self.persistent_columns:
-                        continue
-                    col_index = model.index(row, column, parent_index)
-                    if bool(
-                        model.flags(col_index)
-                        & QtCore.Qt.ItemIsEditable
-                    ):
-                        self.openPersistentEditor(col_index)
-
     def _on_rows_moved(self, index):
         parent_index = index.parent()
         if not self.isExpanded(parent_index):

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -184,14 +184,14 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self.resize(1200, 600)
         self.setStyleSheet(load_stylesheet())
 
-    def _set_project(self, project_name=None):
+    def _set_project(self, project_name=None, force=False):
         self._create_folders_btn.setEnabled(project_name is not None)
         self._remove_projects_btn.setEnabled(project_name is not None)
         self._add_asset_btn.setEnabled(project_name is not None)
         self._add_task_btn.setEnabled(project_name is not None)
         self._save_btn.setEnabled(project_name is not None)
         self._project_proxy_model.set_filter_default(project_name is not None)
-        self.hierarchy_view.set_project(project_name, True)
+        self.hierarchy_view.set_project(project_name, force)
 
     def _current_project(self):
         row = self._project_combobox.currentIndex()
@@ -229,11 +229,11 @@ class ProjectManagerWindow(QtWidgets.QWidget):
                 self._project_combobox.setCurrentIndex(row)
 
         selected_project = self._current_project()
-        self._set_project(selected_project)
+        self._set_project(selected_project, True)
 
     def _on_project_change(self):
         selected_project = self._current_project()
-        self._set_project(selected_project)
+        self._set_project(selected_project, False)
 
     def _on_project_refresh(self):
         self.refresh_projects()


### PR DESCRIPTION
## Brief description
Open persistent editors on project change/refresh in Project manager. Issue caused by [PR](https://github.com/pypeclub/OpenPype/pull/3216).

## Description
Insert signals are ignored on initial items fill on project refresh which cause that persistent editors are not opened. Opening of persistent editors is "faked" after project refresh. This change make it a little bit slower.

## Testing notes:
1. Open project manager
2. Select a project
3. All editors should be visible on all items and their values should match
4. The same should work on project change or on save