### PR TITLE
Maya: Fix swaped width and height in reviews

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -340,10 +340,10 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "expectedFiles": full_exp_files,
                 "publishRenderMetadataFolder": common_publish_meta_path,
                 "resolutionWidth": lib.get_attr_in_layer(
-                    "defaultResolution.height", layer=layer_name
+                    "defaultResolution.width", layer=layer_name
                 ),
                 "resolutionHeight": lib.get_attr_in_layer(
-                    "defaultResolution.width", layer=layer_name
+                    "defaultResolution.height", layer=layer_name
                 ),
                 "pixelAspect": lib.get_attr_in_layer(
                     "defaultResolution.pixelAspect", layer=layer_name


### PR DESCRIPTION
## Brief description
Reviews from Maya had swaped width and height collected from scene.

## Testing notes:
1. Publish from maya with some review in scene