### PR TITLE
Maya: renderman displays needs to be filtered

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1093,6 +1093,11 @@ class RenderProductsRenderman(ARenderProducts):
             if not enabled:
                 continue
 
+            # Skip display types not producing any file output.
+            # Is there a better way to do it?
+            if not display_types.get(display["driverNode"]["type"]):
+                continue
+
             aov_name = name
             if aov_name == "rmanDefaultDisplay":
                 aov_name = "beauty"


### PR DESCRIPTION
## Bug fix

This changes allows skipping processing of display type of Renderman that doesn't produce any file output. It should fix publishing renders on farm where validator was expecting produced files from those unsupported display types.

## How to test

1) Open Maya with Renderman
2) Load / Create scene for testing rendering
3) Create Rendering instance
4) Configure some render channels / displays

Running this should list all your displays currently present:
```python
from rfm2.api.displays import get_displays


displays = get_displays()["displays"]
for name, display in displays.items():
    print(f"{name}: {display['driverNode']['type']}")
```
you should get bunch of `d_openexr` (per number of displays you've created)

5) Open Renderman IPR
6) After it did some work, run the above code again. You should get the same number of `d_openexr` **plus** one `d_it`. That's expected.
7) Now publish/submit you renders. Publishing script on farm should publish the renders.



Close #3241 