### PR TITLE
Maya: Fix collector Maya 2019 support

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -28,18 +28,19 @@ def get_all_children(nodes):
         dag = sel.getDagPath(0)
 
         iterator.reset(dag)
-        iterator.next()  # ignore self
+        # ignore self
+        iterator.next()  # noqa: B305
         while not iterator.isDone():
 
             path = iterator.fullPathName()
 
             if path in traversed:
                 iterator.prune()
-                iterator.next()
+                iterator.next()  # noqa: B305
                 continue
 
             traversed.add(path)
-            iterator.next()
+            iterator.next()  # noqa: B305
 
     return list(traversed)
 

--- a/openpype/hosts/maya/plugins/publish/collect_instances.py
+++ b/openpype/hosts/maya/plugins/publish/collect_instances.py
@@ -28,18 +28,18 @@ def get_all_children(nodes):
         dag = sel.getDagPath(0)
 
         iterator.reset(dag)
-        next(iterator)  # ignore self
+        iterator.next()  # ignore self
         while not iterator.isDone():
 
             path = iterator.fullPathName()
 
             if path in traversed:
                 iterator.prune()
-                next(iterator)
+                iterator.next()
                 continue
 
             traversed.add(path)
-            next(iterator)
+            iterator.next()
 
     return list(traversed)
 


### PR DESCRIPTION
## Brief description

Maya 2019 support was broken in collectors. This was reported to me by Petr Kalis on Discord.
Explanation in comment [here](https://github.com/pypeclub/OpenPype/commit/122536675fb043fda7d62710149c65cfd089d674#commitcomment-76327122)

## Description

`__iter__` is only implemented in Maya 2020+ for Maya Python 2.0 iterators.

## Testing notes:
1. Use Maya 2019
2. Publish an instance