### PR TITLE
AfterEffects: Use client query functions

### DIFF
--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -65,14 +65,14 @@ def on_pyblish_instance_toggled(instance, old_value, new_value):
     instance[0].Visible = new_value
 
 
-def get_asset_settings():
+def get_asset_settings(asset_doc):
     """Get settings on current asset from database.
 
     Returns:
         dict: Scene data.
 
     """
-    asset_data = lib.get_asset()["data"]
+    asset_data = asset_doc["data"]
     fps = asset_data.get("fps")
     frame_start = asset_data.get("frameStart")
     frame_end = asset_data.get("frameEnd")

--- a/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
+++ b/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
@@ -1,4 +1,5 @@
 import openpype.hosts.aftereffects.api as api
+from openpype.client import get_asset_by_name
 from openpype.pipeline import (
     AutoCreator,
     CreatedInstance,
@@ -41,10 +42,7 @@ class AEWorkfileCreator(AutoCreator):
         host_name = legacy_io.Session["AVALON_APP"]
 
         if existing_instance is None:
-            asset_doc = legacy_io.find_one({
-                "type": "asset",
-                "name": asset_name
-            })
+            asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(
                 variant, task_name, asset_doc, project_name, host_name
             )
@@ -69,10 +67,7 @@ class AEWorkfileCreator(AutoCreator):
             existing_instance["asset"] != asset_name
             or existing_instance["task"] != task_name
         ):
-            asset_doc = legacy_io.find_one({
-                "type": "asset",
-                "name": asset_name
-            })
+            asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(
                 variant, task_name, asset_doc, project_name, host_name
             )

--- a/openpype/hosts/aftereffects/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/aftereffects/plugins/publish/validate_scene_settings.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Validate scene settings."""
+"""Validate scene settings.
+Requires:
+    instance    -> assetEntity
+    instance    -> anatomyData
+"""
 import os
 import re
 
@@ -67,7 +71,8 @@ class ValidateSceneSettings(OptionalPyblishPluginMixin,
         if not self.is_active(instance.data):
             return
 
-        expected_settings = get_asset_settings()
+        asset_doc = instance.data["assetEntity"]
+        expected_settings = get_asset_settings(asset_doc)
         self.log.info("config from DB::{}".format(expected_settings))
 
         task_name = instance.data["anatomyData"]["task"]["name"]


### PR DESCRIPTION
## Brief description
Modified AfterEffects host to use query functions from [PR](https://github.com/pypeclub/OpenPype/pull/3288).

## Description
AfterEffects is using query functions from `openpype.client` to get assets. Function `get_asset_settings` expects asset document to be passed.

## Question
Function `get_asset_settings` is used only in plugin `ValidateSceneSettings` which always used asset from current context to get expected data which does not seem to make much sense? Shouldn't that plugin be context plugins instead of instance plugin? Or should it pass asset document from context data instead of instance data? Not sure if is possible to have multiple instances for different assets in afters...

## Testing notes:
### Workfile creator
1. Run legacy workfile creator

### Validator
1. Run publishing (ideally with more complex scene with multiple instances)
2. Validate scene settings should work