### PR TITLE
General: Get current context document functions

### DIFF
--- a/openpype/hosts/harmony/api/pipeline.py
+++ b/openpype/hosts/harmony/api/pipeline.py
@@ -15,6 +15,7 @@ from openpype.pipeline import (
     deregister_creator_plugin_path,
     AVALON_CONTAINER_ID,
 )
+from openpype.pipeline.context_tools import get_current_project_asset
 import openpype.hosts.harmony
 import openpype.hosts.harmony.api as harmony
 
@@ -50,7 +51,9 @@ def get_asset_settings():
         dict: Scene data.
 
     """
-    asset_data = lib.get_asset()["data"]
+
+    asset_doc = get_current_project_asset()
+    asset_data = asset_doc["data"]
     fps = asset_data.get("fps")
     frame_start = asset_data.get("frameStart")
     frame_end = asset_data.get("frameEnd")

--- a/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
+++ b/openpype/hosts/harmony/plugins/publish/validate_scene_settings.py
@@ -55,6 +55,10 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         """Plugin entry point."""
+
+        # TODO 'get_asset_settings' could expect asset document as argument
+        #   which is available on 'context.data["assetEntity"]'
+        #   - the same approach can be used in 'ValidateSceneSettingsRepair'
         expected_settings = harmony.get_asset_settings()
         self.log.info("scene settings from DB:".format(expected_settings))
 

--- a/openpype/hosts/hiero/api/plugin.py
+++ b/openpype/hosts/hiero/api/plugin.py
@@ -10,6 +10,7 @@ import qargparse
 
 import openpype.api as openpype
 from openpype.pipeline import LoaderPlugin, LegacyCreator
+from openpype.pipeline.context_tools import get_current_project_asset
 from . import lib
 
 log = openpype.Logger().get_logger(__name__)
@@ -484,7 +485,7 @@ class ClipLoader:
 
         """
         asset_name = self.context["representation"]["context"]["asset"]
-        asset_doc = openpype.get_asset(asset_name)
+        asset_doc = get_current_project_asset(asset_name)
         log.debug("__ asset_doc: {}".format(pformat(asset_doc)))
         self.data["assetData"] = asset_doc["data"]
 

--- a/openpype/hosts/houdini/api/lib.py
+++ b/openpype/hosts/houdini/api/lib.py
@@ -5,8 +5,8 @@ from contextlib import contextmanager
 import six
 
 from openpype.client import get_asset_by_name
-from openpype.api import get_asset
 from openpype.pipeline import legacy_io
+from openpype.pipeline.context_tools import get_current_project_asset
 
 
 import hou
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 def get_asset_fps():
     """Return current asset fps."""
-    return get_asset()["data"].get("fps")
+    return get_current_project_asset()["data"].get("fps")
 
 
 def set_id(node, unique_id, overwrite=False):

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -15,13 +15,13 @@ from openpype.hosts.maya.api import (
 from openpype.lib import requests_get
 from openpype.api import (
     get_system_settings,
-    get_project_settings,
-    get_asset)
+    get_project_settings)
 from openpype.modules import ModulesManager
 from openpype.pipeline import (
     CreatorError,
     legacy_io,
 )
+from openpype.pipeline.context_tools import get_current_project_asset
 
 
 class CreateRender(plugin.Creator):
@@ -413,7 +413,7 @@ class CreateRender(plugin.Creator):
                      prefix,
                      type="string")
 
-        asset = get_asset()
+        asset = get_current_project_asset()
 
         if renderer == "arnold":
             # set format to exr

--- a/openpype/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/openpype/hosts/maya/plugins/publish/validate_maya_units.py
@@ -2,8 +2,8 @@ import maya.cmds as cmds
 
 import pyblish.api
 import openpype.api
-from openpype import lib
 import openpype.hosts.maya.api.lib as mayalib
+from openpype.pipeline.context_tools import get_current_project_asset
 from math import ceil
 
 
@@ -41,7 +41,9 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         # now flooring the value?
         fps = float_round(context.data.get('fps'), 2, ceil)
 
-        asset_fps = lib.get_asset()["data"]["fps"]
+        # TODO repace query with using 'context.data["assetEntity"]'
+        asset_doc = get_current_project_asset()
+        asset_fps = asset_doc["data"]["fps"]
 
         self.log.info('Units (linear): {0}'.format(linearunits))
         self.log.info('Units (angular): {0}'.format(angularunits))
@@ -91,5 +93,7 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         cls.log.debug(current_linear)
 
         cls.log.info("Setting time unit to match project")
-        asset_fps = lib.get_asset()["data"]["fps"]
+        # TODO repace query with using 'context.data["assetEntity"]'
+        asset_doc = get_current_project_asset()
+        asset_fps = asset_doc["data"]["fps"]
         mayalib.set_scene_fps(asset_fps)

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -24,7 +24,6 @@ from openpype.api import (
     BuildWorkfile,
     get_version_from_path,
     get_workdir_data,
-    get_asset,
     get_current_project_settings,
 )
 from openpype.tools.utils import host_tools
@@ -40,6 +39,7 @@ from openpype.pipeline import (
     legacy_io,
     Anatomy,
 )
+from openpype.pipeline.context_tools import get_current_project_asset
 
 from . import gizmo_menu
 
@@ -1766,7 +1766,7 @@ class WorkfileSettings(object):
             kwargs.get("asset_name")
             or legacy_io.Session["AVALON_ASSET"]
         )
-        self._asset_entity = get_asset(self._asset)
+        self._asset_entity = get_current_project_asset(self._asset)
         self._root_node = root_node or nuke.root()
         self._nodes = self.get_nodes(nodes=nodes)
 

--- a/openpype/hosts/nuke/plugins/publish/validate_script.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_script.py
@@ -1,7 +1,6 @@
 import pyblish.api
 
-from openpype.client import get_project, get_asset_by_id
-from openpype import lib
+from openpype.client import get_project, get_asset_by_id, get_asset_by_name
 from openpype.pipeline import legacy_io
 
 
@@ -17,10 +16,11 @@ class ValidateScript(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         ctx_data = instance.context.data
-        asset_name = ctx_data["asset"]
-        asset = lib.get_asset(asset_name)
-        asset_data = asset["data"]
         project_name = legacy_io.active_project()
+        asset_name = ctx_data["asset"]
+        # TODO repace query with using 'instance.data["assetEntity"]'
+        asset = get_asset_by_name(project_name, asset_name)
+        asset_data = asset["data"]
 
         # These attributes will be checked
         attributes = [

--- a/openpype/hosts/resolve/api/plugin.py
+++ b/openpype/hosts/resolve/api/plugin.py
@@ -4,11 +4,11 @@ import uuid
 import qargparse
 from Qt import QtWidgets, QtCore
 
-import openpype.api as pype
 from openpype.pipeline import (
     LegacyCreator,
     LoaderPlugin,
 )
+from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.hosts import resolve
 from . import lib
 
@@ -375,7 +375,7 @@ class ClipLoader:
 
         """
         asset_name = self.context["representation"]["context"]["asset"]
-        self.data["assetData"] = pype.get_asset(asset_name)["data"]
+        self.data["assetData"] = get_current_project_asset(asset_name)["data"]
 
     def load(self):
         # create project bin for the media to be imported into

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial.py
@@ -19,6 +19,7 @@ import os
 import opentimelineio as otio
 import pyblish.api
 from openpype import lib as plib
+from openpype.pipeline.context_tools import get_current_project_asset
 
 
 class OTIO_View(pyblish.api.Action):
@@ -116,7 +117,7 @@ class CollectEditorial(pyblish.api.InstancePlugin):
             if extension == ".edl":
                 # EDL has no frame rate embedded so needs explicit
                 # frame rate else 24 is asssumed.
-                kwargs["rate"] = plib.get_asset()["data"]["fps"]
+                kwargs["rate"] = get_current_project_asset()["data"]["fps"]
 
             instance.data["otio_timeline"] = otio.adapters.read_from_file(
                 file_path, **kwargs)

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
@@ -1,8 +1,12 @@
 import os
+from copy import deepcopy
+
 import opentimelineio as otio
 import pyblish.api
+
 from openpype import lib as plib
-from copy import deepcopy
+from openpype.pipeline.context_tools import get_current_project_asset
+
 
 class CollectInstances(pyblish.api.InstancePlugin):
     """Collect instances from editorial's OTIO sequence"""
@@ -48,7 +52,7 @@ class CollectInstances(pyblish.api.InstancePlugin):
 
         # get timeline otio data
         timeline = instance.data["otio_timeline"]
-        fps = plib.get_asset()["data"]["fps"]
+        fps = get_current_project_asset()["data"]["fps"]
 
         tracks = timeline.each_child(
             descended_from_type=otio.schema.Track

--- a/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/validate_frame_ranges.py
@@ -3,8 +3,8 @@ import re
 import pyblish.api
 
 import openpype.api
-from openpype import lib
 from openpype.pipeline import PublishXmlValidationError
+from openpype.pipeline.context_tools import get_current_project_asset
 
 
 class ValidateFrameRange(pyblish.api.InstancePlugin):
@@ -27,7 +27,8 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
                for pattern in self.skip_timelines_check):
             self.log.info("Skipping for {} task".format(instance.data["task"]))
 
-        asset_data = lib.get_asset(instance.data["asset"])["data"]
+        # TODO repace query with using 'instance.data["assetEntity"]'
+        asset_data = get_current_project_asset(instance.data["asset"])["data"]
         frame_start = asset_data["frameStart"]
         frame_end = asset_data["frameEnd"]
         handle_start = asset_data["handleStart"]

--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -8,13 +8,13 @@ from unreal import EditorAssetLibrary
 from unreal import MovieSceneSkeletalAnimationTrack
 from unreal import MovieSceneSkeletalAnimationSection
 
+from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.pipeline import (
     get_representation_path,
     AVALON_CONTAINER_ID
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
-from openpype.api import get_asset
 
 
 class AnimationFBXLoader(plugin.Loader):
@@ -53,6 +53,8 @@ class AnimationFBXLoader(plugin.Loader):
         if not actor:
             return None
 
+        asset_doc = get_current_project_asset(fields=["data.fps"])
+
         task.set_editor_property('filename', self.fname)
         task.set_editor_property('destination_path', asset_dir)
         task.set_editor_property('destination_name', asset_name)
@@ -80,7 +82,7 @@ class AnimationFBXLoader(plugin.Loader):
         task.options.anim_sequence_import_data.set_editor_property(
             'use_default_sample_rate', False)
         task.options.anim_sequence_import_data.set_editor_property(
-            'custom_sample_rate', get_asset()["data"].get("fps"))
+            'custom_sample_rate', asset_doc.get("data", {}).get("fps"))
         task.options.anim_sequence_import_data.set_editor_property(
             'import_custom_attribute', True)
         task.options.anim_sequence_import_data.set_editor_property(
@@ -246,6 +248,7 @@ class AnimationFBXLoader(plugin.Loader):
     def update(self, container, representation):
         name = container["asset_name"]
         source_path = get_representation_path(representation)
+        asset_doc = get_current_project_asset(fields=["data.fps"])
         destination_path = container["namespace"]
 
         task = unreal.AssetImportTask()
@@ -279,7 +282,7 @@ class AnimationFBXLoader(plugin.Loader):
         task.options.anim_sequence_import_data.set_editor_property(
             'use_default_sample_rate', False)
         task.options.anim_sequence_import_data.set_editor_property(
-            'custom_sample_rate', get_asset()["data"].get("fps"))
+            'custom_sample_rate', asset_doc.get("data", {}).get("fps"))
         task.options.anim_sequence_import_data.set_editor_property(
             'import_custom_attribute', True)
         task.options.anim_sequence_import_data.set_editor_property(

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -20,7 +20,7 @@ from openpype.pipeline import (
     AVALON_CONTAINER_ID,
     legacy_io,
 )
-from openpype.api import get_asset
+from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 
@@ -225,6 +225,7 @@ class LayoutLoader(plugin.Loader):
 
         anim_path = f"{asset_dir}/animations/{anim_file_name}"
 
+        asset_doc = get_current_project_asset()
         # Import animation
         task = unreal.AssetImportTask()
         task.options = unreal.FbxImportUI()
@@ -259,7 +260,7 @@ class LayoutLoader(plugin.Loader):
         task.options.anim_sequence_import_data.set_editor_property(
             'use_default_sample_rate', False)
         task.options.anim_sequence_import_data.set_editor_property(
-            'custom_sample_rate', get_asset()["data"].get("fps"))
+            'custom_sample_rate', asset_doc.get("data", {}).get("fps"))
         task.options.anim_sequence_import_data.set_editor_property(
             'import_custom_attribute', True)
         task.options.anim_sequence_import_data.set_editor_property(

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -236,7 +236,7 @@ def any_outdated():
     return False
 
 
-@with_pipeline_io
+@deprecated("openpype.pipeline.context_tools.get_current_project_asset")
 def get_asset(asset_name=None):
     """ Returning asset document from database by its name.
 
@@ -249,15 +249,9 @@ def get_asset(asset_name=None):
         (MongoDB document)
     """
 
-    project_name = legacy_io.active_project()
-    if not asset_name:
-        asset_name = legacy_io.Session["AVALON_ASSET"]
+    from openpype.pipeline.context_tools import get_current_project_asset
 
-    asset_document = get_asset_by_name(project_name, asset_name)
-    if not asset_document:
-        raise TypeError("Entity \"{}\" was not found in DB".format(asset_name))
-
-    return asset_document
+    return get_current_project_asset(asset_name=asset_name)
 
 
 def get_system_general_anatomy_data(system_settings=None):

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -10,6 +10,11 @@ import pyblish.api
 from pyblish.lib import MessageHandler
 
 import openpype
+from openpype.client import (
+    get_project,
+    get_asset_by_id,
+    get_asset_by_name,
+)
 from openpype.modules import load_modules, ModulesManager
 from openpype.settings import get_project_settings
 from openpype.lib import filter_pyblish_plugins
@@ -282,3 +287,50 @@ def debug_host():
     })
 
     return host
+
+
+def get_current_project(fields=None):
+    """Helper function to get project document based on global Session.
+
+    This function should be called only in process where host is installed.
+
+    Returns:
+        dict: Project document.
+        None: Project is not set.
+    """
+
+    project_name = legacy_io.active_project()
+    return get_project(project_name, fields=fields)
+
+
+def get_current_project_asset(asset_name=None, asset_id=None, fields=None):
+    """Helper function to get asset document based on global Session.
+
+    This function should be called only in process where host is installed.
+
+    Asset is found out based on passed asset name or id (not both). Asset name
+    is not used for filtering if asset id is passed. When both asset name and
+    id are missing then asset name from current process is used.
+
+    Args:
+        asset_name (str): Name of asset used for filter.
+        asset_id (Union[str, ObjectId]): Asset document id. If entered then
+            is used as only filter.
+        fields (Union[List[str], None]): Limit returned data of asset documents
+            to specific keys.
+
+    Returns:
+        dict: Asset document.
+        None: Asset is not set or not exist.
+    """
+
+    project_name = legacy_io.active_project()
+    if asset_id:
+        return get_asset_by_id(project_name, asset_id, fields=fields)
+
+    if not asset_name:
+        asset_name = legacy_io.Session.get("AVALON_ASSET")
+        # Skip if is not set even on context
+        if not asset_name:
+            return None
+    return get_asset_by_name(project_name, asset_name, fields=fields)

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -240,29 +240,7 @@ def registered_host():
 
 
 def deregister_host():
-    _registered_host["_"] = default_host()
-
-
-def default_host():
-    """A default host, in place of anything better
-
-    This may be considered as reference for the
-    interface a host must implement. It also ensures
-    that the system runs, even when nothing is there
-    to support it.
-
-    """
-
-    host = types.ModuleType("defaultHost")
-
-    def ls():
-        return list()
-
-    host.__dict__.update({
-        "ls": ls
-    })
-
-    return host
+    _registered_host["_"] = None
 
 
 def debug_host():


### PR DESCRIPTION
## Brief description
Moved function `get_asset` from `openpype.lib.avalon_context` into `openpype.pipeline.context_tools` and renamed to `get_current_project_asset`. Also was added function `get_current_project` to receive current project document.

## Description
Function in `openpype.lib` was marked as deprecated and internally is calling the new function in context tools. New function has extended arguments with ability to pass asset id and define fields that will be returned.

## Additional information
At some places there is possibility to use different source for asset documents, e.g. during publishing should be asset documents already available on instance or context (marked with TODO).

## Testing notes:
Hosts should work as before:
- [x] Harmony
    - validation of scene settings (workfile publishing)
- [x] Hiero
    - clip loader
- [x] Houdini
    - fps should be set correctly based on asset data
- [x] Maya
    - scene settings should be set on workfile open
    - validation of fps
    - creation of render
- [x] Nuke
    - workfiles settings (not sure how to trigger?)
    - validation of scene (workfile publishing)
- [x] Resolve
    - load clip
- [x] StandalonePublisher
    - editorial publishing
- [x] Unreal
    - load layout
    - load animation