### PR TITLE
Nuke: Collect representation files based on Write

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/precollect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_writes.py
@@ -56,9 +56,21 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             first_frame = int(node["first"].getValue())
             last_frame = int(node["last"].getValue())
 
-        # get path
-        path = nuke.filename(node)
-        output_dir = os.path.dirname(path)
+        # Prepare expected output paths by evaluating each frame of write node
+        #   - paths are first collected to set to avoid duplicated paths, then
+        #       sorted and converted to list
+        node_file = node["file"]
+        expected_paths = list(sorted({
+            node_file.evaluate(frame)
+            for frame in range(first_frame, last_frame + 1)
+        }))
+        expected_filenames = [
+            os.path.basename(filepath)
+            for filepath in expected_paths
+        ]
+
+        output_dir = os.path.dirname(expected_paths[0])
+
         self.log.debug('output dir: {}'.format(output_dir))
 
         # create label
@@ -83,8 +95,11 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             }
 
             try:
-                collected_frames = [f for f in os.listdir(output_dir)
-                                    if ext in f]
+                collected_frames = [
+                    filename
+                    for filename in os.listdir(output_dir)
+                    if filename in expected_filenames
+                ]
                 if collected_frames:
                     collected_frames_len = len(collected_frames)
                     frame_start_str = "%0{}d".format(

--- a/openpype/hosts/nuke/plugins/publish/precollect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_writes.py
@@ -68,8 +68,8 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             os.path.basename(filepath)
             for filepath in expected_paths
         ]
-
-        output_dir = os.path.dirname(expected_paths[0])
+        path = nuke.filename(node)
+        output_dir = os.path.dirname(path)
 
         self.log.debug('output dir: {}'.format(output_dir))
 


### PR DESCRIPTION
## Brief description
Collect output frames based on Write node file input field instead of guessing based on files in output directory.

## Description
Using previous approach expected that output folder contains only output from current state of the write node but didn't handle previous renders with different frame range or different output extensions. New approach is using nuke api to collect all possible output files from write node based on it's current state by evaluating path with each possible frame.

This change fixed bug/removed feature - it is NOT possible that more frames is integrated then Write node has defined with frame start and frame end.
Example: Write node would render 1001-1010, but I could manually hit `Render Local` and render 999-1020. In that case were integrated frames 999-1020, that is not possible now.

## Testing notes:
### Render family
1. Launch Nuke
2. Create render instance
3. Hit local render and change frame range that extends frame start or frame end
4. Publish
5. Only expected frame range is integrated
![image](https://user-images.githubusercontent.com/43494761/175544947-416816cf-fb68-44c7-8171-0e804d126c7f.png)

### Still frame
1. Launch Nuke
2. Create Still image instance
3. Render output of created write node
4. Change settings of `CreateWriteStill` plugin in `project_anatomy/imageio/nuke/nodes/requiredNodes/` to use different extension
5. Remove previous write node
6. Create again Still image instance with same variant as in step 2.
7. Hit publish
8. Integration should not fail