### PR TITLE
General: Extract review use first frame of input sequence

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -452,10 +452,16 @@ class ExtractReview(pyblish.api.InstancePlugin):
             # Calculate first frame that should be used
             cols, _ = clique.assemble(repre["files"])
             input_frames = list(sorted(cols[0].indexes))
+            first_sequence_frame = input_frames[0]
             # WARNING: This is an issue as we don't know if first frame
             #   is with or without handles!
-            # - in theory we should add handle start but how do we know we can?
-            first_sequence_frame = input_frames[0]
+            # - handle start is added but how do not know if we should
+            output_duration = (output_frame_end - output_frame_start) + 1
+            if (
+                without_handles
+                and len(input_frames) - handle_start >= output_duration
+            ):
+                first_sequence_frame += handle_start
 
             ext = os.path.splitext(repre["files"][0])[1].replace(".", "")
             if ext in self.alpha_exts:

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -446,11 +446,17 @@ class ExtractReview(pyblish.api.InstancePlugin):
             with_audio = False
 
         input_is_sequence = self.input_is_sequence(repre)
-        first_sequence_frame = None
         input_allow_bg = False
+        first_sequence_frame = None
         if input_is_sequence and repre["files"]:
+            # Calculate first frame that should be used
             cols, _ = clique.assemble(repre["files"])
-            first_sequence_frame = list(sorted(cols[0].indexes))[0]
+            input_frames = list(sorted(cols[0].indexes))
+            # WARNING: This is an issue as we don't know if first frame
+            #   is with or without handles!
+            # - in theory we should add handle start but how do we know we can?
+            first_sequence_frame = input_frames[0]
+
             ext = os.path.splitext(repre["files"][0])[1].replace(".", "")
             if ext in self.alpha_exts:
                 input_allow_bg = True

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -446,8 +446,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
             with_audio = False
 
         input_is_sequence = self.input_is_sequence(repre)
+        first_sequence_frame = None
         input_allow_bg = False
         if input_is_sequence and repre["files"]:
+            cols, _ = clique.assemble(repre["files"])
+            first_sequence_frame = list(sorted(cols[0].indexes))[0]
             ext = os.path.splitext(repre["files"][0])[1].replace(".", "")
             if ext in self.alpha_exts:
                 input_allow_bg = True
@@ -467,6 +470,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
             "resolution_height": instance.data.get("resolutionHeight"),
             "origin_repre": repre,
             "input_is_sequence": input_is_sequence,
+            "first_sequence_frame": first_sequence_frame,
             "input_allow_bg": input_allow_bg,
             "with_audio": with_audio,
             "without_handles": without_handles,
@@ -545,9 +549,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
         if temp_data["input_is_sequence"]:
             # Set start frame of input sequence (just frame in filename)
             # - definition of input filepath
-            ffmpeg_input_args.append(
-                "-start_number {}".format(temp_data["output_frame_start"])
-            )
+            ffmpeg_input_args.extend([
+                "-start_number", str(temp_data["first_sequence_frame"])
+            ])
 
             # TODO add fps mapping `{fps: fraction}` ?
             # - e.g.: {


### PR DESCRIPTION
## Brief description
Fixed issue when output frame start does not match input frame range when sequence is used as input.

## Description
We tell ffmpeg which is the first frame of an input sequence but we used output frame start to define it. But output frame start could be different. Thus first frame of an sequence is used. There may be caviads when handles should be used. I've tried to "guess" it but not sure if it will cover all usages.

## Additional info
This was discovered with AfterEffects which store frame start/end from scene into instance data `frameStart` and `frameEnd`. I'm not sure if we should store scene data there, but the keys probably don't have any defined usage.

## Testing notes:
Trigger publishing which creates sequences that should be processed by extract review.
- I know about AfterEffects, TVPaint, Maya on farm and standalone publisher