### PR TITLE
Maya: add pointcache family to gpu cache loader

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_gpucache.py
+++ b/openpype/hosts/maya/plugins/load/load_gpucache.py
@@ -10,7 +10,7 @@ from openpype.api import get_project_settings
 class GpuCacheLoader(load.LoaderPlugin):
     """Load Alembic as gpuCache"""
 
-    families = ["model"]
+    families = ["model", "pointcache"]
     representations = ["abc"]
 
     label = "Import Gpu Cache"

--- a/openpype/hosts/maya/plugins/load/load_gpucache.py
+++ b/openpype/hosts/maya/plugins/load/load_gpucache.py
@@ -10,7 +10,7 @@ from openpype.api import get_project_settings
 class GpuCacheLoader(load.LoaderPlugin):
     """Load Alembic as gpuCache"""
 
-    families = ["model", "pointcache"]
+    families = ["model", "animation", "pointcache"]
     representations = ["abc"]
 
     label = "Import Gpu Cache"


### PR DESCRIPTION
## Enhancement

This simple PR is adding `pointcache` family to GPU loader so alembic published as pointcaches can be loaded with it.

### Testing

Try to load pointcache alembic as GPU cache in Maya

Close #3313