### PR TITLE
Maya: Allow more data to be published along camera 🎥 

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_camera_alembic.py
+++ b/openpype/hosts/maya/plugins/publish/extract_camera_alembic.py
@@ -34,7 +34,6 @@ class ExtractCameraAlembic(openpype.api.Extractor):
                           dag=True, type="camera")
 
         # validate required settings
-        assert len(cameras) == 1, "Not a single camera found in extraction"
         assert isinstance(step, float), "Step must be a float value"
         camera = cameras[0]
 
@@ -44,8 +43,12 @@ class ExtractCameraAlembic(openpype.api.Extractor):
         path = os.path.join(dir_path, filename)
 
         # Perform alembic extraction
+        member_shapes = cmds.ls(
+            members, leaf=True, shapes=True, long=True, dag=True)
         with lib.maintained_selection():
-            cmds.select(camera, replace=True, noExpand=True)
+            cmds.select(
+                member_shapes,
+                replace=True, noExpand=True)
 
             # Enforce forward slashes for AbcExport because we're
             # embedding it into a job string
@@ -57,10 +60,12 @@ class ExtractCameraAlembic(openpype.api.Extractor):
             job_str += ' -step {0} '.format(step)
 
             if bake_to_worldspace:
-                transform = cmds.listRelatives(camera,
-                                               parent=True,
-                                               fullPath=True)[0]
-                job_str += ' -worldSpace -root {0}'.format(transform)
+                job_str += ' -worldSpace'
+                for member in member_shapes:
+                    self.log.info(f"processing {member}")
+                    transform = cmds.listRelatives(
+                        member, parent=True, fullPath=True)[0]
+                    job_str += ' -root {0}'.format(transform)
 
             job_str += ' -file "{0}"'.format(path)
 

--- a/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
@@ -20,6 +20,7 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
     hosts = ['maya']
     label = 'Camera Contents'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
+    validate_shapes = True
 
     @classmethod
     def get_invalid(cls, instance):
@@ -49,6 +50,8 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
 
                 raise RuntimeError("No cameras found in empty instance.")
 
+        if not cls.validate_shapes:
+            return
         # non-camera shapes
         valid_shapes = cmds.ls(shapes, type=('camera', 'locator'), long=True)
         shapes = set(shapes) - set(valid_shapes)

--- a/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
@@ -33,7 +33,7 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
         invalid = []
         cameras = cmds.ls(shapes, type='camera', long=True)
         if len(cameras) != 1:
-            cls.log.warning("Camera instance must have a single camera. "
+            cls.log.error("Camera instance must have a single camera. "
                             "Found {0}: {1}".format(len(cameras), cameras))
             invalid.extend(cameras)
 
@@ -51,15 +51,31 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
                 raise RuntimeError("No cameras found in empty instance.")
 
         if not cls.validate_shapes:
-            return
+            cls.log.info("not validating shapes in the content")
+
+            for member in members:
+                parents = cmds.ls(member, long=True)[0].split("|")[1:-1]
+                cls.log.info(parents)
+                parents_long_named = [
+                    "|".join(parents[:i]) for i in range(1, 1 + len(parents))
+                ]
+                cls.log.info(parents_long_named)
+                if cameras[0] in parents_long_named:
+                    cls.log.error(
+                        "{} is parented under camera {}".format(member, cameras[0]))
+                    invalid.extend(member)
+            return invalid
+
         # non-camera shapes
         valid_shapes = cmds.ls(shapes, type=('camera', 'locator'), long=True)
         shapes = set(shapes) - set(valid_shapes)
         if shapes:
             shapes = list(shapes)
-            cls.log.warning("Camera instance should only contain camera "
+            cls.log.error("Camera instance should only contain camera "
                             "shapes. Found: {0}".format(shapes))
             invalid.extend(shapes)
+
+
 
         invalid = list(set(invalid))
 

--- a/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
@@ -51,18 +51,17 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
                 raise RuntimeError("No cameras found in empty instance.")
 
         if not cls.validate_shapes:
-            cls.log.info("not validating shapes in the content")
+            cls.log.info("Not validating shapes in the content.")
 
             for member in members:
                 parents = cmds.ls(member, long=True)[0].split("|")[1:-1]
-                cls.log.info(parents)
                 parents_long_named = [
                     "|".join(parents[:i]) for i in range(1, 1 + len(parents))
                 ]
-                cls.log.info(parents_long_named)
                 if cameras[0] in parents_long_named:
                     cls.log.error(
-                        "{} is parented under camera {}".format(member, cameras[0]))
+                        "{} is parented under camera {}".format(
+                            member, cameras[0]))
                     invalid.extend(member)
             return invalid
 

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -413,6 +413,11 @@
             "optional": true,
             "active": true
         },
+        "ValidateCameraContents": {
+            "enabled": true,
+            "optional": true,
+            "validate_shapes": true
+        },
         "ExtractPlayblast": {
             "capture_preset": {
                 "Codec": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -571,6 +571,30 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "ValidateCameraContents",
+            "label": "Validate Camera Content",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "optional",
+                    "label": "Optional"
+                },
+                {
+                    "type": "boolean",
+                    "key": "validate_shapes",
+                    "label": "Validate presence of shapes"
+                }
+            ]
+        },
+        {
             "type": "splitter"
         },
         {


### PR DESCRIPTION
## Enhancement

This PR is releasing restrictions in camera extractors to allow more data to be published along with the camera. There is still validator that validates camera content and by default allows only camera to be passed down the line, but it can be set to allow more data. Usefull for proxy geometry / locators / pointcloud to be published with the camera.

### How to test it

in the Settings, there are new options for **Validate Camera Content** - `project_settings/maya/publish/ValidateCameraContents`. It can be disabled, it can be set as optional and also you can disable validating presence of shapes - in another words, disabling this option will allow more then cameras to pass this validator.

![image](https://user-images.githubusercontent.com/33513211/172643034-f2b5e456-6aba-4487-b205-82e4d26922ee.png)


* Create camera instance and put for example box and camera under it
* Publish it with `Validate presence of shapes` **ON**
* Validator should trigger

---

* Disable `Validate presence of shapes` and try again
* Validator should pass and publish should be successful
* Loading camera as abc and ma should pull in camera and whatever geometry attached.

---

❔ not sure about the `Validate presence of shapes` as it is technically incorrect