### PR TITLE
Unreal: Fix Camera Loading if Layout is missing

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_camera.py
+++ b/openpype/hosts/unreal/plugins/load/load_camera.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import unreal
 from unreal import EditorAssetLibrary
 from unreal import EditorLevelLibrary
+from unreal import EditorLevelUtils
 
 from openpype.pipeline import (
     AVALON_CONTAINER_ID,
@@ -84,10 +85,10 @@ class CameraLoader(plugin.Loader):
         hierarchy = context.get('asset').get('data').get('parents')
         root = "/Game/OpenPype"
         hierarchy_dir = root
-        hierarchy_list = []
+        hierarchy_dir_list = []
         for h in hierarchy:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
-            hierarchy_list.append(hierarchy_dir)
+            hierarchy_dir_list.append(hierarchy_dir)
         asset = context.get('asset').get('name')
         suffix = "_CON"
         if asset:
@@ -121,27 +122,40 @@ class CameraLoader(plugin.Loader):
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{hierarchy_dir}/{asset}/{name}_{unique_number:02d}", suffix="")
 
+        asset_path = Path(asset_dir)
+        asset_path_parent = str(asset_path.parent.as_posix())
+
         container_name += suffix
 
-        current_level = EditorLevelLibrary.get_editor_world().get_full_name()
+        EditorAssetLibrary.make_directory(asset_dir)
+
+        # Create map for the shot, and create hierarchy of map. If the maps
+        # already exist, we will use them.
+        h_dir = hierarchy_dir_list[0]
+        h_asset = hierarchy[0]
+        master_level = f"{h_dir}/{h_asset}_map.{h_asset}_map"
+        if not EditorAssetLibrary.does_asset_exist(master_level):
+            EditorLevelLibrary.new_level(f"{h_dir}/{h_asset}_map")
+
+        level = f"{asset_path_parent}/{asset}_map.{asset}_map"
+        if not EditorAssetLibrary.does_asset_exist(level):
+            EditorLevelLibrary.new_level(f"{asset_path_parent}/{asset}_map")
+
+            EditorLevelLibrary.load_level(master_level)
+            EditorLevelUtils.add_level_to_world(
+                EditorLevelLibrary.get_editor_world(),
+                level,
+                unreal.LevelStreamingDynamic
+            )
         EditorLevelLibrary.save_all_dirty_levels()
-
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-        filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{hierarchy_dir}/{asset}/"],
-            recursive_paths=True)
-        maps = ar.get_assets(filter)
-
-        # There should be only one map in the list
-        EditorLevelLibrary.load_level(maps[0].get_full_name())
+        EditorLevelLibrary.load_level(level)
 
         # Get all the sequences in the hierarchy. It will create them, if
         # they don't exist.
         sequences = []
         frame_ranges = []
         i = 0
-        for h in hierarchy_list:
+        for h in hierarchy_dir_list:
             root_content = EditorAssetLibrary.list_assets(
                 h, recursive=False, include_folder=False)
 
@@ -256,7 +270,7 @@ class CameraLoader(plugin.Loader):
             "{}/{}".format(asset_dir, container_name), data)
 
         EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(current_level)
+        EditorLevelLibrary.load_level(master_level)
 
         asset_content = EditorAssetLibrary.list_assets(
             asset_dir, recursive=True, include_folder=True


### PR DESCRIPTION
## Brief description
Fixes a problem when loading a camera asset when the layout is missing.

## Description
When loading a camera, the loader checks for the master level. If no layout has been loaded, the master level is missing. Now when loading the camera, if there's no master level, it is created similarly to the master level sequence.