### PR TITLE
General: Use Anatomy after move to pipeline

### DIFF
--- a/openpype/hooks/pre_global_host_data.py
+++ b/openpype/hooks/pre_global_host_data.py
@@ -1,11 +1,10 @@
-from openpype.api import Anatomy
 from openpype.lib import (
     PreLaunchHook,
     EnvironmentPrepData,
     prepare_app_environments,
     prepare_context_environments
 )
-from openpype.pipeline import AvalonMongoDB
+from openpype.pipeline import AvalonMongoDB, Anatomy
 
 
 class GlobalHostDataHook(PreLaunchHook):

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -19,8 +19,9 @@ from openpype.client import (
     get_last_versions,
     get_representations,
 )
-from openpype.pipeline import legacy_io
-from openpype.api import (Logger, Anatomy, get_anatomy_settings)
+from openpype.settings import get_anatomy_settings
+from openpype.pipeline import legacy_io, Anatomy
+from openpype.api import Logger
 from . import tags
 
 try:

--- a/openpype/hosts/houdini/vendor/husdoutputprocessors/avalon_uri_processor.py
+++ b/openpype/hosts/houdini/vendor/husdoutputprocessors/avalon_uri_processor.py
@@ -5,8 +5,7 @@ import husdoutputprocessors.base as base
 import colorbleed.usdlib as usdlib
 
 from openpype.client import get_asset_by_name
-from openpype.api import Anatomy
-from openpype.pipeline import legacy_io
+from openpype.pipeline import legacy_io, Anatomy
 
 
 class AvalonURIOutputProcessor(base.OutputProcessorBase):

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -9,8 +9,8 @@ from openpype.pipeline import (
     LoaderPlugin,
     get_representation_path,
     AVALON_CONTAINER_ID,
+    Anatomy,
 )
-from openpype.api import Anatomy
 from openpype.settings import get_project_settings
 from .pipeline import containerise
 from . import lib

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -20,21 +20,23 @@ from openpype.client import (
 )
 from openpype.api import (
     Logger,
-    Anatomy,
     BuildWorkfile,
     get_version_from_path,
-    get_anatomy_settings,
     get_workdir_data,
     get_asset,
     get_current_project_settings,
 )
 from openpype.tools.utils import host_tools
 from openpype.lib.path_tools import HostDirmap
-from openpype.settings import get_project_settings
+from openpype.settings import (
+    get_project_settings,
+    get_anatomy_settings,
+)
 from openpype.modules import ModulesManager
 from openpype.pipeline import (
     discover_legacy_creator_plugins,
     legacy_io,
+    Anatomy,
 )
 
 from . import gizmo_menu

--- a/openpype/hosts/tvpaint/plugins/load/load_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/load/load_workfile.py
@@ -10,8 +10,8 @@ from openpype.lib import (
 from openpype.pipeline import (
     registered_host,
     legacy_io,
+    Anatomy,
 )
-from openpype.api import Anatomy
 from openpype.hosts.tvpaint.api import lib, pipeline, plugin
 
 

--- a/openpype/hosts/unreal/api/rendering.py
+++ b/openpype/hosts/unreal/api/rendering.py
@@ -2,7 +2,7 @@ import os
 
 import unreal
 
-from openpype.api import Anatomy
+from openpype.pipeline import Anatomy
 from openpype.hosts.unreal.api import pipeline
 
 

--- a/openpype/hosts/unreal/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/unreal/plugins/publish/collect_render_instances.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import unreal
 
-from openpype.api import Anatomy
+from openpype.pipeline import Anatomy
 from openpype.hosts.unreal.api import pipeline
 import pyblish.api
 

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -20,10 +20,7 @@ from openpype.settings.constants import (
     METADATA_KEYS,
     M_DYNAMIC_KEY_LABEL
 )
-from . import (
-    PypeLogger,
-    Anatomy
-)
+from . import PypeLogger
 from .profiles_filtering import filter_profiles
 from .local_settings import get_openpype_username
 from .avalon_context import (
@@ -1305,7 +1302,7 @@ def get_app_environments_for_context(
         dict: Environments for passed context and application.
     """
 
-    from openpype.pipeline import AvalonMongoDB
+    from openpype.pipeline import AvalonMongoDB, Anatomy
 
     # Avalon database connection
     dbcon = AvalonMongoDB()

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -604,7 +604,10 @@ def get_workdir_with_workdir_data(
 
     anatomy_filled = anatomy.format(workdir_data)
     # Output is TemplateResult object which contain useful data
-    return anatomy_filled[template_key]["folder"]
+    path = anatomy_filled[template_key]["folder"]
+    if path:
+        path = os.path.normpath(path)
+    return path
 
 
 def get_workdir(

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -768,7 +768,10 @@ def get_workdir_from_session(session=None, template_key=None):
             host_name,
             project_name=project_name
         )
-    return anatomy_filled[template_key]["folder"]
+    path = anatomy_filled[template_key]["folder"]
+    if path:
+        path = os.path.normpath(path)
+    return path
 
 
 @with_pipeline_io

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -14,7 +14,6 @@ from openpype.settings import (
     get_project_settings,
     get_system_settings
 )
-from .anatomy import Anatomy
 from .profiles_filtering import filter_profiles
 from .events import emit_event
 from .path_templates import StringTemplate
@@ -593,6 +592,7 @@ def get_workdir_with_workdir_data(
         ))
 
     if not anatomy:
+        from openpype.pipeline import Anatomy
         anatomy = Anatomy(project_name)
 
     if not template_key:
@@ -638,6 +638,7 @@ def get_workdir(
         TemplateResult: Workdir path.
     """
     if not anatomy:
+        from openpype.pipeline import Anatomy
         anatomy = Anatomy(project_doc["name"])
 
     workdir_data = get_workdir_data(
@@ -750,6 +751,8 @@ def compute_session_changes(
 
 @with_pipeline_io
 def get_workdir_from_session(session=None, template_key=None):
+    from openpype.pipeline import Anatomy
+
     if session is None:
         session = legacy_io.Session
     project_name = session["AVALON_PROJECT"]
@@ -856,6 +859,8 @@ def create_workfile_doc(asset_doc, task_name, filename, workdir, dbcon=None):
         dbcon (AvalonMongoDB): Optionally enter avalon AvalonMongoDB object and
             `legacy_io` is used if not entered.
     """
+    from openpype.pipeline import Anatomy
+
     # Use legacy_io if dbcon is not entered
     if not dbcon:
         dbcon = legacy_io
@@ -1676,6 +1681,7 @@ def _get_task_context_data_for_anatomy(
     """
 
     if anatomy is None:
+        from openpype.pipeline import Anatomy
         anatomy = Anatomy(project_doc["name"])
 
     asset_name = asset_doc["name"]
@@ -1744,6 +1750,7 @@ def get_custom_workfile_template_by_context(
     """
 
     if anatomy is None:
+        from openpype.pipeline import Anatomy
         anatomy = Anatomy(project_doc["name"])
 
     # get project, asset, task anatomy context data

--- a/openpype/lib/path_tools.py
+++ b/openpype/lib/path_tools.py
@@ -9,7 +9,6 @@ import platform
 from openpype.client import get_project
 from openpype.settings import get_project_settings
 
-from .anatomy import Anatomy
 from .profiles_filtering import filter_profiles
 
 log = logging.getLogger(__name__)
@@ -227,6 +226,7 @@ def fill_paths(path_list, anatomy):
 
 
 def create_project_folders(basic_paths, project_name):
+    from openpype.pipeline import Anatomy
     anatomy = Anatomy(project_name)
 
     concat_paths = concatenate_splitted_paths(basic_paths, anatomy)

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -1045,7 +1045,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                     get publish_path
 
         Args:
-            anatomy (pype.lib.anatomy.Anatomy):
+            anatomy (openpype.pipeline.anatomy.Anatomy):
             template_data (dict): pre-calculated collected data for process
             asset (string): asset name
             subset (string): subset name (actually group name of subset)

--- a/openpype/modules/ftrack/event_handlers_server/event_user_assigment.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_user_assigment.py
@@ -2,10 +2,10 @@ import re
 import subprocess
 
 from openpype.client import get_asset_by_id, get_asset_by_name
+from openpype.settings import get_project_settings
+from openpype.pipeline import Anatomy
 from openpype_modules.ftrack.lib import BaseEvent
 from openpype_modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
-
-from openpype.api import Anatomy, get_project_settings
 
 
 class UserAssigmentEvent(BaseEvent):

--- a/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_folders.py
@@ -1,7 +1,7 @@
 import os
 import collections
 import copy
-from openpype.api import Anatomy
+from openpype.pipeline import Anatomy
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 
 

--- a/openpype/modules/ftrack/event_handlers_user/action_delete_old_versions.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delete_old_versions.py
@@ -11,9 +11,8 @@ from openpype.client import (
     get_versions,
     get_representations
 )
-from openpype.api import Anatomy
 from openpype.lib import StringTemplate, TemplateUnsolved
-from openpype.pipeline import AvalonMongoDB
+from openpype.pipeline import AvalonMongoDB, Anatomy
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 
 

--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -10,12 +10,13 @@ from openpype.client import (
     get_versions,
     get_representations
 )
-from openpype.api import Anatomy, config
+from openpype.pipeline import Anatomy
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 from openpype_modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
 from openpype_modules.ftrack.lib.custom_attributes import (
     query_custom_attributes
 )
+from openpype.lib import config
 from openpype.lib.delivery import (
     path_from_representation,
     get_format_dict,

--- a/openpype/modules/ftrack/event_handlers_user/action_fill_workfile_attr.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_fill_workfile_attr.py
@@ -11,13 +11,13 @@ from openpype.client import (
     get_project,
     get_assets,
 )
-from openpype.api import get_project_settings
+from openpype.settings import get_project_settings
 from openpype.lib import (
     get_workfile_template_key,
     get_workdir_data,
-    Anatomy,
     StringTemplate,
 )
+from openpype.pipeline import Anatomy
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 from openpype_modules.ftrack.lib.avalon_sync import create_chunks
 

--- a/openpype/modules/ftrack/event_handlers_user/action_rv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_rv.py
@@ -11,10 +11,10 @@ from openpype.client import (
     get_version_by_name,
     get_representation_by_name
 )
-from openpype.api import Anatomy
 from openpype.pipeline import (
     get_representation_path,
     AvalonMongoDB,
+    Anatomy,
 )
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 

--- a/openpype/modules/ftrack/event_handlers_user/action_store_thumbnails_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_store_thumbnails_to_avalon.py
@@ -14,8 +14,7 @@ from openpype.client import (
     get_representations
 )
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
-from openpype.api import Anatomy
-from openpype.pipeline import AvalonMongoDB
+from openpype.pipeline import AvalonMongoDB, Anatomy
 
 from openpype_modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
 

--- a/openpype/modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/sync_server/providers/local_drive.py
@@ -4,10 +4,11 @@ import shutil
 import threading
 import time
 
-from openpype.api import Logger, Anatomy
+from openpype.api import Logger
+from openpype.pipeline import Anatomy
 from .abstract_provider import AbstractProvider
 
-log = Logger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 class LocalDriveHandler(AbstractProvider):

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -9,14 +9,12 @@ from collections import deque, defaultdict
 
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import ITrayModule
-from openpype.api import (
-    Anatomy,
+from openpype.settings import (
     get_project_settings,
     get_system_settings,
-    get_local_site_id
 )
-from openpype.lib import PypeLogger
-from openpype.pipeline import AvalonMongoDB
+from openpype.lib import PypeLogger, get_local_site_id
+from openpype.pipeline import AvalonMongoDB, Anatomy
 from openpype.settings.lib import (
     get_default_anatomy_settings,
     get_anatomy_settings
@@ -28,7 +26,7 @@ from .providers import lib
 from .utils import time_function, SyncStatus, SiteAlreadyPresentError
 
 
-log = PypeLogger().get_logger("SyncServer")
+log = PypeLogger.get_logger("SyncServer")
 
 
 class SyncServerModule(OpenPypeModule, ITrayModule):

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -14,11 +14,8 @@ from pyblish.lib import MessageHandler
 import openpype
 from openpype.modules import load_modules, ModulesManager
 from openpype.settings import get_project_settings
-from openpype.lib import (
-    Anatomy,
-    filter_pyblish_plugins,
-)
-
+from openpype.lib import filter_pyblish_plugins
+from .anatomy import Anatomy
 from . import (
     legacy_io,
     register_loader_plugin_path,

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -9,10 +9,10 @@ import numbers
 import six
 from bson.objectid import ObjectId
 
-from openpype.lib import Anatomy
 from openpype.pipeline import (
     schema,
     legacy_io,
+    Anatomy,
 )
 
 log = logging.getLogger(__name__)

--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -9,9 +9,8 @@ import qargparse
 from Qt import QtWidgets, QtCore
 
 from openpype import style
-from openpype.pipeline import load, AvalonMongoDB
+from openpype.pipeline import load, AvalonMongoDB, Anatomy
 from openpype.lib import StringTemplate
-from openpype.api import Anatomy
 
 
 class DeleteOldVersions(load.SubsetLoaderPlugin):

--- a/openpype/plugins/load/delivery.py
+++ b/openpype/plugins/load/delivery.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 
 from Qt import QtWidgets, QtCore, QtGui
 
-from openpype.pipeline import load, AvalonMongoDB
-from openpype.api import Anatomy, config
+from openpype.lib import config
+from openpype.pipeline import load, AvalonMongoDB, Anatomy
 from openpype import resources, style
 
 from openpype.lib.delivery import (

--- a/openpype/plugins/publish/collect_anatomy_object.py
+++ b/openpype/plugins/publish/collect_anatomy_object.py
@@ -4,11 +4,11 @@ Requires:
     os.environ -> AVALON_PROJECT
 
 Provides:
-    context -> anatomy (pype.api.Anatomy)
+    context -> anatomy (openpype.pipeline.anatomy.Anatomy)
 """
 import os
-from openpype.api import Anatomy
 import pyblish.api
+from openpype.pipeline import Anatomy
 
 
 class CollectAnatomyObject(pyblish.api.ContextPlugin):

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -17,8 +17,7 @@ from openpype.client import (
     get_thumbnail_id_from_source,
     get_thumbnail,
 )
-from openpype.api import Anatomy
-from openpype.pipeline import HeroVersionType
+from openpype.pipeline import HeroVersionType, Anatomy
 from openpype.pipeline.thumbnail import get_thumbnail_binary
 from openpype.pipeline.load import (
     discover_loader_plugins,

--- a/openpype/tools/texture_copy/app.py
+++ b/openpype/tools/texture_copy/app.py
@@ -6,8 +6,7 @@ import speedcopy
 
 from openpype.client import get_project, get_asset_by_name
 from openpype.lib import Terminal
-from openpype.api import Anatomy
-from openpype.pipeline import legacy_io
+from openpype.pipeline import legacy_io, Anatomy
 
 
 t = Terminal()

--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -11,7 +11,6 @@ from openpype.tools.utils import PlaceholderLineEdit
 from openpype.tools.utils.delegates import PrettyTimeDelegate
 from openpype.lib import (
     emit_event,
-    Anatomy,
     get_workfile_template_key,
     create_workdir_extra_folders,
 )
@@ -22,6 +21,7 @@ from openpype.lib.avalon_context import (
 from openpype.pipeline import (
     registered_host,
     legacy_io,
+    Anatomy,
 )
 from .model import (
     WorkAreaFilesModel,


### PR DESCRIPTION
## Brief description
Changed imports of Anatomy to use `openpype.pipeline.anatomy.Anatomy` instead of `openpype.lib.anatomy.Anatomy`.

## Description
Import anatomy from `openpype.pipeline` at all current places to avoid deprecated warnings after [PR](https://github.com/pypeclub/OpenPype/pull/3435) (destination of this PR).

## Testing notes:
- [x] Applications should launch
- [x] Hiero should initialize OpenPype
- [x] Nuke should initialize OpenPype
- [x] Maya should initialize OpenPype
- [ ] Unreal should initialize OpenPype
- [x] TVPaint load workfiles loader should work
- [x] Ftrack actions should be visible (if they're visible it's ok only imports changed)
    - [x] Delete old versions
    - [x] Create folders
    - [x] Fill workfile attribute
    - [x] Store thumbnails
- [x] Loading should work
- [x] Workfiles tool should work
- [x] Loader tool shoul work
- [x] TextureCopy tool should work