### PR TITLE
Settings: Clean default values of environments

### DIFF
--- a/openpype/settings/defaults/system_settings/general.json
+++ b/openpype/settings/defaults/system_settings/general.json
@@ -2,11 +2,7 @@
     "studio_name": "Studio name",
     "studio_code": "stu",
     "admin_password": "",
-    "environment": {
-        "__environment_keys__": {
-            "global": []
-        }
-    },
+    "environment": {},
     "log_to_server": true,
     "disk_mapping": {
         "windows": [],


### PR DESCRIPTION
## Brief description
Removed unused metadata values from default environments settings.

## Description
Default values of environments settings contain metadata values that are not used anymore.

## Testing notes:
1. Nothing should change really