### PR TITLE
TVPaint: Make sure exit code is set to not None

### DIFF
--- a/openpype/hosts/tvpaint/api/communication_server.py
+++ b/openpype/hosts/tvpaint/api/communication_server.py
@@ -707,6 +707,9 @@ class BaseCommunicator:
         if exit_code is not None:
             self.exit_code = exit_code
 
+        if self.exit_code is None:
+            self.exit_code = 0
+
     def stop(self):
         """Stop communication and currently running python process."""
         log.info("Stopping communication")


### PR DESCRIPTION
## Brief description
Server process for TVPaint is not exiting properly and crashed on invalid return code sent to QApplication.

## Description
Make sure the exit code is set to not `None` on calling `_exit` in communicator.

## Testing notes:
1. Run openpype with console
2. Launch TVPaint - this should show console and TVPaint
3. Close TVPaint
4. The console should shut down