### PR TITLE
General: editorial collection one frame longer

### DIFF
--- a/openpype/lib/editorial.py
+++ b/openpype/lib/editorial.py
@@ -168,7 +168,7 @@ def make_sequence_collection(path, otio_range, metadata):
     first, last = otio_range_to_frame_range(otio_range)
     collection = clique.Collection(
         head=head, tail=tail, padding=metadata["padding"])
-    collection.indexes.update([i for i in range(first, (last + 1))])
+    collection.indexes.update(list(range(first, last)))
     return dir_path, collection
 
 


### PR DESCRIPTION
## Brief description
Fixing editorial data, resolving

## Description
Editorial in Hiero was not correctly resolving frame range - it was making them one frame longer. Following plugins were crashing because they could not find the redundant frame.

## Additional info
Editorial library function was not correctly looking at framerange.
