### PR TITLE
NewPublisher: Align creator attributes from top to bottom

### DIFF
--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1225,6 +1225,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
     different creators. If creator have same (similar) definitions their
     widgets are merged into one (different label does not count).
     """
+
     def __init__(self, controller, parent):
         super(CreatorAttrsWidget, self).__init__(parent)
 
@@ -1275,6 +1276,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
         content_layout = QtWidgets.QGridLayout(content_widget)
         content_layout.setColumnStretch(0, 0)
         content_layout.setColumnStretch(1, 1)
+        content_layout.setAlignment(QtCore.Qt.AlignTop)
 
         row = 0
         for attr_def, attr_instances, values in result:


### PR DESCRIPTION
## Brief description
Align attribute definition widgets from top to bottom instead of keeping them in center.

## Description
Change alignment on main layout in attributes defininition widget.

## Testing notes:
1. Create an instanace in new publisher (for which creator define attribute definitions or has some values)
2. Select created instance in instances view
3. Check if creator attribute are alignet from top to bottom

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/43494761/178318026-0ccaa536-a5cc-48ed-8d4d-8abc5b073c5b.png)

### Now
![image](https://user-images.githubusercontent.com/43494761/178317895-25a8dc3e-f4a5-4259-9b60-543d85f22bea.png)
