### PR TITLE
Module interfaces: Fix import error

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -49,6 +49,7 @@ class _ModuleClass(object):
     Object of this class can be stored to `sys.modules` and used for storing
     dynamically imported modules.
     """
+
     def __init__(self, name):
         # Call setattr on super class
         super(_ModuleClass, self).__setattr__("name", name)
@@ -116,12 +117,13 @@ class _InterfacesClass(_ModuleClass):
     - this is because interfaces must be available even if are missing
         implementation
     """
+
     def __getattr__(self, attr_name):
         if attr_name not in self.__attributes__:
             if attr_name in ("__path__", "__file__"):
                 return None
 
-            raise ImportError((
+            raise AttributeError((
                 "cannot import name '{}' from 'openpype_interfaces'"
             ).format(attr_name))
 


### PR DESCRIPTION
## Brief description
OpenPype interfaces are raising `AttributeError` instead of `ImportError` when some attribute is missing.

## Description
Import error should be raised by Python interpreter when attribute is not available which we're by passing. 
```
import openpype_interfaces

# This should not raise `ImportError` but `AttributeError`
some = getattr(openpype_interfaces, "something")

# This should return `None` but would crash
missing = getattr(openpype_interfaces, "missing", None)
```

## Testing notes:
This code snipped should not crash but print "None"
```
import openpype_interfaces

result = getattr(openpype_interfaces, "missing", None)
print(result)
```

At the same time this should cause `ImportError`
```
from openpype_interfaces import missing
```

Resolves https://github.com/pypeclub/OpenPype/issues/3541