### PR TITLE
Assets Widget UI: Fix refresh of model

### DIFF
--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -494,8 +494,6 @@ class AssetModel(QtGui.QStandardItemModel):
         # Remove cache of removed items
         for asset_id in removed_asset_ids:
             self._items_by_asset_id.pop(asset_id)
-            if asset_id in self._items_with_color_by_id:
-                self._items_with_color_by_id.pop(asset_id)
 
         # Refresh data
         # - all items refresh all data except id


### PR DESCRIPTION
## Brief description
Removed usage of unused attribute `_items_with_color_by_id` in `AssetsWidget`.

## Description
The missing attribute cause `AttributeError` when an asset was removed from project.

## Testing notes:
1. Open Launcher UI and go to a project
2. Open Project manager and go to the same project
3. Remove an asset from project manager and hit Save
4. Hit refresh in Launcher
5. Refresh should work

Resolves https://github.com/pypeclub/OpenPype/issues/3212