### PR TITLE
General: Interactive console in cli

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -2,7 +2,7 @@
 """Package for handling pype command line arguments."""
 import os
 import sys
-
+import code
 import click
 
 # import sys
@@ -424,3 +424,17 @@ def pack_project(project, dirpath):
 def unpack_project(zipfile, root):
     """Create a package of project with all files and database dump."""
     PypeCommands().unpack_project(zipfile, root)
+
+
+@main.command()
+def interactive():
+    """Interative (Python like) console.
+
+    Helpfull command not only for development to directly work with python
+    interpreter.
+
+    Warning:
+        Executable 'openpype_gui' on windows won't work.
+    """
+
+    code.interact()

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -437,4 +437,9 @@ def interactive():
         Executable 'openpype_gui' on windows won't work.
     """
 
-    code.interact()
+    from openpype.version import __version__
+
+    banner = "OpenPype {}\nPython {} on {}".format(
+        __version__, sys.version, sys.platform
+    )
+    code.interact(banner)

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -7,7 +7,7 @@ import time
 
 from openpype.lib import PypeLogger
 from openpype.api import get_app_environments_for_context
-from openpype.lib.plugin_tools import parse_json, get_batch_asset_task_info
+from openpype.lib.plugin_tools import get_batch_asset_task_info
 from openpype.lib.remote_publish import (
     get_webpublish_conn,
     start_webpublish_log,

--- a/website/docs/admin_openpype_commands.md
+++ b/website/docs/admin_openpype_commands.md
@@ -45,6 +45,7 @@ For more information [see here](admin_use.md#run-openpype).
 | publish | Pype takes JSON from provided path and use it to publish data in it. | [📑](#publish-arguments) |
 | extractenvironments | Extract environment variables for entered context to a json file. | [📑](#extractenvironments-arguments) |
 | run | Execute given python script within OpenPype environment. | [📑](#run-arguments) |
+| interactive | Start python like interactive console session. | |
 | projectmanager | Launch Project Manager UI | [📑](#projectmanager-arguments) |
 | settings | Open Settings UI | [📑](#settings-arguments) |
 | standalonepublisher | Open Standalone Publisher UI | [📑](#standalonepublisher-arguments) |


### PR DESCRIPTION
## Brief description
Added ability to run interactive console through OpenPype cli.

## Description
Added new cli command `interactive` which will launch OpenPype and start interactive session like when python executable does. This may be helpful for development or debuging purposes.

## Additional information
This does not work on windows when `openpype_gui.exe` executable is used. That's because the executable disable stdin, stdout and stderr so there is no way how it could start in "interactive" mode.

## Testing notes:
1. Run `./openpype_console interactive` (from code: `poetry run python "./start.py" interactive`)
2. Try to write some code like in python interpreter