### PR TITLE
NewPublisher: Python 2 compatible html escape

### DIFF
--- a/openpype/tools/publisher/publish_report_viewer/model.py
+++ b/openpype/tools/publisher/publish_report_viewer/model.py
@@ -1,9 +1,9 @@
 import uuid
-import html
 from Qt import QtCore, QtGui
 
 import pyblish.api
 
+from openpype.tools.utils.lib import html_escape
 from .constants import (
     ITEM_ID_ROLE,
     ITEM_IS_GROUP_ROLE,
@@ -46,7 +46,7 @@ class InstancesModel(QtGui.QStandardItemModel):
             all_removed = True
             for instance_item in instance_items:
                 item = QtGui.QStandardItem(instance_item.label)
-                instance_label = html.escape(instance_item.label)
+                instance_label = html_escape(instance_item.label)
                 item.setData(instance_label, ITEM_LABEL_ROLE)
                 item.setData(instance_item.errored, ITEM_ERRORED_ROLE)
                 item.setData(instance_item.id, ITEM_ID_ROLE)

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -22,13 +22,13 @@ Only one item can be selected at a time.
 
 import re
 import collections
-import html
 
 from Qt import QtWidgets, QtCore
 
 from openpype.widgets.nice_checkbox import NiceCheckbox
 
 from openpype.tools.utils import BaseClickableFrame
+from openpype.tools.utils.lib import html_escape
 from .widgets import (
     AbstractInstanceView,
     ContextWarningLabel,
@@ -308,7 +308,7 @@ class InstanceCardWidget(CardWidget):
         self._last_variant = variant
         self._last_subset_name = subset_name
         # Make `variant` bold
-        label = html.escape(self.instance.label)
+        label = html_escape(self.instance.label)
         found_parts = set(re.findall(variant, label, re.IGNORECASE))
         if found_parts:
             for part in found_parts:

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -23,12 +23,12 @@ selection can be enabled disabled using checkbox or keyboard key presses:
 ```
 """
 import collections
-import html
 
 from Qt import QtWidgets, QtCore, QtGui
 
 from openpype.style import get_objected_colors
 from openpype.widgets.nice_checkbox import NiceCheckbox
+from openpype.tools.utils.lib import html_escape
 from .widgets import AbstractInstanceView
 from ..constants import (
     INSTANCE_ID_ROLE,
@@ -114,7 +114,7 @@ class InstanceListItemWidget(QtWidgets.QWidget):
 
         self.instance = instance
 
-        instance_label = html.escape(instance.label)
+        instance_label = html_escape(instance.label)
 
         subset_name_label = QtWidgets.QLabel(instance_label, self)
         subset_name_label.setObjectName("ListViewSubsetName")
@@ -181,7 +181,7 @@ class InstanceListItemWidget(QtWidgets.QWidget):
         # Check subset name
         label = self.instance.label
         if label != self._instance_label_widget.text():
-            self._instance_label_widget.setText(html.escape(label))
+            self._instance_label_widget.setText(html_escape(label))
         # Check active state
         self.set_active(self.instance["active"])
         # Check valid states

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -37,6 +37,19 @@ def center_window(window):
     window.move(geo.topLeft())
 
 
+def html_escape(text):
+    """Basic escape of html syntax symbols in text."""
+
+    return (
+        text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#x27;")
+    )
+
+
 def set_style_property(widget, property_name, property_value):
     """Set widget's property that may affect style.
 


### PR DESCRIPTION
## Brief description
Escape of html syntax symbols is implemented in openpype instead of using Python 3 module.

## Description
We've used Python 3 module `html` for escaping of html symbols which is not available in Python 2 hosts. Thus we needed to add that option for them too. The basic escaping is easy to implement and does not need special python module for that so a function was added.

## Testing notes:
1. Open NewPublisher in host with Python 2
2. UI should show their labels and not crash

Resolves https://github.com/pypeclub/OpenPype/issues/3558