### PR TITLE
Project Manager: Directly make task editable when clicking on the add Task button

### DIFF
--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -386,7 +386,7 @@ class HierarchyView(QtWidgets.QTreeView):
         self._source_model.delete_indexes(indexes)
 
     def _on_ctrl_shift_enter_pressed(self):
-        self._add_task_and_edit()
+        self.add_task_and_edit()
 
     def add_asset(self, parent_index=None):
         if parent_index is None:
@@ -428,9 +428,9 @@ class HierarchyView(QtWidgets.QTreeView):
         self.edit(new_index)
 
     def _add_task_action(self):
-        self._add_task_and_edit()
+        self.add_task_and_edit()
 
-    def _add_task_and_edit(self):
+    def add_task_and_edit(self):
         new_index = self.add_task()
         if new_index is None:
             return

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -245,7 +245,6 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self.hierarchy_view.add_asset()
 
     def _on_add_task(self):
-        # Colorbleed edit: force the task to directly be in edit mode
         self.hierarchy_view.add_task_and_edit()
 
     def _on_create_folders(self):

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -245,7 +245,8 @@ class ProjectManagerWindow(QtWidgets.QWidget):
         self.hierarchy_view.add_asset()
 
     def _on_add_task(self):
-        self.hierarchy_view.add_task()
+        # Colorbleed edit: force the task to directly be in edit mode
+        self.hierarchy_view._add_task_and_edit()
 
     def _on_create_folders(self):
         project_name = self._current_project()

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -246,7 +246,7 @@ class ProjectManagerWindow(QtWidgets.QWidget):
 
     def _on_add_task(self):
         # Colorbleed edit: force the task to directly be in edit mode
-        self.hierarchy_view._add_task_and_edit()
+        self.hierarchy_view.add_task_and_edit()
 
     def _on_create_folders(self):
         project_name = self._current_project()


### PR DESCRIPTION
(cherry picked from commit 96ca15b565b952d4e17c2010e8846ca18272d681)

## Brief description

This makes the "Task" button create a directly editable task for name/type like when doing right click -> Add Task.
Otherwise it makes a task for which it's unclear what to do next.

## Description

Before:
![afbeelding](https://user-images.githubusercontent.com/2439881/173113480-df205da8-0a53-4ddc-a655-374b3b484cfe.png)


After:
![afbeelding](https://user-images.githubusercontent.com/2439881/173113329-f031c81a-d6e5-46cc-b91c-bcdd52a9247e.png)


## Additional info

~I know this is not the way to fix it because it calls a private method. However, I'm opening this to start the discussion and approach a better solution. Maybe make that method not private?~ Made public with https://github.com/pypeclub/OpenPype/pull/3325/commits/cbc6fb8b330abc88c0e8c64c57a966cd09fd8077


## Testing notes:
1. Open Project Manager
2. Select an asset
3. Click on the "Task" button in the top left
4. The task should now directly be clearly editable and have a default type.