### PR TITLE
Nuke: Fix precollect writes

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/precollect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_writes.py
@@ -72,12 +72,12 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             if "representations" not in instance.data:
                 instance.data["representations"] = list()
 
-                representation = {
-                    'name': ext,
-                    'ext': ext,
-                    "stagingDir": output_dir,
-                    "tags": list()
-                }
+            representation = {
+                'name': ext,
+                'ext': ext,
+                "stagingDir": output_dir,
+                "tags": list()
+            }
 
             try:
                 collected_frames = [f for f in os.listdir(output_dir)


### PR DESCRIPTION
## Brief description
Always create variable representation in precollect writes.

## Description
Representation variable was created only if "representations" key was not in instance.data.

## Testing notes:
1. Create instance of write in nuke
2. Run publish
3. Collecting should not crash