### PR TITLE
Harmony: message length in 21.1

### DIFF
--- a/openpype/hosts/harmony/api/server.py
+++ b/openpype/hosts/harmony/api/server.py
@@ -88,21 +88,25 @@ class Server(threading.Thread):
         """
         current_time = time.time()
         while True:
-
+            self.log.info("wait ttt")
             # Receive the data in small chunks and retransmit it
             request = None
-            header = self.connection.recv(6)
+            header = self.connection.recv(10)
             if len(header) == 0:
                 # null data received, socket is closing.
                 self.log.info(f"[{self.timestamp()}] Connection closing.")
                 break
+
             if header[0:2] != b"AH":
                 self.log.error("INVALID HEADER")
-            length = struct.unpack(">I", header[2:])[0]
+            content_length_str = header[2:].decode()
+
+            length = int(content_length_str, 16)
             data = self.connection.recv(length)
             while (len(data) < length):
                 # we didn't received everything in first try, lets wait for
                 # all data.
+                self.log.info("loop")
                 time.sleep(0.1)
                 if self.connection is None:
                     self.log.error(f"[{self.timestamp()}] "
@@ -113,7 +117,7 @@ class Server(threading.Thread):
                     break
 
                 data += self.connection.recv(length - len(data))
-
+            self.log.debug("data:: {} {}".format(data, type(data)))
             self.received += data.decode("utf-8")
             pretty = self._pretty(self.received)
             self.log.debug(


### PR DESCRIPTION
## Brief description
Additional fix for message length.

## Additional info
Harmony 21.1 doesn't have QDataStream anymore.

      This means we aren't able to write bytes into QByteArray so we had
      modify how content length sent do the server.
      Content length is sent as string of 8 char convertible into integer
      (instead of 0x00000001[4 bytes] > "000000001"[8 bytes])
