### PR TITLE
Harmony: Use client query functions

### DIFF
--- a/openpype/hosts/harmony/api/README.md
+++ b/openpype/hosts/harmony/api/README.md
@@ -610,7 +610,8 @@ class ImageSequenceLoader(load.LoaderPlugin):
     def update(self, container, representation):
         node = container.pop("node")
 
-        version = legacy_io.find_one({"_id": representation["parent"]})
+        project_name = legacy_io.active_project()
+        version = get_version_by_id(project_name, representation["parent"])
         files = []
         for f in version["data"]["files"]:
             files.append(


### PR DESCRIPTION
## Brief description
Modified Harmony host to use query functions from [PR](https://github.com/pypeclub/OpenPype/pull/3288).

## Description
Harmony is using query functions from `openpype.client` to get representations when checking outdated containers.

## Testing notes:
1. Load "not last version" of representation to some workfile.
2. Open the workfile to trigger check of outdated containers.