### PR TITLE
Ftrack: Validate that the user exists on ftrack

### DIFF
--- a/openpype/modules/ftrack/lib/credentials.py
+++ b/openpype/modules/ftrack/lib/credentials.py
@@ -92,14 +92,18 @@ def check_credentials(username, api_key, ftrack_server=None):
     if not ftrack_server or not username or not api_key:
         return False
 
+    user_exists = False
     try:
         session = ftrack_api.Session(
             server_url=ftrack_server,
             api_key=api_key,
             api_user=username
         )
+        # Validated that the username actually exists
+        user = session.query("User where username is \"{}\"".format(username))
+        user_exists = user is not None
         session.close()
 
     except Exception:
-        return False
-    return True
+        pass
+    return user_exists


### PR DESCRIPTION
## Brief description
Validation of ftrack credentials also check if the username exists on ftrack.

## Description
Ftrack connection is primarilly available by using ftrack api key and invalid username may not be discovered on session creation but can cause few issues when timer listener is launched in Tray. Due to these issues a validation of ftrack username existensce was added.

## Testing notes:
1. Open OpenPype tray
2. Login in OpenPype ftrack module
3. Close OpenPype tray
4. Change username in ftrack
5. Open OpenPype tray and ftrack loin popup should show