### PR TITLE
Maya: FBX camera export

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_fbx_camera.py
+++ b/openpype/hosts/maya/plugins/publish/collect_fbx_camera.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from maya import cmds  # noqa
+import pyblish.api
+
+
+class CollectFbxCamera(pyblish.api.InstancePlugin):
+    """Collect Camera for FBX export."""
+
+    order = pyblish.api.CollectorOrder + 0.2
+    label = "Collect Camera for FBX export"
+    families = ["camera"]
+
+    def process(self, instance):
+        if not instance.data.get("families"):
+            instance.data["families"] = []
+
+        if "fbx" not in instance.data["families"]:
+            instance.data["families"].append("fbx")
+
+        instance.data["cameras"] = True

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -165,6 +165,9 @@
         "CollectMayaRender": {
             "sync_workfile_version": false
         },
+        "CollectFbxCamera": {
+            "enabled": false
+        },
         "ValidateInstanceInContext": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -22,6 +22,20 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CollectFbxCamera",
+            "label": "Collect Camera for FBX export",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                }
+            ]
+        },
+        {
             "type": "splitter"
         },
         {


### PR DESCRIPTION
## Feature

This is adding support for publishing camera from Maya as FBX. This is disabled by default

You can enable it in the Settings here `project_settings/maya/publish/CollectFbxCamera` by enabling **Collect Camera for FBX export**. When you publish your camera, fbx representation will be made.