### PR TITLE
rescan frames and collections after slate render

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_rescan_after_slate.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_rescan_after_slate.py
@@ -1,13 +1,12 @@
 import os
 import clique
 import pyblish.api
-from openpype.hosts.nuke.api.lib import maintained_selection
 
 
 class RescanAfterSlate(pyblish.api.InstancePlugin):
     """Rescans extracted representations after slate.
     Helps integration consistency if files were added
-    during the slate extraction step, since the 
+    during the slate extraction step, since the
     Representation file list and collection gets
     collected only once before it.
     """
@@ -34,7 +33,7 @@ class RescanAfterSlate(pyblish.api.InstancePlugin):
 
             if len(repre["files"]) < len(collected_frames):
                 self.log.debug(
-                    "Found more files in staging than in representation," + \
+                    "Found more files in staging than in representation," +
                     " updating with new files (slate frame)..."
                 )
                 repre["files"] = collected_frames

--- a/openpype/hosts/nuke/plugins/publish/extract_rescan_after_slate.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_rescan_after_slate.py
@@ -1,0 +1,49 @@
+import os
+import clique
+import pyblish.api
+from openpype.hosts.nuke.api.lib import maintained_selection
+
+
+class RescanAfterSlate(pyblish.api.InstancePlugin):
+    """Rescans extracted representations after slate.
+    Helps integration consistency if files were added
+    during the slate extraction step, since the 
+    Representation file list and collection gets
+    collected only once before it.
+    """
+    label = 'Rescan Repre After Slate'
+    order = pyblish.api.ExtractorOrder + 0.005
+    families = ["slate"]
+    hosts = ['nuke']
+
+    def process(self, instance):
+
+        for repre in instance.data["representations"]:
+
+            if isinstance(repre["files"], str):
+                return
+
+            self.log.debug("Current representation: {0}".format(repre))
+            self.log.debug("Current collection: {0}".format(
+                instance.data["collection"]
+            ))
+
+            staged_files = os.listdir(repre["stagingDir"])
+
+            collected_frames = [x for x in staged_files if repre["ext"] in x]
+
+            if len(repre["files"]) < len(collected_frames):
+                self.log.debug(
+                    "Found more files in staging than in representation," + \
+                    " updating with new files (slate frame)..."
+                )
+                repre["files"] = collected_frames
+                collections, remainder = clique.assemble(collected_frames)
+                if collections:
+                    instance.data["collection"] = collections[0]
+                self.log.debug("Rescanned representation: {0}".format(repre))
+                self.log.debug("Rescanned collection: {0}".format(
+                    instance.data["collection"]
+                ))
+            else:
+                self.log.debug("No range issue found, moving on...")


### PR DESCRIPTION
## Brief description
Representation file list and collection will be recomputed after slate rendering

## Description
We found mismatches between a representation collected data and actual files on disk when rendering from existing frames on nuke. This happened only if the artist was rendering manually without including the slate (ie. from frame 1001 instead of 1000).
Since data gets collected before the extraction step all frameranges after slate rendering were one frame less at the head, and the subsequent Review Mov and integration were all missing a frame.
This does not happen when selecting on local, since the script will always launch rendering from first_frame-1
By adding an extra "rescan" step just after slate rendering all subsequent extractions and integrations behave as expected now.

## Additional info
This pr supersedes completely my old one #2962 , which can now be removed as this pr does not affect integrate new.
Should be possible to merge without waiting for #2898 as the code does not modify it anymore.

## Documentation (add _"type: documentation"_ label)
no docs

## Testing notes:
To reproduce the bug with current develop:
1. set up a shot with slate workflow, framerange 1001-1050, slate setup at 1000
2. render a comp from first frame to last frame (1001-1050)
3. select "use existing frames" in the render group and be sure to also check "publish" and "review"
4. start publish
5. the integrated render and the review mov should be both one frame less at the head.

The same behaviour should yeld the correct framerange now.