### PR TITLE
Nuke: render family integration consistency 

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_render_local.py
@@ -105,13 +105,16 @@ class NukeRenderLocal(openpype.api.Extractor):
             instance.data['family'] = 'render'
             families.remove('render.local')
             families.insert(0, "render2d")
+            instance.data["anatomyData"]["family"] = "render"
         elif "prerender.local" in families:
             instance.data['family'] = 'prerender'
             families.remove('prerender.local')
             families.insert(0, "prerender")
+            instance.data["anatomyData"]["family"] = "prerender"
         elif "still.local" in families:
             instance.data['family'] = 'image'
             families.remove('still.local')
+            instance.data["anatomyData"]["family"] = "image"
         instance.data["families"] = families
 
         collections, remainder = clique.assemble(filenames)

--- a/openpype/hosts/nuke/plugins/publish/extract_render_local.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_render_local.py
@@ -123,4 +123,4 @@ class NukeRenderLocal(openpype.api.Extractor):
 
         self.log.info('Finished render')
 
-        self.log.debug("instance extracted: {}".format(instance.data))
+        self.log.debug("_ instance.data: {}".format(instance.data))

--- a/openpype/hosts/nuke/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_instances.py
@@ -50,7 +50,7 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
             # establish families
             family = avalon_knob_data["family"]
             families_ak = avalon_knob_data.get("families", [])
-            families = list()
+            families = []
 
             # except disabled nodes but exclude backdrops in test
             if ("nukenodes" not in family) and (node["disable"].value()):
@@ -111,10 +111,10 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
             self.log.debug("__ families: `{}`".format(families))
 
             # Get format
-            format = root['format'].value()
-            resolution_width = format.width()
-            resolution_height = format.height()
-            pixel_aspect = format.pixelAspect()
+            format_ = root['format'].value()
+            resolution_width = format_.width()
+            resolution_height = format_.height()
+            pixel_aspect = format_.pixelAspect()
 
             # get publish knob value
             if "publish" not in node.knobs():
@@ -125,8 +125,11 @@ class PreCollectNukeInstances(pyblish.api.ContextPlugin):
             self.log.debug("__ _families_test: `{}`".format(_families_test))
             for family_test in _families_test:
                 if family_test in self.sync_workfile_version_on_families:
-                    self.log.debug("Syncing version with workfile for '{}'"
-                                   .format(family_test))
+                    self.log.debug(
+                        "Syncing version with workfile for '{}'".format(
+                            family_test
+                        )
+                    )
                     # get version to instance for integration
                     instance.data['version'] = instance.context.data['version']
 

--- a/openpype/hosts/nuke/plugins/publish/precollect_writes.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_writes.py
@@ -144,8 +144,10 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             self.log.debug("colorspace: `{}`".format(colorspace))
 
         version_data = {
-            "families": [f.replace(".local", "").replace(".farm", "")
-                         for f in _families_test if "write" not in f],
+            "families": [
+                _f.replace(".local", "").replace(".farm", "")
+                for _f in _families_test if "write" != _f
+            ],
             "colorspace": colorspace
         }
 


### PR DESCRIPTION
## Brief description
Families are integrating to the same family from any render target.

## Description
Any chosen render target should now produce the same result in published folder.

## Additional info
Integrator is using `anatomyData` keys for filling up templates and choosing what template to use from Anatomy. So family has to be correct.

## Testing notes:
1. Nuke render local, farm, existing frames from render and prerender node
2. published versions should be the same family

closes https://github.com/pypeclub/OpenPype/issues/3568