### PR TITLE
Settings: Add missing default settings for nuke gizmo

### DIFF
--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -27,6 +27,34 @@
             }
         ]
     },
+    "gizmo": [
+        {
+            "toolbar_menu_name": "OpenPype Gizmo",
+            "gizmo_source_dir": {
+                "windows": [],
+                "darwin": [],
+                "linux": []
+            },
+            "toolbar_icon_path": {
+                "windows": "",
+                "darwin": "",
+                "linux": ""
+            },
+            "gizmo_definition": [
+                {
+                    "gizmo_toolbar_path": "/path/to/menu",
+                    "sub_gizmo_list": [
+                        {
+                            "sourcetype": "python",
+                            "title": "Gizmo Note",
+                            "command": "nuke.nodes.StickyNote(label='You can create your own toolbar menu in the Nuke GizmoMenu of OpenPype')",
+                            "shortcut": ""
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
     "create": {
         "CreateWriteRender": {
             "fpath_template": "{work}/renders/nuke/{subset}/{subset}.{frame}.{ext}",
@@ -290,29 +318,5 @@
             }
         ]
     },
-    "gizmo": [
-        {
-            "toolbar_menu_name": "OpenPype Gizmo",
-            "gizmo_path": {
-                "windows": [],
-                "darwin": [],
-                "linux": []
-            },
-            "toolbar_icon_path": {},
-            "gizmo_definition": [
-                {
-                    "gizmo_toolbar_path": "/path/to/menu",
-                    "sub_gizmo_list": [
-                        {
-                            "sourcetype": "python",
-                            "title": "Gizmo Note",
-                            "command": "nuke.nodes.StickyNote(label='You can create your own toolbar menu in the Nuke GizmoMenu of OpenPype')",
-                            "shortcut": ""
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
     "filters": {}
 }


### PR DESCRIPTION
## Brief description
Added missing default settings for nuke gizmo.

## Description
[PR](https://github.com/pypeclub/OpenPype/pull/3172) had missing default settings for nuke gizmos which were added.

## Testing notes:
1. Open settings UI
2. Nuke gizmo settings should not be blue (changed)