### PR TITLE
Nuke: Workfile tools open on start

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 import clique
 
 import nuke
+from Qt import QtCore, QtWidgets
 
 from openpype.client import (
     get_project,
@@ -27,6 +28,7 @@ from openpype.api import (
     get_current_project_settings,
 )
 from openpype.tools.utils import host_tools
+from openpype.lib import env_value_to_bool
 from openpype.lib.path_tools import HostDirmap
 from openpype.settings import (
     get_project_settings,
@@ -63,7 +65,10 @@ class Context:
     main_window = None
     context_label = None
     project_name = os.getenv("AVALON_PROJECT")
+    # Workfile related code
     workfiles_launched = False
+    workfiles_tool_timer = None
+
     # Seems unused
     _project_doc = None
 
@@ -2384,12 +2389,19 @@ def select_nodes(nodes):
 
 
 def launch_workfiles_app():
-    '''Function letting start workfiles after start of host
-    '''
-    from openpype.lib import (
-        env_value_to_bool
-    )
-    from .pipeline import get_main_window
+    """Show workfiles tool on nuke launch.
+
+    Trigger to show workfiles tool on application launch. Can be executed only
+    once all other calls are ignored.
+
+    Workfiles tool show is deffered after application initialization using
+    QTimer.
+    """
+
+    if Context.workfiles_launched:
+        return
+
+    Context.workfiles_launched = True
 
     # get all imortant settings
     open_at_start = env_value_to_bool(
@@ -2400,10 +2412,38 @@ def launch_workfiles_app():
     if not open_at_start:
         return
 
-    if not Context.workfiles_launched:
-        Context.workfiles_launched = True
-        main_window = get_main_window()
-        host_tools.show_workfiles(parent=main_window)
+    # Show workfiles tool using timer
+    # - this will be probably triggered during initialization in that case
+    #   the application is not be able to show uis so it must be
+    #   deffered using timer
+    # - timer should be processed when initialization ends
+    #       When applications starts to process events.
+    timer = QtCore.QTimer()
+    timer.timeout.connect(_launch_workfile_app)
+    timer.setInterval(100)
+    Context.workfiles_tool_timer = timer
+    timer.start()
+
+
+def _launch_workfile_app():
+    # Safeguard to not show window when application is still starting up
+    #   or is already closing down.
+    closing_down = QtWidgets.QApplication.closingDown()
+    starting_up = QtWidgets.QApplication.startingUp()
+
+    # Stop the timer if application finished start up of is closing down
+    if closing_down or not starting_up:
+        Context.workfiles_tool_timer.stop()
+        Context.workfiles_tool_timer = None
+
+    # Skip if application is starting up or closing down
+    if starting_up or closing_down:
+        return
+
+    from .pipeline import get_main_window
+
+    main_window = get_main_window()
+    host_tools.show_workfiles(parent=main_window)
 
 
 def process_workfile_builder():

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -120,8 +120,9 @@ def install():
     nuke.addOnCreate(workfile_settings.set_context_settings, nodeClass="Root")
     nuke.addOnCreate(workfile_settings.set_favorites, nodeClass="Root")
     nuke.addOnCreate(process_workfile_builder, nodeClass="Root")
-    nuke.addOnCreate(launch_workfiles_app, nodeClass="Root")
+
     _install_menu()
+    launch_workfiles_app()
 
 
 def uninstall():


### PR DESCRIPTION
## Brief description
Workfiles tool properly shows on Nuke launch.

## Description
Feature to open workfiles tool on application launch did not work if last workfile is not opened (or any workfile). It is due to race conditions because current callback to show workfiles tool was based on creation of Root node which may happen before application initialization if no workfile is opened.

## Additional info
Showing workfiles tool is not showed using QTimer. That should deffer showing the tool when application event processing started.

## Testing notes:
1. Disable open last workfile in `project_settings/global/tools/Workfiles/last_workfile_on_startup`
2. Enable workfiles tool on launch in `project_settings/global/tools/Workfiles/open_workfile_tool_on_startup`
3. Launch nuke
4. Workfiles tool should show