### PR TITLE
Fix - added local targets to install host

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -66,7 +66,7 @@ def install():
     log.info("Installing callbacks ... ")
     register_event_callback("init", on_init)
 
-    if os.environ.get("HEADLESS_PUBLISH"):
+    if os.environ.get("OPENPYPE_REMOTE_PUBLISH"):
         # Maya launched on farm, lib.IS_HEADLESS might be triggered locally too
         # target "farm" == rendering on farm, expects OPENPYPE_PUBLISH_DATA
         # target "remote" == remote execution

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -66,22 +66,11 @@ def install():
     log.info("Installing callbacks ... ")
     register_event_callback("init", on_init)
 
-    if os.environ.get("OPENPYPE_REMOTE_PUBLISH"):
-        # Maya launched on farm, lib.IS_HEADLESS might be triggered locally too
-        # target "farm" == rendering on farm, expects OPENPYPE_PUBLISH_DATA
-        # target "remote" == remote execution
-        print("Registering pyblish target: remote")
-        pyblish.api.register_target("remote")
-        return
-
     if lib.IS_HEADLESS:
         log.info(("Running in headless mode, skipping Maya "
                  "save/open/new callback installation.."))
 
         return
-
-    print("Registering pyblish target: local")
-    pyblish.api.register_target("local")
 
     _set_project()
     _register_callbacks()

--- a/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
@@ -115,7 +115,7 @@ class MayaSubmitRemotePublishDeadline(openpype.api.Integrator):
         environment["OPENPYPE_REMOTE_JOB"] = "1"
         environment["OPENPYPE_USERNAME"] = instance.context.data["user"]
         environment["OPENPYPE_PUBLISH_SUBSET"] = instance.data["subset"]
-        environment["HEADLESS_PUBLISH"] = "1"
+        environment["OPENPYPE_REMOTE_PUBLISH"] = "1"
 
         payload["JobInfo"].update({
             "EnvironmentKeyValue%d" % index: "{key}={value}".format(

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -104,6 +104,14 @@ def install_host(host):
 
     MessageHandler.emit = modified_emit
 
+    if os.environ.get("OPENPYPE_REMOTE_PUBLISH"):
+        # target "farm" == rendering on farm, expects OPENPYPE_PUBLISH_DATA
+        # target "remote" == remote execution, installs host
+        print("Registering pyblish target: remote")
+        pyblish.api.register_target("remote")
+    else:
+        pyblish.api.register_target("local")
+
     install_openpype_plugins()
 
 

--- a/openpype/plugin.py
+++ b/openpype/plugin.py
@@ -23,7 +23,7 @@ class Integrator(InstancePlugin):
 
     Wraps pyblish instance plugin. Targets set to "local" which means all
     integrators should run on "local" publishes, by default.
-    "farm" targets could be used for integrators that should run on a farm.
+    "remote" targets could be used for integrators that should run externally.
     """
     targets = ["local"]
 


### PR DESCRIPTION
## Brief description
By default when host is started, it should register targets to 'local', only if specific env var is set (OPENPYPE_REMOTE_PUBLISH) it should be 'remote'. This means
farm is using host to collect/validate/extract and publish on behalf of artist.

## Description
Without this extractors weren't triggered in other host than Maya (which is explicitly setting targets to local because of implementation of remote pointcache publishing).
This PR sets 'targetst = ["local"]' to any host not started on a farm.


## Testing notes:
1. Retry Maya ABC pointcache farm publishing
2. Try publish locally in Nuke