### PR TITLE
New Publisher: Disabled context change allows creation

### DIFF
--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -1164,14 +1164,13 @@ class CreateDialog(QtWidgets.QDialog):
         family = index.data(FAMILY_ROLE)
         variant = self.variant_input.text()
         # Care about subset name only if context change is enabled
+        subset_name = None
+        asset_name = None
+        task_name = None
         if self._context_change_is_enabled():
             subset_name = self.subset_name_input.text()
             asset_name = self._get_asset_name()
             task_name = self._get_task_name()
-        else:
-            subset_name = None
-            asset_name = None
-            task_name = None
 
         pre_create_data = self._pre_create_widget.current_value()
         # Where to define these data?

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -717,7 +717,7 @@ class CreateDialog(QtWidgets.QDialog):
         # Make sure there is a selection
         indexes = self.creators_view.selectedIndexes()
         if not indexes:
-            index = self.creators_model.index(0, 0)
+            index = self._creators_sort_model.index(0, 0)
             self.creators_view.setCurrentIndex(index)
         else:
             index = indexes[0]

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -576,7 +576,10 @@ class CreateDialog(QtWidgets.QDialog):
     def _set_context_enabled(self, enabled):
         self._assets_widget.set_enabled(enabled)
         self._tasks_widget.set_enabled(enabled)
+        check_prereq = self._context_widget.isEnabled() != enabled
         self._context_widget.setEnabled(enabled)
+        if check_prereq:
+            self._invalidate_prereq()
 
     def refresh(self):
         # Get context before refresh to keep selection of asset and

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -616,7 +616,7 @@ class CreateDialog(QtWidgets.QDialog):
             prereq_available = False
             creator_btn_tooltips.append("Creator is not selected")
 
-        if self._asset_doc is None:
+        if self._context_change_is_enabled() and self._asset_doc is None:
             # QUESTION how to handle invalid asset?
             prereq_available = False
             creator_btn_tooltips.append("Context is not selected")
@@ -1010,11 +1010,16 @@ class CreateDialog(QtWidgets.QDialog):
         if variant_value is None:
             variant_value = self.variant_input.text()
 
-        self.create_btn.setEnabled(True)
         if not self._compiled_name_pattern.match(variant_value):
             self.create_btn.setEnabled(False)
             self._set_variant_state_property("invalid")
             self.subset_name_input.setText("< Invalid variant >")
+            return
+
+        if not self._context_change_is_enabled():
+            self.create_btn.setEnabled(True)
+            self._set_variant_state_property("")
+            self.subset_name_input.setText("< Valid variant >")
             return
 
         project_name = self.controller.project_name
@@ -1034,6 +1039,7 @@ class CreateDialog(QtWidgets.QDialog):
 
         self.subset_name_input.setText(subset_name)
 
+        self.create_btn.setEnabled(True)
         self._validate_subset_name(subset_name, variant_value)
 
     def _validate_subset_name(self, subset_name, variant_value):
@@ -1145,10 +1151,17 @@ class CreateDialog(QtWidgets.QDialog):
         creator_label = index.data(QtCore.Qt.DisplayRole)
         creator_identifier = index.data(CREATOR_IDENTIFIER_ROLE)
         family = index.data(FAMILY_ROLE)
-        subset_name = self.subset_name_input.text()
         variant = self.variant_input.text()
-        asset_name = self._get_asset_name()
-        task_name = self._get_task_name()
+        # Care about subset name only if context change is enabled
+        if self._context_change_is_enabled():
+            subset_name = self.subset_name_input.text()
+            asset_name = self._get_asset_name()
+            task_name = self._get_task_name()
+        else:
+            subset_name = variant
+            asset_name = None
+            task_name = None
+
         pre_create_data = self._pre_create_widget.current_value()
         # Where to define these data?
         # - what data show be stored?

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -615,7 +615,12 @@ class CreateDialog(QtWidgets.QDialog):
     def _invalidate_prereq(self):
         prereq_available = True
         creator_btn_tooltips = []
-        if self.creators_model.rowCount() < 1:
+
+        available_creators = self.creators_model.rowCount() > 0
+        if available_creators != self.creators_view.isEnabled():
+            self.creators_view.setEnabled(available_creators)
+
+        if not available_creators:
             prereq_available = False
             creator_btn_tooltips.append("Creator is not selected")
 
@@ -628,7 +633,6 @@ class CreateDialog(QtWidgets.QDialog):
             self._prereq_available = prereq_available
 
             self.create_btn.setEnabled(prereq_available)
-            self.creators_view.setEnabled(prereq_available)
             self.variant_input.setEnabled(prereq_available)
             self.variant_hints_btn.setEnabled(prereq_available)
 

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -342,7 +342,9 @@ class CreateDialog(QtWidgets.QDialog):
 
         creators_view = QtWidgets.QListView(self)
         creators_model = QtGui.QStandardItemModel()
-        creators_view.setModel(creators_model)
+        creators_sort_model = QtCore.QSortFilterProxyModel()
+        creators_sort_model.setSourceModel(creators_model)
+        creators_view.setModel(creators_sort_model)
 
         variant_widget = VariantInputsWidget(self)
 
@@ -516,6 +518,7 @@ class CreateDialog(QtWidgets.QDialog):
         self.creators_model = creators_model
         self.creators_view = creators_view
         self.create_btn = create_btn
+        self._creators_sort_model = creators_sort_model
 
         self._creator_short_desc_widget = creator_short_desc_widget
         self._pre_create_widget = pre_create_widget
@@ -703,6 +706,7 @@ class CreateDialog(QtWidgets.QDialog):
         if self.creators_model.rowCount() < 1:
             return
 
+        self._creators_sort_model.sort(0)
         # Make sure there is a selection
         indexes = self.creators_view.selectedIndexes()
         if not indexes:

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -1158,7 +1158,7 @@ class CreateDialog(QtWidgets.QDialog):
             asset_name = self._get_asset_name()
             task_name = self._get_task_name()
         else:
-            subset_name = variant
+            subset_name = None
             asset_name = None
             task_name = None
 

--- a/openpype/tools/publisher/widgets/create_dialog.py
+++ b/openpype/tools/publisher/widgets/create_dialog.py
@@ -465,7 +465,7 @@ class CreateDialog(QtWidgets.QDialog):
         desc_width_anim_timer = QtCore.QTimer()
         desc_width_anim_timer.setInterval(10)
 
-        prereq_timer.timeout.connect(self._on_prereq_timer)
+        prereq_timer.timeout.connect(self._invalidate_prereq)
 
         desc_width_anim_timer.timeout.connect(self._on_desc_animation)
 
@@ -600,16 +600,16 @@ class CreateDialog(QtWidgets.QDialog):
         self._tasks_widget.set_asset_name(asset_name)
         self._tasks_widget.select_task_name(task_name)
 
-        self._invalidate_prereq()
+        self._invalidate_prereq_deffered()
 
-    def _invalidate_prereq(self):
+    def _invalidate_prereq_deffered(self):
         self._prereq_timer.start()
 
     def _on_asset_filter_height_change(self, height):
         self._creators_header_widget.setMinimumHeight(height)
         self._creators_header_widget.setMaximumHeight(height)
 
-    def _on_prereq_timer(self):
+    def _invalidate_prereq(self):
         prereq_available = True
         creator_btn_tooltips = []
         if self.creators_model.rowCount() < 1:
@@ -726,11 +726,11 @@ class CreateDialog(QtWidgets.QDialog):
         asset_name = self._assets_widget.get_selected_asset_name()
         self._tasks_widget.set_asset_name(asset_name)
         if self._context_change_is_enabled():
-            self._invalidate_prereq()
+            self._invalidate_prereq_deffered()
 
     def _on_task_change(self):
         if self._context_change_is_enabled():
-            self._invalidate_prereq()
+            self._invalidate_prereq_deffered()
 
     def _on_current_session_context_request(self):
         self._assets_widget.set_current_session_asset()


### PR DESCRIPTION
## Brief description
It is possible to hit create for creators which do not require context selection.

## Description
Creator plugins could define if want to allow context selection but UI did not support to hit Create button if it's so. In that case asset name, task name and subset name are set to `None` because context which would be used to fill subset name are not enabled.

## Additional info
This kind of creation make sense only for bulk creators which have to get asset, task and subset name from elsewhere during creation. Added sorting of create plugins based on label. Converted few attributes to be private.

## Testing notes:
1. Add plugin that define to disable context selection on creation
2. Create button should be enabled in that case