### PR TITLE
Maya: fix hashing in Python 3 for tile rendering

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -710,7 +710,9 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
                 new_payload["JobInfo"].update(tiles_data["JobInfo"])
                 new_payload["PluginInfo"].update(tiles_data["PluginInfo"])
 
-                job_hash = hashlib.sha256("{}_{}".format(file_index, file))
+                self.log.info("hashing {} - {}".format(file_index, file))
+                job_hash = hashlib.sha256(
+                    ("{}_{}".format(file_index, file)).encode("utf-8"))
                 frame_jobs[frame] = job_hash.hexdigest()
                 new_payload["JobInfo"]["ExtraInfo0"] = job_hash.hexdigest()
                 new_payload["JobInfo"]["ExtraInfo1"] = file


### PR DESCRIPTION
## Bug

Hashing function used for tile rendering doesn't work in Python 3.

### Test

Use Maya with python 3 and publish tile job for rendering. It should submit to deadline ok.