### PR TITLE
Project manager: Speed up but without persistent editors

### DIFF
--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -139,6 +139,7 @@ class HierarchyView(QtWidgets.QTreeView):
         self.setAlternatingRowColors(True)
         self.setSelectionMode(HierarchyView.ExtendedSelection)
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.setEditTriggers(HierarchyView.AllEditTriggers)
 
         column_delegates = {}
         column_key_to_index = {}
@@ -301,16 +302,6 @@ class HierarchyView(QtWidgets.QTreeView):
     def rowsInserted(self, parent_index, start, end):
         super(HierarchyView, self).rowsInserted(parent_index, start, end)
 
-        for row in range(start, end + 1):
-            for key, column in self._column_key_to_index.items():
-                if key not in self.persistent_columns:
-                    continue
-                col_index = self._source_model.index(row, column, parent_index)
-                if bool(
-                    self._source_model.flags(col_index)
-                    & QtCore.Qt.ItemIsEditable
-                ):
-                    self.openPersistentEditor(col_index)
 
         # Expand parent on insert
         if not self.isExpanded(parent_index):


### PR DESCRIPTION
## Brief description
Do not create persistent editors but create then on demand.

## Description
Creation of persistent editors is making the UI initialization slow but at the same time it's easy to see what can be modified. This change cause that editors are not visible so it's unclear what can be modified but it's really fast on initialization. All other functionality should stay the same. Also the columns are not resized to editor's size hint because are not known at the moment.

### Screenshots
![image](https://user-images.githubusercontent.com/43494761/169796705-f7a3238d-b477-4c43-89ee-08262f7795fb.png)
![image](https://user-images.githubusercontent.com/43494761/169796861-bdc260d6-4030-4e65-b1af-f22166c8e189.png)

## Testing notes:
1. Run project manager
2. Select project
3. Loading of project should be fast
4. Change any value on items