### PR TITLE
TrayPublisher: Make sure host name is filled

### DIFF
--- a/openpype/hosts/traypublisher/api/__init__.py
+++ b/openpype/hosts/traypublisher/api/__init__.py
@@ -1,20 +1,8 @@
 from .pipeline import (
-    install,
-    ls,
-
-    set_project_name,
-    get_context_title,
-    get_context_data,
-    update_context_data,
+    TrayPublisherHost,
 )
 
 
 __all__ = (
-    "install",
-    "ls",
-
-    "set_project_name",
-    "get_context_title",
-    "get_context_data",
-    "update_context_data",
+    "TrayPublisherHost",
 )

--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -37,6 +37,21 @@ class TrayPublishCreator(Creator):
         # Use same attributes as for instance attrobites
         return self.get_instance_attr_defs()
 
+    def _store_new_instance(self, new_instance):
+        """Tray publisher specific method to store instance.
+
+        Instance is stored into "workfile" of traypublisher and also add it
+        to CreateContext.
+
+        Args:
+            new_instance (CreatedInstance): Instance that should be stored.
+        """
+
+        # Host implementation of storing metadata about instance
+        HostContext.add_instance(new_instance.data_to_store())
+        # Add instance to current context
+        self._add_instance_to_context(new_instance)
+
 
 class SettingsCreator(TrayPublishCreator):
     create_allow_context_change = True
@@ -58,10 +73,8 @@ class SettingsCreator(TrayPublishCreator):
         data["settings_creator"] = True
         # Create new instance
         new_instance = CreatedInstance(self.family, subset_name, data, self)
-        # Host implementation of storing metadata about instance
-        HostContext.add_instance(new_instance.data_to_store())
-        # Add instance to current context
-        self._add_instance_to_context(new_instance)
+
+        self._store_new_instance(new_instance)
 
     def get_instance_attr_defs(self):
         return [

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -102,6 +102,10 @@ class BaseCreator:
 
         return self.create_context.project_name
 
+    @property
+    def host(self):
+        return self.create_context.host
+
     def get_group_label(self):
         """Group label under which are instances grouped in UI.
 

--- a/openpype/tools/traypublisher/window.py
+++ b/openpype/tools/traypublisher/window.py
@@ -12,9 +12,7 @@ from openpype.pipeline import (
     install_host,
     AvalonMongoDB,
 )
-from openpype.hosts.traypublisher import (
-    api as traypublisher
-)
+from openpype.hosts.traypublisher.api import TrayPublisherHost
 from openpype.tools.publisher import PublisherWindow
 from openpype.tools.utils.constants import PROJECT_NAME_ROLE
 from openpype.tools.utils.models import (
@@ -111,9 +109,13 @@ class StandaloneOverlayWidget(QtWidgets.QFrame):
         if project_name:
             self._set_project(project_name)
 
+    @property
+    def host(self):
+        return self._publisher_window.controller.host
+
     def _set_project(self, project_name):
         self._project_name = project_name
-        traypublisher.set_project_name(project_name)
+        self.host.set_project_name(project_name)
         self.setVisible(False)
         self.project_selected.emit(project_name)
 
@@ -190,7 +192,8 @@ class TrayPublishWindow(PublisherWindow):
 
 
 def main():
-    install_host(traypublisher)
+    host = TrayPublisherHost()
+    install_host(host)
     app = QtWidgets.QApplication([])
     window = TrayPublishWindow()
     window.show()


### PR DESCRIPTION
## Brief description
Converted Tray Publisher to host inheriting from HostBase which makes sure `AVALON_APP` is filled.

## Description
Make sure `AVALON_APP` is filled in both environment and legacy io session. Tray publisher is using `HostBase` as source for implementation. Traypublisher creator has helper method to store new instance. Creators have access to host.

## Testing notes:
1. AVALON_APP should be available in both environments and legacy_io.Session during publishing

Resovles https://github.com/pypeclub/OpenPype/issues/3500