### PR TITLE
General: Add ability to change user value for templates

### DIFF
--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -7,7 +7,6 @@ import platform
 import logging
 import collections
 import functools
-import getpass
 
 from bson.objectid import ObjectId
 
@@ -19,6 +18,7 @@ from .anatomy import Anatomy
 from .profiles_filtering import filter_profiles
 from .events import emit_event
 from .path_templates import StringTemplate
+from .local_settings import get_openpype_username
 
 legacy_io = None
 
@@ -550,7 +550,7 @@ def get_workdir_data(project_doc, asset_doc, task_name, host_name):
         "asset": asset_doc["name"],
         "parent": parent_name,
         "app": host_name,
-        "user": getpass.getuser(),
+        "user": get_openpype_username(),
         "hierarchy": hierarchy,
     }
 

--- a/openpype/plugins/publish/collect_current_pype_user.py
+++ b/openpype/plugins/publish/collect_current_pype_user.py
@@ -1,5 +1,3 @@
-import os
-import getpass
 import pyblish.api
 from openpype.lib import get_openpype_username
 

--- a/website/docs/admin_settings_project_anatomy.md
+++ b/website/docs/admin_settings_project_anatomy.md
@@ -68,6 +68,7 @@ We have a few required anatomy templates for OpenPype to work properly, however 
 | `representation` | Representation name |
 | `frame` | Frame number for sequence files. |
 | `app` | Application Name |
+| `user` | User's login name (can be overridden in local settings) |
 | `output` |  |
 | `comment` |  |
 


### PR DESCRIPTION
## Brief description
Use `get_openpype_username` to receive value for `user` key in template data collection.

## Description
This function is in openpype for a long time but was not fully used. It just gives ability to change username for templates instead of usign user name from machine by changing it in local settings.

## Documentation
Added `"user"` key to available template keys.

## Testing notes:
1. Change username in local settings UI
2. Add `"{user}"` to any template (e.g. publish)
3. Do something in a way that template is filled (e.g. run publish)
4. Check the create filepath if contains changed username from local settings