### PR TITLE
Nuke: load clip with options from settings

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -54,25 +54,27 @@ class LoadClip(plugin.NukeLoader):
     script_start = int(nuke.root()["first_frame"].value())
 
     # option gui
-    defaults = {
+    options_defaults = {
         "start_at_workfile": True,
         "add_retime": True
     }
 
-    options = [
-        qargparse.Boolean(
-            "start_at_workfile",
-            help="Load at workfile start frame",
-            default=True
-        ),
-        qargparse.Boolean(
-            "add_retime",
-            help="Load with retime",
-            default=True
-        )
-    ]
-
     node_name_template = "{class_name}_{ext}"
+
+    @classmethod
+    def get_options(cls, *args):
+        return [
+            qargparse.Boolean(
+                "start_at_workfile",
+                help="Load at workfile start frame",
+                default=cls.options_defaults["start_at_workfile"]
+            ),
+            qargparse.Boolean(
+                "add_retime",
+                help="Load with retime",
+                default=cls.options_defaults["add_retime"]
+            )
+        ]
 
     @classmethod
     def get_representations(cls):
@@ -92,10 +94,10 @@ class LoadClip(plugin.NukeLoader):
         file = self.fname.replace("\\", "/")
 
         start_at_workfile = options.get(
-            "start_at_workfile", self.defaults["start_at_workfile"])
+            "start_at_workfile", self.options_defaults["start_at_workfile"])
 
         add_retime = options.get(
-            "add_retime", self.defaults["add_retime"])
+            "add_retime", self.options_defaults["add_retime"])
 
         version = context['version']
         version_data = version.get("data", {})
@@ -214,7 +216,7 @@ class LoadClip(plugin.NukeLoader):
 
         # TODO: find `addRetime` add openpipe data
         # add_retime = options.get(
-        #     "add_retime", self.defaults["add_retime"])
+        #     "add_retime", self.options_defaults["add_retime"])
 
         project_name = legacy_io.active_project()
         version_doc = get_version_by_id(project_name, representation["parent"])

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -212,11 +212,12 @@ class LoadClip(plugin.NukeLoader):
         read_node = nuke.toNode(container['objectName'])
         file = get_representation_path(representation).replace("\\", "/")
 
-        start_at_workfile = bool("start at" in read_node['frame_mode'].value())
+        start_at_workfile = "start at" in read_node['frame_mode'].value()
 
-        # TODO: find `addRetime` add openpipe data
-        # add_retime = options.get(
-        #     "add_retime", self.options_defaults["add_retime"])
+        add_retime = [
+            key for key in read_node.knobs().keys()
+            if "addRetime" in key
+        ]
 
         project_name = legacy_io.active_project()
         version_doc = get_version_by_id(project_name, representation["parent"])

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -287,7 +287,11 @@
         "LoadClip": {
             "enabled": true,
             "_representations": [],
-            "node_name_template": "{class_name}_{ext}"
+            "node_name_template": "{class_name}_{ext}",
+            "options_defaults": {
+                "start_at_workfile": true,
+                "add_retime": true
+            }
         }
     },
     "workfile_builder": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_load.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_load.json
@@ -11,10 +11,52 @@
                 {
                     "key": "LoadImage",
                     "label": "Image Loader"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "LoadClip",
+            "label": "Clip Loader",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
                 },
                 {
-                    "key": "LoadClip",
-                    "label": "Clip Loader"
+                    "type": "list",
+                    "key": "_representations",
+                    "label": "Representations",
+                    "object_type": "text"
+                },
+                {
+                    "type": "text",
+                    "key": "node_name_template",
+                    "label": "Node name template"
+                },
+                {
+                    "type": "splitter"
+                },
+                {
+                    "type": "dict",
+                    "collapsible": false,
+                    "key": "options_defaults",
+                    "label": "Loader option defaults",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "start_at_workfile",
+                            "label": "Start at worfile beggining"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "add_retime",
+                            "label": "Add retime"
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
## Brief description
Loading of options can be set in settings.

## Description
In case production needs to set loading options for all retimed plates to ignore retime settings, this can be now done from settings.

## Testing notes:
1. open nuke workfile
2. make sure you are having some retimed plate to load - ideally more that one version.
3. Load first older version with option set to add_retime to False
4. Update to latest version
5. It should load first read node without retime node connected to it, and then during update it should just update the read node without retime nodes.