### PR TITLE
Unreal: add support for skeletalMesh and staticMesh to loaders

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_rig.py
+++ b/openpype/hosts/unreal/plugins/load/load_rig.py
@@ -14,7 +14,7 @@ import unreal  # noqa
 class SkeletalMeshFBXLoader(plugin.Loader):
     """Load Unreal SkeletalMesh from FBX."""
 
-    families = ["rig"]
+    families = ["rig", "skeletalMesh"]
     label = "Import FBX Skeletal Mesh"
     representations = ["fbx"]
     icon = "cube"

--- a/openpype/hosts/unreal/plugins/load/load_staticmeshfbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_staticmeshfbx.py
@@ -14,7 +14,7 @@ import unreal  # noqa
 class StaticMeshFBXLoader(plugin.Loader):
     """Load Unreal StaticMesh from FBX."""
 
-    families = ["model", "unrealStaticMesh"]
+    families = ["model", "staticMesh"]
     label = "Import FBX Static Mesh"
     representations = ["fbx"]
     icon = "cube"


### PR DESCRIPTION
## Enhancement

This small PR is just adding support for `skeletalMesh` and `staticMesh` to Unreal loaders.

### Testing

Just publish skeletal mesh and static mesh in Maya and load it in Unreal