### PR TITLE
Deadline: removed wrong targets on Extractor

### DIFF
--- a/openpype/api.py
+++ b/openpype/api.py
@@ -44,7 +44,6 @@ from . import resources
 
 from .plugin import (
     Extractor,
-    Integrator,
 
     ValidatePipelineOrder,
     ValidateContentsOrder,
@@ -87,7 +86,6 @@ __all__ = [
 
     # plugin classes
     "Extractor",
-    "Integrator",
     # ordering
     "ValidatePipelineOrder",
     "ValidateContentsOrder",

--- a/openpype/hosts/aftereffects/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/aftereffects/plugins/publish/validate_scene_settings.py
@@ -54,7 +54,7 @@ class ValidateSceneSettings(OptionalPyblishPluginMixin,
 
     order = pyblish.api.ValidatorOrder
     label = "Validate Scene Settings"
-    families = ["render.farm", "render"]
+    families = ["render.farm", "render.local", "render"]
     hosts = ["aftereffects"]
     optional = True
 

--- a/openpype/modules/deadline/plugins/publish/submit_aftereffects_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_aftereffects_deadline.py
@@ -33,6 +33,7 @@ class AfterEffectsSubmitDeadline(
     hosts = ["aftereffects"]
     families = ["render.farm"]  # cannot be "render' as that is integrated
     use_published = True
+    targets = ["local"]
 
     priority = 50
     chunk_size = 1000000

--- a/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -238,6 +238,7 @@ class HarmonySubmitDeadline(
     order = pyblish.api.IntegratorOrder + 0.1
     hosts = ["harmony"]
     families = ["render.farm"]
+    targets = ["local"]
 
     optional = True
     use_published = False

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -287,6 +287,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
     order = pyblish.api.IntegratorOrder + 0.1
     hosts = ["maya"]
     families = ["renderlayer"]
+    targets = ["local"]
 
     use_published = True
     tile_assembler_plugin = "OpenPypeTileAssembler"

--- a/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
@@ -10,7 +10,7 @@ import openpype.api
 import pyblish.api
 
 
-class MayaSubmitRemotePublishDeadline(openpype.api.Integrator):
+class MayaSubmitRemotePublishDeadline(pyblish.api.InstancePlugin):
     """Submit Maya scene to perform a local publish in Deadline.
 
     Publishing in Deadline can be helpful for scenes that publish very slow.
@@ -31,6 +31,7 @@ class MayaSubmitRemotePublishDeadline(openpype.api.Integrator):
     order = pyblish.api.IntegratorOrder
     hosts = ["maya"]
     families = ["publish.farm"]
+    targets = ["local"]
 
     def process(self, instance):
         settings = get_project_settings(os.getenv("AVALON_PROJECT"))

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -23,6 +23,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
     hosts = ["nuke", "nukestudio"]
     families = ["render.farm", "prerender.farm"]
     optional = True
+    targets = ["local"]
 
     # presets
     priority = 50

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -103,6 +103,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
     order = pyblish.api.IntegratorOrder + 0.2
     icon = "tractor"
     deadline_plugin = "OpenPype"
+    targets = ["local"]
 
     hosts = ["fusion", "maya", "nuke", "celaction", "aftereffects", "harmony"]
 

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -829,9 +829,10 @@ class CreateContext:
             discover_result = publish_plugins_discover()
             publish_plugins = discover_result.plugins
 
-            targets = pyblish.logic.registered_targets() or ["default"]
+            targets = set(pyblish.logic.registered_targets())
+            targets.add("default")
             plugins_by_targets = pyblish.logic.plugins_by_targets(
-                publish_plugins, targets
+                publish_plugins, list(targets)
             )
             # Collect plugins that can have attribute definitions
             for plugin in publish_plugins:

--- a/openpype/plugin.py
+++ b/openpype/plugin.py
@@ -18,16 +18,6 @@ class InstancePlugin(pyblish.api.InstancePlugin):
         super(InstancePlugin, cls).process(cls, *args, **kwargs)
 
 
-class Integrator(InstancePlugin):
-    """Integrator base class.
-
-    Wraps pyblish instance plugin. Targets set to "local" which means all
-    integrators should run on "local" publishes, by default.
-    "remote" targets could be used for integrators that should run externally.
-    """
-    targets = ["local"]
-
-
 class Extractor(InstancePlugin):
     """Extractor base class.
 
@@ -37,8 +27,6 @@ class Extractor(InstancePlugin):
     This temporary directory is generated through `tempfile.mkdtemp()`
 
     """
-
-    targets = ["local"]
 
     order = 2.0
 


### PR DESCRIPTION
## Brief description
This caused missing extractors that should be running on a farm (Slate extractor for Nuke...).
Explicitly set all plugins creating jobs on DL to be triggered only on local.


## Testing notes:
1. Try publish Nuke job that renders and publish Slates.
2. Try publishing Maya job