### PR TITLE
Maya: better handling of legacy review subsets names

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_review.py
+++ b/openpype/hosts/maya/plugins/publish/collect_review.py
@@ -77,15 +77,14 @@ class CollectReview(pyblish.api.InstancePlugin):
                 instance.data['remove'] = True
                 self.log.debug('isntance data {}'.format(instance.data))
         else:
-            if self.legacy:
-                instance.data['subset'] = task + 'Review'
-            else:
-                subset = "{}{}{}".format(
-                    task,
-                    instance.data["subset"][0].upper(),
-                    instance.data["subset"][1:]
-                )
-                instance.data['subset'] = subset
+            legacy_subset_name = task + 'Review'
+            asset_doc_id = instance.context.data['assetEntity']["_id"]
+            subsets = legacy_io.find({"type": "subset",
+                                      "name": legacy_subset_name,
+                                      "parent": asset_doc_id}).distinct("_id")
+            if len(list(subsets)) > 0:
+                self.log.debug("Existing subsets found, keep legacy name.")
+                instance.data['subset'] = legacy_subset_name
 
             instance.data['review_camera'] = camera
             instance.data['frameStartFtrack'] = \

--- a/openpype/hosts/maya/plugins/publish/help/validate_review_subset_uniqueness.xml
+++ b/openpype/hosts/maya/plugins/publish/help/validate_review_subset_uniqueness.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <error id="main">
+        <title>Review subsets not unique</title>
+        <description>
+            ## Non unique subset name found
+
+            Non unique subset names: '{non_unique}'
+            <detail>
+                ### __Detailed Info__ (optional)
+
+                This might happen if you already published for this asset
+                review subset with legacy name {task}Review.
+                This legacy name limits possibility of publishing of multiple
+                reviews from a single workfile. Proper review subset name should
+                now
+                contain variant also (as 'Main', 'Default' etc.). That would
+                result in completely new subset though, so this situation must
+                be handled manually.
+            </detail>
+            ### How to repair?
+
+            Legacy subsets must be removed from Openpype DB, please ask admin
+            to do that. Please provide them asset and subset names.
+
+        </description>
+    </error>
+</root>

--- a/openpype/hosts/maya/plugins/publish/validate_review_subset_uniqueness.py
+++ b/openpype/hosts/maya/plugins/publish/validate_review_subset_uniqueness.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import collections
+import pyblish.api
+import openpype.api
+from openpype.pipeline import PublishXmlValidationError
+
+
+class ValidateReviewSubsetUniqueness(pyblish.api.ContextPlugin):
+    """Validates that nodes has common root."""
+
+    order = openpype.api.ValidateContentsOrder
+    hosts = ["maya"]
+    families = ["review"]
+    label = "Validate Review Subset Unique"
+
+    def process(self, context):
+        subset_names = []
+
+        for instance in context:
+            self.log.info("instance:: {}".format(instance.data))
+            if instance.data.get('publish'):
+                subset_names.append(instance.data.get('subset'))
+
+        non_unique = \
+            [item
+             for item, count in collections.Counter(subset_names).items()
+             if count > 1]
+        msg = ("Instance subset names {} are not unique. ".format(non_unique) +
+               "Ask admin to remove subset from DB for multiple reviews.")
+        formatting_data = {
+            "non_unique": ",".join(non_unique)
+        }
+
+        if non_unique:
+            raise PublishXmlValidationError(self, msg,
+                                            formatting_data=formatting_data)


### PR DESCRIPTION
## Brief description
Multiple reviews from a Maya workfile are blocked by legacy subset names without variant. These names could be used in later process so we cannot replace them.


## Description
Legacy subset name (`{task}Review}`) is queried for presence in DB for published asset. If at least one subset found, subset name is kept (which limits possibility of multiple reviews), in other case proper from Creator (which could be configured by 
Validator to check uniqueness of subset names was added to catch multiple reviews with legacy name.

## Testing notes:
Test A
0. Before pulling this PR create camera and Review instance in Maya and publish
1. Create at least 2 cameras in Maya
2. create for them 'Review' instances
3. Publish
4. It should fail on Validation

Test B
0. Use different asset then in Test A
1. Create at least 2 cameras in Maya
2. create for them 'Review' instances
3. 3. Publish
4. It **shouldnt** fail on Validation