### PR TITLE
Traypublisher: added thumbnail extract 

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -46,7 +46,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             self.log.info("Skipping - no review set on instance.")
             return
 
-        if self._has_thumbnail_already(instance):
+        if self._already_has_thumbnail(instance):
             self.log.info("Thumbnail representation already present.")
             return
 
@@ -106,7 +106,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             # There is no need to create more then one thumbnail
             break
 
-    def _has_thumbnail_already(self, instance):
+    def _already_has_thumbnail(self, instance):
         for repre in instance.data.get("representations", []):
             self.log.info("repre {}".format(repre))
             if repre["name"] == "thumbnail":

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -22,7 +22,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "imagesequence", "render", "render2d", "prerender",
         "source", "plate", "take"
     ]
-    hosts = ["shell", "fusion", "resolve"]
+    hosts = ["shell", "fusion", "resolve", "traypublisher"]
     enabled = False
 
     # presetable attribute
@@ -44,6 +44,10 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         # Skip if review not set.
         if not instance.data.get("review", True):
             self.log.info("Skipping - no review set on instance.")
+            return
+
+        if self._has_thumbnail_already(instance):
+            self.log.info("Thumbnail representation already present.")
             return
 
         filtered_repres = self._get_filtered_repres(instance)
@@ -101,6 +105,14 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             instance.data["representations"].append(new_repre)
             # There is no need to create more then one thumbnail
             break
+
+    def _has_thumbnail_already(self, instance):
+        for repre in instance.data.get("representations", []):
+            self.log.info("repre {}".format(repre))
+            if repre["name"] == "thumbnail":
+                return True
+
+        return False
 
     def _get_filtered_repres(self, instance):
         filtered_repres = []


### PR DESCRIPTION
## Brief description
Used global plugin for thumbnail extraction even in Traypublisher

## Additional info
Added check if thumbnail representation is not present, created by different plugin by any chance.
ExtractThumbnailSP should be removed when SP is removed, no need to copy and have 2 plugins.


## Testing notes:
1. try publish render with TrayPublisher
2. it should create thumbnail in publish folder