### PR TITLE
Ftrack: Removed requirement of pypeclub role from default settings

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_create_cust_attrs.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_cust_attrs.py
@@ -140,9 +140,9 @@ class CustomAttributes(BaseAction):
     identifier = 'create.update.attributes'
     #: Action label.
     label = "OpenPype Admin"
-    variant = '- Create/Update Avalon Attributes'
+    variant = '- Create/Update Custom Attributes'
     #: Action description.
-    description = 'Creates Avalon/Mongo ID for double check'
+    description = 'Creates required custom attributes in ftrack'
     icon = statics_icon("ftrack", "action_icons", "OpenPypeAdmin.svg")
     settings_key = "create_update_attributes"
 

--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -59,13 +59,11 @@
                 "applications": {
                     "write_security_roles": [
                         "API",
-                        "Administrator",
-                        "Pypeclub"
+                        "Administrator"
                     ],
                     "read_security_roles": [
                         "API",
-                        "Administrator",
-                        "Pypeclub"
+                        "Administrator"
                     ]
                 }
             },
@@ -73,25 +71,21 @@
                 "tools_env": {
                     "write_security_roles": [
                         "API",
-                        "Administrator",
-                        "Pypeclub"
+                        "Administrator"
                     ],
                     "read_security_roles": [
                         "API",
-                        "Administrator",
-                        "Pypeclub"
+                        "Administrator"
                     ]
                 },
                 "avalon_mongo_id": {
                     "write_security_roles": [
                         "API",
-                        "Administrator",
-                        "Pypeclub"
+                        "Administrator"
                     ],
                     "read_security_roles": [
                         "API",
-                        "Administrator",
-                        "Pypeclub"
+                        "Administrator"
                     ]
                 },
                 "fps": {

--- a/website/docs/module_ftrack.md
+++ b/website/docs/module_ftrack.md
@@ -26,7 +26,7 @@ You can only use our Ftrack Actions and publish to Ftrack if each artist is logg
 ### Custom Attributes
 After successfully connecting OpenPype with you Ftrack, you can right click on any project in Ftrack and you should see a bunch of actions available. The most important one is called `OpenPype Admin` and contains multiple options inside.
 
-To prepare Ftrack for working with OpenPype you'll need to run [OpenPype Admin - Create/Update Avalon Attributes](manager_ftrack_actions.md#create-update-avalon-attributes), which creates and sets the Custom Attributes necessary for OpenPype to function. 
+To prepare Ftrack for working with OpenPype you'll need to run [OpenPype Admin - Create/Update Custom Attributes](manager_ftrack_actions.md#create-update-avalon-attributes), which creates and sets the Custom Attributes necessary for OpenPype to function. 
 
 
 


### PR DESCRIPTION
## Brief description
Ftrack settings don't have `pypeclub` role for custom attributes creation in defaults.

## Descritpion
Create/Update of custom attributes does not require `pypeclub` role by default. Changed label of action to `Create/Update Custom Attributes`.

## Testing notes:
1. Remove `pypeclub` role from ftrack (if is there)
2. Run action to Create/Update Avalon attributes which should not fail if the role is not in ftrack