### PR TITLE
General: Use query functions in integrator

### DIFF
--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -307,7 +307,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             repre_doc["name"].lower(): repre_doc
             for repre_doc in get_representations(
                 project_name,
-                version_ids=version["_id"],
+                version_ids=[version["_id"]],
                 fields=["_id", "name"]
             )
         }

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -297,7 +297,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         template_name = self.get_template_name(instance)
 
         subset, subset_writes = self.prepare_subset(instance, project_name)
-        version, version_writes = self.prepare_version(instance, subset)
+        version, version_writes = self.prepare_version(
+            instance, subset, project_name
+        )
         instance.data["versionEntity"] = version
 
         # Get existing representations (if any)


### PR DESCRIPTION
## Brief description
New integrator plugin is using query functions from `openpype.client`.

## Description
Integrator PR was created before query functions were available (legacy integrator is already using them).

## Testing notes:
1. New integrator should work as did before but is using query functions