### PR TITLE
Windows installer: Clean old files and add version subfolder

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -18,7 +18,8 @@ AppPublisher=Orbi Tools s.r.o
 AppPublisherURL=http://pype.club
 AppSupportURL=http://pype.club
 AppUpdatesURL=http://pype.club
-DefaultDirName={autopf}\{#MyAppName}
+DefaultDirName={autopf}\{#MyAppName}\{#AppVer}
+UsePreviousAppDir=no
 DisableProgramGroupPage=yes
 OutputBaseFilename={#MyAppName}-{#AppVer}-install
 AllowCancelDuringInstall=yes
@@ -27,7 +28,7 @@ AllowCancelDuringInstall=yes
 PrivilegesRequiredOverridesAllowed=dialog
 SetupIconFile=igniter\openpype.ico
 OutputDir=build\
-Compression=lzma
+Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
 
@@ -36,6 +37,11 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[InstallDelete]
+; clean everything in previous installation folder
+Type: filesandordirs; Name: "{app}\*"
+
 
 [Files]
 Source: "build\{#build}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
## Enhancement

This PR is addressing issue where old file were left when OP version was reinstalled to the same folder.  This has one important effect - this will currently delete all files there without any remorse (deleting any user stuff that might be there).

I've also added version subfolder to the path so OpenPype will install to `C:\Program Files (x86)\OpenPype\3.12.1-nightly.1`
This is in preparation for implementing #3415 

### Testing instructions

- use `.\tools\build_win_installer.ps1` to create installer.
- run the installation. Dialog should ask for the destination path and provide the one to program files with version at the end
- finish the installation
- add arbitrary file to installation directory
- run the installation again and install to the same directory
- your arbitrary file should be gone

Resolve #3440 