### PR TITLE
hiero: otio p3 compatibility issue - metadata on effect use update 3.11

### DIFF
--- a/openpype/hosts/hiero/api/otio/hiero_export.py
+++ b/openpype/hosts/hiero/api/otio/hiero_export.py
@@ -132,7 +132,7 @@ def create_time_effects(otio_clip, track_item):
         otio_effect = otio.schema.TimeEffect()
         otio_effect.name = name
         otio_effect.effect_name = effect_name
-        otio_effect.metadata = metadata
+        otio_effect.metadata.update(metadata)
 
         # add otio effect to clip effects
         otio_clip.effects.append(otio_effect)


### PR DESCRIPTION
## Brief description
Effect object uses update rather then __setter__ method


## Testing notes:
1. open hiero (13 <) script with timeline with animated timewarp on clip
2. publish
3. all should look fine

# Alternative to
https://github.com/pypeclub/OpenPype/pull/3194