### PR TITLE
Settings: Settings can be extracted from UI

### DIFF
--- a/openpype/tools/settings/settings/base.py
+++ b/openpype/tools/settings/settings/base.py
@@ -284,7 +284,7 @@ class BaseWidget(QtWidgets.QWidget):
             )
 
             # Copy as json
-            value = settings_data["value"]
+            value = settings_data[VALUE_KEY]
             json_encoded_data = None
             if isinstance(value, (dict, list)):
                 json_encoded_data = QtCore.QByteArray()

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -45,8 +45,15 @@ from .breadcrumbs_widget import (
     SystemSettingsBreadcrumbs,
     ProjectSettingsBreadcrumbs
 )
-
-from .base import GUIWidget
+from .constants import (
+    SETTINGS_PATH_KEY,
+    ROOT_KEY,
+    VALUE_KEY,
+)
+from .base import (
+    ExtractHelper,
+    GUIWidget,
+)
 from .list_item_widget import ListWidget
 from .list_strict_widget import ListStrictWidget
 from .dict_mutable_widget import DictMutableKeysWidget
@@ -627,10 +634,34 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
                 self._on_context_version_trigger
             )
             submenu.addAction(action)
+
         menu.addMenu(submenu)
+
+        extract_action = QtWidgets.QAction("Extract to file", menu)
+        extract_action.triggered.connect(self._on_extract_to_file)
+
+        menu.addAction(extract_action)
 
     def _on_context_version_trigger(self, version):
         self._on_source_version_change(version)
+
+    def _on_extract_to_file(self):
+        filepath = ExtractHelper.ask_for_save_filepath(self)
+        if not filepath:
+            return
+
+        settings_data = {
+            SETTINGS_PATH_KEY: self.entity.root_key,
+            ROOT_KEY: self.entity.root_key,
+            VALUE_KEY: self.entity.value
+        }
+        project_name = 0
+        if hasattr(self, "project_name"):
+            project_name = self.project_name
+
+        ExtractHelper.extract_settings_to_json(
+            filepath, settings_data, project_name
+        )
 
     def _on_reset_crash(self):
         self.save_btn.setEnabled(False)

--- a/openpype/tools/settings/settings/constants.py
+++ b/openpype/tools/settings/settings/constants.py
@@ -7,6 +7,12 @@ PROJECT_IS_ACTIVE_ROLE = QtCore.Qt.UserRole + 2
 PROJECT_IS_SELECTED_ROLE = QtCore.Qt.UserRole + 3
 PROJECT_VERSION_ROLE = QtCore.Qt.UserRole + 4
 
+# Save/Extract keys
+SETTINGS_PATH_KEY = "__settings_path__"
+ROOT_KEY = "__root_key__"
+VALUE_KEY = "__value__"
+SAVE_TIME_KEY = "__extracted__"
+PROJECT_NAME_KEY = "__project_name__"
 
 __all__ = (
     "DEFAULT_PROJECT_LABEL",
@@ -15,4 +21,11 @@ __all__ = (
     "PROJECT_IS_ACTIVE_ROLE",
     "PROJECT_IS_SELECTED_ROLE",
     "PROJECT_VERSION_ROLE",
+
+    "SETTINGS_PATH_KEY",
+    "ROOT_KEY",
+    "SETTINGS_PATH_KEY",
+    "VALUE_KEY",
+    "SAVE_TIME_KEY",
+    "PROJECT_NAME_KEY",
 )


### PR DESCRIPTION
## Brief description
Added option to extract current values into json file.

## Description
Extraction takes current values and extract them to a json file. It takes all values no matter if are overriden or not. Values are stored under keys with double underscores to be able differentiate what is value and what are metadata. Also added option to paste values from clipboard that are copied from different source or when whole file is copied.

## Additional information
Didn't add option to "open json file" because it would be hard to find out what user want's to do with it. This is not meant as backup of Project settings as it does not save only overrides but all values.

## Testing notes
### Extract values to file
1. Open settings UI
2. Right click on any item in settings and hit `Extract to file`
3. Select output file and hit Save
4. Check output

### Using extracted file
1. Open settings UI
2. Copy file in file explorer
3. Right click in settings where would you like to paste values
4. `Paste` action should be visible and if the saved file contains path there should be also `Paste to same place`
5. Try them

### Paste value as text
1. Open settings UI
2. Copy json content as text
```
# For example 'system_settings/modules/avalon'
{
    "AVALON_TIMEOUT": 666,
    "AVALON_THUMBNAIL_ROOT": {
        "windows": "D:/evil/directory",
        "darwin": "",
        "linux": ""
    }
}
```
3. Try to paste it into settings UI

Resolves https://github.com/pypeclub/OpenPype/issues/3271