### PR TITLE
General: Remove hosts filter on integrator plugins

### DIFF
--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -104,10 +104,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
     label = "Integrate Asset"
     order = pyblish.api.IntegratorOrder
-    hosts = ["aftereffects", "blender", "celaction", "flame", "harmony",
-             "hiero", "houdini", "nuke", "photoshop", "resolve",
-             "standalonepublisher", "traypublisher", "tvpaint", "unreal",
-             "webpublisher"]
     families = ["workfile",
                 "pointcache",
                 "camera",

--- a/openpype/plugins/publish/integrate_legacy.py
+++ b/openpype/plugins/publish/integrate_legacy.py
@@ -72,10 +72,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
     label = "Integrate Asset (legacy)"
     # Make sure it happens after new integrator
     order = pyblish.api.IntegratorOrder + 0.00001
-    hosts = ["aftereffects", "blender", "celaction", "flame", "harmony",
-             "hiero", "houdini", "nuke", "photoshop", "resolve",
-             "standalonepublisher", "traypublisher", "tvpaint", "unreal",
-             "webpublisher"]
     families = ["workfile",
                 "pointcache",
                 "camera",


### PR DESCRIPTION
## Brief description
Removed hosts filters from integrator plugins.

## Description
Integrators accidentaly kept hosts filters that should not be there.

## Testing notes:
1. Integration should work in all hosts