### PR TITLE
General: Create workfile documents works again

### DIFF
--- a/openpype/hosts/flame/plugins/publish/integrate_batch_group.py
+++ b/openpype/hosts/flame/plugins/publish/integrate_batch_group.py
@@ -325,7 +325,6 @@ class IntegrateBatchGroup(pyblish.api.InstancePlugin):
         asset_entity = instance.data["assetEntity"]
         anatomy = instance.context.data["anatomy"]
 
-        workdir = get_workdir(
+        return get_workdir(
             project_doc, asset_entity, task_data["name"], "flame", anatomy
         )
-        return os.path.normpath(workdir)

--- a/openpype/hosts/flame/plugins/publish/integrate_batch_group.py
+++ b/openpype/hosts/flame/plugins/publish/integrate_batch_group.py
@@ -323,8 +323,9 @@ class IntegrateBatchGroup(pyblish.api.InstancePlugin):
     def _get_shot_task_dir_path(self, instance, task_data):
         project_doc = instance.data["projectEntity"]
         asset_entity = instance.data["assetEntity"]
+        anatomy = instance.context.data["anatomy"]
 
         workdir = get_workdir(
-            project_doc, asset_entity, task_data["name"], "flame"
+            project_doc, asset_entity, task_data["name"], "flame", anatomy
         )
         return os.path.normpath(workdir)

--- a/openpype/hosts/flame/plugins/publish/integrate_batch_group.py
+++ b/openpype/hosts/flame/plugins/publish/integrate_batch_group.py
@@ -324,5 +324,7 @@ class IntegrateBatchGroup(pyblish.api.InstancePlugin):
         project_doc = instance.data["projectEntity"]
         asset_entity = instance.data["assetEntity"]
 
-        return get_workdir(
-            project_doc, asset_entity, task_data["name"], "flame")
+        workdir = get_workdir(
+            project_doc, asset_entity, task_data["name"], "flame"
+        )
+        return os.path.normpath(workdir)

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1638,6 +1638,7 @@ def prepare_context_environments(data, env_group=None):
             "Error in anatomy.format: {}".format(str(exc))
         )
 
+    workdir = os.path.normpath(workdir)
     if not os.path.exists(workdir):
         log.debug(
             "Creating workdir folder: \"{}\"".format(workdir)

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1638,7 +1638,6 @@ def prepare_context_environments(data, env_group=None):
             "Error in anatomy.format: {}".format(str(exc))
         )
 
-    workdir = os.path.normpath(workdir)
     if not os.path.exists(workdir):
         log.debug(
             "Creating workdir folder: \"{}\"".format(workdir)

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -582,7 +582,10 @@ def get_workdir_with_workdir_data(
 
     anatomy_filled = anatomy.format(workdir_data)
     # Output is TemplateResult object which contain useful data
-    return anatomy_filled[template_key]["folder"]
+    output = anatomy_filled[template_key]["folder"]
+    if output:
+        return output.normalized()
+    return output
 
 
 def get_workdir(

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -582,10 +582,7 @@ def get_workdir_with_workdir_data(
 
     anatomy_filled = anatomy.format(workdir_data)
     # Output is TemplateResult object which contain useful data
-    path = anatomy_filled[template_key]["folder"]
-    if path:
-        path = os.path.normpath(path)
-    return path
+    return anatomy_filled[template_key]["folder"]
 
 
 def get_workdir(

--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -409,6 +409,19 @@ class TemplateResult(str):
             self.invalid_types
         )
 
+    def normalized(self):
+        """Convert to normalized path."""
+
+        cls = self.__class__
+        return cls(
+            os.path.normpath(self),
+            self.template,
+            self.solved,
+            self.used_values,
+            self.missing_keys,
+            self.invalid_types
+        )
+
 
 class TemplatesResultDict(dict):
     """Holds and wrap TemplateResults for easy bug report."""

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -380,6 +380,19 @@ class AnatomyTemplateResult(TemplateResult):
         )
         return self.__class__(tmp, self.rootless)
 
+    def normalized(self):
+        """Convert to normalized path."""
+
+        tmp = TemplateResult(
+            os.path.normpath(self),
+            self.template,
+            self.solved,
+            self.used_values,
+            self.missing_keys,
+            self.invalid_types
+        )
+        return self.__class__(tmp, self.rootless)
+
 
 class AnatomyTemplates(TemplatesDict):
     inner_key_pattern = re.compile(r"(\{@.*?[^{}0]*\})")


### PR DESCRIPTION
## Brief description
Workfile documents are broken from [this PR](https://github.com/pypeclub/OpenPype/pull/3436) where return type of `get_workdir_with_workdir_data` was changed to `str` instead of `TemplateResult`.

## Description
`TemplateResult` has method `normalized` which creates copy with normalized output. This is used as output for `get_workdir_with_workdir_data`.

## Additional information
Flame integrator pass anatomy into `get_workdir`.

## Testing notes:
1. Open workfiles tool in any host
2. Add artist note
3. Save it
4. It should reappear on change