### PR TITLE
Maya: Look assigner UI improvements

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1737,8 +1737,11 @@ def apply_shaders(relationships, shadernodes, nodes):
             log.warning("No nodes found for shading engine "
                         "'{0}'".format(id_shading_engines[0]))
             continue
+        try:
+            cmds.sets(filtered_nodes, forceElement=id_shading_engines[0])
+        except RuntimeError as rte:
+            log.error("Error during shader assignment: {}".format(rte))
 
-        cmds.sets(filtered_nodes, forceElement=id_shading_engines[0])
     # endregion
 
     apply_attributes(attributes, nodes_by_id)

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -105,6 +105,7 @@ class HostToolsHelper:
             loader_tool.show()
             loader_tool.raise_()
             loader_tool.activateWindow()
+            loader_tool.showNormal()
 
             if use_context is None:
                 use_context = False
@@ -180,6 +181,7 @@ class HostToolsHelper:
             # Pull window to the front.
             scene_inventory_tool.raise_()
             scene_inventory_tool.activateWindow()
+            scene_inventory_tool.showNormal()
 
     def get_library_loader_tool(self, parent):
         """Create, cache and return library loader tool window."""
@@ -200,7 +202,9 @@ class HostToolsHelper:
             library_loader_tool.show()
             library_loader_tool.raise_()
             library_loader_tool.activateWindow()
+            library_loader_tool.showNormal()
             library_loader_tool.refresh()
+
 
     def show_publish(self, parent=None):
         """Try showing the most desirable publish GUI
@@ -243,6 +247,11 @@ class HostToolsHelper:
             look_assigner_tool = self.get_look_assigner_tool(parent)
             look_assigner_tool.show()
 
+            # Pull window to the front.
+            look_assigner_tool.raise_()
+            look_assigner_tool.activateWindow()
+            look_assigner_tool.showNormal()
+
     def get_experimental_tools_dialog(self, parent=None):
         """Dialog of experimental tools.
 
@@ -270,6 +279,7 @@ class HostToolsHelper:
             dialog.show()
             dialog.raise_()
             dialog.activateWindow()
+            dialog.showNormal()
 
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.


### PR DESCRIPTION
Originally-authored-by: @icyvapor 
follow up on #3208

Look assigner now handles RuntimeError and continues with material assignment; also some UI usability improvements for host tools.

Add a bit error handling so LookAssigner doesn't abort when there's any single RuntimeError.
Also we noticed LookAssigner is not docked as a sub-window of the main Maya window, and once it's opened, clicking the menu item(or icon) wouldn't bring up the UI to the default size. So I added showNormal() call. Did the same for couple of other UI tools.