### PR TITLE
General: Creator Plugins have access to project

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -843,9 +843,8 @@ class CreateContext:
         self.plugins_with_defs = plugins_with_defs
 
         # Prepare settings
-        project_name = self.dbcon.Session["AVALON_PROJECT"]
         system_settings = get_system_settings()
-        project_settings = get_project_settings(project_name)
+        project_settings = get_project_settings(self.project_name)
 
         # Discover and prepare creators
         creators = {}

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -749,6 +749,10 @@ class CreateContext:
         return os.environ["AVALON_APP"]
 
     @property
+    def project_name(self):
+        return self.dbcon.active_project()
+
+    @property
     def log(self):
         """Dynamic access to logger."""
         if self._log is None:

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -96,7 +96,7 @@ class BaseCreator:
     def project_name(self):
         """Family that plugin represents."""
 
-        self.create_context.project_name
+        return self.create_context.project_name
 
     @property
     def log(self):

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -93,6 +93,12 @@ class BaseCreator:
         pass
 
     @property
+    def project_name(self):
+        """Family that plugin represents."""
+
+        self.create_context.project_name
+
+    @property
     def log(self):
         if self._log is None:
             from openpype.api import Logger


### PR DESCRIPTION
## Brief description
Creator plugins in new creation have access to project name.

## Description
In same cases need access to project name during creation which is not possible right now. Project name is traversed from CreateContext which initialized plugin objects.