### PR TITLE
Maya - added support for single frame playblast review

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -135,10 +135,15 @@ class ExtractPlayblast(openpype.api.Extractor):
         # Add camera node name to representation data
         camera_node_name = pm.ls(camera)[0].getTransform().name()
 
+        collected_files = list(frame_collection)
+        # single frame file shouldn't be in list, only as a string
+        if len(collected_files) == 1:
+            collected_files = collected_files[0]
+
         representation = {
             'name': 'png',
             'ext': 'png',
-            'files': list(frame_collection),
+            'files': collected_files,
             "stagingDir": stagingdir,
             "frameStart": start,
             "frameEnd": end,

--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -111,7 +111,8 @@ class ExtractPlayblast(openpype.api.Extractor):
         self.log.debug("playblast path  {}".format(path))
 
         collected_files = os.listdir(stagingdir)
-        collections, remainder = clique.assemble(collected_files)
+        collections, remainder = clique.assemble(collected_files,
+                                                 minimum_items=1)
 
         self.log.debug("filename {}".format(filename))
         frame_collection = None

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -762,7 +762,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         """
         start_frame = int(start_frame)
         end_frame = int(end_frame)
-        collections = clique.assemble(files, minimum_items=1)[0]
+        collections = clique.assemble(files)[0]
         msg = "Multiple collections {} found.".format(collections)
         assert len(collections) == 1, msg
         col = collections[0]
@@ -846,7 +846,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         dst_staging_dir = new_repre["stagingDir"]
 
         if temp_data["input_is_sequence"]:
-            collections = clique.assemble(repre["files"], minimum_items=1)[0]
+            collections = clique.assemble(repre["files"])[0]
             full_input_path = os.path.join(
                 src_staging_dir,
                 collections[0].format("{head}{padding}{tail}")

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -762,8 +762,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
         """
         start_frame = int(start_frame)
         end_frame = int(end_frame)
-        collections = clique.assemble(files)[0]
-        assert len(collections) == 1, "Multiple collections found."
+        collections = clique.assemble(files, minimum_items=1)[0]
+        msg = "Multiple collections {} found.".format(collections)
+        assert len(collections) == 1, msg
         col = collections[0]
 
         # do nothing if no gap is found in input range
@@ -845,7 +846,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         dst_staging_dir = new_repre["stagingDir"]
 
         if temp_data["input_is_sequence"]:
-            collections = clique.assemble(repre["files"])[0]
+            collections = clique.assemble(repre["files"], minimum_items=1)[0]
             full_input_path = os.path.join(
                 src_staging_dir,
                 collections[0].format("{head}{padding}{tail}")


### PR DESCRIPTION
## Brief description
Before clique.assemble returns empty collections

Closes #2561

## Testing notes:
1. create single frame review in Maya
2. `ExtractPlayblast` nor `ExtractReview` should fail