### PR TITLE
Documentation: Add app key to template documentation

### DIFF
--- a/website/docs/admin_settings_project_anatomy.md
+++ b/website/docs/admin_settings_project_anatomy.md
@@ -67,6 +67,7 @@ We have a few required anatomy templates for OpenPype to work properly, however 
 | `ext` | File extension |
 | `representation` | Representation name |
 | `frame` | Frame number for sequence files. |
+| `app` | Application Name |
 | `output` |  |
 | `comment` |  |
 


### PR DESCRIPTION
## Brief description
I added the app key which was missing in the documentation on the list of existing keys in the templates.