### PR TITLE
General: Fix Oiio tool path resolving

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -116,7 +116,10 @@ def get_oiio_tools_path(tool="oiiotool"):
         tool (string): Tool name (oiiotool, maketx, ...).
             Default is "oiiotool".
     """
+
     oiio_dir = get_vendor_bin_path("oiio")
+    if platform.system().lower() == "linux":
+        oiio_dir = os.path.join(oiio_dir, "bin")
     return find_executable(os.path.join(oiio_dir, tool))
 
 


### PR DESCRIPTION
## Brief description
Fix path to oiio tool on linux.

## Description
It seems that oiiotool was not used on linux at all. This is a quick fix before resolving issue https://github.com/pypeclub/OpenPype/issues/3276.

## Testing notes:
1. It should be possible to use oiiotool on linux machines
- e.g. by running script on tray admin console
```
from openpype.lib.transcoding import get_oiio_info_for_input

some_path_to_image = ""
print(get_oiio_info_for_input(some_path_to_image))
```