### PR TITLE
Deadline: added OPENPYPE_MONGO to filter

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -128,7 +128,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         "OPENPYPE_LOG_NO_COLORS",
         "OPENPYPE_USERNAME",
         "OPENPYPE_RENDER_JOB",
-        "OPENPYPE_PUBLISH_JOB"
+        "OPENPYPE_PUBLISH_JOB",
+        "OPENPYPE_MONGO"
     ]
 
     # custom deadline attributes


### PR DESCRIPTION
## Brief description
Submit job has filter of allowed environment values, it missed OPENPYPE_MONGO.

## Additional info
This issue will probably manifest only if deadline publish machine doesn't have set OPENPYPE_MONGO itself.

