### PR TITLE
General: Fix Plist loading for application launch

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -665,7 +665,11 @@ class ApplicationExecutable:
             if os.path.exists(plist_filepath):
                 import plistlib
 
-                parsed_plist = plistlib.readPlist(plist_filepath)
+                if hasattr(plistlib, "load"):
+                    with open(plist_filepath, "rb") as stream:
+                        parsed_plist = plistlib.load(stream)
+                else:
+                    parsed_plist = plistlib.readPlist(plist_filepath)
                 executable_filename = parsed_plist.get("CFBundleExecutable")
 
             if executable_filename:


### PR DESCRIPTION
## Brief description
Use `plist.load` instead of `plist.readPlist` which seems to be deprecated.

## Description
Kept both access for cases when `load` function is not available (bust should be always).

## Testing notes:
1. Launch application on MacOs
2. Application should be launched