### PR TITLE
General: Create only one thumbnail per instance

### DIFF
--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -105,6 +105,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 "Adding thumbnail representation: {}".format(new_repre)
             )
             instance.data["representations"].append(new_repre)
+            # There is no need to create more then one thumbnail
+            break
 
     def _get_filtered_repres(self, instance):
         filtered_repres = []

--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -92,17 +92,19 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 return
 
             new_repre = {
-                    "name": "thumbnail",
-                    "ext": "jpg",
-                    "files": jpeg_file,
-                    "stagingDir": stagingdir,
-                    "thumbnail": True,
-                    "tags": ["thumbnail"]
-                }
+                "name": "thumbnail",
+                "ext": "jpg",
+                "files": jpeg_file,
+                "stagingDir": stagingdir,
+                "thumbnail": True,
+                "tags": ["thumbnail"]
+            }
 
-        # adding representation
-        self.log.debug("Adding: {}".format(new_repre))
-        instance.data["representations"].append(new_repre)
+            # adding representation
+            self.log.debug(
+                "Adding thumbnail representation: {}".format(new_repre)
+            )
+            instance.data["representations"].append(new_repre)
 
     def _get_filtered_repres(self, instance):
         filtered_repres = []


### PR DESCRIPTION
## Brief description
Fixed unexisting variable and only one thumbnail is created for an instance.

## Description
Extract thumbnail plugin did not check if any thumbnail was created or if was created more than one thumbnail. In case when more thumbnails was created was used only the last one, and plugin crashes if none was created.

## Testing notes:
1. Trigger farm publish which won't have representation that would be used as thumbnail source.
2. It should not crash if none thumbnail was created.
Don't know how to achieve that.