### PR TITLE
Nuke: anatomy compatibility issue hacks

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -539,7 +539,9 @@ def get_created_node_imageio_setting_legacy(nodeclass, creator, subset):
 
     imageio_nodes = get_nuke_imageio_settings()["nodes"]
     required_nodes = imageio_nodes["requiredNodes"]
-    override_nodes = imageio_nodes["overrideNodes"]
+
+    # HACK: for backward compatibility this needs to be optional
+    override_nodes = imageio_nodes.get("overrideNodes", [])
 
     imageio_node = None
     for node in required_nodes:

--- a/openpype/hosts/nuke/plugins/create/create_write_still.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_still.py
@@ -9,6 +9,7 @@ from openpype.hosts.nuke.api.lib import (
 
 # HACK: just to disable still image on projects which
 # are not having anatomy imageio preset for CreateWriteStill
+# TODO: remove this code as soon as it will be obsolete
 imageio_writes = get_created_node_imageio_setting_legacy(
     "Write",
     "CreateWriteStill",

--- a/openpype/hosts/nuke/plugins/create/create_write_still.py
+++ b/openpype/hosts/nuke/plugins/create/create_write_still.py
@@ -2,7 +2,19 @@ import nuke
 
 from openpype.hosts.nuke.api import plugin
 from openpype.hosts.nuke.api.lib import (
-    create_write_node, create_write_node_legacy)
+    create_write_node,
+    create_write_node_legacy,
+    get_created_node_imageio_setting_legacy
+)
+
+# HACK: just to disable still image on projects which
+# are not having anatomy imageio preset for CreateWriteStill
+imageio_writes = get_created_node_imageio_setting_legacy(
+    "Write",
+    "CreateWriteStill",
+    "stillMain"
+)
+print(imageio_writes["knobs"])
 
 
 class CreateWriteStill(plugin.AbstractWriteRender):


### PR DESCRIPTION
## Brief description
Temporarily fixing anatomy backward compatibility

## Description
Anatomy had changed bit in the way it is configuring node knobs. Backward compatibility had to be maintained on projects which are locked on production.

## Additional info
- changes are annotated as `HACK` and needs to be removed as soon as they will not be needed

## Testing notes:
1. open nuke on project with anatomy versioned back to 3.9
2. open Creator and see Still image plugin is missing (if it is not available in `project_anatomy/imageio/nuke/nodes/requiredNodes`)
3. create Render, Prerender nodes and see those are created fine.
