### PR TITLE
NewPublisher: Groups work and enum multivalue

### DIFF
--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -98,6 +98,7 @@ class GroupWidget(QtWidgets.QWidget):
             instances(list<CreatedInstance>): List of instances in
                 CreateContext.
         """
+    
         # Store instances by id and by subset name
         instances_by_id = {}
         instances_by_subset_name = collections.defaultdict(list)
@@ -142,6 +143,7 @@ class GroupWidget(QtWidgets.QWidget):
 
 class CardWidget(BaseClickableFrame):
     """Clickable card used as bigger button."""
+
     selected = QtCore.Signal(str, str)
     # Group identifier of card
     # - this must be set because if send when mouse is released with card id
@@ -178,6 +180,7 @@ class ContextCardWidget(CardWidget):
 
     Is not visually under group widget and is always at the top of card view.
     """
+
     def __init__(self, parent):
         super(ContextCardWidget, self).__init__(parent)
 
@@ -204,13 +207,14 @@ class ContextCardWidget(CardWidget):
 
 class InstanceCardWidget(CardWidget):
     """Card widget representing instance."""
+
     active_changed = QtCore.Signal()
 
     def __init__(self, instance, group_icon, parent):
         super(InstanceCardWidget, self).__init__(parent)
 
         self._id = instance.id
-        self._group_identifier = instance.creator_label
+        self._group_identifier = instance.group_label
         self._group_icon = group_icon
 
         self.instance = instance

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -1,4 +1,5 @@
 from .widgets import (
+    CustomTextComboBox,
     PlaceholderLineEdit,
     BaseClickableFrame,
     ClickableFrame,
@@ -28,6 +29,7 @@ from .overlay_messages import (
 
 
 __all__ = (
+    "CustomTextComboBox",
     "PlaceholderLineEdit",
     "BaseClickableFrame",
     "ClickableFrame",

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -11,6 +11,28 @@ from openpype.style import (
 log = logging.getLogger(__name__)
 
 
+class CustomTextComboBox(QtWidgets.QComboBox):
+    """Combobox which can have different text showed."""
+
+    def __init__(self, *args, **kwargs):
+        self._custom_text = None
+        super(CustomTextComboBox, self).__init__(*args, **kwargs)
+
+    def set_custom_text(self, text=None):
+        if self._custom_text != text:
+            self._custom_text = text
+            self.repaint()
+
+    def paintEvent(self, event):
+        painter = QtWidgets.QStylePainter(self)
+        option = QtWidgets.QStyleOptionComboBox()
+        self.initStyleOption(option)
+        if self._custom_text is not None:
+            option.currentText = self._custom_text
+        painter.drawComplexControl(QtWidgets.QStyle.CC_ComboBox, option)
+        painter.drawControl(QtWidgets.QStyle.CE_ComboBoxLabel, option)
+
+
 class PlaceholderLineEdit(QtWidgets.QLineEdit):
     """Set placeholder color of QLineEdit in Qt 5.12 and higher."""
     def __init__(self, *args, **kwargs):

--- a/openpype/widgets/attribute_defs/widgets.py
+++ b/openpype/widgets/attribute_defs/widgets.py
@@ -374,6 +374,10 @@ class EnumAttrWidget(_BaseAttrDefWidget):
         combo_delegate = QtWidgets.QStyledItemDelegate(input_widget)
         input_widget.setItemDelegate(combo_delegate)
 
+        line_edit = QtWidgets.QLineEdit(input_widget)
+        line_edit.setReadOnly(True)
+        input_widget.setLineEdit(line_edit)
+
         if self.attr_def.tooltip:
             input_widget.setToolTip(self.attr_def.tooltip)
 
@@ -408,7 +412,8 @@ class EnumAttrWidget(_BaseAttrDefWidget):
                 self._input_widget.setCurrentIndex(idx)
 
         else:
-            self._input_widget.lineEdit().setText("Multiselection")
+            line_edit = self._input_widget.lineEdit()
+            line_edit.setText("Multiselection")
 
 
 class UnknownAttrWidget(_BaseAttrDefWidget):

--- a/openpype/widgets/attribute_defs/widgets.py
+++ b/openpype/widgets/attribute_defs/widgets.py
@@ -376,6 +376,7 @@ class EnumAttrWidget(_BaseAttrDefWidget):
 
         line_edit = QtWidgets.QLineEdit(input_widget)
         line_edit.setReadOnly(True)
+        line_edit.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
         input_widget.setLineEdit(line_edit)
 
         if self.attr_def.tooltip:
@@ -413,7 +414,7 @@ class EnumAttrWidget(_BaseAttrDefWidget):
 
         else:
             line_edit = self._input_widget.lineEdit()
-            line_edit.setText("Multiselection")
+            line_edit.setText("< Multiselection> ")
 
 
 class UnknownAttrWidget(_BaseAttrDefWidget):


### PR DESCRIPTION
## Brief description
Instances refresh use right source for groups and enum attribute can handle multivalue.

## Description
Groups on update of instance were still using old implementation. And enum multivalue didn't work because combobox did not have line edit available.

## Testing notes:
Change view few times after instance creation.
- it should not crash and should use right groups

Select multiple instances which have defined enumerator attribute.
- it should not crash and `< Multivalue >` should be showed as label if instances have different values