### PR TITLE
Nuke: bake reformat was failing on string type

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -18,7 +18,8 @@ from .lib import (
     maintained_selection,
     set_avalon_knob_data,
     add_publish_knob,
-    get_nuke_imageio_settings
+    get_nuke_imageio_settings,
+    set_node_knobs_from_settings
 )
 
 
@@ -497,16 +498,7 @@ class ExporterReviewMov(ExporterReview):
             add_tags.append("reformated")
 
             rf_node = nuke.createNode("Reformat")
-            for kn_conf in reformat_node_config:
-                _type = kn_conf["type"]
-                k_name = str(kn_conf["name"])
-                k_value = kn_conf["value"]
-
-                # to remove unicode as nuke doesn't like it
-                if _type == "string":
-                    k_value = str(kn_conf["value"])
-
-                rf_node[k_name].setValue(k_value)
+            set_node_knobs_from_settings(rf_node, reformat_node_config)
 
             # connect
             rf_node.setInput(0, self.previous_node)


### PR DESCRIPTION
## Brief description
Bake stream reformat knob settings improvements

## Description
Knob type from settings was not allowing unicode to be set as value.



## Testing notes:
1. in settings on any bake output preset activate reformat and set some knob values
2. Open nuke workfile and render some render family node
3. all should work as expected