### PR TITLE
Maya look: skip empty file attributes

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -601,8 +601,10 @@ class CollectLook(pyblish.api.InstancePlugin):
                                                      source,
                                                      computed_source))
 
-            if not source:
-                self.log.info("source is empty, skipping...")
+            # renderman allows nodes to have filename attribute empty while
+            # you can have another incoming connection from different node.
+            if not source and cmds.nodeType(node).lower().startswith("pxr"):
+                self.log.info("Renderman: source is empty, skipping...")
                 continue
             # We replace backslashes with forward slashes because V-Ray
             # can't handle the UDIM files with the backslashes in the

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -601,6 +601,9 @@ class CollectLook(pyblish.api.InstancePlugin):
                                                      source,
                                                      computed_source))
 
+            if not source:
+                self.log.info("source is empty, skipping...")
+                continue
             # We replace backslashes with forward slashes because V-Ray
             # can't handle the UDIM files with the backslashes in the
             # paths as the computed patterns

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -603,7 +603,14 @@ class CollectLook(pyblish.api.InstancePlugin):
 
             # renderman allows nodes to have filename attribute empty while
             # you can have another incoming connection from different node.
-            if not source and cmds.nodeType(node).lower().startswith("pxr"):
+            pxr_nodes = set()
+            if cmds.pluginInfo("RenderMan_for_Maya", query=True, loaded=True):
+                pxr_nodes = set(
+                    cmds.pluginInfo("RenderMan_for_Maya",
+                                    query=True,
+                                    dependNode=True)
+                )
+            if not source and cmds.nodeType(node) in pxr_nodes:
                 self.log.info("Renderman: source is empty, skipping...")
                 continue
             # We replace backslashes with forward slashes because V-Ray


### PR DESCRIPTION
## Fix

This is fixing look collector so it will skip empty filename attributes. Useful mainly on nodes that defines file attribute but can accept also input from other nodes.

### Testing

Create look with shader network, connecting **PxrTexture** to **PxrBump** for example in renderman (leaving filename attribute in **PxrBump** empty. Publishing and loading of the look should be successfull
