### PR TITLE
Maya: fix active pane loss

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -128,8 +128,10 @@ class ExtractPlayblast(openpype.api.Extractor):
             # Update preset with current panel setting
             # if override_viewport_options is turned off
             if not override_viewport_options:
+                panel = cmds.getPanel(with_focus=True)
                 panel_preset = capture.parse_active_view()
                 preset.update(panel_preset)
+                cmds.setFocus(panel)
 
             path = capture.capture(**preset)
 

--- a/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
@@ -110,8 +110,10 @@ class ExtractThumbnail(openpype.api.Extractor):
             # Update preset with current panel setting
             # if override_viewport_options is turned off
             if not override_viewport_options:
+                panel = cmds.getPanel(with_focus=True)
                 panel_preset = capture.parse_active_view()
                 preset.update(panel_preset)
+                cmds.setFocus(panel)
 
             path = capture.capture(**preset)
             playblast = self._fix_playblast_output_path(path)


### PR DESCRIPTION
## Fix

This little PR is fixing situation when ative pane is lost during applying capturing presets in Maya, resulting in crash of `extract_playblast` and `extract_thumbnail` plugins.

### Testing

Publishing of review playblast from Maya should work as expected.