### PR TITLE
Standalone: settings improvements

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_trim_video_audio.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_trim_video_audio.py
@@ -39,10 +39,13 @@ class ExtractTrimVideoAudio(openpype.api.Extractor):
         # Generate mov file.
         fps = instance.data["fps"]
         video_file_path = instance.data["editorialSourcePath"]
-        extensions = instance.data.get("extensions", [".mov"])
+        extensions = instance.data.get("extensions", ["mov"])
 
         for ext in extensions:
             self.log.info("Processing ext: `{}`".format(ext))
+
+            if not ext.startswith("."):
+                ext = "." + ext
 
             clip_trimed_path = os.path.join(
                 staging_dir, instance.data["name"] + ext)

--- a/openpype/settings/defaults/project_settings/standalonepublisher.json
+++ b/openpype/settings/defaults/project_settings/standalonepublisher.json
@@ -257,12 +257,14 @@
             ]
         },
         "CollectHierarchyInstance": {
+            "shot_rename": true,
             "shot_rename_template": "{project[code]}_{_sequence_}_{_shot_}",
             "shot_rename_search_patterns": {
-                "_sequence_": "(\\d{4})(?=_\\d{4})",
-                "_shot_": "(\\d{4})(?!_\\d{4})"
+                "_sequence_": "(sc\\d{3})",
+                "_shot_": "(sh\\d{3})"
             },
             "shot_add_hierarchy": {
+                "enabled": true,
                 "parents_path": "{project}/{folder}/{sequence}",
                 "parents": {
                     "project": "{project[name]}",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_standalonepublisher.json
@@ -272,6 +272,11 @@
                     "is_group": true,
                     "children": [
                         {
+                            "type": "boolean",
+                            "key": "shot_rename",
+                            "label": "Shot Rename"
+                        },
+                        {
                             "type": "text",
                             "key": "shot_rename_template",
                             "label": "Shot rename template"
@@ -289,7 +294,13 @@
                             "type": "dict",
                             "key": "shot_add_hierarchy",
                             "label": "Shot hierarchy",
+                            "checkbox_key": "enabled",
                             "children": [
+                                {
+                                    "type": "boolean",
+                                    "key": "enabled",
+                                    "label": "Enabled"
+                                },
                                 {
                                     "type": "text",
                                     "key": "parents_path",
@@ -343,8 +354,8 @@
                             "type": "number",
                             "key": "timeline_frame_start",
                             "label": "Timeline start frame",
-                            "default": 900000,
-                            "minimum": 1,
+                            "default": 90000,
+                            "minimum": 0,
                             "maximum": 10000000
                         },
                         {


### PR DESCRIPTION
## Brief description
Added missing settings for shot rename switch

## Description
- also added hierarchy switch for cases we dont need to create hierarchy from scratch and want to use selected hierarchy from standalone.

## Additional info
For testing of simple editorial publishing use (this files)[https://drive.google.com/drive/folders/1iMAcgRvt6Px-LCwJmwhJDi0qBSaPf7Cn]

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. open standalone publisher
2. in Settings on your project set `project_settings/standalonepublisher/publish/CollectHierarchyInstance/shot_add_hierarchy/enabled` to False.
3. use testing .edl as file to process, set hierarchy where you want those to be at parent and select `editorial` family