### PR TITLE
Hosts: More options for in-host callbacks

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -797,8 +797,14 @@ def update_current_task(task=None, asset=None, app=None, template_key=None):
         else:
             os.environ[key] = value
 
+    data = changes.copy()
+    # Convert env keys to human readable keys
+    data["project_name"] = legacy_io.Session["AVALON_PROJECT"]
+    data["asset_name"] = legacy_io.Session["AVALON_ASSET"]
+    data["task_name"] = legacy_io.Session["AVALON_TASK"]
+
     # Emit session change
-    emit_event("taskChanged", changes.copy())
+    emit_event("taskChanged", data)
 
     return changes
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -463,6 +463,25 @@ class OpenPypeModule:
 
         pass
 
+    def on_host_install(self, host, host_name, project_name):
+        """Host was installed which gives option to handle in-host logic.
+
+        It is a good option to register in-host event callbacks which are
+        specific for the module. The module is kept in memory for rest of
+        the process.
+
+        Arguments may change in future. E.g. 'host_name' should be possible
+        to receive from 'host' object.
+
+        Args:
+            host (ModuleType): Access to installed/registered host object.
+            host_name (str): Name of host.
+            project_name (str): Project name which is main part of host
+                context.
+        """
+
+        pass
+
     def cli(self, module_click_group):
         """Add commands to click group.
 

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -16,9 +16,7 @@ from openpype.modules import load_modules, ModulesManager
 from openpype.settings import get_project_settings
 from openpype.lib import (
     Anatomy,
-    register_event_callback,
     filter_pyblish_plugins,
-    change_timer_to_current_context,
 )
 
 from . import (
@@ -117,8 +115,6 @@ def install_host(host):
 
     register_host(host)
 
-    register_event_callback("taskChanged", _on_task_change)
-
     def modified_emit(obj, record):
         """Method replacing `emit` in Pyblish's MessageHandler."""
         record.msg = record.getMessage()
@@ -195,10 +191,6 @@ def install_openpype_plugins(project_name=None, host_name=None):
             register_loader_plugin_path(path)
             register_creator_plugin_path(path)
             register_inventory_action(path)
-
-
-def _on_task_change():
-    change_timer_to_current_context()
 
 
 def uninstall_host():

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -88,7 +88,6 @@ def install_host(host):
             avalon host-interface.
     """
     global _is_installed
-    global _modules_manager
 
     _is_installed = True
 


### PR DESCRIPTION
## Brief description
Modules are acknowledged on host installation that host was installed so they can register their specific callbacks. Workfiles tool also trigger events on workfile open. Moved start timer callback on task change to timers manager.

## Description
Modules have method `on_host_install` which is called when `install_host` is called, these modules are kept in memory (they're not refreshed for rest of process) that is because modules would be garbage collected and their callbacks would not work. Workfiles tool is triggering `workfile.open.before` and `workfile.open.after`. All events triggered from workfiles tool also contain context information (host name, project name, asset name and task name) so it's not just blind information. Task changed topic has human readable keys. Logic related to start timer on task change was moved to timers manager module.

## Additional information
Reason of this feature is to be able register event callbacks which are module specific and to be able catch workfiles opening when workfiles tool is used.

## Testing notes:
Change related to timers manager:
1. Make that you have some module with time management enabled (e.g. ftrack module)
2. Run application on a task (timer should start for the task)
3. Change context to different task using workfiles tool inside host
4. Check if timer for the new task was started

New feature adding ability to catch host installation:
1. Implement in any module method `on_host_install` where you can do some logic which you want.