### PR TITLE
LogViewer: Escape html characters in log message

### DIFF
--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -1,3 +1,4 @@
+import html
 from Qt import QtCore, QtWidgets
 import qtawesome
 from .models import LogModel, LogsFilterProxy
@@ -286,7 +287,7 @@ class OutputWidget(QtWidgets.QWidget):
             if level == "debug":
                 line_f = (
                     "<font color=\"Yellow\"> -"
-                    " <font color=\"Lime\">{{  {loggerName}  }}: ["
+                    " <font color=\"Lime\">{{  {logger_name}  }}: ["
                     " <font color=\"White\">{message}"
                     " <font color=\"Lime\">]"
                 )
@@ -299,7 +300,7 @@ class OutputWidget(QtWidgets.QWidget):
             elif level == "warning":
                 line_f = (
                     "<font color=\"Yellow\">*** WRN:"
-                    " <font color=\"Lime\"> >>> {{ {loggerName} }}: ["
+                    " <font color=\"Lime\"> >>> {{ {logger_name} }}: ["
                     " <font color=\"White\">{message}"
                     " <font color=\"Lime\">]"
                 )
@@ -307,16 +308,25 @@ class OutputWidget(QtWidgets.QWidget):
                 line_f = (
                     "<font color=\"Red\">!!! ERR:"
                     " <font color=\"White\">{timestamp}"
-                    " <font color=\"Lime\">>>> {{ {loggerName} }}: ["
+                    " <font color=\"Lime\">>>> {{ {logger_name} }}: ["
                     " <font color=\"White\">{message}"
                     " <font color=\"Lime\">]"
                 )
 
+            logger_name = log["loggerName"]
+            timestamp = ""
+            if not show_timecode:
+                timestamp = log["timestamp"]
+            message = log["message"]
             exc = log.get("exception")
             if exc:
-                log["message"] = exc["message"]
+                message = exc["message"]
 
-            line = line_f.format(**log)
+            line = line_f.format(
+                message=html.escape(message),
+                logger_name=logger_name,
+                timestamp=timestamp
+            )
 
             if show_timecode:
                 timestamp = log["timestamp"]


### PR DESCRIPTION
## Brief description
Messages with html tags are not shown as expected.

## Description
Escape html characters in log message so `<MyObject...>` is shown in UI.

## Testing notes:
1. Log to mogno must be enabled
2. Log something using OpenPype logger
    - e.g. in Tray>Admin>Console
    ```
    from openpype.lib.anatomy import log
    log.info("<div>")
    ```
2. Open log viewer UI, find process where this log happened and check output which should show `"<div>"`.