### PR TITLE
General: Mongo core connection moved to client

### DIFF
--- a/openpype/client/__init__.py
+++ b/openpype/client/__init__.py
@@ -1,3 +1,7 @@
+from .mongo import (
+    OpenPypeMongoConnection,
+)
+
 from .entities import (
     get_projects,
     get_project,
@@ -40,6 +44,8 @@ from .entities import (
 )
 
 __all__ = (
+    "OpenPypeMongoConnection",
+
     "get_projects",
     "get_project",
     "get_whole_project",

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -20,7 +20,21 @@ def _get_project_database():
     return OpenPypeMongoConnection.get_mongo_client()[db_name]
 
 
-def _get_project_connection(project_name):
+def get_project_connection(project_name):
+    """Direct access to mongo collection.
+
+    We're trying to avoid using direct access to mongo. This should be used
+    only for Create, Update and Remove operations until there are implemented
+    api calls for that.
+
+    Args:
+        project_name(str): Project name for which collection should be
+            returned.
+
+    Returns:
+        pymongo.Collection: Collection realated to passed project.
+    """
+
     if not project_name:
         raise ValueError("Invalid project name {}".format(str(project_name)))
     return _get_project_database()[project_name]
@@ -93,7 +107,7 @@ def get_project(project_name, active=True, inactive=False, fields=None):
             {"data.active": False},
         ]
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
@@ -108,7 +122,7 @@ def get_whole_project(project_name):
             project collection.
     """
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find({})
 
 
@@ -131,7 +145,7 @@ def get_asset_by_id(project_name, asset_id, fields=None):
         return None
 
     query_filter = {"type": "asset", "_id": asset_id}
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
@@ -153,7 +167,7 @@ def get_asset_by_name(project_name, asset_name, fields=None):
         return None
 
     query_filter = {"type": "asset", "name": asset_name}
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
@@ -222,7 +236,7 @@ def _get_assets(
             return []
         query_filter["data.visualParent"] = {"$in": parent_ids}
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
 
     return conn.find(query_filter, _prepare_fields(fields))
 
@@ -319,7 +333,7 @@ def get_asset_ids_with_subsets(project_name, asset_ids=None):
             return []
         subset_query["parent"] = {"$in": asset_ids}
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     result = conn.aggregate([
         {
             "$match": subset_query
@@ -359,7 +373,7 @@ def get_subset_by_id(project_name, subset_id, fields=None):
         return None
 
     query_filters = {"type": "subset", "_id": subset_id}
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filters, _prepare_fields(fields))
 
 
@@ -390,7 +404,7 @@ def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
         "name": subset_name,
         "parent": asset_id
     }
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filters, _prepare_fields(fields))
 
 
@@ -463,7 +477,7 @@ def get_subsets(
             return []
         query_filter["$or"] = or_query
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find(query_filter, _prepare_fields(fields))
 
 
@@ -487,7 +501,7 @@ def get_subset_families(project_name, subset_ids=None):
             return set()
         subset_filter["_id"] = {"$in": list(subset_ids)}
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     result = list(conn.aggregate([
         {"$match": subset_filter},
         {"$project": {
@@ -525,7 +539,7 @@ def get_version_by_id(project_name, version_id, fields=None):
         "type": {"$in": ["version", "hero_version"]},
         "_id": version_id
     }
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
@@ -548,7 +562,7 @@ def get_version_by_name(project_name, version, subset_id, fields=None):
     if not subset_id:
         return None
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     query_filter = {
         "type": "version",
         "parent": subset_id,
@@ -602,7 +616,7 @@ def _get_versions(
         else:
             query_filter["name"] = {"$in": versions}
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
 
     return conn.find(query_filter, _prepare_fields(fields))
 
@@ -760,7 +774,7 @@ def get_output_link_versions(project_name, version_id, fields=None):
     if not version_id:
         return []
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     # Does make sense to look for hero versions?
     query_filter = {
         "type": "version",
@@ -825,7 +839,7 @@ def get_last_versions(project_name, subset_ids, fields=None):
         {"$group": group_item}
     ]
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     aggregate_result = conn.aggregate(aggregation_pipeline)
     if limit_query:
         output = {}
@@ -943,7 +957,7 @@ def get_representation_by_id(project_name, representation_id, fields=None):
     if representation_id is not None:
         query_filter["_id"] = _convert_id(representation_id)
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
 
     return conn.find_one(query_filter, _prepare_fields(fields))
 
@@ -976,7 +990,7 @@ def get_representation_by_name(
         "parent": version_id
     }
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
@@ -1039,7 +1053,7 @@ def _get_representations(
             return []
         query_filter["$or"] = or_query
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
 
     return conn.find(query_filter, _prepare_fields(fields))
 
@@ -1250,7 +1264,7 @@ def get_thumbnail_id_from_source(project_name, src_type, src_id):
 
     query_filter = {"_id": _convert_id(src_id)}
 
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     src_doc = conn.find_one(query_filter, {"data.thumbnail_id"})
     if src_doc:
         return src_doc.get("data", {}).get("thumbnail_id")
@@ -1282,7 +1296,7 @@ def get_thumbnails(project_name, thumbnail_ids, fields=None):
         "type": "thumbnail",
         "_id": {"$in": thumbnail_ids}
     }
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find(query_filter, _prepare_fields(fields))
 
 
@@ -1303,7 +1317,7 @@ def get_thumbnail(project_name, thumbnail_id, fields=None):
     if not thumbnail_id:
         return None
     query_filter = {"type": "thumbnail", "_id": _convert_id(thumbnail_id)}
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 
@@ -1334,7 +1348,7 @@ def get_workfile_info(
         "task_name": task_name,
         "filename": filename
     }
-    conn = _get_project_connection(project_name)
+    conn = get_project_connection(project_name)
     return conn.find_one(query_filter, _prepare_fields(fields))
 
 

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -12,7 +12,7 @@ import collections
 import six
 from bson.objectid import ObjectId
 
-from openpype.lib.mongo import OpenPypeMongoConnection
+from .mongo import OpenPypeMongoConnection
 
 
 def _get_project_database():

--- a/openpype/client/mongo.py
+++ b/openpype/client/mongo.py
@@ -1,0 +1,210 @@
+import os
+import sys
+import time
+import logging
+import pymongo
+import certifi
+
+if sys.version_info[0] == 2:
+    from urlparse import urlparse, parse_qs
+else:
+    from urllib.parse import urlparse, parse_qs
+
+
+class MongoEnvNotSet(Exception):
+    pass
+
+
+def _decompose_url(url):
+    """Decompose mongo url to basic components.
+
+    Used for creation of MongoHandler which expect mongo url components as
+    separated kwargs. Components are at the end not used as we're setting
+    connection directly this is just a dumb components for MongoHandler
+    validation pass.
+    """
+
+    # Use first url from passed url
+    #   - this is because it is possible to pass multiple urls for multiple
+    #       replica sets which would crash on urlparse otherwise
+    #   - please don't use comma in username of password
+    url = url.split(",")[0]
+    components = {
+        "scheme": None,
+        "host": None,
+        "port": None,
+        "username": None,
+        "password": None,
+        "auth_db": None
+    }
+
+    result = urlparse(url)
+    if result.scheme is None:
+        _url = "mongodb://{}".format(url)
+        result = urlparse(_url)
+
+    components["scheme"] = result.scheme
+    components["host"] = result.hostname
+    try:
+        components["port"] = result.port
+    except ValueError:
+        raise RuntimeError("invalid port specified")
+    components["username"] = result.username
+    components["password"] = result.password
+
+    try:
+        components["auth_db"] = parse_qs(result.query)['authSource'][0]
+    except KeyError:
+        # no auth db provided, mongo will use the one we are connecting to
+        pass
+
+    return components
+
+
+def get_default_components():
+    mongo_url = os.environ.get("OPENPYPE_MONGO")
+    if mongo_url is None:
+        raise MongoEnvNotSet(
+            "URL for Mongo logging connection is not set."
+        )
+    return _decompose_url(mongo_url)
+
+
+def should_add_certificate_path_to_mongo_url(mongo_url):
+    """Check if should add ca certificate to mongo url.
+
+    Since 30.9.2021 cloud mongo requires newer certificates that are not
+    available on most of workstation. This adds path to certifi certificate
+    which is valid for it. To add the certificate path url must have scheme
+    'mongodb+srv' or has 'ssl=true' or 'tls=true' in url query.
+    """
+
+    parsed = urlparse(mongo_url)
+    query = parse_qs(parsed.query)
+    lowered_query_keys = set(key.lower() for key in query.keys())
+    add_certificate = False
+    # Check if url 'ssl' or 'tls' are set to 'true'
+    for key in ("ssl", "tls"):
+        if key in query and "true" in query["ssl"]:
+            add_certificate = True
+            break
+
+    # Check if url contains 'mongodb+srv'
+    if not add_certificate and parsed.scheme == "mongodb+srv":
+        add_certificate = True
+
+    # Check if url does already contain certificate path
+    if add_certificate and "tlscafile" in lowered_query_keys:
+        add_certificate = False
+
+    return add_certificate
+
+
+def validate_mongo_connection(mongo_uri):
+    """Check if provided mongodb URL is valid.
+
+    Args:
+        mongo_uri (str): URL to validate.
+
+    Raises:
+        ValueError: When port in mongo uri is not valid.
+        pymongo.errors.InvalidURI: If passed mongo is invalid.
+        pymongo.errors.ServerSelectionTimeoutError: If connection timeout
+            passed so probably couldn't connect to mongo server.
+
+    """
+
+    client = OpenPypeMongoConnection.create_connection(
+        mongo_uri, retry_attempts=1
+    )
+    client.close()
+
+
+class OpenPypeMongoConnection:
+    """Singleton MongoDB connection.
+
+    Keeps MongoDB connections by url.
+    """
+
+    mongo_clients = {}
+    log = logging.getLogger("OpenPypeMongoConnection")
+
+    @staticmethod
+    def get_default_mongo_url():
+        return os.environ["OPENPYPE_MONGO"]
+
+    @classmethod
+    def get_mongo_client(cls, mongo_url=None):
+        if mongo_url is None:
+            mongo_url = cls.get_default_mongo_url()
+
+        connection = cls.mongo_clients.get(mongo_url)
+        if connection:
+            # Naive validation of existing connection
+            try:
+                connection.server_info()
+                with connection.start_session():
+                    pass
+            except Exception:
+                connection = None
+
+        if not connection:
+            cls.log.debug("Creating mongo connection to {}".format(mongo_url))
+            connection = cls.create_connection(mongo_url)
+            cls.mongo_clients[mongo_url] = connection
+
+        return connection
+
+    @classmethod
+    def create_connection(cls, mongo_url, timeout=None, retry_attempts=None):
+        parsed = urlparse(mongo_url)
+        # Force validation of scheme
+        if parsed.scheme not in ["mongodb", "mongodb+srv"]:
+            raise pymongo.errors.InvalidURI((
+                "Invalid URI scheme:"
+                " URI must begin with 'mongodb://' or 'mongodb+srv://'"
+            ))
+
+        if timeout is None:
+            timeout = int(os.environ.get("AVALON_TIMEOUT") or 1000)
+
+        kwargs = {
+            "serverSelectionTimeoutMS": timeout
+        }
+        if should_add_certificate_path_to_mongo_url(mongo_url):
+            kwargs["ssl_ca_certs"] = certifi.where()
+
+        mongo_client = pymongo.MongoClient(mongo_url, **kwargs)
+
+        if retry_attempts is None:
+            retry_attempts = 3
+
+        elif not retry_attempts:
+            retry_attempts = 1
+
+        last_exc = None
+        valid = False
+        t1 = time.time()
+        for attempt in range(1, retry_attempts + 1):
+            try:
+                mongo_client.server_info()
+                with mongo_client.start_session():
+                    pass
+                valid = True
+                break
+
+            except Exception as exc:
+                last_exc = exc
+                if attempt < retry_attempts:
+                    cls.log.warning(
+                        "Attempt {} failed. Retrying... ".format(attempt)
+                    )
+                    time.sleep(1)
+
+        if not valid:
+            raise last_exc
+
+        cls.log.info("Connected to {}, delay {:.3f}s".format(
+            mongo_url, time.time() - t1
+        ))
+        return mongo_client

--- a/openpype/hosts/maya/api/shader_definition_editor.py
+++ b/openpype/hosts/maya/api/shader_definition_editor.py
@@ -6,7 +6,7 @@ Shader names are stored as simple text file over GridFS in mongodb.
 """
 import os
 from Qt import QtWidgets, QtCore, QtGui
-from openpype.lib.mongo import OpenPypeMongoConnection
+from openpype.client.mongo import OpenPypeMongoConnection
 from openpype import resources
 import gridfs
 

--- a/openpype/hosts/maya/plugins/publish/validate_model_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_name.py
@@ -10,7 +10,7 @@ from openpype.pipeline import legacy_io
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.shader_definition_editor import (
     DEFINITION_FILENAME)
-from openpype.lib.mongo import OpenPypeMongoConnection
+from openpype.client.mongo import OpenPypeMongoConnection
 import gridfs
 
 

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -10,9 +10,9 @@ from aiohttp.web_response import Response
 from openpype.client import (
     get_projects,
     get_assets,
+    OpenPypeMongoConnection,
 )
 from openpype.lib import (
-    OpenPypeMongoConnection,
     PypeLogger,
 )
 from openpype.lib.remote_publish import (

--- a/openpype/hosts/webpublisher/webserver_service/webserver_cli.py
+++ b/openpype/hosts/webpublisher/webserver_service/webserver_cli.py
@@ -6,6 +6,7 @@ import requests
 import json
 import subprocess
 
+from openpype.client import OpenPypeMongoConnection
 from openpype.lib import PypeLogger
 
 from .webpublish_routes import (
@@ -121,8 +122,6 @@ def run_webserver(*args, **kwargs):
 
 def reprocess_failed(upload_dir, webserver_url):
     # log.info("check_reprocesable_records")
-    from openpype.lib import OpenPypeMongoConnection
-
     mongo_client = OpenPypeMongoConnection.get_mongo_client()
     database_name = os.environ["OPENPYPE_DATABASE_NAME"]
     dbcon = mongo_client[database_name]["webpublishes"]

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -34,7 +34,7 @@ from openpype.settings import (
     get_system_settings
 )
 
-from .import validate_mongo_connection
+from openpype.client.mongo import validate_mongo_connection
 
 _PLACEHOLDER = object()
 

--- a/openpype/lib/log.py
+++ b/openpype/lib/log.py
@@ -24,12 +24,13 @@ import traceback
 import threading
 import copy
 
-from . import Terminal
-from .mongo import (
+from openpype.client.mongo import (
     MongoEnvNotSet,
     get_default_components,
-    OpenPypeMongoConnection
+    OpenPypeMongoConnection,
 )
+from . import Terminal
+
 try:
     import log4mongo
     from log4mongo.handlers import MongoHandler

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -1,206 +1,31 @@
-import os
-import sys
-import time
-import logging
-import pymongo
-import certifi
-
-if sys.version_info[0] == 2:
-    from urlparse import urlparse, parse_qs
-else:
-    from urllib.parse import urlparse, parse_qs
-
-
-class MongoEnvNotSet(Exception):
-    pass
-
-
-def _decompose_url(url):
-    """Decompose mongo url to basic components.
-
-    Used for creation of MongoHandler which expect mongo url components as
-    separated kwargs. Components are at the end not used as we're setting
-    connection directly this is just a dumb components for MongoHandler
-    validation pass.
-    """
-    # Use first url from passed url
-    #   - this is because it is possible to pass multiple urls for multiple
-    #       replica sets which would crash on urlparse otherwise
-    #   - please don't use comma in username of password
-    url = url.split(",")[0]
-    components = {
-        "scheme": None,
-        "host": None,
-        "port": None,
-        "username": None,
-        "password": None,
-        "auth_db": None
-    }
-
-    result = urlparse(url)
-    if result.scheme is None:
-        _url = "mongodb://{}".format(url)
-        result = urlparse(_url)
-
-    components["scheme"] = result.scheme
-    components["host"] = result.hostname
-    try:
-        components["port"] = result.port
-    except ValueError:
-        raise RuntimeError("invalid port specified")
-    components["username"] = result.username
-    components["password"] = result.password
-
-    try:
-        components["auth_db"] = parse_qs(result.query)['authSource'][0]
-    except KeyError:
-        # no auth db provided, mongo will use the one we are connecting to
-        pass
-
-    return components
+from openpype.client.mongo import (
+    MongoEnvNotSet,
+    OpenPypeMongoConnection,
+)
 
 
 def get_default_components():
-    mongo_url = os.environ.get("OPENPYPE_MONGO")
-    if mongo_url is None:
-        raise MongoEnvNotSet(
-            "URL for Mongo logging connection is not set."
-        )
-    return _decompose_url(mongo_url)
+    from openpype.client.mongo import get_default_components
+
+    return get_default_components()
 
 
 def should_add_certificate_path_to_mongo_url(mongo_url):
-    """Check if should add ca certificate to mongo url.
+    from openpype.client.mongo import should_add_certificate_path_to_mongo_url
 
-    Since 30.9.2021 cloud mongo requires newer certificates that are not
-    available on most of workstation. This adds path to certifi certificate
-    which is valid for it. To add the certificate path url must have scheme
-    'mongodb+srv' or has 'ssl=true' or 'tls=true' in url query.
-    """
-    parsed = urlparse(mongo_url)
-    query = parse_qs(parsed.query)
-    lowered_query_keys = set(key.lower() for key in query.keys())
-    add_certificate = False
-    # Check if url 'ssl' or 'tls' are set to 'true'
-    for key in ("ssl", "tls"):
-        if key in query and "true" in query["ssl"]:
-            add_certificate = True
-            break
-
-    # Check if url contains 'mongodb+srv'
-    if not add_certificate and parsed.scheme == "mongodb+srv":
-        add_certificate = True
-
-    # Check if url does already contain certificate path
-    if add_certificate and "tlscafile" in lowered_query_keys:
-        add_certificate = False
-
-    return add_certificate
+    return should_add_certificate_path_to_mongo_url(mongo_url)
 
 
 def validate_mongo_connection(mongo_uri):
-    """Check if provided mongodb URL is valid.
+    from openpype.client.mongo import validate_mongo_connection
 
-    Args:
-        mongo_uri (str): URL to validate.
-
-    Raises:
-        ValueError: When port in mongo uri is not valid.
-        pymongo.errors.InvalidURI: If passed mongo is invalid.
-        pymongo.errors.ServerSelectionTimeoutError: If connection timeout
-            passed so probably couldn't connect to mongo server.
-
-    """
-    client = OpenPypeMongoConnection.create_connection(
-        mongo_uri, retry_attempts=1
-    )
-    client.close()
+    return validate_mongo_connection(mongo_uri)
 
 
-class OpenPypeMongoConnection:
-    """Singleton MongoDB connection.
-
-    Keeps MongoDB connections by url.
-    """
-    mongo_clients = {}
-    log = logging.getLogger("OpenPypeMongoConnection")
-
-    @staticmethod
-    def get_default_mongo_url():
-        return os.environ["OPENPYPE_MONGO"]
-
-    @classmethod
-    def get_mongo_client(cls, mongo_url=None):
-        if mongo_url is None:
-            mongo_url = cls.get_default_mongo_url()
-
-        connection = cls.mongo_clients.get(mongo_url)
-        if connection:
-            # Naive validation of existing connection
-            try:
-                connection.server_info()
-                with connection.start_session():
-                    pass
-            except Exception:
-                connection = None
-
-        if not connection:
-            cls.log.debug("Creating mongo connection to {}".format(mongo_url))
-            connection = cls.create_connection(mongo_url)
-            cls.mongo_clients[mongo_url] = connection
-
-        return connection
-
-    @classmethod
-    def create_connection(cls, mongo_url, timeout=None, retry_attempts=None):
-        parsed = urlparse(mongo_url)
-        # Force validation of scheme
-        if parsed.scheme not in ["mongodb", "mongodb+srv"]:
-            raise pymongo.errors.InvalidURI((
-                "Invalid URI scheme:"
-                " URI must begin with 'mongodb://' or 'mongodb+srv://'"
-            ))
-
-        if timeout is None:
-            timeout = int(os.environ.get("AVALON_TIMEOUT") or 1000)
-
-        kwargs = {
-            "serverSelectionTimeoutMS": timeout
-        }
-        if should_add_certificate_path_to_mongo_url(mongo_url):
-            kwargs["ssl_ca_certs"] = certifi.where()
-
-        mongo_client = pymongo.MongoClient(mongo_url, **kwargs)
-
-        if retry_attempts is None:
-            retry_attempts = 3
-
-        elif not retry_attempts:
-            retry_attempts = 1
-
-        last_exc = None
-        valid = False
-        t1 = time.time()
-        for attempt in range(1, retry_attempts + 1):
-            try:
-                mongo_client.server_info()
-                with mongo_client.start_session():
-                    pass
-                valid = True
-                break
-
-            except Exception as exc:
-                last_exc = exc
-                if attempt < retry_attempts:
-                    cls.log.warning(
-                        "Attempt {} failed. Retrying... ".format(attempt)
-                    )
-                    time.sleep(1)
-
-        if not valid:
-            raise last_exc
-
-        cls.log.info("Connected to {}, delay {:.3f}s".format(
-            mongo_url, time.time() - t1
-        ))
-        return mongo_client
+__all__ = (
+    "MongoEnvNotSet",
+    "OpenPypeMongoConnection",
+    "get_default_components",
+    "should_add_certificate_path_to_mongo_url",
+    "validate_mongo_connection",
+)

--- a/openpype/lib/mongo.py
+++ b/openpype/lib/mongo.py
@@ -1,21 +1,51 @@
+import warnings
+import functools
 from openpype.client.mongo import (
     MongoEnvNotSet,
     OpenPypeMongoConnection,
 )
 
 
+class MongoDeprecatedWarning(DeprecationWarning):
+    pass
+
+
+def mongo_deprecated(func):
+    """Mark functions as deprecated.
+
+    It will result in a warning being emitted when the function is used.
+    """
+
+    @functools.wraps(func)
+    def new_func(*args, **kwargs):
+        warnings.simplefilter("always", MongoDeprecatedWarning)
+        warnings.warn(
+            (
+                "Call to deprecated function '{}'."
+                " Function was moved to 'openpype.client.mongo'."
+            ).format(func.__name__),
+            category=MongoDeprecatedWarning,
+            stacklevel=2
+        )
+        return func(*args, **kwargs)
+    return new_func
+
+
+@mongo_deprecated
 def get_default_components():
     from openpype.client.mongo import get_default_components
 
     return get_default_components()
 
 
+@mongo_deprecated
 def should_add_certificate_path_to_mongo_url(mongo_url):
     from openpype.client.mongo import should_add_certificate_path_to_mongo_url
 
     return should_add_certificate_path_to_mongo_url(mongo_url)
 
 
+@mongo_deprecated
 def validate_mongo_connection(mongo_uri):
     from openpype.client.mongo import validate_mongo_connection
 

--- a/openpype/lib/remote_publish.py
+++ b/openpype/lib/remote_publish.py
@@ -7,7 +7,7 @@ from bson.objectid import ObjectId
 import pyblish.util
 import pyblish.api
 
-from openpype.lib.mongo import OpenPypeMongoConnection
+from openpype.client.mongo import OpenPypeMongoConnection
 from openpype.lib.plugin_tools import parse_json
 
 ERROR_STATUS = "error"

--- a/openpype/modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/ftrack/ftrack_server/event_server_cli.py
@@ -1,11 +1,9 @@
 import os
-import sys
 import signal
 import datetime
 import subprocess
 import socket
 import json
-import platform
 import getpass
 import atexit
 import time
@@ -13,12 +11,14 @@ import uuid
 
 import ftrack_api
 import pymongo
+from openpype.client.mongo import (
+    OpenPypeMongoConnection,
+    validate_mongo_connection,
+)
 from openpype.lib import (
     get_openpype_execute_args,
-    OpenPypeMongoConnection,
     get_openpype_version,
     get_build_version,
-    validate_mongo_connection
 )
 from openpype_modules.ftrack import FTRACK_MODULE_DIR
 from openpype_modules.ftrack.lib import credentials

--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -24,7 +24,7 @@ except ImportError:
     from ftrack_api._weakref import WeakMethod
 from openpype_modules.ftrack.lib import get_ftrack_event_mongo_info
 
-from openpype.lib import OpenPypeMongoConnection
+from openpype.client import OpenPypeMongoConnection
 from openpype.api import Logger
 
 TOPIC_STATUS_SERVER = "openpype.event.server.status"

--- a/openpype/modules/ftrack/scripts/sub_event_storer.py
+++ b/openpype/modules/ftrack/scripts/sub_event_storer.py
@@ -6,6 +6,8 @@ import socket
 import pymongo
 
 import ftrack_api
+
+from openpype.client import OpenPypeMongoConnection
 from openpype_modules.ftrack.ftrack_server.ftrack_server import FtrackServer
 from openpype_modules.ftrack.ftrack_server.lib import (
     SocketSession,
@@ -15,7 +17,6 @@ from openpype_modules.ftrack.ftrack_server.lib import (
 )
 from openpype_modules.ftrack.lib import get_ftrack_event_mongo_info
 from openpype.lib import (
-    OpenPypeMongoConnection,
     get_openpype_version,
     get_build_version
 )

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -4,8 +4,8 @@ import pyblish.api
 import copy
 from datetime import datetime
 
+from openpype.client import OpenPypeMongoConnection
 from openpype.lib.plugin_tools import prepare_template_data
-from openpype.lib import OpenPypeMongoConnection
 
 
 class IntegrateSlackAPI(pyblish.api.InstancePlugin):

--- a/openpype/pipeline/mongodb.py
+++ b/openpype/pipeline/mongodb.py
@@ -5,6 +5,8 @@ import logging
 import pymongo
 from uuid import uuid4
 
+from openpype.client import OpenPypeMongoConnection
+
 from . import schema
 
 
@@ -156,8 +158,6 @@ class AvalonMongoDB:
 
     @property
     def mongo_client(self):
-        from openpype.lib import OpenPypeMongoConnection
-
         return OpenPypeMongoConnection.get_mongo_client()
 
     @property

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod
 import six
 
 import openpype.version
+from openpype.client.mongo import OpenPypeMongoConnection
 
 from .constants import (
     GLOBAL_SETTINGS_KEY,
@@ -337,7 +338,6 @@ class MongoSettingsHandler(SettingsHandler):
 
     def __init__(self):
         # Get mongo connection
-        from openpype.lib import OpenPypeMongoConnection
         from openpype.pipeline import AvalonMongoDB
 
         settings_collection = OpenPypeMongoConnection.get_mongo_client()

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -8,6 +8,7 @@ import six
 
 import openpype.version
 from openpype.client.mongo import OpenPypeMongoConnection
+from openpype.client.entities import get_project_connection, get_project
 
 from .constants import (
     GLOBAL_SETTINGS_KEY,
@@ -338,8 +339,6 @@ class MongoSettingsHandler(SettingsHandler):
 
     def __init__(self):
         # Get mongo connection
-        from openpype.pipeline import AvalonMongoDB
-
         settings_collection = OpenPypeMongoConnection.get_mongo_client()
 
         self._anatomy_keys = None
@@ -362,7 +361,6 @@ class MongoSettingsHandler(SettingsHandler):
         self.collection_name = collection_name
 
         self.collection = settings_collection[database_name][collection_name]
-        self.avalon_db = AvalonMongoDB()
 
         self.system_settings_cache = CacheValues()
         self.project_settings_cache = collections.defaultdict(CacheValues)
@@ -607,16 +605,14 @@ class MongoSettingsHandler(SettingsHandler):
         new_data = data_cache.data_copy()
 
         # Prepare avalon project document
-        collection = self.avalon_db.database[project_name]
-        project_doc = collection.find_one({
-            "type": "project"
-        })
+        project_doc = get_project(project_name)
         if not project_doc:
             raise ValueError((
                 "Project document of project \"{}\" does not exists."
                 " Create project first."
             ).format(project_name))
 
+        collection = get_project_connection(project_name)
         # Project's data
         update_dict_data = {}
         project_doc_data = project_doc.get("data") or {}
@@ -1145,8 +1141,7 @@ class MongoSettingsHandler(SettingsHandler):
                     document, version
                 )
             else:
-                collection = self.avalon_db.database[project_name]
-                project_doc = collection.find_one({"type": "project"})
+                project_doc = get_project(project_name)
                 self.project_anatomy_cache[project_name].update_data(
                     self.project_doc_to_anatomy_data(project_doc),
                     self._current_version


### PR DESCRIPTION
## Brief description
Moved core of Mongo connection `OpenPypeMongoConnection` from `openpype.lib` into `openpype.client`. This change makes `openpype.client` independent from openpype lib functions and can be considered as self contained.

## Description
Changed parts of code using `OpenPypeMongoConnection` to use new source and marked lib functions as deprecated. That is unfortunatelly not possible for classes located there too.

## Testing notes:
- [x] Logging to mongo should work (can be validated using LogViewer in tray)
- [x] Webpublisher should work
- [x] Maya shader publishing can be possible (not sure if is used?)
- [x] OpenPype MongoURL can be changed in local settings UI
- [x] Remote (automated) publishing can get and update jobs to do
- [x] Ftrack event server (service) can process ftrack events
- [x] Integration to slack should work
- [x] Project Settings can be loaded and saved