### PR TITLE
Nuke: publish existing frames with slate with correct range

### DIFF
--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -181,8 +181,6 @@ class ExporterReview(object):
             # get first and last frame
             self.first_frame = min(self.collection.indexes)
             self.last_frame = max(self.collection.indexes)
-            if "slate" in self.instance.data["families"]:
-                self.first_frame += 1
         else:
             self.fname = os.path.basename(self.path_in)
             self.fhead = os.path.splitext(self.fname)[0] + "."

--- a/openpype/hosts/nuke/plugins/publish/collect_slate_node.py
+++ b/openpype/hosts/nuke/plugins/publish/collect_slate_node.py
@@ -33,6 +33,7 @@ class CollectSlate(pyblish.api.InstancePlugin):
 
             if slate_node:
                 instance.data["slateNode"] = slate_node
+                instance.data["slate"] = True
                 instance.data["families"].append("slate")
                 instance.data["versionData"]["families"].append("slate")
                 self.log.info(

--- a/openpype/hosts/nuke/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_render_local.py
@@ -80,8 +80,11 @@ class NukeRenderLocal(openpype.api.Extractor):
             repre = {
                 'name': ext,
                 'ext': ext,
-                'frameStart': "%0{}d".format(
-                    len(str(last_frame))) % first_frame,
+                'frameStart': (
+                    "{{:0>{}}}"
+                    .format(len(str(last_frame)))
+                    .format(first_frame)
+                ),
                 'files': filenames,
                 "stagingDir": out_dir
             }

--- a/openpype/hosts/nuke/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_render_local.py
@@ -31,10 +31,6 @@ class NukeRenderLocal(openpype.api.Extractor):
 
         first_frame = instance.data.get("frameStartHandle", None)
 
-        # exception for slate workflow
-        if "slate" in families:
-            first_frame -= 1
-
         last_frame = instance.data.get("frameEndHandle", None)
         node_subset_name = instance.data.get("name", None)
 
@@ -67,10 +63,6 @@ class NukeRenderLocal(openpype.api.Extractor):
             int(first_frame),
             int(last_frame)
         )
-
-        # exception for slate workflow
-        if "slate" in families:
-            first_frame += 1
 
         ext = node["file_type"].value()
 

--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -13,6 +13,7 @@ from openpype.hosts.nuke.api import (
     get_view_process_node
 )
 
+
 class ExtractSlateFrame(openpype.api.Extractor):
     """Extracts movie and thumbnail with baked in luts
 

--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -237,6 +237,7 @@ class ExtractSlateFrame(openpype.api.Extractor):
     def _render_slate_to_sequence(self, instance):
         # set slate frame
         first_frame = instance.data["frameStartHandle"]
+        last_frame = instance.data["frameEndHandle"]
         slate_first_frame = first_frame - 1
 
         # render slate as sequence frame
@@ -285,6 +286,13 @@ class ExtractSlateFrame(openpype.api.Extractor):
             matching_repre["files"] = [first_filename, slate_filename]
         elif slate_filename not in matching_repre["files"]:
             matching_repre["files"].insert(0, slate_filename)
+            matching_repre["frameStart"] = (
+                "{{:0>{}}}"
+                .format(len(str(last_frame)))
+                .format(slate_first_frame)
+            )
+            self.log.debug(
+                "__ matching_repre: {}".format(pformat(matching_repre)))
 
         self.log.warning("Added slate frame to representation files")
 

--- a/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
+++ b/openpype/hosts/nuke/plugins/publish/validate_rendered_frames.py
@@ -98,7 +98,7 @@ class ValidateRenderedFrames(pyblish.api.InstancePlugin):
                     self.log.error(msg)
                     raise ValidationException(msg)
 
-            collected_frames_len = int(len(collection.indexes))
+            collected_frames_len = len(collection.indexes)
             coll_start = min(collection.indexes)
             coll_end = max(collection.indexes)
 

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -80,10 +80,6 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
                     "Using published scene for render {}".format(script_path)
                 )
 
-        # exception for slate workflow
-        if "slate" in instance.data["families"]:
-            submit_frame_start -= 1
-
         response = self.payload_submit(
             instance,
             script_path,
@@ -99,10 +95,6 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         instance.data["publishJobState"] = "Suspended"
 
         if instance.data.get("bakingNukeScripts"):
-            # exception for slate workflow
-            if "slate" in instance.data["families"]:
-                submit_frame_start += 1
-
             for baking_script in instance.data["bakingNukeScripts"]:
                 render_path = baking_script["bakeRenderPath"]
                 script_path = baking_script["bakeScriptPath"]
@@ -365,7 +357,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         if not instance.data.get("expectedFiles"):
             instance.data["expectedFiles"] = []
 
-        dir = os.path.dirname(path)
+        dirname = os.path.dirname(path)
         file = os.path.basename(path)
 
         if "#" in file:
@@ -377,9 +369,12 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             instance.data["expectedFiles"].append(path)
             return
 
+        if instance.data.get("slate"):
+            start_frame -= 1
+
         for i in range(start_frame, (end_frame + 1)):
             instance.data["expectedFiles"].append(
-                os.path.join(dir, (file % i)).replace("\\", "/"))
+                os.path.join(dirname, (file % i)).replace("\\", "/"))
 
     def get_limit_groups(self):
         """Search for limit group nodes and return group name.

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -158,7 +158,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
     # mapping of instance properties to be transfered to new instance for every
     # specified family
     instance_transfer = {
-        "slate": ["slateFrames"],
+        "slate": ["slateFrames", "slate"],
         "review": ["lutPath"],
         "render2d": ["bakingNukeScripts", "version"],
         "renderlayer": ["convertToScanline"]
@@ -585,11 +585,15 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                     " This may cause issues on farm."
                 ).format(staging))
 
+            frame_start = int(instance.get("frameStartHandle"))
+            if instance.get("slate"):
+                frame_start -= 1
+
             rep = {
                 "name": ext,
                 "ext": ext,
                 "files": [os.path.basename(f) for f in list(collection)],
-                "frameStart": int(instance.get("frameStartHandle")),
+                "frameStart": frame_start,
                 "frameEnd": int(instance.get("frameEndHandle")),
                 # If expectedFile are absolute, we need only filenames
                 "stagingDir": staging,


### PR DESCRIPTION
## Brief description
Range is correct when published slate from existing frames

## Description
The miscalculation was removed.

## Testing notes:
1. open nuke workfile with slate workflow
2. publish from existing frames
3. notice that frame range is correct and not frame shorter