### PR TITLE
TVPaint: Extractor use mark in/out range to render

### DIFF
--- a/openpype/hosts/tvpaint/api/pipeline.py
+++ b/openpype/hosts/tvpaint/api/pipeline.py
@@ -390,7 +390,7 @@ def ls():
             if "objectName" not in item and "members" in item:
                 members = item["members"]
                 if isinstance(members, list):
-                    members = "|".join(members)
+                    members = "|".join([str(member) for member in members])
                 item["objectName"] = members
     return output
 

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -73,14 +73,8 @@ class ExtractSequence(pyblish.api.Extractor):
 
         scene_bg_color = instance.context.data["sceneBgColor"]
 
-        # --- Fallbacks ----------------------------------------------------
-        # This is required if validations of ranges are ignored.
-        # - all of this code won't change processing if range to render
-        #   match to range of expected output
-
         # Prepare output frames
         output_frame_start = frame_start - handle_start
-        output_frame_end = frame_end + handle_end
 
         # Change output frame start to 0 if handles cause it's negative number
         if output_frame_start < 0:
@@ -90,32 +84,8 @@ class ExtractSequence(pyblish.api.Extractor):
             ).format(frame_start, handle_start))
             output_frame_start = 0
 
-        # Check Marks range and output range
-        output_range = output_frame_end - output_frame_start
-        marks_range = mark_out - mark_in
-
-        # Lower Mark Out if mark range is bigger than output
-        # - do not rendered not used frames
-        if output_range < marks_range:
-            new_mark_out = mark_out - (marks_range - output_range)
-            self.log.warning((
-                "Lowering render range to {} frames. Changed Mark Out {} -> {}"
-            ).format(marks_range + 1, mark_out, new_mark_out))
-            # Assign new mark out to variable
-            mark_out = new_mark_out
-
-        # Lower output frame end so representation has right `frameEnd` value
-        elif output_range > marks_range:
-            new_output_frame_end = (
-                output_frame_end - (output_range - marks_range)
-            )
-            self.log.warning((
-                "Lowering representation range to {} frames."
-                " Changed frame end {} -> {}"
-            ).format(output_range + 1, mark_out, new_output_frame_end))
-            output_frame_end = new_output_frame_end
-
-        # -------------------------------------------------------------------
+        # Calculate frame end
+        output_frame_end = output_frame_start + (mark_out - mark_in)
 
         # Save to staging dir
         output_dir = instance.data.get("stagingDir")


### PR DESCRIPTION
## Brief description
Extractor does not change rendered frame range based on frame start/end on instance but uses mark in/out.

## Description
Extractor forced to use frame start/end stored on instance data, which is ignoring what is set to be rendered. So even if validation of mark in/out is turned off it is not possible to render different range of images from TVPaint. With this change is used only frame start as "offset" for filename frame and frame end is calculated using frame start and marks range.

## Testing notes:
1. Open TVPaint
2. Change Mark in or Mark out so the range does not match frame range on asset
3. Run publish
4. Disable validation of mark in/out
5. Hit publish
6. Extraction should work and render the range defined by mark in/out

3.9.x variant of [PR](https://github.com/pypeclub/OpenPype/pull/3309).