### PR TITLE
Maya: added jpg to filter for Image Plane Loader

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -83,7 +83,7 @@ class ImagePlaneLoader(load.LoaderPlugin):
 
     families = ["image", "plate", "render"]
     label = "Load imagePlane"
-    representations = ["mov", "exr", "preview", "png"]
+    representations = ["mov", "exr", "preview", "png", "jpg"]
     icon = "image"
     color = "orange"
 


### PR DESCRIPTION
## Brief description
Only mov, exr, preview and png were present, jpg should work too.

Develop version https://github.com/pypeclub/OpenPype/pull/3223
## Testing notes:
1. try to right click on jpg plate in Maya's Loader
2. ImagePlaneLoader should appear