### PR TITLE
General: Handle empty source key on instance

### DIFF
--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -940,9 +940,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         families += current_families
 
         # create relative source path for DB
-        if "source" in instance.data:
-            source = instance.data["source"]
-        else:
+        source = instance.data.get("source")
+        if not source:
             source = context.data["currentFile"]
             anatomy = instance.context.data["anatomy"]
             source = self.get_rootless_path(anatomy, source)


### PR DESCRIPTION
## Brief description
Handle cases when instance contain `"source"` key but is empty during integration.

## Description
Missing `"source"` key causes crashes because of invalid type in version document. Changed in a way that empty source value on instance is ignored and in that case is used source as current file from context.

## Testing notes:
Not sure?
1. Happened during publishing in hiero

Develop variant of [PR](https://github.com/pypeclub/OpenPype/pull/3341)