### PR TITLE
Editorial publishing workflow improvements

### DIFF
--- a/openpype/hosts/flame/plugins/publish/collect_timeline_instances.py
+++ b/openpype/hosts/flame/plugins/publish/collect_timeline_instances.py
@@ -136,7 +136,8 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
                 "tasks": {
                     task["name"]: {"type": task["type"]}
                     for task in self.add_tasks},
-                "representations": []
+                "representations": [],
+                "newAssetPublishing": True
             })
             self.log.debug("__ inst_data: {}".format(pformat(inst_data)))
 

--- a/openpype/hosts/hiero/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_instances.py
@@ -109,7 +109,8 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
                 "clipAnnotations": annotations,
 
                 # add all additional tags
-                "tags": phiero.get_track_item_tags(track_item)
+                "tags": phiero.get_track_item_tags(track_item),
+                "newAssetPublishing": True
             })
 
             # otio clip data

--- a/openpype/hosts/resolve/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/resolve/plugins/publish/precollect_instances.py
@@ -70,7 +70,8 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
                 "publish": resolve.get_publish_attribute(timeline_item),
                 "fps": context.data["fps"],
                 "handleStart": handle_start,
-                "handleEnd": handle_end
+                "handleEnd": handle_end,
+                "newAssetPublishing": True
             })
 
             # otio clip data

--- a/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/collect_editorial_instances.py
@@ -170,7 +170,8 @@ class CollectInstances(pyblish.api.InstancePlugin):
                     "frameStart": frame_start,
                     "frameEnd": frame_end,
                     "frameStartH": frame_start - handle_start,
-                    "frameEndH": frame_end + handle_end
+                    "frameEndH": frame_end + handle_end,
+                    "newAssetPublishing": True
                 }
 
                 for data_key in instance_data_filter:

--- a/openpype/plugins/publish/extract_hierarchy_avalon.py
+++ b/openpype/plugins/publish/extract_hierarchy_avalon.py
@@ -186,6 +186,9 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
 
     def _set_avalon_data_to_relative_instances(self, context, asset_doc):
         for instance in context:
+            # Skip instance if has filled asset entity
+            if instance.data.get("assetEntity"):
+                continue
             asset_name = asset_doc["name"]
             inst_asset_name = instance.data["asset"]
 

--- a/openpype/plugins/publish/extract_hierarchy_avalon.py
+++ b/openpype/plugins/publish/extract_hierarchy_avalon.py
@@ -199,6 +199,7 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
                 parents = asset_doc["data"].get("parents") or list()
 
                 # equire only relative parent
+                parent_name = project_name
                 if parents:
                     parent_name = parents[-1]
 

--- a/openpype/plugins/publish/extract_hierarchy_avalon.py
+++ b/openpype/plugins/publish/extract_hierarchy_avalon.py
@@ -140,7 +140,11 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
                         entity = self.unarchive_entity(unarchive_entity, data)
 
                 # make sure all relative instances have correct avalon data
-                self._set_avalon_data_to_relative_instances(context, entity)
+                self._set_avalon_data_to_relative_instances(
+                    context,
+                    project_name,
+                    entity
+                )
 
             if update_data:
                 # Update entity data with input data
@@ -184,7 +188,12 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
 
         return asset_doc
 
-    def _set_avalon_data_to_relative_instances(self, context, asset_doc):
+    def _set_avalon_data_to_relative_instances(
+        self,
+        context,
+        project_name,
+        asset_doc
+    ):
         for instance in context:
             # Skip instance if has filled asset entity
             if instance.data.get("assetEntity"):

--- a/openpype/plugins/publish/extract_hierarchy_avalon.py
+++ b/openpype/plugins/publish/extract_hierarchy_avalon.py
@@ -133,7 +133,7 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
                     if unarchive_entity is None:
                         # Create entity if doesn"t exist
                         entity = self.create_avalon_asset(
-                            project_name, name, data
+                            name, data
                         )
                     else:
                         # Unarchive if entity was archived

--- a/openpype/plugins/publish/extract_hierarchy_avalon.py
+++ b/openpype/plugins/publish/extract_hierarchy_avalon.py
@@ -200,7 +200,7 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
                     parent_name = parents[-1]
 
                 # update avalon data on instance
-                instance.data["avalonData"].update({
+                instance.data["anatomyData"].update({
                     "hierarchy": "/".join(parents),
                     "task": {},
                     "parent": parent_name

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -274,14 +274,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     def register(self, instance, file_transactions, filtered_repres):
         project_name = legacy_io.active_project()
 
-        # making sure editorial instances have its `assetEntity`
-        if instance.data.get("newAssetPublishing"):
-            asset_doc = get_asset_by_name(
-                project_name,
-                instance.data["asset"]
-            )
-            instance.data["assetEntity"] = asset_doc
-
         instance_stagingdir = instance.data.get("stagingDir")
         if not instance_stagingdir:
             self.log.info((

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -12,7 +12,6 @@ import pyblish.api
 import openpype.api
 from openpype.client import (
     get_representations,
-    get_asset_by_name,
     get_subset_by_name,
     get_version_by_name,
 )

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -12,6 +12,7 @@ import pyblish.api
 import openpype.api
 from openpype.client import (
     get_representations,
+    get_asset_by_name,
     get_subset_by_name,
     get_version_by_name,
 )
@@ -273,6 +274,14 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     def register(self, instance, file_transactions, filtered_repres):
         project_name = legacy_io.active_project()
 
+        # making sure editorial instances have its `assetEntity`
+        if instance.data.get("newAssetPublishing"):
+            asset_doc = get_asset_by_name(
+                project_name,
+                instance.data["asset"]
+            )
+            instance.data["assetEntity"] = asset_doc
+
         instance_stagingdir = instance.data.get("stagingDir")
         if not instance_stagingdir:
             self.log.info((
@@ -426,7 +435,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                       "".format(len(prepared_representations)))
 
     def prepare_subset(self, instance, project_name):
-        asset_doc = instance.data.get("assetEntity")
+        asset_doc = instance.data["assetEntity"]
         subset_name = instance.data["subset"]
         self.log.debug("Subset: {}".format(subset_name))
 

--- a/openpype/plugins/publish/validate_asset_docs.py
+++ b/openpype/plugins/publish/validate_asset_docs.py
@@ -24,6 +24,10 @@ class ValidateAssetDocs(pyblish.api.InstancePlugin):
         if instance.data.get("assetEntity"):
             self.log.info("Instance has set asset document in its data.")
 
+        elif instance.data.get("newAssetPublishing"):
+            # skip if it is editorial
+            self.log.info("Editorial instance is no need to check...")
+
         else:
             raise PublishValidationError((
                 "Instance \"{}\" doesn't have asset document "


### PR DESCRIPTION
## Brief description
Editorial instances are not failing due missing assetEntity

## Description
Editorial workflow was missing instance data flag telling validator and integrators they should be treated with missing asset entity, since this is created during publishing and is not available at the time of collecting phase.

## Additional info
global, flame, hiero, resolve, sp: implementing `newAssetPublishing`