### PR TITLE
Nuke: bake streams with slate on farm

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -55,8 +55,8 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         self._ver = re.search(r"\d+\.\d+", context.data.get("hostVersion"))
         self._deadline_user = context.data.get(
             "deadlineUser", getpass.getuser())
-        self._frame_start = int(instance.data["frameStartHandle"])
-        self._frame_end = int(instance.data["frameEndHandle"])
+        submit_frame_start = int(instance.data["frameStartHandle"])
+        submit_frame_end = int(instance.data["frameEndHandle"])
 
         # get output path
         render_path = instance.data['path']
@@ -82,13 +82,16 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
 
         # exception for slate workflow
         if "slate" in instance.data["families"]:
-            self._frame_start -= 1
+            submit_frame_start -= 1
 
-        response = self.payload_submit(instance,
-                                       script_path,
-                                       render_path,
-                                       node.name()
-                                       )
+        response = self.payload_submit(
+            instance,
+            script_path,
+            render_path,
+            node.name(),
+            submit_frame_start,
+            submit_frame_end
+        )
         # Store output dir for unified publisher (filesequence)
         instance.data["deadlineSubmissionJob"] = response.json()
         instance.data["outputDir"] = os.path.dirname(
@@ -96,20 +99,22 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         instance.data["publishJobState"] = "Suspended"
 
         if instance.data.get("bakingNukeScripts"):
+            # exception for slate workflow
+            if "slate" in instance.data["families"]:
+                submit_frame_start += 1
+
             for baking_script in instance.data["bakingNukeScripts"]:
                 render_path = baking_script["bakeRenderPath"]
                 script_path = baking_script["bakeScriptPath"]
                 exe_node_name = baking_script["bakeWriteNodeName"]
-
-                # exception for slate workflow
-                if "slate" in instance.data["families"]:
-                    self._frame_start += 1
 
                 resp = self.payload_submit(
                     instance,
                     script_path,
                     render_path,
                     exe_node_name,
+                    submit_frame_start,
+                    submit_frame_end,
                     response.json()
                 )
 
@@ -126,13 +131,16 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             families.insert(0, "prerender")
         instance.data["families"] = families
 
-    def payload_submit(self,
-                       instance,
-                       script_path,
-                       render_path,
-                       exe_node_name,
-                       responce_data=None
-                       ):
+    def payload_submit(
+        self,
+        instance,
+        script_path,
+        render_path,
+        exe_node_name,
+        start_frame,
+        end_frame,
+        responce_data=None
+    ):
         render_dir = os.path.normpath(os.path.dirname(render_path))
         script_name = os.path.basename(script_path)
         jobname = "%s - %s" % (script_name, instance.name)
@@ -192,8 +200,8 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
 
                 "Plugin": "Nuke",
                 "Frames": "{start}-{end}".format(
-                    start=self._frame_start,
-                    end=self._frame_end
+                    start=start_frame,
+                    end=end_frame
                 ),
                 "Comment": self._comment,
 
@@ -293,7 +301,13 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         self.log.info(json.dumps(payload, indent=4, sort_keys=True))
 
         # adding expectied files to instance.data
-        self.expected_files(instance, render_path)
+        self.expected_files(
+            instance,
+            render_path,
+            start_frame,
+            end_frame
+        )
+
         self.log.debug("__ expectedFiles: `{}`".format(
             instance.data["expectedFiles"]))
         response = requests.post(self.deadline_url, json=payload, timeout=10)
@@ -339,9 +353,13 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             self.log.debug("_ path: `{}`".format(path))
         return path
 
-    def expected_files(self,
-                       instance,
-                       path):
+    def expected_files(
+        self,
+        instance,
+        path,
+        start_frame,
+        end_frame
+    ):
         """ Create expected files in instance data
         """
         if not instance.data.get("expectedFiles"):
@@ -359,7 +377,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             instance.data["expectedFiles"].append(path)
             return
 
-        for i in range(self._frame_start, (self._frame_end + 1)):
+        for i in range(start_frame, (end_frame + 1)):
             instance.data["expectedFiles"].append(
                 os.path.join(dir, (file % i)).replace("\\", "/"))
 


### PR DESCRIPTION
## Brief description
Nuke multiple bake stream with slate create correct frame range on farm.

## Description
When multiple baking streams were configured in `project_settings/nuke/publish/ExtractReviewDataMov/outputs` with active slate node, deadline nuke submiter was miscreating frame range to be rendered on farm and there fore was publishing wrong video length.

## Testing notes:
1. in settings on your project make sure you are having more than one baking stream `project_settings/nuke/publish/ExtractReviewDataMov/outputs`
2. Open your nuke testing workfile with Slate node
3. publish to farm 
4. look to deadline jobs at baking script jobs and see that the framerange at rendering job is correct and consistent on both jobs.