### PR TITLE
Enable write color sets on animation publish automatically

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -22,7 +22,7 @@ class CreateAnimation(plugin.Creator):
             self.data[key] = value
 
         # Write vertex colors with the geometry.
-        self.data["writeColorSets"] = False
+        self.data["writeColorSets"] = True
         self.data["writeFaceSets"] = False
 
         # Include only renderable visible shapes.

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -11,6 +11,7 @@ class CreateAnimation(plugin.Creator):
     label = "Animation"
     family = "animation"
     icon = "male"
+    write_color_sets = False 
 
     def __init__(self, *args, **kwargs):
         super(CreateAnimation, self).__init__(*args, **kwargs)
@@ -22,7 +23,7 @@ class CreateAnimation(plugin.Creator):
             self.data[key] = value
 
         # Write vertex colors with the geometry.
-        self.data["writeColorSets"] = True
+        self.data["writeColorSets"] = self.write_color_sets
         self.data["writeFaceSets"] = False
 
         # Include only renderable visible shapes.

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -90,9 +90,11 @@
         },
         "CreateAnimation": {
             "enabled": true,
+            "write_color_sets": false,
             "defaults": [
                 "Main"
             ]
+          
         },
         "CreateAss": {
             "enabled": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -144,6 +144,31 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CreateAnimation",
+            "label": "Create Animation",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_color_sets",
+                    "label": "Write Color Sets"
+                },
+                {
+                    "type": "list",
+                    "key": "defaults",
+                    "label": "Default Subsets",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
             "type": "schema_template",
             "name": "template_create_plugin",
             "template_data": [
@@ -158,10 +183,6 @@
                 {
                     "key": "CreateMultiverseUsdOver",
                     "label": "Create Multiverse USD Override"
-                },
-                {
-                    "key": "CreateAnimation",
-                    "label": "Create Animation"
                 },
                 {
                     "key": "CreateAss",


### PR DESCRIPTION
## Brief description
This is the request from the Line. They want the "write color sets" to be on by default on the animation publish
See the ticket here: https://app.clickup.com/t/6658547/OP-3371
## Solution
Set` self.data["writeColorSets"] = True` in _create_animation.py_ in ./maya/plugins/publish folder
