### PR TITLE
Harmony: added unc path to zifile command in Harmony

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -322,7 +322,9 @@ class HarmonySubmitDeadline(
         )
         unzip_dir = (published_scene.parent / published_scene.stem)
         with _ZipFile(published_scene, "r") as zip_ref:
-            zip_ref.extractall(unzip_dir.as_posix())
+            # UNC path (//?/) added to minimalize risk with extracting
+            # to large file paths
+            zip_ref.extractall("//?/" + str(unzip_dir.as_posix()))
 
         # find any xstage files in directory, prefer the one with the same name
         # as directory (plus extension)


### PR DESCRIPTION
## Brief description
`Submit to Deadline` failed with some workfiles.

## Description
Extracting too large url resulted in 'File not found' issue (side effect was that files in offending directory were skipped).
UNC path seems to help.
