### PR TITLE
NewPublisher: Added ability to use label of instance

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -497,7 +497,7 @@ class CreatedInstance:
         return self._data["subset"]
 
     @property
-    def instance_label(self):
+    def label(self):
         label = self._data.get("label")
         if not label:
             label = self.subset_name

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -497,6 +497,13 @@ class CreatedInstance:
         return self._data["subset"]
 
     @property
+    def instance_label(self):
+        label = self._data.get("label")
+        if not label:
+            label = self.subset_name
+        return label
+
+    @property
     def creator_identifier(self):
         return self.creator.identifier
 

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -303,13 +303,14 @@ class InstanceCardWidget(CardWidget):
         self._last_variant = variant
         self._last_subset_name = subset_name
         # Make `variant` bold
-        found_parts = set(re.findall(variant, subset_name, re.IGNORECASE))
+        label = self.instance.label
+        found_parts = set(re.findall(variant, label, re.IGNORECASE))
         if found_parts:
             for part in found_parts:
                 replacement = "<b>{}</b>".format(part)
-                subset_name = subset_name.replace(part, replacement)
+                label = label.replace(part, replacement)
 
-        self._label_widget.setText(subset_name)
+        self._label_widget.setText(label)
         # HTML text will cause that label start catch mouse clicks
         # - disabling with changing interaction flag
         self._label_widget.setTextInteractionFlags(

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -113,7 +113,7 @@ class InstanceListItemWidget(QtWidgets.QWidget):
 
         self.instance = instance
 
-        subset_name_label = QtWidgets.QLabel(instance["subset"], self)
+        subset_name_label = QtWidgets.QLabel(instance.label, self)
         subset_name_label.setObjectName("ListViewSubsetName")
 
         active_checkbox = NiceCheckbox(parent=self)


### PR DESCRIPTION
## Brief description
Instance can have defined label in it's data which is shown in instances view.

## Description
Previously instance used only subset name of instance which makes it complicated when instances are created in bulk for multiple different contexts so each has same name. If label is not available then subset name is used as fallback.

## Additional info
To use label just pass `"label"` to instance data of `CreatedInstance`.

## Testing notes:
1. Create instance which has `"label"` key in data
2. Label should be visible in create UI