### PR TITLE
Nuke: Load full model hierarchy by default

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -60,6 +60,10 @@ class AlembicModelLoader(load.LoaderPlugin):
                 inpanel=False
             )
             model_node.forceValidate()
+
+            # workaround to load all geo nodes, not just top level ones
+            model_node.knob('scene_view').setAllItems(model_node.knob('scene_view').getAllItems(), True)
+
             model_node["frame_rate"].setValue(float(fps))
 
             # workaround because nuke's bug is not adding
@@ -141,6 +145,9 @@ class AlembicModelLoader(load.LoaderPlugin):
 
             model_node["frame_rate"].setValue(float(fps))
             model_node["file"].setValue(file)
+
+            # workaround to load all geo nodes, not just top level ones
+            model_node.knob('scene_view').setAllItems(model_node.knob('scene_view').getAllItems(), True)
 
             # workaround because nuke's bug is
             # not adding animation keys properly

--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -62,7 +62,9 @@ class AlembicModelLoader(load.LoaderPlugin):
             model_node.forceValidate()
 
             # workaround to load all geo nodes, not just top level ones
-            model_node.knob('scene_view').setAllItems(model_node.knob('scene_view').getAllItems(), True)
+            model_node.knob("scene_view").setAllItems(
+                model_node.knob("scene_view").getAllItems(), True
+            )
 
             model_node["frame_rate"].setValue(float(fps))
 
@@ -147,7 +149,9 @@ class AlembicModelLoader(load.LoaderPlugin):
             model_node["file"].setValue(file)
 
             # workaround to load all geo nodes, not just top level ones
-            model_node.knob('scene_view').setAllItems(model_node.knob('scene_view').getAllItems(), True)
+            model_node.knob("scene_view").setAllItems(
+                model_node.knob("scene_view").getAllItems(), True
+            )
 
             # workaround because nuke's bug is
             # not adding animation keys properly

--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -61,10 +61,10 @@ class AlembicModelLoader(load.LoaderPlugin):
             )
             model_node.forceValidate()
 
-            # workaround to load all geo nodes, not just top level ones
-            model_node.knob("scene_view").setAllItems(
-                model_node.knob("scene_view").getAllItems(), True
-            )
+            # Ensure all items are imported and selected.
+            scene_view = model_node.knob('scene_view')
+            scene_view.setImportedItems(scene_view.getAllItems())
+            scene_view.setSelectedItems(scene_view.getAllItems())
 
             model_node["frame_rate"].setValue(float(fps))
 
@@ -148,10 +148,10 @@ class AlembicModelLoader(load.LoaderPlugin):
             model_node["frame_rate"].setValue(float(fps))
             model_node["file"].setValue(file)
 
-            # workaround to load all geo nodes, not just top level ones
-            model_node.knob("scene_view").setAllItems(
-                model_node.knob("scene_view").getAllItems(), True
-            )
+            # Ensure all items are imported and selected.
+            scene_view = model_node.knob('scene_view')
+            scene_view.setImportedItems(scene_view.getAllItems())
+            scene_view.setSelectedItems(scene_view.getAllItems())
 
             # workaround because nuke's bug is
             # not adding animation keys properly


### PR DESCRIPTION
## Brief description
Fix Nuke model loader to select all geo nodes in the hierarchy for loading by default

## Description
The current implementation only selects top level geo nodes form the hierarchy, this fixes it by always selecting all geo nodes

## Additional info
Nuke pops up the Hierarchy window during Alembic loading to show which geo nodes are selected for loading. To avoid this popup, you have to set the following in preferences:

```python
preferencesNode = nuke.toNode('preferences')
preferencesNode.knob('DfltAbcAlwaysCreateAllInOne').setValue(True)
```

We put this into Nuke's `init.py` in our pipeline, we didn't want to hardcode it in here.  Without it loading/version switching especially on multiple geo nodes is really annoying.  Maybe there's a more streamlined solution to avoid this window? 