### PR TITLE
General: Global thumbnail extractor is ready for more cases

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -41,9 +41,14 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             "Processing instance with subset name {}".format(subset_name)
         )
 
-        # Skip if instance does not have review
+        # Skip if instance have 'review' key in data set to 'False'
         if not self._is_review_instance(instance):
             self.log.info("Skipping - no review set on instance.")
+            return
+
+        # Check if already has thumbnail created
+        if self._already_has_thumbnail(instance_repres):
+            self.log.info("Thumbnail representation already present.")
             return
 
         # skip crypto passes.
@@ -56,9 +61,6 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             self.log.info("Skipping crypto passes.")
             return
 
-        if self._already_has_thumbnail(instance):
-            self.log.info("Thumbnail representation already present.")
-            return
 
         filtered_repres = self._get_filtered_repres(instance)
         for repre in filtered_repres:
@@ -123,12 +125,11 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             return True
         return False
 
-    def _already_has_thumbnail(self, instance):
-        for repre in instance.data.get("representations", []):
+    def _already_has_thumbnail(self, repres):
+        for repre in repres:
             self.log.info("repre {}".format(repre))
             if repre["name"] == "thumbnail":
                 return True
-
         return False
 
     def _get_filtered_repres(self, instance):

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -29,7 +29,17 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     ffmpeg_args = None
 
     def process(self, instance):
-        self.log.info("subset {}".format(instance.data['subset']))
+        subset_name = instance.data["subset"]
+        instance_repres = instance.data.get("representations")
+        if not instance_repres:
+            self.log.debug((
+                "Instance {} does not have representations. Skipping"
+            ).format(subset_name))
+            return
+
+        self.log.info(
+            "Processing instance with subset name {}".format(subset_name)
+        )
 
         # skip crypto passes.
         # TODO: This is just a quick fix and has its own side-effects - it is

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -72,7 +72,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         # - this is to avoid "override" of source file
         dst_staging = tempfile.mkdtemp(prefix="pyblish_tmp_")
         self.log.debug(
-            "Create temp directory {} for thumbnail".formap(dst_staging)
+            "Create temp directory {} for thumbnail".format(dst_staging)
         )
         # Store new staging to cleanup paths
         instance.context.data["cleanupFullPaths"].append(dst_staging)

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -41,6 +41,11 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             "Processing instance with subset name {}".format(subset_name)
         )
 
+        # Skip if instance does not have review
+        if not self._is_review_instance(instance):
+            self.log.info("Skipping - no review set on instance.")
+            return
+
         # skip crypto passes.
         # TODO: This is just a quick fix and has its own side-effects - it is
         #       affecting every subset name with `crypto` in its name.
@@ -49,11 +54,6 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         #       with better precision.
         if 'crypto' in instance.data['subset'].lower():
             self.log.info("Skipping crypto passes.")
-            return
-
-        # Skip if review not set.
-        if not instance.data.get("review", True):
-            self.log.info("Skipping - no review set on instance.")
             return
 
         if self._already_has_thumbnail(instance):
@@ -115,6 +115,13 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             instance.data["representations"].append(new_repre)
             # There is no need to create more then one thumbnail
             break
+
+    def _is_review_instance(self, instance):
+        # TODO: We should probably handle "not creating" of thumbnail
+        #   other way then checking for "review" key on instance data?
+        if instance.data.get("review", True):
+            return True
+        return False
 
     def _already_has_thumbnail(self, instance):
         for repre in instance.data.get("representations", []):

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -167,12 +167,12 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     def create_thumbnail_oiio(self, src_path, dst_path):
         self.log.info("outputting {}".format(dst_path))
         oiio_tool_path = get_oiio_tools_path()
-        oiio_cmd = [oiio_tool_path, "-a",
-                    src_path, "-o",
-                    dst_path
-                    ]
-        subprocess_exr = " ".join(oiio_cmd)
-        self.log.info(f"running: {subprocess_exr}")
+        oiio_cmd = [
+            oiio_tool_path,
+            "-a", src_path,
+            "-o", dst_path
+        ]
+        self.log.info("running: {}".format(" ".join(oiio_cmd)))
         try:
             run_subprocess(oiio_cmd, logger=self.log)
             return True


### PR DESCRIPTION
## Brief description
It seems that only adding `traypublisher` to global thumbnail extractor is not enough. There are few issues related to the plugin which was not prepared to be used elsewhere then on farm.

## Description
Added or modified preflight checks. First check is if instance have representations and skip when not. Instance check for review and already existing thumbnail were moved earlier. Thumbnail representation has staging in temp rather then reuse source staging, that is because if input is `.jpg` it is just replaced so source is "replaced" (happend to my jpg sequence - not fun in production). Limited creation of thumbnail into 2 conditions and the creation of thumbnail is tried on all representations that can be used for that (if first crashes it will try create it from next). Added few logs.

## Notes
- We could maybe remove the cryptomate check? The plugin won't crash if conversion fails.
- We should probably remove the check for `instance.data.get("review", True)`. It's "deprecated" way how to tag instance for review for more then 2 years.
    - At the same time we should probably check if passed instance have `review` family in families rather. This may have massive impact on farm publishing so we should do it as totally separated PR.
- We should probably add more families to the plugin e.g. `image` family won't be processed by the plugin.

## Testing notes:
1. Publish `render` family through tray publisher
2. Should be integrated and thumbnail should be created

1. Publish something on farm
2. Thumbnails should be created as before