### PR TITLE
Ftrack: Trigger custom ftrack topic of project structure creation

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_create_project_structure.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_create_project_structure.py
@@ -84,6 +84,11 @@ class CreateProjectFolders(BaseAction):
             create_project_folders(basic_paths, project_name)
             self.create_ftrack_entities(basic_paths, project_entity)
 
+            self.trigger_event(
+                "openpype.project.structure.created",
+                {"project_name": project_name}
+            )
+
         except Exception as exc:
             self.log.warning("Creating of structure crashed.", exc_info=True)
             session.rollback()


### PR DESCRIPTION
## Brief description
Trigger custom ftrack topic with project name in event data on triggering or create project structure action.

## Description
Topic triggered on finish is `openpype.project.structure.created` which can be listened to and trigger custom callback when finishes. This may have usage for example for customuzation of permissions on first folder structure creation.

## Testing notes:
This change require to have custom code implemented.
```
import ftrack_api

def my_callback(event):
    print("Project structure was created on project {}".format(
        event["data"]["project_name"]))


if __name__ == "__main__":
    ftrack_url = "https://<your domain>.ftrackapp.com"
    ftrack_api_key = "<ftrack api key>"
    ftrack_username = "<ftrack username>"
    session = ftrack_api.Session(
        ftrack_url,
        ftrack_api_key,
        ftrack_username,
        auto_connect_event_hub=True
    )
    session.event_hub.subscribe(
        "topic=openpype.project.structure.created",
        my_callback
    )
    session.event_hub.wait()
```

1. Run this python script
2. Trigger project create structure action (e.g. through prepare project with checked "Create project structure")