### PR TITLE
Project Manager: Allow to paste Tasks into multiple assets at the same time

### DIFF
--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1476,12 +1476,7 @@ class HierarchyModel(QtCore.QAbstractItemModel):
         mimedata.setData("application/copy_task", encoded_data)
         return mimedata
 
-    def paste_mime_data(self, index, mime_data):
-        if not index.isValid():
-            return
-
-        item_id = index.data(IDENTIFIER_ROLE)
-        item = self._items_by_id[item_id]
+    def paste_mime_data(self, item, mime_data):
         if not isinstance(item, (AssetItem, TaskItem)):
             return
 
@@ -1514,6 +1509,25 @@ class HierarchyModel(QtCore.QAbstractItemModel):
 
             task_item = TaskItem(task_data, True)
             self.add_item(task_item, parent)
+
+    def paste(self, indices, mime_data):
+
+        # Get the selected Assets uniquely
+        items = set()
+        for index in indices:
+            if not index.isValid():
+                return
+            item_id = index.data(IDENTIFIER_ROLE)
+            item = self._items_by_id[item_id]
+
+            # Do not copy into the Task Item so get parent Asset instead
+            if isinstance(item, TaskItem):
+                item = item.parent()
+
+            items.add(item)
+
+        for item in items:
+            self.paste_mime_data(item, mime_data)
 
 
 class BaseItem:

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -1476,7 +1476,7 @@ class HierarchyModel(QtCore.QAbstractItemModel):
         mimedata.setData("application/copy_task", encoded_data)
         return mimedata
 
-    def paste_mime_data(self, item, mime_data):
+    def _paste_mime_data(self, item, mime_data):
         if not isinstance(item, (AssetItem, TaskItem)):
             return
 
@@ -1510,11 +1510,11 @@ class HierarchyModel(QtCore.QAbstractItemModel):
             task_item = TaskItem(task_data, True)
             self.add_item(task_item, parent)
 
-    def paste(self, indices, mime_data):
+    def paste(self, indexes, mime_data):
 
         # Get the selected Assets uniquely
         items = set()
-        for index in indices:
+        for index in indexes:
             if not index.isValid():
                 return
             item_id = index.data(IDENTIFIER_ROLE)
@@ -1527,7 +1527,7 @@ class HierarchyModel(QtCore.QAbstractItemModel):
             items.add(item)
 
         for item in items:
-            self.paste_mime_data(item, mime_data)
+            self._paste_mime_data(item, mime_data)
 
 
 class BaseItem:

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -376,9 +376,9 @@ class HierarchyView(QtWidgets.QTreeView):
             self._show_message(str(exc))
 
     def _paste_items(self):
-        index = self.currentIndex()
         mime_data = QtWidgets.QApplication.clipboard().mimeData()
-        self._source_model.paste_mime_data(index, mime_data)
+        rows = self.selectionModel().selectedRows()
+        self._source_model.paste(rows, mime_data)
 
     def _delete_items(self, indexes=None):
         if indexes is None:

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -365,14 +365,18 @@ class HierarchyView(QtWidgets.QTreeView):
             event.accept()
 
     def _copy_items(self, indexes=None):
+        clipboard = QtWidgets.QApplication.clipboard()
         try:
             if indexes is None:
                 indexes = self.selectedIndexes()
             mime_data = self._source_model.copy_mime_data(indexes)
 
-            QtWidgets.QApplication.clipboard().setMimeData(mime_data)
+            clipboard.setMimeData(mime_data)
             self._show_message("Tasks copied")
         except ValueError as exc:
+            # Change clipboard to contain empty data
+            empty_mime_data = QtCore.QMimeData()
+            clipboard.setMimeData(empty_mime_data)
             self._show_message(str(exc))
 
     def _paste_items(self):


### PR DESCRIPTION
## Brief description

You can now paste Tasks from the clipboard onto multiple assets at once instead of having to paste into only the 'currentIndex' and thus having to paste per asset individually

## Testing notes:
1. Select some Tasks
2. CTRL + C
3. Select some Tasks/Assets
4. Paste

It should consistenly copy things across and feel logical as to what it does in the end.