### PR TITLE
Blender: Use client query functions

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -10,6 +10,7 @@ from . import ops
 
 import pyblish.api
 
+from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     schema,
     legacy_io,
@@ -83,11 +84,9 @@ def uninstall():
 
 
 def set_start_end_frames():
+    project_name = legacy_io.active_project()
     asset_name = legacy_io.Session["AVALON_ASSET"]
-    asset_doc = legacy_io.find_one({
-        "type": "asset",
-        "name": asset_name
-    })
+    asset_doc = get_asset_by_name(project_name, asset_name)
 
     scene = bpy.context.scene
 

--- a/openpype/hosts/blender/plugins/publish/extract_layout.py
+++ b/openpype/hosts/blender/plugins/publish/extract_layout.py
@@ -1,13 +1,11 @@
 import os
 import json
 
-from bson.objectid import ObjectId
-
 import bpy
 import bpy_extras
 import bpy_extras.anim_utils
 
-from openpype.pipeline import legacy_io
+from openpype.client import get_representation_by_name
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import AVALON_PROPERTY
 import openpype.api
@@ -131,43 +129,32 @@ class ExtractLayout(openpype.api.Extractor):
 
         fbx_count = 0
 
+        project_name = instance.context["projectEntity"]["name"]
         for asset in asset_group.children:
             metadata = asset.get(AVALON_PROPERTY)
 
-            parent = metadata["parent"]
+            version_id = metadata["parent"]
             family = metadata["family"]
 
-            self.log.debug("Parent: {}".format(parent))
+            self.log.debug("Parent: {}".format(version_id))
             # Get blend reference
-            blend = legacy_io.find_one(
-                {
-                    "type": "representation",
-                    "parent": ObjectId(parent),
-                    "name": "blend"
-                },
-                projection={"_id": True})
+            blend = get_representation_by_name(
+                project_name, "blend", version_id, fields=["_id"]
+            )
             blend_id = None
             if blend:
                 blend_id = blend["_id"]
             # Get fbx reference
-            fbx = legacy_io.find_one(
-                {
-                    "type": "representation",
-                    "parent": ObjectId(parent),
-                    "name": "fbx"
-                },
-                projection={"_id": True})
+            fbx = get_representation_by_name(
+                project_name, "fbx", version_id, fields=["_id"]
+            )
             fbx_id = None
             if fbx:
                 fbx_id = fbx["_id"]
             # Get abc reference
-            abc = legacy_io.find_one(
-                {
-                    "type": "representation",
-                    "parent": ObjectId(parent),
-                    "name": "abc"
-                },
-                projection={"_id": True})
+            abc = get_representation_by_name(
+                project_name, "abc", version_id, fields=["_id"]
+            )
             abc_id = None
             if abc:
                 abc_id = abc["_id"]

--- a/openpype/hosts/blender/plugins/publish/extract_layout.py
+++ b/openpype/hosts/blender/plugins/publish/extract_layout.py
@@ -129,7 +129,7 @@ class ExtractLayout(openpype.api.Extractor):
 
         fbx_count = 0
 
-        project_name = instance.context["projectEntity"]["name"]
+        project_name = instance.context.data["projectEntity"]["name"]
         for asset in asset_group.children:
             metadata = asset.get(AVALON_PROPERTY)
 


### PR DESCRIPTION
## Brief description
Blender is using query functions from [PR](https://github.com/pypeclub/OpenPype/pull/3288) instead of direct use of mongo queries.

## Description
Blender uses query functions from `openpype.client`.

## Testing notes:
1. Run blender
2. Frame start/end should be set to asset's resolution
3. Publish layout

PR waits for merge of [PR](https://github.com/pypeclub/OpenPype/pull/3288)