### PR TITLE
Houdini: fix loading and updating vbd/bgeo sequences

### DIFF
--- a/openpype/hosts/houdini/plugins/load/load_bgeo.py
+++ b/openpype/hosts/houdini/plugins/load/load_bgeo.py
@@ -70,7 +70,6 @@ class BgeoLoader(load.LoaderPlugin):
         # The path is either a single file or sequence in a folder.
         if not is_sequence:
             filename = path
-            print("single")
         else:
             filename = re.sub(r"(.*)\.(\d+)\.(bgeo.*)", "\\1.$F4.\\3", path)
 
@@ -94,9 +93,10 @@ class BgeoLoader(load.LoaderPlugin):
 
         # Update the file path
         file_path = get_representation_path(representation)
-        file_path = self.format_path(file_path)
+        is_sequence = bool(representation["context"].get("frame"))
+        file_path = self.format_path(file_path, is_sequence)
 
-        file_node.setParms({"fileName": file_path})
+        file_node.setParms({"file": file_path})
 
         # Update attribute
         node.setParms({"representation": str(representation["_id"])})

--- a/openpype/hosts/houdini/plugins/load/load_vdb.py
+++ b/openpype/hosts/houdini/plugins/load/load_vdb.py
@@ -31,6 +31,7 @@ class VdbLoader(load.LoaderPlugin):
 
         # Create a new geo node
         container = obj.createNode("geo", node_name=node_name)
+        is_sequence = bool(context["representation"]["context"].get("frame"))
 
         # Remove the file node, it only loads static meshes
         # Houdini 17 has removed the file node from the geo node
@@ -40,7 +41,7 @@ class VdbLoader(load.LoaderPlugin):
 
         # Explicitly create a file node
         file_node = container.createNode("file", node_name=node_name)
-        file_node.setParms({"file": self.format_path(self.fname)})
+        file_node.setParms({"file": self.format_path(self.fname, is_sequence)})
 
         # Set display on last node
         file_node.setDisplayFlag(True)
@@ -57,30 +58,19 @@ class VdbLoader(load.LoaderPlugin):
             suffix="",
         )
 
-    def format_path(self, path):
+    @staticmethod
+    def format_path(path, is_sequence):
         """Format file path correctly for single vdb or vdb sequence."""
         if not os.path.exists(path):
             raise RuntimeError("Path does not exist: %s" % path)
 
         # The path is either a single file or sequence in a folder.
-        is_single_file = os.path.isfile(path)
-        if is_single_file:
+        if not is_sequence:
             filename = path
         else:
-            # The path points to the publish .vdb sequence folder so we
-            # find the first file in there that ends with .vdb
-            files = sorted(os.listdir(path))
-            first = next((x for x in files if x.endswith(".vdb")), None)
-            if first is None:
-                raise RuntimeError(
-                    "Couldn't find first .vdb file of "
-                    "sequence in: %s" % path
-                )
+            filename = re.sub(r"(.*)\.(\d+)\.vdb$", "\\1.$F4.vdb", path)
 
-            # Set <frame>.vdb to $F.vdb
-            first = re.sub(r"\.(\d+)\.vdb$", ".$F.vdb", first)
-
-            filename = os.path.join(path, first)
+            filename = os.path.join(path, filename)
 
         filename = os.path.normpath(filename)
         filename = filename.replace("\\", "/")
@@ -100,7 +90,8 @@ class VdbLoader(load.LoaderPlugin):
 
         # Update the file path
         file_path = get_representation_path(representation)
-        file_path = self.format_path(file_path)
+        is_sequence = bool(representation["context"].get("frame"))
+        file_path = self.format_path(file_path, is_sequence)
 
         file_node.setParms({"file": file_path})
 


### PR DESCRIPTION
## Fix

This is fixing loading and updating vdb and bgeo sequences in Houdini. There was problem with sequence token replacement and some syntax errors.

### Testing

Try to load vbd and bgeo sequence, try to switch it to older version and back. Observe file name on the node - it should point to proper sequence and should have frame token in it (`$F4`)