### PR TITLE
Blender: Bugfix - Set fps properly on open

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -93,7 +93,7 @@ def set_start_end_frames():
     # Default scene settings
     frameStart = scene.frame_start
     frameEnd = scene.frame_end
-    fps = scene.render.fps
+    fps = scene.render.fps / scene.render.fps_base
     resolution_x = scene.render.resolution_x
     resolution_y = scene.render.resolution_y
 
@@ -116,7 +116,8 @@ def set_start_end_frames():
 
     scene.frame_start = frameStart
     scene.frame_end = frameEnd
-    scene.render.fps = fps
+    scene.render.fps = round(fps)
+    scene.render.fps_base = round(fps) / fps
     scene.render.resolution_x = resolution_x
     scene.render.resolution_y = resolution_y
 


### PR DESCRIPTION
## Brief description
Fix event callback on new/open to set fps and frame range properly.

## Description
See issue: `Blender 3.1+ don't set frame range and fps on open` -> https://github.com/pypeclub/OpenPype/issues/3424

## Testing notes:
- Just open a shot task with setted frameStar, frameEnd and fps in a Blender 3.1+ host.