### PR TITLE
Nuke: prerender reviewable fails

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_review_data_mov.py
@@ -104,7 +104,10 @@ class ExtractReviewDataMov(openpype.api.Extractor):
                     self, instance, o_name, o_data["extension"],
                     multiple_presets)
 
-                if "render.farm" in families:
+                if (
+                    "render.farm" in families or
+                    "prerender.farm" in families
+                ):
                     if "review" in instance.data["families"]:
                         instance.data["families"].remove("review")
 

--- a/openpype/plugins/publish/extract_jpeg_exr.py
+++ b/openpype/plugins/publish/extract_jpeg_exr.py
@@ -19,7 +19,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     label = "Extract Thumbnail"
     order = pyblish.api.ExtractorOrder
     families = [
-        "imagesequence", "render", "render2d",
+        "imagesequence", "render", "render2d", "prerender",
         "source", "plate", "take"
     ]
     hosts = ["shell", "fusion", "resolve"]


### PR DESCRIPTION
## Brief description
Prerender reviewable is functioning well

## Description
Prerender reviewable workflow was broken.

## Additional info
- `prerender.farm` had to be added to condition in extract review mov plugin.\
- thumbnail extractor on farm were not activated for  `prerender` family

## Testing notes:
1. make sure you have toggled ON `project_settings/nuke/create/CreateWritePrerender/reviewable` at your testing project.
2. create prerender node in your nuke testing node - Make sure prerender node is above of Slate node if you have any in the testing scene.
3. Test Review ON on the node with On farm rendering.