### PR TITLE
Ftrack: Handle missing published path in integrator

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -26,8 +26,6 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
     families = ["ftrack"]
 
     def process(self, instance):
-        session = instance.context.data["ftrackSession"]
-        context = instance.context
         component_list = instance.data.get("ftrackComponentsList")
         if not component_list:
             self.log.info(
@@ -36,8 +34,8 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
             )
             return
 
-        session = instance.context.data["ftrackSession"]
         context = instance.context
+        session = context.data["ftrackSession"]
 
         parent_entity = None
         default_asset_name = None

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -380,6 +380,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             str: Path to representation file.
             None: Path is not filled or does not exists.
         """
+
         published_path = repre.get("published_path")
         if published_path:
             published_path = os.path.normpath(published_path)

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -360,6 +360,30 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         ))
         instance.data["ftrackComponentsList"] = component_list
 
+    def _get_repre_path(self, instance, repre, only_published):
+        published_path = repre.get("published_path")
+        if published_path:
+            published_path = os.path.normpath(published_path)
+            if os.path.exists(published_path):
+                return published_path
+
+        if only_published:
+            return None
+
+        comp_files = repre["files"]
+        if isinstance(comp_files, (tuple, list, set)):
+            filename = comp_files[0]
+        else:
+            filename = comp_files
+
+        staging_dir = repre.get("stagingDir")
+        if not staging_dir:
+            staging_dir = instance.data["stagingDir"]
+        src_path = os.path.normpath(os.path.join(staging_dir, filename))
+        if os.path.exists(src_path):
+            return src_path
+        return None
+
     def _get_asset_version_status_name(self, instance):
         if not self.asset_versions_status_profiles:
             return None

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -360,6 +360,26 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         instance.data["ftrackComponentsList"] = component_list
 
     def _get_repre_path(self, instance, repre, only_published):
+        """Get representation path that can be used for integration.
+
+        When 'only_published' is set to true the validation of path is not
+        relevant. In that case we just need what is set in 'published_path'
+        as "reference". The reference is not used to get or upload the file but
+        for reference where the file was published.
+
+        Args:
+            instance (pyblish.Instance): Processed instance object. Used
+                for source of staging dir if representation does not have
+                filled it.
+            repre (dict): Representation on instance which could be and
+                could not be integrated with main integrator.
+            only_published (bool): Care only about published paths and
+                ignore if filepath is not existing anymore.
+
+        Returns:
+            str: Path to representation file.
+            None: Path is not filled or does not exists.
+        """
         published_path = repre.get("published_path")
         if published_path:
             published_path = os.path.normpath(published_path)


### PR DESCRIPTION
## Brief description
Ftrack integrator can handle if `published_path` is not filled on representation.

## Description
Ftrack integrator expected that `published_path` is always filled on representation for review and thumbnail upload, but in some very specifici cases they may not be integrated with `IntegrateAsset` thus they don't have filled the key at all. But in that cases can be used their source path.
Before this PR it crashed with `KeyError`.

## Traceback
```
Traceback (most recent call last):
   File "C:\Program Files (x86)\OpenPype\dependencies\pyblish\plugin.py", line 522, in __explicit_process
     runner(*args)
   File "C:\Program Files (x86)\OpenPype\openpype\modules\ftrack\plugins\publish\integrate_ftrack_instances.py", line 273, in process
 KeyError: 'published_path'
```
## Testing notes:
Not sure how it is possible to make reviewable that is not integrated to validate it won't crash.
1. Run publish that should integrate at lease review or thumbnail to ftrack
2. Validate they are integrated