### PR TITLE
NewPublisher: Fix subset name change on change of creator plugin

### DIFF
--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -977,7 +977,12 @@ class CreateDialog(QtWidgets.QDialog):
             elif variant:
                 self.variant_hints_menu.addAction(variant)
 
-        self.variant_input.setText(default_variant or "Main")
+        variant_text = default_variant or "Main"
+        # Make sure subset name is updated to new plugin
+        if variant_text == self.variant_input.text():
+            self._on_variant_change()
+        else:
+            self.variant_input.setText(variant_text)
 
     def _on_variant_widget_resize(self):
         self.variant_hints_btn.setFixedHeight(self.variant_input.height())


### PR DESCRIPTION
## Brief description
Subset name is properly change on creator plugin selection change.

## Testing notes:
1. Open NewPublisher (e.g. experimental Tray publisher)
2. Make sure you have 2 creator plugins with same default variant name (e.g. `Main`)
3. Select context (asset and task) so subset name is filled but don't change variant
4. Change creator to the other one
5. Subset name should be filled based on subset template of selected creator even if variant didn't change