### PR TITLE
Project Manager: fix tools not being visible until when editable

### DIFF
--- a/openpype/tools/project_manager/project_manager/delegates.py
+++ b/openpype/tools/project_manager/project_manager/delegates.py
@@ -205,3 +205,9 @@ class ToolsDelegate(QtWidgets.QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         model.setData(index, editor.value(), QtCore.Qt.EditRole)
+
+    def displayText(self, value, locale):
+        if value:
+            return ", ".join(value)
+        else:
+            return


### PR DESCRIPTION
(cherry picked from commit fbdd225c8b0cc579a022d69c179a5f90fc6a387d)

## Brief description

Show Tools of an asset even when not currently editing in Project Manager

## Description

Before:
![before](https://user-images.githubusercontent.com/2439881/173112659-3269ee22-1631-4259-8fce-6a130168817a.png)

After:
![after](https://user-images.githubusercontent.com/2439881/173112667-2e2adc3b-00e8-47c3-9926-577f1f593593.png)

## Testing notes:
1. Open Project Manager in a project that has custom tools assigned per asset
2. Confirm they are visible when directly going into the project (even when not editing)