### PR TITLE
Workfiles tool: Show of tool and it's flags

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2440,10 +2440,12 @@ def _launch_workfile_app():
     if starting_up or closing_down:
         return
 
-    from .pipeline import get_main_window
-
-    main_window = get_main_window()
-    host_tools.show_workfiles(parent=main_window)
+    # Make sure on top is enabled on first show so the window is not hidden
+    #   under main nuke window
+    #   - this happened on Centos 7 and it is because the focus of nuke
+    #       changes to the main window after showing because of initialization
+    #       which moves workfiles tool under it
+    host_tools.show_workfiles(parent=None, on_top=True)
 
 
 def process_workfile_builder():

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -142,6 +142,14 @@ def uninstall():
     _uninstall_menu()
 
 
+def _show_workfiles():
+    # Make sure parent is not set
+    # - this makes Workfiles tool as separated window which
+    #   avoid issues with reopening
+    # - it is possible to explicitly change on top flag of the tool
+    host_tools.show_workfiles(parent=None, on_top=False)
+
+
 def _install_menu():
     # uninstall original avalon menu
     main_window = get_main_window()
@@ -158,7 +166,7 @@ def _install_menu():
     menu.addSeparator()
     menu.addCommand(
         "Work Files...",
-        lambda: host_tools.show_workfiles(parent=main_window)
+        _show_workfiles
     )
 
     menu.addSeparator()

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -395,9 +395,9 @@ def show_tool_by_name(tool_name, parent=None, *args, **kwargs):
     _SingletonPoint.show_tool_by_name(tool_name, parent, *args, **kwargs)
 
 
-def show_workfiles(parent=None, use_context=None, save=None):
+def show_workfiles(*args, **kwargs):
     _SingletonPoint.show_tool_by_name(
-        "workfiles", parent, use_context=use_context, save=save
+        "workfiles", *args, **kwargs
     )
 
 

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -60,31 +60,14 @@ class HostToolsHelper:
 
         return self._workfiles_tool
 
-    def show_workfiles(self, parent=None, use_context=None, save=None):
+    def show_workfiles(
+        self, parent=None, use_context=None, save=None, on_top=None
+    ):
         """Workfiles tool for changing context and saving workfiles."""
-        if use_context is None:
-            use_context = True
-
-        if save is None:
-            save = True
 
         with qt_app_context():
             workfiles_tool = self.get_workfiles_tool(parent)
-            workfiles_tool.set_save_enabled(save)
-
-            if not workfiles_tool.isVisible():
-                workfiles_tool.show()
-
-                if use_context:
-                    context = {
-                        "asset": legacy_io.Session["AVALON_ASSET"],
-                        "task": legacy_io.Session["AVALON_TASK"]
-                    }
-                    workfiles_tool.set_context(context)
-
-            # Pull window to the front.
-            workfiles_tool.raise_()
-            workfiles_tool.activateWindow()
+            workfiles_tool.ensure_visible(use_context, save, on_top)
 
     def get_loader_tool(self, parent):
         """Create, cache and return loader tool window."""

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -229,6 +229,49 @@ class Window(QtWidgets.QWidget):
         self._first_show = True
         self._context_to_set = None
 
+    def ensure_visible(
+        self, use_context=None, save=None, on_top=None
+    ):
+        if save is None:
+            save = True
+
+        self.set_save_enabled(save)
+
+        if self.isVisible():
+            use_context = False
+        elif use_context is None:
+            use_context = True
+
+        if on_top is None and self._first_show:
+            on_top = self.parent() is None
+
+        window_flags = self.windowFlags()
+        new_window_flags = window_flags
+        if on_top is True:
+            new_window_flags = window_flags | QtCore.Qt.WindowStaysOnTopHint
+        elif on_top is False:
+            new_window_flags = window_flags & ~QtCore.Qt.WindowStaysOnTopHint
+
+        if new_window_flags != window_flags:
+            # Note this is not propagated after initialization of widget in
+            #   some Qt builds
+            self.setWindowFlags(new_window_flags)
+            self.show()
+
+        elif not self.isVisible():
+            self.show()
+
+        if use_context is None or use_context is True:
+            context = {
+                "asset": legacy_io.Session["AVALON_ASSET"],
+                "task": legacy_io.Session["AVALON_TASK"]
+            }
+            self.set_context(context)
+
+        # Pull window to the front.
+        self.raise_()
+        self.activateWindow()
+
     @property
     def project_name(self):
         return legacy_io.Session["AVALON_PROJECT"]

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -331,6 +331,7 @@ class Window(QtWidgets.QMainWindow):
         if self.assets_widget.refreshing:
             return
 
+        self._set_context_timer.stop()
         self._context_to_set, context = None, self._context_to_set
         if "asset" in context:
             asset_doc = get_asset_by_name(

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -143,23 +143,19 @@ class SidePanelWidget(QtWidgets.QWidget):
         return self._workfile_doc, data
 
 
-class Window(QtWidgets.QMainWindow):
+class Window(QtWidgets.QWidget):
     """Work Files Window"""
     title = "Work Files"
 
     def __init__(self, parent=None):
         super(Window, self).__init__(parent=parent)
         self.setWindowTitle(self.title)
-        window_flags = QtCore.Qt.Window | QtCore.Qt.WindowCloseButtonHint
-        if not parent:
-            window_flags |= QtCore.Qt.WindowStaysOnTopHint
-        self.setWindowFlags(window_flags)
         icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
         self.setWindowIcon(icon)
+        self.setWindowFlags(self.windowFlags() | QtCore.Qt.Window)
 
         # Create pages widget and set it as central widget
         pages_widget = QtWidgets.QStackedWidget(self)
-        self.setCentralWidget(pages_widget)
 
         home_page_widget = QtWidgets.QWidget(pages_widget)
         home_body_widget = QtWidgets.QWidget(home_page_widget)
@@ -193,6 +189,9 @@ class Window(QtWidgets.QMainWindow):
         # Add top margin for tasks to align it visually with files as
         # the files widget has a filter field which tasks does not.
         tasks_widget.setContentsMargins(0, 32, 0, 0)
+
+        main_layout = QtWidgets.QHBoxLayout(self)
+        main_layout.addWidget(pages_widget, 1)
 
         # Set context after asset widget is refreshed
         # - to do so it is necessary to wait until refresh is done

--- a/openpype/tools/workfiles/window.py
+++ b/openpype/tools/workfiles/window.py
@@ -1,6 +1,6 @@
 import os
 import datetime
-from Qt import QtCore, QtWidgets
+from Qt import QtCore, QtWidgets, QtGui
 
 from openpype.client import (
     get_asset_by_id,
@@ -8,6 +8,7 @@ from openpype.client import (
     get_workfile_info,
 )
 from openpype import style
+from openpype import resources
 from openpype.lib import (
     create_workfile_doc,
     save_workfile_data_to_doc,
@@ -153,6 +154,8 @@ class Window(QtWidgets.QMainWindow):
         if not parent:
             window_flags |= QtCore.Qt.WindowStaysOnTopHint
         self.setWindowFlags(window_flags)
+        icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
+        self.setWindowIcon(icon)
 
         # Create pages widget and set it as central widget
         pages_widget = QtWidgets.QStackedWidget(self)


### PR DESCRIPTION
## Brief description
Change is related to showing workfiles tool on launch in Nuke. On some linux distributions is workfiles tool hidden under main nuke window and has issues with reshowing it correctly.

## Description
Workfiles tool has ability to change `AlwaysOnTop` window flag on show. This has some other issues but all are less affecting then hidden workfiles tool. Workfiles tool is not also `QMainWindow` but `QWidget` with `Window` flag and nuke does not pass parent widget to initialization of workfiles tool. This cause that workfiles tool is showed as separate window from nuke window and at the same time is fixing bugs related to re-opening the tool.

## Additional info
Change of window flags is not always supported so on some OS distribution it can cause that the workfiles tool window will stay always on top. That will happen only if workfiles tool was showed on launch otherwise is nuke forcing to not show the window on top.

This change should be backwards compatible for other hosts.

## Testing notes:
1. Make sure that "Open workfiles on launch" is enabled for nuke (`project_settings/global/tools/Workfiles/open_workfile_tool_on_startup`)
2. Launch Nuke
3. Workfiles tool should show and should be on top of main nuke window