### PR TITLE
Harmony: 21.1 fix

### DIFF
--- a/openpype/hosts/harmony/api/TB_sceneOpened.js
+++ b/openpype/hosts/harmony/api/TB_sceneOpened.js
@@ -279,19 +279,13 @@ function Client() {
     };
 
     self._send = function(message) {
-        var data = new QByteArray();
-        var outstr = new QDataStream(data, QIODevice.WriteOnly);
-        outstr.writeInt(0);
-        data.append('UTF-8');
-        outstr.device().seek(0);
-        outstr.writeInt(data.size() - 4);
-        var codec = QTextCodec.codecForUtfText(data);
-        var msg = codec.fromUnicode(message);
-        var l = msg.size();
-        var coded = new QByteArray('AH').append(self.pack(l));
-        coded = coded.append(msg);
-        self.socket.write(new QByteArray(coded));
-        self.logDebug('Sent.');
+      var codec_name = new QByteArray().append("ISO-8859-1");
+      var codec = QTextCodec.codecForName(codec_name);
+      var msg = codec.fromUnicode(message);
+      var l = msg.size();
+      var coded = new QByteArray().append('AH').append(self.pack(l)).append(msg);
+      self.socket.write(new QByteArray(coded));
+      self.logDebug('Sent.');
     };
 
     self.waitForLock = function() {
@@ -351,7 +345,14 @@ function start() {
         app.avalonClient = new Client();
         app.avalonClient.socket.connectToHost(host, port);
     }
-    var menuBar = QApplication.activeWindow().menuBar();
+    var mainWindow = null;
+    var widgets = QApplication.topLevelWidgets();
+    for (var i = 0 ; i < widgets.length; i++) {
+      if (widgets[i] instanceof QMainWindow){
+          mainWindow = widgets[i];
+      }
+    }
+    var menuBar = mainWindow.menuBar();
     var actions = menuBar.actions();
     app.avalonMenu = null;
 


### PR DESCRIPTION
## Brief description
Harmony 21.1 changed Qt Javascript API from 4 to 6 which resulted in issue with missing QDataStream.
Different approach of getting QtTextCodec implemented.

## Testing notes:
1. start Harmony 21.1.
2. Openpype menu should show up and work