### PR TITLE
Ftrack: add source into Note

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
@@ -45,7 +45,7 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             "files": filenames
         })
 
-        instance.data["source"] = filepaths
+        instance.data["source"] = "\n".join(filepaths)
 
         self.log.debug("Created Simple Settings instance {}".format(
             instance.data

--- a/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
@@ -45,6 +45,8 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             "files": filenames
         })
 
+        instance.data["source"] = filepaths
+
         self.log.debug("Created Simple Settings instance {}".format(
             instance.data
         ))

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -116,6 +116,7 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
                 "app_name": app_name,
                 "app_label": app_label,
                 "published_paths": "<br/>".join(sorted(published_paths)),
+                "source": instance.data.get("source", '')
             }
             comment = template.format(**format_data)
             if not comment:

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -822,7 +822,7 @@
                         },
                         {
                             "type": "label",
-                            "label": "Template may contain formatting keys <b>intent</b>, <b>comment</b>, <b>host_name</b>, <b>app_name</b>, <b>app_label</b> and <b>published_paths</b>."
+                            "label": "Template may contain formatting keys <b>intent</b>, <b>comment</b>, <b>host_name</b>, <b>app_name</b>, <b>app_label</b>, <b>published_paths</b> and <b>source</b>."
                         },
                         {
                             "type": "text",


### PR DESCRIPTION
## Brief description
Customer wants to be able to see source files published from TrayPublisher somehow in Ftrack.

## Description
Added possibility of Basic Creators (eg without specific Creator class) to store its source files into `instance.data["source"]`.
Added usage of {source} key in formatting of Ftrack note.
This value will also show up in DB version document. There is only for debugging purposes.

Each additional TrayPublisher Creator must implement storing of source file into `instance.data["source"]` if it wishes to be filled on Ftrack side.

![Screenshot 2022-07-13 155020](https://user-images.githubusercontent.com/4457962/178749996-1800614e-e4ad-4c0b-bd5b-f7b29d147d2f.png)


## Testing notes:
1. put `{source}` placeholder into `project_settings/ftrack/publish/IntegrateFtrackNote/note_template`
2. publish anything via TrayPublisher that should send something into Ftrack
3. validate on version if Ftrack that Notes contains source file of the publish
![Screenshot 2022-07-13 155117](https://user-images.githubusercontent.com/4457962/178750269-9a16da7a-e9ae-4f90-bba8-999e9fb6edab.png)
 