### PR TITLE
Maya: Added wrapper around cmds.setAttr

### DIFF
--- a/openpype/vendor/python/common/capture.py
+++ b/openpype/vendor/python/common/capture.py
@@ -403,7 +403,7 @@ def apply_view(panel, **options):
     camera_options = options.get("camera_options", {})
     _iteritems = getattr(camera_options, "iteritems", camera_options.items)
     for key, value in _iteritems:
-        cmds.setAttr("{0}.{1}".format(camera, key), value)
+        _safe_setAttr("{0}.{1}".format(camera, key), value)
 
     # Viewport options
     viewport_options = options.get("viewport_options", {})
@@ -417,7 +417,7 @@ def apply_view(panel, **options):
     )
     for key, value in _iteritems():
         attr = "hardwareRenderingGlobals.{0}".format(key)
-        cmds.setAttr(attr, value)
+        _safe_setAttr(attr, value)
 
 
 def parse_active_panel():
@@ -551,10 +551,10 @@ def apply_scene(**options):
         cmds.playbackOptions(maxTime=options["end_frame"])
 
     if "width" in options:
-        cmds.setAttr("defaultResolution.width", options["width"])
+        _safe_setAttr("defaultResolution.width", options["width"])
 
     if "height" in options:
-        cmds.setAttr("defaultResolution.height", options["height"])
+        _safe_setAttr("defaultResolution.height", options["height"])
 
     if "compression" in options:
         cmds.optionVar(
@@ -665,7 +665,7 @@ def _applied_camera_options(options, panel):
 
     _iteritems = getattr(options, "iteritems", options.items)
     for opt, value in _iteritems():
-        cmds.setAttr(camera + "." + opt, value)
+        _safe_setAttr(camera + "." + opt, value)
 
     try:
         yield
@@ -673,7 +673,7 @@ def _applied_camera_options(options, panel):
         if old_options:
             _iteritems = getattr(old_options, "iteritems", old_options.items)
             for opt, value in _iteritems():
-                cmds.setAttr(camera + "." + opt, value)
+                _safe_setAttr(camera + "." + opt, value)
 
 
 @contextlib.contextmanager
@@ -760,7 +760,7 @@ def _applied_viewport2_options(options):
     # Apply settings
     _iteritems = getattr(options, "iteritems", options.items)
     for opt, value in _iteritems():
-        cmds.setAttr("hardwareRenderingGlobals." + opt, value)
+        _safe_setAttr("hardwareRenderingGlobals." + opt, value)
 
     try:
         yield
@@ -768,7 +768,7 @@ def _applied_viewport2_options(options):
         # Restore previous settings
         _iteritems = getattr(original, "iteritems", original.items)
         for opt, value in _iteritems():
-            cmds.setAttr("hardwareRenderingGlobals." + opt, value)
+            _safe_setAttr("hardwareRenderingGlobals." + opt, value)
 
 
 @contextlib.contextmanager
@@ -802,14 +802,14 @@ def _maintain_camera(panel, camera):
     else:
         state = dict((camera, cmds.getAttr(camera + ".rnd"))
                      for camera in cmds.ls(type="camera"))
-        cmds.setAttr(camera + ".rnd", True)
+        _safe_setAttr(camera + ".rnd", True)
 
     try:
         yield
     finally:
         _iteritems = getattr(state, "iteritems", state.items)
         for camera, renderable in _iteritems():
-            cmds.setAttr(camera + ".rnd", renderable)
+            _safe_setAttr(camera + ".rnd", renderable)
 
 
 @contextlib.contextmanager
@@ -844,6 +844,18 @@ def _get_screen_size():
 
 def _in_standalone():
     return not hasattr(cmds, "about") or cmds.about(batch=True)
+
+
+def _safe_setAttr(*args, **kwargs):
+    """Wrapper to handle failures when attribute is locked.
+
+    Temporary hotfix until better approach (store value, unlock, set new,
+    return old, lock again) is implemented.
+    """
+    try:
+        cmds.setAttr(*args, **kwargs)
+    except RuntimeError:
+        print("Cannot setAttr {}!".format(args))
 
 
 # --------------------------------


### PR DESCRIPTION
## Brief description
Logs and captures exception when attribute is not possible to set (when locked).

## Description
Next paragraf is more elaborate text with more info. This will be displayed for example in collapsed form under the first sentence in a changelog.

## Additional info
This is temporary hotfix, in the future decorator should be implemented, which will try to store old value, unlock attribute, set new, reset old one back and lock again. In that case new wrapper method could be as a base of decorator.


## Testing notes:
1. create Review subset in Maya
2. lock some attribute on Camera shape (I tried `Depth of Field`)
3. Thumbnail nor Extract Playblast should fail