### PR TITLE
Nuke: option to bake viewer ip before slate

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -49,12 +49,12 @@ class ExtractSlateFrame(openpype.api.Extractor):
 
     def render_slate(self, instance):
         node_subset_name = instance.data.get("name", None)
-        node = instance[0] # group node
+        node = instance[0]  # group node
         # get the slate node
         slate_node = instance.data.get("slateNode")
         # get the last comp node before slate
         last_comp_node = slate_node.input(0)
- 
+
         self.log.info("Creating staging dir...")
 
         if "representations" not in instance.data:
@@ -112,8 +112,10 @@ class ExtractSlateFrame(openpype.api.Extractor):
         # clipboard space. This fixes the erratic
         # behaviour nuke has with system clipboard '%clipboard%'
         # when used from openpype context.
-        instance.data["clipboard"] = os.path.join(instance.data["stagingDir"],
-            "{0}clipboard.txt".format(fhead))
+        instance.data["clipboard"] = os.path.join(
+            instance.data["stagingDir"],
+            "{0}clipboard.txt".format(fhead)
+        )
 
         # get the current viewer viewing lut, there seems to be
         # no setting in op that is relevant to this.
@@ -138,10 +140,10 @@ class ExtractSlateFrame(openpype.api.Extractor):
             ipn.setInput(0, previous_node)
             previous_node = ipn
             temporary_nodes.append(ipn)
-        
+
         # compensate source to not have a double viewer lut applied
         # this is needed since baking viewer process happens now
-        # before the slate and not after. 
+        # before the slate and not after.
         if not self.viewer_lut_raw and self.vwip_before_slate:
             invlut_node = nuke.createNode("OCIODisplay")
             invlut_node.setInput(0, previous_node)
@@ -199,7 +201,6 @@ class ExtractSlateFrame(openpype.api.Extractor):
 
         slate_node.setInput(0, last_comp_node)
         node.setInput(0, slate_node)
-
 
     # Commodity function to clear selections.
     def clear_selection(self):

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -249,6 +249,7 @@
         },
         "ExtractSlateFrame": {
             "viewer_lut_raw": false,
+            "vwip_before_slate": false,
             "key_value_mapping": {
                 "f_submission_note": [
                     true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -323,6 +323,14 @@
                     "type": "separator"
                 },
                 {
+                    "type": "boolean",
+                    "key": "vwip_before_slate",
+                    "label": "Bake Viewer IP before Slate"
+                },
+                {
+                    "type": "separator"
+                },
+                {
                     "type": "label",
                     "label": "Fill specific slate node values with templates. Uncheck the checkbox to not change the value.",
                     "word_wrap": true


### PR DESCRIPTION
## Brief description
Introduce an optional workflow to bake viewer input process before the slate. 

## Description
This pr introduces an optional workflow that is intended to not change the colorspace of the slate by applying the viewer input process baking before the actual slate.
We use this since our slate layouts itself after the input resolution, and our Input process has also the ability to repo and reformat.
Also, it does not make sense to us to apply a lut on the slate, especially if CDL + LUT are very invasive.
The code also compensate for viewer process baking, where if Rec.709 is used (for instance) to bake the slate the source gts converted form Rec.709 to linear before the slate to have correct colors in the slate itself (in case of thumbnails)

## Additional info
Setting for this live under Project Settings > Nuke > Publish Plugins > ExtractSlateFrame
there's a new boolean switch called "Bake Viewer IP berfore Slate"
Also, we found the problem with nuke.nodeCopy and nodePaste, which is that the system clipboard when OP is driving nuke is sometimes not available. Fortunately the same functionality can be used by specifying a text file, which we save in the instance staging directory.

## Documentation (add _"type: documentation"_ label)
no docs

## Testing notes:
1. enable this under Project Settings > Nuke > Publish Plugins > ExtractSlateFrame > Bake Viewer IP berfore Slate
2. You should see the viewer input process node copied before the slate and the slate connected after it when publishing