### PR TITLE
Maya: Fix support for multiple resolutions

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -339,9 +339,15 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "source": filepath,
                 "expectedFiles": full_exp_files,
                 "publishRenderMetadataFolder": common_publish_meta_path,
-                "resolutionWidth": cmds.getAttr("defaultResolution.width"),
-                "resolutionHeight": cmds.getAttr("defaultResolution.height"),
-                "pixelAspect": cmds.getAttr("defaultResolution.pixelAspect"),
+                "resolutionWidth": lib.get_attr_in_layer(
+                    "defaultResolution.height", layer=layer
+                ),
+                "resolutionHeight": lib.get_attr_in_layer(
+                    "defaultResolution.width", layer=layer
+                ),
+                "pixelAspect": lib.get_attr_in_layer(
+                    "defaultResolution.pixelAspect", layer=layer
+                ),
                 "tileRendering": render_instance.data.get("tileRendering") or False,  # noqa: E501
                 "tilesX": render_instance.data.get("tilesX") or 2,
                 "tilesY": render_instance.data.get("tilesY") or 2,

--- a/openpype/hosts/maya/plugins/publish/collect_vrayscene.py
+++ b/openpype/hosts/maya/plugins/publish/collect_vrayscene.py
@@ -124,9 +124,15 @@ class CollectVrayScene(pyblish.api.InstancePlugin):
                 # Add source to allow tracing back to the scene from
                 # which was submitted originally
                 "source": context.data["currentFile"].replace("\\", "/"),
-                "resolutionWidth": cmds.getAttr("defaultResolution.width"),
-                "resolutionHeight": cmds.getAttr("defaultResolution.height"),
-                "pixelAspect": cmds.getAttr("defaultResolution.pixelAspect"),
+                "resolutionWidth": lib.get_attr_in_layer(
+                    "defaultResolution.height", layer=layer
+                ),
+                "resolutionHeight": lib.get_attr_in_layer(
+                    "defaultResolution.width", layer=layer
+                ),
+                "pixelAspect": lib.get_attr_in_layer(
+                    "defaultResolution.pixelAspect", layer=layer
+                ),
                 "priority": instance.data.get("priority"),
                 "useMultipleSceneFiles": instance.data.get(
                     "vraySceneMultipleFiles")


### PR DESCRIPTION
## Bug

Resolution was taken from default, so overridden values were ignored. This is changing how width, height and pixel aspect are resolved.

### How to test

Create two render layers, override on one resolution. Render / review should respect that.