### PR TITLE
Fix typo in documentation: pyenv on mac

### DIFF
--- a/website/docs/dev_build.md
+++ b/website/docs/dev_build.md
@@ -214,7 +214,7 @@ $ brew install cmake
 3) Install [pyenv](https://github.com/pyenv/pyenv):
 ```shell
 $ brew install pyenv
-$ echo 'eval "$(pypenv init -)"' >> ~/.zshrc
+$ echo 'eval "$(pyenv init -)"' >> ~/.zshrc
 $ pyenv init
 $ exec "$SHELL"
 $ PATH=$(pyenv root)/shims:$PATH


### PR DESCRIPTION
## Brief description
Fixes `pyenv` typo that doesn't allow `$SHELL` to run

## Description
When following the install steps for macOS, 3rd step is to install `PyEnv`, on the second line, `echo 'eval "$(pypenv init -)"' >> ~/.zshrc` there's an extra 'p' in `pypenv init` that should be `pyenv init`.

This is a simple typo fix.