### PR TITLE
Linux: update OIIO package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.3.10-windows.zip"
 hash = "b9950f5d2fa3720b52b8be55bacf5f56d33f9e029d38ee86534995f3d8d253d2"
 
 [openpype.thirdparty.oiio.linux]
-url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.2.20-linux-centos7"
-hash = "BE1ABF8A50E9DA5913298447421AF0A17829D83ED6252AE1D40DA7FA36A78787"
+url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.2.20-linux-centos7.tgz"
+hash = "be1abf8a50e9da5913298447421af0a17829d83ed6252ae1d40da7fa36a78787"
 
 [openpype.thirdparty.oiio.darwin]
 url = "https://distribute.openpype.io/thirdparty/oiio-2.2.0-darwin.tgz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ build-backend = "poetry.core.masonry.api"
 # https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers
 version = "==5.15.2"
 
+# TODO: we will need to handle different linux flavours here and
+#       also different macos versions too.
 [openpype.thirdparty.ffmpeg.windows]
 url = "https://distribute.openpype.io/thirdparty/ffmpeg-4.4-windows.zip"
 hash = "dd51ba29d64ee238e7c4c3c7301b19754c3f0ee2e2a729c20a0e2789e72db925"
@@ -131,8 +133,8 @@ url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.3.10-windows.zip"
 hash = "b9950f5d2fa3720b52b8be55bacf5f56d33f9e029d38ee86534995f3d8d253d2"
 
 [openpype.thirdparty.oiio.linux]
-url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.2.12-linux.tgz"
-hash = "de63a8bf7f6c45ff59ecafeba13123f710c2cbc1783ec9e0b938e980d4f5c37f"
+url = "https://distribute.openpype.io/thirdparty/oiio_tools-2.2.20-linux-centos7"
+hash = "BE1ABF8A50E9DA5913298447421AF0A17829D83ED6252AE1D40DA7FA36A78787"
 
 [openpype.thirdparty.oiio.darwin]
 url = "https://distribute.openpype.io/thirdparty/oiio-2.2.0-darwin.tgz"

--- a/website/docs/dev_requirements.md
+++ b/website/docs/dev_requirements.md
@@ -87,9 +87,11 @@ This can also be hosted on the cloud in fully distributed deployments.
 - [**Avalon**](https://github.com/getavalon)
 - [**Pyblish**](https://github.com/pyblish)
 - [**OpenTimelineIO**](https://github.com/PixarAnimationStudios/OpenTimelineIO)
-- [**OpenImageIO**](https://github.com/OpenImageIO/oiio)
+- [**OpenImageIO**](https://github.com/OpenImageIO/oiio) [^centos7]
 - [**FFmpeg**](https://github.com/FFmpeg/FFmpeg)
 
+[^centos7]: On Centos 7 you need to install additional libraries to support OIIO there - mainly boost
+and libraw (`sudo yum install boost-1.53.0` and `sudo yum install LibRaw`)
 
 ### Python modules we use and their licenses
 


### PR DESCRIPTION
## Update

This PR is linking newer version of OIIO for linux that is more self-contained.

It still needs **boost** (`sudo yum install boost-1.53.0` on centos 7) and **LibRaw** (`sudo yum install LibRaw`).