### PR TITLE
Ftrack: Trigger custom ftrack events on project creation or preparation

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_prepare_project.py
@@ -374,6 +374,10 @@ class PrepareProjectServer(ServerAction):
                 project_name, project_code
             ))
             create_project(project_name, project_code)
+            self.trigger_event(
+                "openpype.project.created",
+                {"project_name": project_name}
+            )
 
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]

--- a/openpype/modules/ftrack/event_handlers_server/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_prepare_project.py
@@ -1,4 +1,5 @@
 import json
+import copy
 
 from openpype.client import get_project
 from openpype.api import ProjectSettings
@@ -399,6 +400,10 @@ class PrepareProjectServer(ServerAction):
                 project_entity["custom_attributes"][key] = value
                 self.log.debug("- Key \"{}\" set to \"{}\"".format(key, value))
             session.commit()
+
+        event_data = copy.deepcopy(in_data)
+        event_data["project_name"] = project_name
+        self.trigger_event("openpype.project.prepared", event_data)
 
         return True
 

--- a/openpype/modules/ftrack/event_handlers_server/action_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_sync_to_avalon.py
@@ -1,7 +1,8 @@
 import time
 import sys
 import json
-import traceback
+
+import ftrack_api
 
 from openpype_modules.ftrack.lib import ServerAction
 from openpype_modules.ftrack.lib.avalon_sync import SyncEntitiesFactory
@@ -179,6 +180,13 @@ class SyncToAvalonServer(ServerAction):
             self.log.debug(
                 "* Total time: {}".format(time_7 - time_start)
             )
+
+            if self.entities_factory.project_created:
+                event = ftrack_api.event.base.Event(
+                    topic="openpype.project.created",
+                    data={"project_name": project_name}
+                )
+                self.session.event_hub.publish(event)
 
             report = self.entities_factory.report()
             if report and report.get("items"):

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -400,6 +400,10 @@ class PrepareProjectLocal(BaseAction):
                 project_name, project_code
             ))
             create_project(project_name, project_code)
+            self.trigger_event(
+                "openpype.project.created",
+                {"project_name": project_name}
+            )
 
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -1,4 +1,5 @@
 import json
+import copy
 
 from openpype.client import get_project
 from openpype.api import ProjectSettings
@@ -433,6 +434,10 @@ class PrepareProjectLocal(BaseAction):
                 self.process_identifier()
             )
             self.trigger_action(trigger_identifier, event)
+
+        event_data = copy.deepcopy(in_data)
+        event_data["project_name"] = project_name
+        self.trigger_event("openpype.project.prepared", event_data)
         return True
 
 

--- a/openpype/modules/ftrack/event_handlers_user/action_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_sync_to_avalon.py
@@ -1,7 +1,8 @@
 import time
 import sys
 import json
-import traceback
+
+import ftrack_api
 
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
 from openpype_modules.ftrack.lib.avalon_sync import SyncEntitiesFactory
@@ -183,6 +184,13 @@ class SyncToAvalonLocal(BaseAction):
             self.log.debug(
                 "* Total time: {}".format(time_7 - time_start)
             )
+
+            if self.entities_factory.project_created:
+                event = ftrack_api.event.base.Event(
+                    topic="openpype.project.created",
+                    data={"project_name": project_name}
+                )
+                self.session.event_hub.publish(event)
 
             report = self.entities_factory.report()
             if report and report.get("items"):

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -2017,13 +2017,6 @@ class SyncEntitiesFactory:
         if len(self.create_list) > 0:
             self.dbcon.insert_many(self.create_list)
 
-        if self.project_created:
-            event = ftrack_api.event.base.Event(
-                topic="openpype.project.created",
-                data={"project_name": self.project_name}
-            )
-            self.session.event_hub.publish(event)
-
         self.session.commit()
 
         self.log.debug("* Processing entities for update")

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -443,6 +443,7 @@ class SyncEntitiesFactory:
         }
 
         self.create_list = []
+        self.project_created = False
         self.unarchive_list = []
         self.updates = collections.defaultdict(dict)
 
@@ -2016,6 +2017,13 @@ class SyncEntitiesFactory:
         if len(self.create_list) > 0:
             self.dbcon.insert_many(self.create_list)
 
+        if self.project_created:
+            event = ftrack_api.event.base.Event(
+                topic="openpype.project.created",
+                data={"project_name": self.project_name}
+            )
+            self.session.event_hub.publish(event)
+
         self.session.commit()
 
         self.log.debug("* Processing entities for update")
@@ -2214,6 +2222,7 @@ class SyncEntitiesFactory:
         self._avalon_ents_by_name[project_item["name"]] = str(new_id)
 
         self.create_list.append(project_item)
+        self.project_created = True
 
         # store mongo id to ftrack entity
         entity = self.entities_dict[self.ft_project_id]["entity"]

--- a/openpype/modules/ftrack/lib/ftrack_base_handler.py
+++ b/openpype/modules/ftrack/lib/ftrack_base_handler.py
@@ -535,7 +535,7 @@ class BaseHandler(object):
         )
 
     def trigger_event(
-        self, topic, event_data={}, session=None, source=None,
+        self, topic, event_data=None, session=None, source=None,
         event=None, on_error="ignore"
     ):
         if session is None:
@@ -543,6 +543,9 @@ class BaseHandler(object):
 
         if not source and event:
             source = event.get("source")
+
+        if event_data is None:
+            event_data = {}
         # Create and trigger event
         event = ftrack_api.event.base.Event(
             topic=topic,


### PR DESCRIPTION
## Brief description
Trigger events when project is created in openpype mongo (based on ftrack project) and when prepare project action is called in ftrack.

## Description
Event with topic `openpype.project.created` is called when project in openpype mongo is created and `openpype.project.prepared` is called when Prepare project action finished successfully.

## Testing notes:
1. Add custom event handler that listen to these topics and probably log something specific
2. Synchronize new project -> `openpype.project.created` should be triggered
3. Run prepare action on any project -> `openpype.project.prepared` should be triggered

### Example script file
```
def project_created(event):
    print("Project {} created".format(event["data"]["project_name"]))


def project_prepared(event):
    print("Project {} prepared".format(event["data"]["project_name"]))


def register(session):
    session.event_hub.subscribe(
        "topic=openpype.project.created",
        project_created
    )
    session.event_hub.subscribe(
        "topic=openpype.project.prepared",
        project_prepared
    )
```
Put the file in `openpype/modules/ftrack/event_handlers_user` and restart ftrack action server in tray.