### PR TITLE
General: Fix last version function

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -23,7 +23,7 @@ def _get_project_connection(project_name=None):
     return mongodb
 
 
-def _prepare_fields(fields, ensure_fields=None):
+def _prepare_fields(fields, required_fields=None):
     if not fields:
         return None
 
@@ -34,8 +34,8 @@ def _prepare_fields(fields, ensure_fields=None):
     if "_id" not in output:
         output["_id"] = True
 
-    if ensure_fields:
-        for key in ensure_fields:
+    if required_fields:
+        for key in required_fields:
             output[key] = True
     return output
 

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -23,7 +23,7 @@ def _get_project_connection(project_name=None):
     return mongodb
 
 
-def _prepare_fields(fields):
+def _prepare_fields(fields, ensure_fields=None):
     if not fields:
         return None
 
@@ -33,6 +33,10 @@ def _prepare_fields(fields):
     }
     if "_id" not in output:
         output["_id"] = True
+
+    if ensure_fields:
+        for key in ensure_fields:
+            output[key] = True
     return output
 
 
@@ -655,9 +659,8 @@ def get_last_versions(project_name, subset_ids, fields=None):
         doc["_version_id"]
         for doc in conn.aggregate(_pipeline)
     ]
-    fields = _prepare_fields(fields)
-    if fields and "parent" not in fields:
-        fields.append("parent")
+
+    fields = _prepare_fields(fields, ["parent"])
 
     version_docs = get_versions(
         project_name, version_ids=version_ids, fields=fields


### PR DESCRIPTION
## Brief description
Function `get_last_verisons` does not crash if `fields` are passed and do not contain `"parent"` key.

## Description
Missing `"parent"` key was not added to required fields properly.

## Testing notes:
Bug was spotted in standalone publisher where in specific cases is called this function.

It is possible to test in Tray > Admin > Console
```
from openpype.client import get_last_versions, get_subsets

# Fill your project name
project_name = "some project name"

# Find any random subset
any_subset = None
for subset in get_subsets(project_name):
    any_subset = subset
    break

# Run fixed function with fields that don't have "parent" key
# - this line should not crash
versions = get_last_versions(project_name, [any_subset["_id"]], fields=["name"])
```
