### PR TITLE
TrayPublisher: Added more options for grouping of instances

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -505,7 +505,7 @@ class CreatedInstance:
 
     @property
     def group_label(self):
-        label = self._data.get("group_label")
+        label = self._data.get("group")
         if label:
             return label
         return self.creator.get_group_label()

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -504,6 +504,13 @@ class CreatedInstance:
         return label
 
     @property
+    def group_label(self):
+        label = self._data.get("group_label")
+        if label:
+            return label
+        return self.creator.get_group_label()
+
+    @property
     def creator_identifier(self):
         return self.creator.identifier
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 
 from abc import (
     ABCMeta,
@@ -47,6 +46,9 @@ class BaseCreator:
 
     # Label shown in UI
     label = None
+    group_label = None
+    # Cached group label after first call 'get_group_label'
+    _group_label = None
 
     # Variable to store logger
     _log = None
@@ -85,11 +87,13 @@ class BaseCreator:
 
         Default implementation returns plugin's family.
         """
+
         return self.family
 
     @abstractproperty
     def family(self):
         """Family that plugin represents."""
+
         pass
 
     @property
@@ -97,6 +101,16 @@ class BaseCreator:
         """Family that plugin represents."""
 
         return self.create_context.project_name
+
+    def get_group_label(self):
+        if self._group_label is None:
+            if self.group_label:
+                self._group_label = self.group_label
+            elif self.label:
+                self._group_label = self.label
+            else:
+                self._group_label = self.identifier
+        return self._group_label
 
     @property
     def log(self):
@@ -121,6 +135,7 @@ class BaseCreator:
         - must expect all data that were passed to init in previous
             implementation
         """
+
         pass
 
     @abstractmethod
@@ -147,6 +162,7 @@ class BaseCreator:
                     self._add_instance_to_context(instance)
         ```
         """
+
         pass
 
     @abstractmethod
@@ -154,9 +170,10 @@ class BaseCreator:
         """Store changes of existing instances so they can be recollected.
 
         Args:
-            update_list(list<UpdateData>): Gets list of tuples. Each item
+            update_list(List[UpdateData]): Gets list of tuples. Each item
                 contain changed instance and it's changes.
         """
+
         pass
 
     @abstractmethod
@@ -167,9 +184,10 @@ class BaseCreator:
         'True' if did so.
 
         Args:
-            instance(list<CreatedInstance>): Instance objects which should be
+            instance(List[CreatedInstance]): Instance objects which should be
                 removed.
         """
+
         pass
 
     def get_icon(self):
@@ -177,6 +195,7 @@ class BaseCreator:
 
         Can return path to image file or awesome icon name.
         """
+
         return self.icon
 
     def get_dynamic_data(
@@ -187,6 +206,7 @@ class BaseCreator:
         These may be get dynamically created based on current context of
         workfile.
         """
+
         return {}
 
     def get_subset_name(
@@ -211,6 +231,7 @@ class BaseCreator:
             project_name(str): Project name.
             host_name(str): Which host creates subset.
         """
+
         dynamic_data = self.get_dynamic_data(
             variant, task_name, asset_doc, project_name, host_name
         )
@@ -237,9 +258,10 @@ class BaseCreator:
         keys/values when plugin attributes change.
 
         Returns:
-            list<AbtractAttrDef>: Attribute definitions that can be tweaked for
+            List[AbtractAttrDef]: Attribute definitions that can be tweaked for
                 created instance.
         """
+
         return self.instance_attr_defs
 
 
@@ -297,6 +319,7 @@ class Creator(BaseCreator):
         Returns:
             str: Short description of family.
         """
+
         return self.description
 
     def get_detail_description(self):
@@ -307,6 +330,7 @@ class Creator(BaseCreator):
         Returns:
             str: Detailed description of family for artist.
         """
+
         return self.detailed_description
 
     def get_default_variants(self):
@@ -318,8 +342,9 @@ class Creator(BaseCreator):
         By default returns `default_variants` value.
 
         Returns:
-            list<str>: Whisper variants for user input.
+            List[str]: Whisper variants for user input.
         """
+
         return copy.deepcopy(self.default_variants)
 
     def get_default_variant(self):
@@ -338,11 +363,13 @@ class Creator(BaseCreator):
         """Plugin attribute definitions needed for creation.
         Attribute definitions of plugin that define how creation will work.
         Values of these definitions are passed to `create` method.
-        NOTE:
-        Convert method should be implemented which should care about updating
-        keys/values when plugin attributes change.
+
+        Note:
+            Convert method should be implemented which should care about
+            updating keys/values when plugin attributes change.
+
         Returns:
-            list<AbtractAttrDef>: Attribute definitions that can be tweaked for
+            List[AbtractAttrDef]: Attribute definitions that can be tweaked for
                 created instance.
         """
         return self.pre_create_attr_defs

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -48,7 +48,7 @@ class BaseCreator:
     label = None
     group_label = None
     # Cached group label after first call 'get_group_label'
-    _group_label = None
+    _cached_group_label = None
 
     # Variable to store logger
     _log = None
@@ -114,14 +114,14 @@ class BaseCreator:
                 Group label can be overriden by instance itself.
         """
 
-        if self._group_label is None:
+        if self._cached_group_label is None:
             label = self.identifier
             if self.group_label:
                 label = self.group_label
             elif self.label:
                 label = self.label
-            self._group_label = label
-        return self._group_label
+            self._cached_group_label = label
+        return self._cached_group_label
 
     @property
     def log(self):

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -103,17 +103,34 @@ class BaseCreator:
         return self.create_context.project_name
 
     def get_group_label(self):
+        """Group label under which are instances grouped in UI.
+
+        Default implementation use attributes in this order:
+            - 'group_label' -> 'label' -> 'identifier'
+                Keep in mind that 'identifier' use 'family' by default.
+
+        Returns:
+            str: Group label that can be used for grouping of instances in UI.
+                Group label can be overriden by instance itself.
+        """
+
         if self._group_label is None:
+            label = self.identifier
             if self.group_label:
-                self._group_label = self.group_label
+                label = self.group_label
             elif self.label:
-                self._group_label = self.label
-            else:
-                self._group_label = self.identifier
+                label = self.label
+            self._group_label = label
         return self._group_label
 
     @property
     def log(self):
+        """Logger of the plugin.
+
+        Returns:
+            logging.Logger: Logger with name of the plugin.
+        """
+
         if self._log is None:
             from openpype.api import Logger
 
@@ -121,10 +138,30 @@ class BaseCreator:
         return self._log
 
     def _add_instance_to_context(self, instance):
-        """Helper method to ad d"""
+        """Helper method to add instance to create context.
+
+        Instances should be stored to DCC workfile metadata to be able reload
+        them and also stored to CreateContext in which is creator plugin
+        existing at the moment to be able use it without refresh of
+        CreateContext.
+
+        Args:
+            instance (CreatedInstance): New created instance.
+        """
+
         self.create_context.creator_adds_instance(instance)
 
     def _remove_instance_from_context(self, instance):
+        """Helper method to remove instance from create context.
+
+        Instances must be removed from DCC workfile metadat aand from create
+        context in which plugin is existing at the moment of removement to
+        propagate the change without restarting create context.
+
+        Args:
+            instance (CreatedInstance): Instance which should be removed.
+        """
+
         self.create_context.creator_removed_instance(instance)
 
     @abstractmethod

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -436,7 +436,7 @@ class InstanceCardView(AbstractInstanceView):
         instances_by_group = collections.defaultdict(list)
         identifiers_by_group = collections.defaultdict(set)
         for instance in self.controller.instances:
-            group_name = instance.creator_label
+            group_name = instance.group_label
             instances_by_group[group_name].append(instance)
             identifiers_by_group[group_name].add(
                 instance.creator_identifier

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -519,7 +519,7 @@ class InstanceListView(AbstractInstanceView):
         instances_by_group_name = collections.defaultdict(list)
         group_names = set()
         for instance in self.controller.instances:
-            group_label = instance.creator_label
+            group_label = instance.group_label
             group_names.add(group_label)
             instances_by_group_name[group_label].append(instance)
 


### PR DESCRIPTION
## Brief description
Grouping of instances has much more abilities. Instances can have their own group defined in data and creator plugin can define it's group label. This is just UI purpose change.

## Description
Group label is defined by this order (if value is empty then next value is used):
- key `"group"` in created instance data
- attribute `group_label` on creator plugin
- attribute `label` on creator plugin
- attribute `identifier` on creator plugin

## Additional info
Identifier must be available on creator plugin so it is end point. Default implementation returns creator's `family` which can be considered as last source.

## Testing notes:
Creators group label
1. Define `group_label` on creator plugin and create it's instances
2. They should be grouped under that label

Instance group label
1. Create an instance with some string in `"group"` key in it's data
2. Instance should be grouped under that group in UI

Resolves https://github.com/pypeclub/OpenPype/issues/3490