### PR TITLE
Standalone Publisher: Use client query functions

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_bulk_mov_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_bulk_mov_instances.py
@@ -3,7 +3,7 @@ import json
 import pyblish.api
 
 from openpype.lib import get_subset_name_with_asset_doc
-from openpype.pipeline import legacy_io
+from openpype.client import get_asset_by_name
 
 
 class CollectBulkMovInstances(pyblish.api.InstancePlugin):
@@ -24,12 +24,9 @@ class CollectBulkMovInstances(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         context = instance.context
+        project_name = context.data["projectEntity"]["name"]
         asset_name = instance.data["asset"]
-
-        asset_doc = legacy_io.find_one({
-            "type": "asset",
-            "name": asset_name
-        })
+        asset_doc = get_asset_by_name(project_name, asset_name)
         if not asset_doc:
             raise AssertionError((
                 "Couldn't find Asset document with name \"{}\""
@@ -52,7 +49,7 @@ class CollectBulkMovInstances(pyblish.api.InstancePlugin):
             self.subset_name_variant,
             task_name,
             asset_doc,
-            legacy_io.Session["AVALON_PROJECT"]
+            project_name
         )
         instance_name = f"{asset_name}_{subset_name}"
 

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
@@ -3,7 +3,7 @@ import re
 from copy import deepcopy
 import pyblish.api
 
-from openpype.client import get_asset_by_id, get_project
+from openpype.client import get_asset_by_id
 
 
 class CollectHierarchyInstance(pyblish.api.ContextPlugin):

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_hierarchy.py
@@ -3,7 +3,7 @@ import re
 from copy import deepcopy
 import pyblish.api
 
-from openpype.pipeline import legacy_io
+from openpype.client import get_asset_by_id, get_project
 
 
 class CollectHierarchyInstance(pyblish.api.ContextPlugin):
@@ -61,27 +61,32 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
             **instance.data["anatomyData"])
 
     def create_hierarchy(self, instance):
-        parents = list()
-        hierarchy = list()
-        visual_hierarchy = [instance.context.data["assetEntity"]]
+        asset_doc = instance.context.data["assetEntity"]
+        project_doc = instance.context.data["projectEntity"]
+        project_name = project_doc["name"]
+        visual_hierarchy = [asset_doc]
+        current_doc = asset_doc
         while True:
-            visual_parent = legacy_io.find_one(
-                {"_id": visual_hierarchy[-1]["data"]["visualParent"]}
-            )
-            if visual_parent:
-                visual_hierarchy.append(visual_parent)
-            else:
-                visual_hierarchy.append(
-                    instance.context.data["projectEntity"])
+            visual_parent_id = current_doc["data"]["visualParent"]
+            visual_parent = None
+            if visual_parent_id:
+                visual_parent = get_asset_by_id(project_name, visual_parent_id)
+
+            if not visual_parent:
+                visual_hierarchy.append(project_doc)
                 break
+            visual_hierarchy.append(visual_parent)
+            current_doc = visual_parent
 
         # add current selection context hierarchy from standalonepublisher
+        parents = list()
         for entity in reversed(visual_hierarchy):
             parents.append({
                 "entity_type": entity["data"]["entityType"],
                 "entity_name": entity["name"]
             })
 
+        hierarchy = list()
         if self.shot_add_hierarchy:
             parent_template_patern = re.compile(r"\{([a-z]*?)\}")
             # fill the parents parts from presets
@@ -129,9 +134,8 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
         self.log.debug(f"Hierarchy: {hierarchy}")
         self.log.debug(f"parents: {parents}")
 
+        tasks_to_add = dict()
         if self.shot_add_tasks:
-            tasks_to_add = dict()
-            project_doc = legacy_io.find_one({"type": "project"})
             project_tasks = project_doc["config"]["tasks"]
             for task_name, task_data in self.shot_add_tasks.items():
                 _task_data = deepcopy(task_data)
@@ -150,9 +154,7 @@ class CollectHierarchyInstance(pyblish.api.ContextPlugin):
                             task_name,
                             list(project_tasks.keys())))
 
-            instance.data["tasks"] = tasks_to_add
-        else:
-            instance.data["tasks"] = dict()
+        instance.data["tasks"] = tasks_to_add
 
         # updating hierarchy data
         instance.data["anatomyData"].update({

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_matching_asset.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_matching_asset.py
@@ -4,7 +4,7 @@ import collections
 import pyblish.api
 from pprint import pformat
 
-from openpype.pipeline import legacy_io
+from openpype.client import get_assets
 
 
 class CollectMatchingAssetToInstance(pyblish.api.InstancePlugin):
@@ -119,8 +119,9 @@ class CollectMatchingAssetToInstance(pyblish.api.InstancePlugin):
 
     def _asset_docs_by_parent_id(self, instance):
         # Query all assets for project and store them by parent's id to list
+        project_name = instance.context.data["projectEntity"]["name"]
         asset_docs_by_parent_id = collections.defaultdict(list)
-        for asset_doc in legacy_io.find({"type": "asset"}):
+        for asset_doc in get_assets(project_name):
             parent_id = asset_doc["data"]["visualParent"]
             asset_docs_by_parent_id[parent_id].append(asset_doc)
         return asset_docs_by_parent_id

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
@@ -1,9 +1,7 @@
 import pyblish.api
 
-from openpype.pipeline import (
-    PublishXmlValidationError,
-    legacy_io,
-)
+from openpype.client import get_assets
+from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateTaskExistence(pyblish.api.ContextPlugin):
@@ -20,15 +18,11 @@ class ValidateTaskExistence(pyblish.api.ContextPlugin):
         for instance in context:
             asset_names.add(instance.data["asset"])
 
-        asset_docs = legacy_io.find(
-            {
-                "type": "asset",
-                "name": {"$in": list(asset_names)}
-            },
-            {
-                "name": 1,
-                "data.tasks": 1
-            }
+        project_name = context.data["projectEntity"]["name"]
+        asset_docs = get_assets(
+            project_name,
+            asset_names=asset_names,
+            fields=["name", "data.tasks"]
         )
         tasks_by_asset_names = {}
         for asset_doc in asset_docs:


### PR DESCRIPTION
## Brief description
Modified standalone publisher plugins to use query functions from [PR](https://github.com/pypeclub/OpenPype/pull/3288).

## Description
Standalone publisher plugins are using query functions from `openpype.client`.

## Testing notes:
1. Run publishing in standalone publisher using one of modified plugins
    - editorial publishing
    - bulk mov publishing
2. Publishing should work as expected