### PR TITLE
Maya: Renderman display output fix

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1087,7 +1087,7 @@ class RenderProductsRenderman(ARenderProducts):
             "d_tiff": "tif"
         }
 
-        displays = get_displays()["displays"]
+        displays = get_displays(override_dst="render")["displays"]
         for name, display in displays.items():
             enabled = display["params"]["enable"]["value"]
             if not enabled:
@@ -1106,9 +1106,16 @@ class RenderProductsRenderman(ARenderProducts):
                 display["driverNode"]["type"], "exr")
 
             for camera in cameras:
-                product = RenderProduct(productName=aov_name,
-                                        ext=extensions,
-                                        camera=camera)
+                # Create render product and set it as multipart only on
+                # display types supporting it. In all other cases, Renderman
+                # will create separate output per channel.
+                product = RenderProduct(
+                    productName=aov_name,
+                    ext=extensions,
+                    camera=camera,
+                    multipart=display["driverNode"]["type"] in ["d_openexr", "d_deepexr", "d_tiff"]  # noqa
+                )
+
                 products.append(product)
 
         return products

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1109,12 +1109,28 @@ class RenderProductsRenderman(ARenderProducts):
                 # Create render product and set it as multipart only on
                 # display types supporting it. In all other cases, Renderman
                 # will create separate output per channel.
-                product = RenderProduct(
-                    productName=aov_name,
-                    ext=extensions,
-                    camera=camera,
-                    multipart=display["driverNode"]["type"] in ["d_openexr", "d_deepexr", "d_tiff"]  # noqa
-                )
+                if display["driverNode"]["type"] in ["d_openexr", "d_deepexr", "d_tiff"]:  # noqa
+                    product = RenderProduct(
+                        productName=aov_name,
+                        ext=extensions,
+                        camera=camera,
+                        multipart=True
+                    )
+                else:
+                    # this code should handle the case where no multipart
+                    # capable format is selected. But since it involves
+                    # shady logic to determine what channel become what
+                    # lets not do that as all productions will use exr anyway.
+                    """
+                    for channel in display['params']['displayChannels']['value']:  # noqa
+                        product = RenderProduct(
+                            productName="{}_{}".format(aov_name, channel),
+                            ext=extensions,
+                            camera=camera,
+                            multipart=False
+                        )
+                    """
+                    raise UnsupportedImageFormatException("Only exr, deep exr and tiff formats are supported.")
 
                 products.append(product)
 
@@ -1208,3 +1224,7 @@ class UnsupportedRendererException(Exception):
 
     Raised when requesting data from unsupported renderer.
     """
+
+
+class UnsupportedImageFormatException(Exception):
+    """Custom exception to report unsupported output image format."""

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1130,7 +1130,8 @@ class RenderProductsRenderman(ARenderProducts):
                             multipart=False
                         )
                     """
-                    raise UnsupportedImageFormatException("Only exr, deep exr and tiff formats are supported.")
+                    raise UnsupportedImageFormatException(
+                        "Only exr, deep exr and tiff formats are supported.")
 
                 products.append(product)
 


### PR DESCRIPTION
## Problem

Imagine you have two displays in a scene - `beauty` and let say `mattes`. In the `beauty`, there are channels `Z`, `Env`, `id` (and of course `Ci` and `a`) and in the `mattes` there are `foo`, `bar`, `baz`:

```
beauty
   |- Z
   |- Env
   \- id
mattes
   |- foo
   |- bar
   \- baz
```

publishing **without** prior IPR render will result correctly in two displays (and two expected sequences) for example `Layer_beauty.####.exr` and `Layer_mattes.####.exr`. 

But when you do the IPR before publishing, Renderman will breakout existing displays (`beauty` and `mattes`) into `beauty_Z`, `beauty_Env`, `beauty__id` and similar with mattes - `mattes_foo`, `mattes_bar`, `mattes_baz`.

## Solution

is to force rfm to output only displays for render destination (not all - viewport/it/driver). This PR is doing exactly this, plus adding proper `multipart` flag on formats supporting it.

## Testing

Create test scene and add few displays with some channels. Start IPR render, close it and then publish the render job to farm. After rendering, it should publish ok.

This code will show you all expected displays (display == output file sequence):

```python
from rfm2.api.displays import get_displays

displays = get_displays(override_dst="render")["displays"]
print("v" * 80)
for name, display in displays.items():
    print("-" * 80)
    print(f"display name: {name}")
    channels = ", ".join(display['params']['displayChannels']['value'])
    print(f"channels: {channels}")
print("-" * 80)
print("^" * 80)
```