### PR TITLE
Ftrack: Automatic daily review session creation can define trigger hour

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/action_create_review_session.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_create_review_session.py
@@ -123,7 +123,9 @@ class CreateDailyReviewSessionServerAction(ServerAction):
         # Store cycle time which will be used to create next timer
         self._last_cyle_time = cycle_time
         # Create timer thread
-        self._cycle_timer = threading.Timer(seconds_delta, self._timer_callback)
+        self._cycle_timer = threading.Timer(
+            seconds_delta, self._timer_callback
+        )
         self._cycle_timer.start()
 
         self._check_review_session()

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -124,6 +124,11 @@
                 "Project Manager"
             ],
             "cycle_enabled": false,
+            "cycle_hour_start": [
+                0,
+                0,
+                0
+            ],
             "review_session_template": "{yy}{mm}{dd}"
         }
     },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -410,7 +410,10 @@
                         {
                             "type": "boolean",
                             "key": "cycle_enabled",
-                            "label": "Create daily review session"
+                            "label": "Run automatically every day"
+                        },
+                        {
+                            "type": "separator"
                         },
                         {
                             "type": "list-strict",
@@ -419,23 +422,29 @@
                             "tooltip": "This may take affect on next day",
                             "object_types": [
                                 {
-                                    "label": "HMS",
+                                    "label": "H:",
                                     "type": "number",
                                     "minimum": 0,
                                     "maximum": 23,
                                     "decimal": 0
                                 }, {
+                                    "label": "M:",
                                     "type": "number",
                                     "minimum": 0,
                                     "maximum": 59,
                                     "decimal": 0
                                 }, {
+                                    "label": "S:",
                                     "type": "number",
                                     "minimum": 0,
                                     "maximum": 59,
                                     "decimal": 0
                                 }
                             ]
+                        },
+                        {
+                            "type": "label",
+                            "label": "This can't be overriden per project and any change will take effect on the next day or on restart of event server."
                         },
                         {
                             "type": "separator"

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -413,6 +413,31 @@
                             "label": "Create daily review session"
                         },
                         {
+                            "type": "list-strict",
+                            "key": "cycle_hour_start",
+                            "label": "Create daily review session at",
+                            "tooltip": "This may take affect on next day",
+                            "object_types": [
+                                {
+                                    "label": "HMS",
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 23,
+                                    "decimal": 0
+                                }, {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 59,
+                                    "decimal": 0
+                                }, {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 59,
+                                    "decimal": 0
+                                }
+                            ]
+                        },
+                        {
                             "type": "separator"
                         },
                         {


### PR DESCRIPTION
## Brief description
It is possible to define in which time automated creation of daily review session happens.

## Description
The time definition is in project settings but can't be set per project and the change of time in settings take effect on next day or on restart of event server.

## Testing notes:
1. Enable `project_settings/ftrack/events/create_daily_review_session/cycle_enabled`
2. Change `project_settings/ftrack/events/create_daily_review_session/cycle_hour_start` to trigger automated creation at your time (would recommend +5 minutes from current tim)
3. Run ftrack event server
4. Wait until that time
5. Daily review session should be created