### PR TITLE
General: Integrator exclude farm removal

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_instances.py
@@ -94,6 +94,7 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
                         # Farm rendering
                         self.log.info("flagged for farm render")
                         instance.data["transfer"] = False
+                        instance.data["farm"] = True
                         families.append("{}.farm".format(family))
                         family = families_ak.lower()
 

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -156,7 +156,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "mvUsdOverride",
                 "simpleUnrealTexture"
                 ]
-    exclude_families = ["clip", "render.farm"]
+
     default_template_name = "publish"
 
     # Representation context keys that should always be written to
@@ -188,14 +188,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "Skipping, there are no representations"
                 " to integrate for instance {}"
             ).format(instance.data["family"]))
-            return
-
-        # Exclude instances that also contain families from exclude families
-        families = set(get_instance_families(instance))
-        exclude = families & set(self.exclude_families)
-        if exclude:
-            self.log.debug("Instance not integrated due to exclude "
-                           "families found: {}".format(", ".join(exclude)))
             return
 
         file_transactions = FileTransaction(log=self.log)


### PR DESCRIPTION
## Brief description
Removing exclude family filter

## Description
New integrator doesn't need exclude family filter anymore. 

## Additional info
In nuke we had to add `farm` key collector to instance data - this is for Integrator to exclude it from its processing.

## Testing notes:
Test in Nuke by submitting render family subset to farm. It should work normally