### PR TITLE
Maya: add additional validators to Settings

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_review_subset_uniqueness.py
+++ b/openpype/hosts/maya/plugins/publish/validate_review_subset_uniqueness.py
@@ -6,7 +6,7 @@ from openpype.pipeline import PublishXmlValidationError
 
 
 class ValidateReviewSubsetUniqueness(pyblish.api.ContextPlugin):
-    """Validates that nodes has common root."""
+    """Validates that review subset has unique name."""
 
     order = openpype.api.ValidateContentsOrder
     hosts = ["maya"]
@@ -17,7 +17,7 @@ class ValidateReviewSubsetUniqueness(pyblish.api.ContextPlugin):
         subset_names = []
 
         for instance in context:
-            self.log.info("instance:: {}".format(instance.data))
+            self.log.debug("Instance: {}".format(instance.data))
             if instance.data.get('publish'):
                 subset_names.append(instance.data.get('subset'))
 

--- a/openpype/hosts/maya/plugins/publish/validate_setdress_root.py
+++ b/openpype/hosts/maya/plugins/publish/validate_setdress_root.py
@@ -4,8 +4,7 @@ import openpype.api
 
 
 class ValidateSetdressRoot(pyblish.api.InstancePlugin):
-    """
-    """
+    """Validate if set dress top root node is published."""
 
     order = openpype.api.ValidateContentsOrder
     label = "SetDress Root"

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -205,10 +205,15 @@
             "enabled": true,
             "optional": true,
             "active": true,
-            "exclude_families": ["model", "rig", "staticMesh"]
+            "exclude_families": [
+                "model",
+                "rig",
+                "staticMesh"
+            ]
         },
         "ValidateShaderName": {
             "enabled": false,
+            "optional": true,
             "regex": "(?P<asset>.*)_(.*)_SHD"
         },
         "ValidateShadingEngine": {
@@ -222,6 +227,7 @@
         },
         "ValidateLoadedPlugin": {
             "enabled": false,
+            "optional": true,
             "whitelist_native_plugins": false,
             "authorized_plugins": []
         },
@@ -236,6 +242,7 @@
         },
         "ValidateUnrealStaticMeshName": {
             "enabled": true,
+            "optional": true,
             "validate_mesh": false,
             "validate_collision": true
         },
@@ -251,6 +258,81 @@
             "vray_render_attributes": [],
             "redshift_render_attributes": [],
             "renderman_render_attributes": []
+        },
+        "ValidateCurrentRenderLayerIsRenderable": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateRenderImageRule": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateRenderNoDefaultCameras": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateRenderSingleCamera": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateRenderLayerAOVs": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateStepSize": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateVRayDistributedRendering": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateVrayReferencedAOVs": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateVRayTranslatorEnabled": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateVrayProxy": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateVrayProxyMembers": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateYetiRenderScriptCallbacks": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateYetiRigCacheState": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateYetiRigInputShapesInInstance": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateYetiRigSettings": {
+            "enabled": true,
+            "optional": false,
+            "active": true
         },
         "ValidateModelName": {
             "enabled": false,
@@ -270,6 +352,7 @@
         },
         "ValidateTransformNamingSuffix": {
             "enabled": true,
+            "optional": true,
             "SUFFIX_NAMING_TABLE": {
                 "mesh": [
                     "_GEO",
@@ -293,7 +376,7 @@
             "ALLOW_IF_NOT_IN_SUFFIX_TABLE": true
         },
         "ValidateColorSets": {
-            "enabled": false,
+            "enabled": true,
             "optional": true,
             "active": true
         },
@@ -337,6 +420,16 @@
             "optional": true,
             "active": true
         },
+        "ValidateMeshNoNegativeScale": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateMeshNonZeroEdgeLength": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
         "ValidateMeshNormalsUnlocked": {
             "enabled": false,
             "optional": true,
@@ -359,22 +452,22 @@
         },
         "ValidateNoNamespace": {
             "enabled": true,
-            "optional": true,
+            "optional": false,
             "active": true
         },
         "ValidateNoNullTransforms": {
             "enabled": true,
-            "optional": true,
+            "optional": false,
             "active": true
         },
         "ValidateNoUnknownNodes": {
             "enabled": true,
-            "optional": true,
+            "optional": false,
             "active": true
         },
         "ValidateNodeNoGhosting": {
             "enabled": false,
-            "optional": true,
+            "optional": false,
             "active": true
         },
         "ValidateShapeDefaultNames": {
@@ -402,6 +495,21 @@
             "optional": true,
             "active": true
         },
+        "ValidateNoVRayMesh": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateUnrealMeshTriangulated": {
+            "enabled": false,
+            "optional": true,
+            "active": true
+        },
+        "ValidateAlembicVisibleOnly": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
         "ExtractAlembic": {
             "enabled": true,
             "families": [
@@ -425,8 +533,34 @@
             "optional": true,
             "active": true
         },
+        "ValidateAnimationContent": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateOutRelatedNodeIds": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateRigControllersArnoldAttributes": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateSkeletalMeshHierarchy": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateSkinclusterDeformerSet": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
         "ValidateRigOutSetNodeIds": {
             "enabled": true,
+            "optional": false,
             "allow_history_only": false
         },
         "ValidateCameraAttributes": {
@@ -439,14 +573,44 @@
             "optional": true,
             "active": true
         },
+        "ValidateAssemblyNamespaces": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateAssemblyModelTransforms": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
         "ValidateAssRelativePaths": {
             "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateInstancerContent": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateInstancerFrameRanges": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateNoDefaultCameras": {
+            "enabled": true,
+            "optional": false,
+            "active": true
+        },
+        "ValidateUnrealUpAxis": {
+            "enabled": false,
             "optional": true,
             "active": true
         },
         "ValidateCameraContents": {
             "enabled": true,
-            "optional": true,
+            "optional": false,
             "validate_shapes": true
         },
         "ExtractPlayblast": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -108,6 +108,11 @@
                     "label": "Enabled"
                 },
                 {
+                    "type": "boolean",
+                    "key": "optional",
+                    "label": "Optional"
+                },
+                {
                     "type": "label",
                     "label": "Shader name regex can use named capture group <b>asset</b> to validate against current asset name.<p><b>Example:</b><br/><code>^.*(?P=&lt;asset&gt;.+)_SHD</code></p>"
                 },
@@ -158,6 +163,11 @@
                     "type": "boolean",
                     "key": "enabled",
                     "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "optional",
+                    "label": "Optional"
                 },
                 {
                     "type": "boolean",
@@ -248,6 +258,11 @@
                 },
                 {
                     "type": "boolean",
+                    "key": "optional",
+                    "label": "Optional"
+                },
+                {
+                    "type": "boolean",
                     "key": "validate_mesh",
                     "label": "Validate mesh Names "
                 },
@@ -329,6 +344,72 @@
                     "object_type": {
                         "type": "text"
                     }
+                }
+            ]
+        },
+        {
+            "type": "schema_template",
+            "name": "template_publish_plugin",
+            "template_data": [
+                {
+                    "key": "ValidateCurrentRenderLayerIsRenderable",
+                    "label": "Validate Current Render Layer Has Renderable Camera"
+                },
+                {
+                    "key": "ValidateRenderImageRule",
+                    "label": "Validate Images File Rule (Workspace)"
+                },
+                {
+                    "key": "ValidateRenderNoDefaultCameras",
+                    "label": "Validate No Default Cameras Renderable"
+                },
+                {
+                    "key": "ValidateRenderSingleCamera",
+                    "label": "Validate Render Single Camera"
+                },
+                {
+                    "key": "ValidateRenderLayerAOVs",
+                    "label": "Validate Render Passes / AOVs Are Registered"
+                },
+                {
+                    "key": "ValidateStepSize",
+                    "label": "Validate Step Size"
+                },
+                {
+                    "key": "ValidateVRayDistributedRendering",
+                    "label": "VRay Distributed Rendering"
+                },
+                {
+                    "key": "ValidateVrayReferencedAOVs",
+                    "label": "VRay Referenced AOVs"
+                },
+                {
+                    "key": "ValidateVRayTranslatorEnabled",
+                    "label": "VRay Translator Settings"
+                },
+                {
+                    "key": "ValidateVrayProxy",
+                    "label": "VRay Proxy Settings"
+                },
+                {
+                    "key": "ValidateVrayProxyMembers",
+                    "label": "VRay Proxy Members"
+                },
+                {
+                    "key": "ValidateYetiRenderScriptCallbacks",
+                    "label": "Yeti Render Script Callbacks"
+                },
+                {
+                    "key": "ValidateYetiRigCacheState",
+                    "label": "Yeti Rig Cache State"
+                },
+                {
+                    "key": "ValidateYetiRigInputShapesInInstance",
+                    "label": "Yeti Rig Input Shapes In Instance"
+                },
+                {
+                    "key": "ValidateYetiRigSettings",
+                    "label": "Yeti Rig Settings"
                 }
             ]
         },
@@ -417,6 +498,11 @@
                             "label": "Enabled"
                         },
                         {
+                            "type": "boolean",
+                            "key": "optional",
+                            "label": "Optional"
+                        },
+                        {
                             "type": "label",
                             "label": "Validates transform suffix based on the type of its children shapes."
                         },
@@ -473,6 +559,14 @@
                             "label": "ValidateMeshNonManifold"
                         },
                         {
+                            "key": "ValidateMeshNoNegativeScale",
+                            "label": "Validate Mesh No Negative Scale"
+                        },
+                        {
+                            "key": "ValidateMeshNonZeroEdgeLength",
+                            "label": "Validate Mesh Edge Length Non Zero"
+                        },
+                        {
                             "key": "ValidateMeshNormalsUnlocked",
                             "label": "ValidateMeshNormalsUnlocked"
                         },
@@ -525,6 +619,18 @@
                         {
                             "key": "ValidateUniqueNames",
                             "label": "ValidateUniqueNames"
+                        },
+                        {
+                            "key": "ValidateNoVRayMesh",
+                            "label": "Validate No V-Ray Proxies (VRayMesh)"
+                        },
+                        {
+                            "key": "ValidateUnrealMeshTriangulated",
+                            "label": "Validate if Mesh is Triangulated"
+                        },
+                        {
+                            "key": "ValidateAlembicVisibleOnly",
+                            "label": "Validate Alembic visible node"
                         }
                     ]
                 },
@@ -573,6 +679,26 @@
                         {
                             "key": "ValidateRigControllers",
                             "label": "Validate Rig Controllers"
+                        },
+                        {
+                            "key": "ValidateAnimationContent",
+                            "label": "Validate Animation Content"
+                        },
+                        {
+                            "key": "ValidateOutRelatedNodeIds",
+                            "label": "Validate Animation Out Set Related Node Ids"
+                        },
+                        {
+                            "key": "ValidateRigControllersArnoldAttributes",
+                            "label": "Validate Rig Controllers (Arnold Attributes)"
+                        },
+                        {
+                            "key": "ValidateSkeletalMeshHierarchy",
+                            "label": "Validate Skeletal Mesh Top Node"
+                        },
+                         {
+                            "key": "ValidateSkinclusterDeformerSet",
+                            "label": "Validate Skincluster Deformer Relationships"
                         }
                     ]
                 },
@@ -588,6 +714,11 @@
                             "type": "boolean",
                             "key": "enabled",
                             "label": "Enabled"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "optional",
+                            "label": "Optional"
                         },
                         {
                             "type": "boolean",
@@ -612,8 +743,32 @@
                     "label": "Validate Assembly Name"
                 },
                 {
+                    "key": "ValidateAssemblyNamespaces",
+                    "label": "Validate Assembly Namespaces"
+                },
+                {
+                    "key": "ValidateAssemblyModelTransforms",
+                    "label": "Validate Assembly Model Transforms"
+                },
+                {
                     "key": "ValidateAssRelativePaths",
                     "label": "ValidateAssRelativePaths"
+                },
+                {
+                    "key": "ValidateInstancerContent",
+                    "label": "Validate Instancer Content"
+                },
+                {
+                    "key": "ValidateInstancerFrameRanges",
+                    "label": "Validate Instancer Cache Frame Ranges"
+                },
+                {
+                    "key": "ValidateNoDefaultCameras",
+                    "label": "Validate No Default Cameras"
+                },
+                {
+                    "key": "ValidateUnrealUpAxis",
+                    "label": "Validate Unreal Up-Axis check"
                 }
             ]
         },


### PR DESCRIPTION
## Enhancement

With this PR all Maya validators that are more or less safe to disable/enable are added to the Settings.

It is difficult to test, but the state of the validators should be the same as before. They show up in the Settings, where they can be configured (enabled/optional/active)