### PR TITLE
Ftrack: Chunk sizes for queries has minimal condition

### DIFF
--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -143,13 +143,16 @@ def create_chunks(iterable, chunk_size=None):
         list<list>: Chunked items.
     """
     chunks = []
-    if not iterable:
-        return chunks
 
     tupled_iterable = tuple(iterable)
+    if not tupled_iterable:
+        return chunks
     iterable_size = len(tupled_iterable)
     if chunk_size is None:
         chunk_size = 200
+
+    if chunk_size < 1:
+        chunk_size = 1
 
     for idx in range(0, iterable_size, chunk_size):
         chunks.append(tupled_iterable[idx:idx + chunk_size])


### PR DESCRIPTION
## Brief description
Make sure chunk size is at least 1 when chunks are created.

## Additional info
The issue happens in rare ocassions where a lot of entities from ftrack are queried at once.

## Testing notes:
1. There must be a very large project on ftrack (5000 entities at least)
2. Run sync to avalon
3. It should not crash