### PR TITLE
Enhancement/ftrack-restrict-folder-creation-for-shot-and-asset-build-only-(rebranched)

### DIFF
--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -188,16 +188,17 @@ def compute_paths(basic_paths_items, project_root):
     return output
 
 
-def create_project_folders(basic_paths, project_name):
-    anatomy = Anatomy(project_name)
-    roots_paths = []
-    if isinstance(anatomy.roots, dict):
-        for root in anatomy.roots.values():
-            roots_paths.append(root.value)
-    else:
-        roots_paths.append(anatomy.roots.value)
+def create_project_folders(basic_paths, project_name, root_paths=None):
+    if root_paths is None:
+        anatomy = Anatomy(project_name)
+        root_paths=[]
+        if isinstance(anatomy.roots, dict):
+            for root in anatomy.roots.values():
+                root_paths.append(root.value)
+        else:
+            root_paths.append(anatomy.roots.value)
 
-    for root_path in roots_paths:
+    for root_path in root_paths:
         project_root = os.path.join(root_path, project_name)
         full_paths = compute_paths(basic_paths, project_root)
         # Create folders

--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -191,7 +191,7 @@ def compute_paths(basic_paths_items, project_root):
 def create_project_folders(basic_paths, project_name, root_paths=None):
     if root_paths is None:
         anatomy = Anatomy(project_name)
-        root_paths=[]
+        root_paths = []
         if isinstance(anatomy.roots, dict):
             for root in anatomy.roots.values():
                 root_paths.append(root.value)

--- a/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
@@ -75,10 +75,10 @@ class CreateFolders(BaseAction):
             {
                 "type": "label",
                 "value": "Create <b>Local Work</b> folders from OpenPype \
-                    template"
+                    Project Folders Template"
             },
             {
-                "name": "from_local_template",
+                "name": "from_local",
                 "type": "boolean",
                 "value": False
             },
@@ -103,11 +103,11 @@ class CreateFolders(BaseAction):
         with_interface = event["data"]["values"]["with_interface"]
         with_childrens = True
         restrict_folders = False
-        from_local_template = False
+        from_local = False
         if with_interface:
             with_childrens = event["data"]["values"]["children_included"]
             restrict_folders = event["data"]["values"]["restrict_folders"]
-            from_local_template = event["data"]["values"]["from_local_template"]
+            from_local = event["data"]["values"]["from_local"]
 
         filtered_entities = []
         for entity in entities:
@@ -230,15 +230,18 @@ class CreateFolders(BaseAction):
 
         self.log.info("Creating local template folders...")
 
-        if from_local_template:
+        if from_local:
             try:
                 # Get paths based on presets
                 basic_paths = get_project_basic_paths(project_name)
                 if not basic_paths:
                     pass
                 # Invoking OpenPype API to create the project folders
-                create_project_folders(basic_paths, project_name,
-                                    root_paths=[work_root])
+                create_project_folders(
+                    basic_paths,
+                    project_name,
+                    root_paths=[work_root]
+                )
                 self.log.info("successfully created local template folders.")
             except Exception as exc:
                 self.log.warning(

--- a/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
@@ -1,7 +1,11 @@
 import os
 import collections
 import copy
-from openpype.api import Anatomy
+from openpype.api import (
+    Anatomy,
+    get_project_basic_paths,
+    create_project_folders
+)
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 
 
@@ -51,10 +55,30 @@ class CreateFolders(BaseAction):
             },
             {
                 "type": "label",
-                "value": "With all chilren entities"
+                "value": "Create with all children entities"
             },
             {
                 "name": "children_included",
+                "type": "boolean",
+                "value": False
+            },
+            {
+                "type": "label",
+                "value": "Create publish and work folders \
+                    for <b>Shots</b> and <b>Asset Build</b> only"
+            },
+            {
+                "name": "restrict_folders",
+                "type": "boolean",
+                "value": False
+            },
+            {
+                "type": "label",
+                "value": "Create <b>Local Work</b> folders from OpenPype \
+                    template"
+            },
+            {
+                "name": "from_local_template",
                 "type": "boolean",
                 "value": False
             },
@@ -78,8 +102,12 @@ class CreateFolders(BaseAction):
 
         with_interface = event["data"]["values"]["with_interface"]
         with_childrens = True
+        restrict_folders = False
+        from_local_template = False
         if with_interface:
             with_childrens = event["data"]["values"]["children_included"]
+            restrict_folders = event["data"]["values"]["restrict_folders"]
+            from_local_template = event["data"]["values"]["from_local_template"]
 
         filtered_entities = []
         for entity in entities:
@@ -121,6 +149,10 @@ class CreateFolders(BaseAction):
         for key in work_keys:
             work_template = work_template[key]
 
+        work_root = self.compute_template(
+            anatomy, {}, work_keys
+        )
+
         publish_keys = ["publish", "folder"]
         publish_template = anatomy.templates
         for key in publish_keys:
@@ -154,7 +186,7 @@ class CreateFolders(BaseAction):
                 "parent": parent_name
             })
 
-            if not task_entities:
+            if not task_entities and not restrict_folders:
                 # create path for entity
                 collected_paths.append(self.compute_template(
                     anatomy, parent_data, work_keys
@@ -173,7 +205,7 @@ class CreateFolders(BaseAction):
                     "type": task_type_name
                 }
 
-                # Template wok
+                # Template work
                 collected_paths.append(self.compute_template(
                     anatomy, task_data, work_keys
                 ))
@@ -195,6 +227,24 @@ class CreateFolders(BaseAction):
             self.log.info(path)
             if not os.path.exists(path):
                 os.makedirs(path)
+
+        self.log.info("Creating local template folders...")
+
+        if from_local_template:
+            try:
+                # Get paths based on presets
+                basic_paths = get_project_basic_paths(project_name)
+                if not basic_paths:
+                    pass
+                # Invoking OpenPype API to create the project folders
+                create_project_folders(basic_paths, project_name,
+                                    root_paths=[work_root])
+                self.log.info("successfully created local template folders.")
+            except Exception as exc:
+                self.log.warning(
+                    "Cannot create starting folders: {}".format(exc),
+                    exc_info=True
+                )
 
         return {
             "success": True,

--- a/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
@@ -228,7 +228,6 @@ class CreateFolders(BaseAction):
             if not os.path.exists(path):
                 os.makedirs(path)
 
-
         if from_local:
             self.log.info("Creating local template folders...") 
             try:
@@ -241,7 +240,9 @@ class CreateFolders(BaseAction):
                         project_name,
                         root_paths=[work_root]
                     )
-                    self.log.info("successfully created local template folders.")
+                    self.log.info(
+                        "successfully created local template folders."
+                    )
             except Exception as exc:
                 self.log.warning(
                     "Cannot create starting folders: {}".format(exc),

--- a/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
@@ -228,21 +228,20 @@ class CreateFolders(BaseAction):
             if not os.path.exists(path):
                 os.makedirs(path)
 
-        self.log.info("Creating local template folders...")
 
         if from_local:
+            self.log.info("Creating local template folders...") 
             try:
                 # Get paths based on presets
                 basic_paths = get_project_basic_paths(project_name)
-                if not basic_paths:
-                    pass
-                # Invoking OpenPype API to create the project folders
-                create_project_folders(
-                    basic_paths,
-                    project_name,
-                    root_paths=[work_root]
-                )
-                self.log.info("successfully created local template folders.")
+                if basic_paths:
+                    # Invoking OpenPype API to create the project folders
+                    create_project_folders(
+                        basic_paths,
+                        project_name,
+                        root_paths=[work_root]
+                    )
+                    self.log.info("successfully created local template folders.")
             except Exception as exc:
                 self.log.warning(
                     "Cannot create starting folders: {}".format(exc),


### PR DESCRIPTION
## Brief description
Option to skip folders without tasks when creating publish and work folders ahead of time
Option to create the local folder structure directly from Ftrack (only in the work root, where it makes sense)

## Description
Current behaviour was creating publish and work folders in every ftrack folder indiscriminately, and also replicated the whole structure in all the root paths when triggered from the standalone project manager.
Made the first step optional using a checkbox on Creation dialog, and also added the option (still through checkbox) to create the complete project directory structure taken from the global project settings directly from Ftrack.

## Additional info
REBRANCHED FROM DEVELOP TO FIX BRANCH INDEPENDENCE ISSUE!
There was a need to override the logic in lib/path_tools.py (to restrict the creation to the work root only).
I exposed a new named arg that has the default value reflecting the old behaviour for compatibility (and while the old behaviour seems like a bug to me it can actually be correct in other places so..)

## Documentation (add "type: documentation" label)
no docs

Testing notes:
1. go to ftrack
2. get to the project
3. actions/create folders
4. set the checkbox as needed (we check all of three to get the desidered output)
5. enjoy the folders if you need them!