### PR TITLE
deadline: fixing misidentification of revieables

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -642,9 +642,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
     def _solve_families(self, instance, preview=False):
         families = instance.get("families")
 
-        # test also instance data review attribute
-        preview = preview or instance.get("review")
-
         # if we have one representation with preview tag
         # flag whole instance for review and for ftrack
         if preview:
@@ -726,6 +723,10 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
         families = ["render"]
 
+        # pass review to families if marked as review
+        if data.get("review"):
+            families.append("review")
+
         instance_skeleton_data = {
             "family": "render",
             "subset": subset,
@@ -753,10 +754,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             instance_skeleton_data.update({
                 "family": "prerender",
                 "families": []})
-
-        # also include review attribute if available
-        if "review" in data:
-            instance_skeleton_data["review"] = data["review"]
 
         # skip locking version if we are creating v01
         instance_version = instance.data.get("version")  # take this if exists

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -722,14 +722,17 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 " This may cause issues."
             ).format(source))
 
-        families = ["render"]
+        family = "render"
+        if "prerender" in instance.data["families"]:
+            family = "prerender"
+        families = [family]
 
         # pass review to families if marked as review
         if data.get("review"):
             families.append("review")
 
         instance_skeleton_data = {
-            "family": "render",
+            "family": family,
             "subset": subset,
             "families": families,
             "asset": asset,
@@ -750,11 +753,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "jobBatchName": data.get("jobBatchName", ""),
             "useSequenceForReview": data.get("useSequenceForReview", True)
         }
-
-        if "prerender" in instance.data["families"]:
-            instance_skeleton_data.update({
-                "family": "prerender",
-                "families": []})
 
         # skip locking version if we are creating v01
         instance_version = instance.data.get("version")  # take this if exists


### PR DESCRIPTION
## Brief description
fixing wrong `review` attribute distribution

## Testing notes:
1. start your host supporting farm publishing
2. set your farm instance and set it to `review` **on** and publish
2.1. it should be reviewable on ftrack
3. set your farm instance and set it to `review` **off** and publish
3.1. it should not be reveiwable on ftrack