### PR TITLE
Webpublish: remove publish highlight when creating subset name

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
@@ -84,7 +84,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
                 "variant": variant,
                 "family": resolved_family,
                 "task": task_name,
-                "layer": layer.name
+                "layer": layer.clean_name
             }
 
             subset = resolved_subset_template.format(


### PR DESCRIPTION
## Brief description
Reusing OP published workfile in Webpublisher workflow has an issue because of publish highlight (℗).

