### PR TITLE
Harmony: audio validator has wrong logic

### DIFF
--- a/openpype/hosts/harmony/plugins/publish/validate_audio.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_audio.py
@@ -47,6 +47,6 @@ class ValidateAudio(pyblish.api.InstancePlugin):
         formatting_data = {
             "audio_url": audio_path
         }
-        if os.path.isfile(audio_path):
+        if not os.path.isfile(audio_path):
             raise PublishXmlValidationError(self, msg,
                                             formatting_data=formatting_data)


### PR DESCRIPTION
## Brief description
Wrong condition stayed after change from asset to raise (it should be negated).


## Testing notes:
1. add some audio file into Harmony
2. validator shouldnt trigger