### PR TITLE
NewPublisher: Keep plugins with mismatch target in report

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -709,6 +709,7 @@ class CreateContext:
         self.manual_creators = {}
 
         self.publish_discover_result = None
+        self.publish_plugins_mismatch_targets = []
         self.publish_plugins = []
         self.plugins_with_defs = []
         self._attr_plugins_by_family = {}
@@ -831,6 +832,7 @@ class CreateContext:
         discover_result = DiscoverResult()
         plugins_with_defs = []
         plugins_by_targets = []
+        plugins_mismatch_targets = []
         if discover_publish_plugins:
             discover_result = publish_plugins_discover()
             publish_plugins = discover_result.plugins
@@ -840,11 +842,19 @@ class CreateContext:
             plugins_by_targets = pyblish.logic.plugins_by_targets(
                 publish_plugins, list(targets)
             )
+
             # Collect plugins that can have attribute definitions
             for plugin in publish_plugins:
                 if OpenPypePyblishPluginMixin in inspect.getmro(plugin):
                     plugins_with_defs.append(plugin)
 
+            plugins_mismatch_targets = [
+                plugin
+                for plugin in publish_plugins
+                if plugin not in plugins_by_targets
+            ]
+
+        self.publish_plugins_mismatch_targets = plugins_mismatch_targets
         self.publish_discover_result = discover_result
         self.publish_plugins = plugins_by_targets
         self.plugins_with_defs = plugins_with_defs

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -154,14 +154,19 @@ class PublishReport:
         self._all_instances_by_id = {}
         self._current_context = None
 
-    def reset(self, context, publish_discover_result=None):
+    def reset(self, context, create_context):
         """Reset report and clear all data."""
-        self._publish_discover_result = publish_discover_result
+
+        self._publish_discover_result = create_context.publish_discover_result
         self._plugin_data = []
         self._plugin_data_with_plugin = []
         self._current_plugin_data = {}
         self._all_instances_by_id = {}
         self._current_context = context
+
+        for plugin in create_context.publish_plugins_mismatch_targets:
+            plugin_data = self._add_plugin_data_item(plugin)
+            plugin_data["skipped"] = True
 
     def add_plugin_iter(self, plugin, context):
         """Add report about single iteration of plugin."""
@@ -205,6 +210,7 @@ class PublishReport:
             "name": plugin.__name__,
             "label": label,
             "order": plugin.order,
+            "targets": list(plugin.targets),
             "instances_data": [],
             "actions_data": [],
             "skipped": False,
@@ -777,10 +783,7 @@ class PublisherController:
         # - pop the key after first collector using it would be safest option?
         self._publish_context.data["create_context"] = self.create_context
 
-        self._publish_report.reset(
-            self._publish_context,
-            self.create_context.publish_discover_result
-        )
+        self._publish_report.reset(self._publish_context, self.create_context)
         self._publish_validation_errors = []
         self._publish_current_plugin_validation_errors = None
         self._publish_error = None

--- a/openpype/tools/publisher/publish_report_viewer/report_items.py
+++ b/openpype/tools/publisher/publish_report_viewer/report_items.py
@@ -83,10 +83,8 @@ class PublishReport:
 
         logs = []
         plugins_items_by_id = {}
-        plugins_id_order = []
         for plugin_data in data["plugins_data"]:
             item = PluginItem(plugin_data)
-            plugins_id_order.append(item.id)
             plugins_items_by_id[item.id] = item
             for instance_data_item in plugin_data["instances_data"]:
                 instance_id = instance_data_item["id"]
@@ -95,6 +93,14 @@ class PublishReport:
                         copy.deepcopy(log_item_data), item.id, instance_id
                     )
                     logs.append(log_item)
+        sorted_plugins = sorted(
+            plugins_items_by_id.values(),
+            key=lambda item: item.order
+        )
+        plugins_id_order = [
+            plugin_item.id
+            for plugin_item in sorted_plugins
+        ]
 
         logs_by_instance_id = collections.defaultdict(list)
         for log_item in logs:


### PR DESCRIPTION
## Brief description
Add plugins that don't have matching targets to publish report so we have available all loaded plugins.

## Description
Filtered plugins are marked as skipped so they are visible in the report view. The main reason is confusion that plugin is not visible in view and is not in crashed plugin paths.

## Testing notes:
1. Run validation in new publisher
2. Go to report view
3. Unhide skipped plugins
4. You should see plugins that were skipped because if mismatched targets