### PR TITLE
General: Update imports in start script

### DIFF
--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -131,15 +131,16 @@
             }
         }
     },
+    "kitsu": {
+        "enabled": false,
+        "server": ""
+    },
     "shotgrid": {
         "enabled": false,
         "leecher_manager_url": "http://127.0.0.1:3000",
         "leecher_backend_url": "http://127.0.0.1:8090",
+        "filter_projects_by_login": true,
         "shotgrid_settings": {}
-    },
-    "kitsu": {
-        "enabled": false,
-        "server": ""
     },
     "timers_manager": {
         "enabled": true,

--- a/start.py
+++ b/start.py
@@ -1114,7 +1114,11 @@ def boot():
 def get_info(use_staging=None) -> list:
     """Print additional information to console."""
     from openpype.client.mongo import get_default_components
-    from openpype.lib.log import PypeLogger
+    try:
+        from openpype.lib.log import Logger
+    except ImportError:
+        # Backwards compatibility for 'PypeLogger'
+        from openpype.lib.log import PypeLogger as Logger
 
     components = get_default_components()
 
@@ -1141,14 +1145,14 @@ def get_info(use_staging=None) -> list:
                     os.environ.get("MUSTER_REST_URL")))
 
     # Reinitialize
-    PypeLogger.initialize()
+    Logger.initialize()
 
     mongo_components = get_default_components()
     if mongo_components["host"]:
         inf.append(("Logging to MongoDB", mongo_components["host"]))
         inf.append(("  - port", mongo_components["port"] or "<N/A>"))
-        inf.append(("  - database", PypeLogger.log_database_name))
-        inf.append(("  - collection", PypeLogger.log_collection_name))
+        inf.append(("  - database", Logger.log_database_name))
+        inf.append(("  - collection", Logger.log_collection_name))
         inf.append(("  - user", mongo_components["username"] or "<N/A>"))
         if mongo_components["auth_db"]:
             inf.append(("  - auth source", mongo_components["auth_db"]))

--- a/start.py
+++ b/start.py
@@ -1113,7 +1113,7 @@ def boot():
 
 def get_info(use_staging=None) -> list:
     """Print additional information to console."""
-    from openpype.lib.mongo import get_default_components
+    from openpype.client.mongo import get_default_components
     from openpype.lib.log import PypeLogger
 
     components = get_default_components()


### PR DESCRIPTION
## Brief description
Use new imports and names of classes in `start.py` and fixed missing default settings.

## Description
Use `get_default_components` from `openpype.client.mongo` instead of `openpype.lib.mongo` and try to use class `Logger` instead of `PypeLogger`.

## Testing notes:
1. Start of OpenPype should not crash and there should not be deprecated warnings
2. Missing default settings should not popup