### PR TITLE
Maya: reference loaders could store placeholder in referenced url

### DIFF
--- a/openpype/hosts/maya/plugins/load/_load_animation.py
+++ b/openpype/hosts/maya/plugins/load/_load_animation.py
@@ -35,8 +35,9 @@ class AbcLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
         # hero_001 (abc)
         # asset_counter{optional}
-
-        nodes = cmds.file(self.fname,
+        file_url = self.prepare_root_value(self.fname,
+                                           context["project"]["code"])
+        nodes = cmds.file(file_url,
                           namespace=namespace,
                           sharedReferenceFile=False,
                           groupReference=True,

--- a/openpype/hosts/maya/plugins/load/load_ass.py
+++ b/openpype/hosts/maya/plugins/load/load_ass.py
@@ -64,9 +64,11 @@ class AssProxyLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
                     path = os.path.join(publish_folder, filename)
 
             proxyPath = proxyPath_base + ".ma"
-            self.log.info
 
-            nodes = cmds.file(proxyPath,
+            file_url = self.prepare_root_value(proxyPath,
+                                               context["project"]["code"])
+
+            nodes = cmds.file(file_url,
                               namespace=namespace,
                               reference=True,
                               returnNewNodes=True,
@@ -123,7 +125,11 @@ class AssProxyLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         assert os.path.exists(proxyPath), "%s does not exist." % proxyPath
 
         try:
-            content = cmds.file(proxyPath,
+            file_url = self.prepare_root_value(proxyPath,
+                                               representation["context"]
+                                                             ["project"]
+                                                             ["code"])
+            content = cmds.file(file_url,
                                 loadReference=reference_node,
                                 type="mayaAscii",
                                 returnNewNodes=True)

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -31,7 +31,9 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         import maya.cmds as cmds
 
         with lib.maintained_selection():
-            nodes = cmds.file(self.fname,
+            file_url = self.prepare_root_value(self.fname,
+                                               context["project"]["code"])
+            nodes = cmds.file(file_url,
                               namespace=namespace,
                               reference=True,
                               returnNewNodes=True)

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -8,7 +8,6 @@ from openpype.pipeline import (
     legacy_create,
 )
 import openpype.hosts.maya.api.plugin
-from openpype.api import Anatomy
 from openpype.hosts.maya.api.lib import maintained_selection
 
 
@@ -52,8 +51,8 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
         with maintained_selection():
             cmds.loadPlugin("AbcImport.mll", quiet=True)
-            anatomy = Anatomy(context["project"]["code"])
-            file_url = anatomy.replace_root_with_env_key(self.fname, '${{{}}}')
+            file_url = self.prepare_root_value(self.fname,
+                                               context["project"]["code"])
             nodes = cmds.file(file_url,
                               namespace=namespace,
                               sharedReferenceFile=False,

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -8,6 +8,7 @@ from openpype.pipeline import (
     legacy_create,
 )
 import openpype.hosts.maya.api.plugin
+from openpype.api import Anatomy
 from openpype.hosts.maya.api.lib import maintained_selection
 
 
@@ -51,7 +52,9 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
         with maintained_selection():
             cmds.loadPlugin("AbcImport.mll", quiet=True)
-            nodes = cmds.file(self.fname,
+            anatomy = Anatomy(context["project"]["code"])
+            file_url = anatomy.replace_root_with_env_key(self.fname, '${{{}}}')
+            nodes = cmds.file(file_url,
                               namespace=namespace,
                               sharedReferenceFile=False,
                               reference=True,

--- a/openpype/hosts/maya/plugins/load/load_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_rig.py
@@ -53,7 +53,9 @@ class YetiRigLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
         # load rig
         with lib.maintained_selection():
-            nodes = cmds.file(self.fname,
+            file_url = self.prepare_root_value(self.fname,
+                                               context["project"]["code"])
+            nodes = cmds.file(file_url,
                               namespace=namespace,
                               reference=True,
                               returnNewNodes=True,

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -8,6 +8,7 @@
         "yetiRig": "ma"
     },
     "maya-dirmap": {
+        "use_env_var_as_root": true,
         "enabled": false,
         "paths": {
             "source-path": [],

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
@@ -25,7 +25,7 @@
                 {
                     "type": "boolean",
                     "key": "use_env_var_as_root",
-                    "label": "Use env var placeholder in referenced url",
+                    "label": "Use env var placeholder in referenced paths",
                     "docstring": "Use ${} placeholder instead of physical value of root when storing into workfile metadata."
                 },
                 {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
@@ -26,7 +26,7 @@
                     "type": "boolean",
                     "key": "use_env_var_as_root",
                     "label": "Use env var placeholder in referenced paths",
-                    "docstring": "Use ${} placeholder instead of physical value of root when storing into workfile metadata."
+                    "docstring": "Use ${} placeholder instead of absolute value of a root in referenced filepaths."
                 },
                 {
                     "type": "boolean",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
@@ -24,6 +24,12 @@
             "children": [
                 {
                     "type": "boolean",
+                    "key": "use_env_var_as_root",
+                    "label": "Use env var placeholder in referenced url",
+                    "docstring": "Use ${} placeholder instead of physical value of root when storing into workfile metadata."
+                },
+                {
+                    "type": "boolean",
                     "key": "enabled",
                     "label": "Enabled"
                 },


### PR DESCRIPTION
## Brief description
All reference loaders in Maya now could instead of real published folder use environment variable placholder. This would allow to use this workfile in different locations (remote artist computer, studio etc.)

## Description
`OPENPYPE_PROJECT_ROOT_WORK` is calculated for values in Anatomy or overridden values from Local Setting.
This placeholder is physically stored in workfile, each value is resolved when workfile is opened. 
This allows remote artists to reference assets in a workfile and publish it. Same workfile will then work everywhere (studio, different artist) if they have Anatomy or Local Setting configured to existing folder on their machine.

This limits opening workfiles without Openpype, this could be remedied by adding used environment variable to artist environment. (By adding to theirs mel script??)

## Additional info
Flag to trigger this behavior is hardcoded to True for testing. Placement of this toggle in Settings **need to be decided**.
Easiest option is to add it as a plugin variable, this would mean add/modify this behavior on each plugin separately. Usage of
environment variable could be also widened to not only Maya. It could be used in any host which stores full path of referenced files in its workfile metadata. In that case, more general location to enable/disable this behavior should be chosen.

## Testing notes:
1. Open Maya
2. Use Reference Loader to pull in any asset
3. Save workfile
4. Check content of workfile, ${} placeholder should be used instead of real physical root.