### PR TITLE
Enable write color sets on animation publish automatically

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -22,7 +22,7 @@ class CreateAnimation(plugin.Creator):
             self.data[key] = value
 
         # Write vertex colors with the geometry.
-        self.data["writeColorSets"] = False
+        self.data["writeColorSets"] = True
         self.data["writeFaceSets"] = False
 
         # Include only renderable visible shapes.

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -11,6 +11,7 @@ class CreateAnimation(plugin.Creator):
     label = "Animation"
     family = "animation"
     icon = "male"
+    write_color_sets = False 
 
     def __init__(self, *args, **kwargs):
         super(CreateAnimation, self).__init__(*args, **kwargs)
@@ -22,7 +23,7 @@ class CreateAnimation(plugin.Creator):
             self.data[key] = value
 
         # Write vertex colors with the geometry.
-        self.data["writeColorSets"] = True
+        self.data["writeColorSets"] = self.write_color_sets
         self.data["writeFaceSets"] = False
 
         # Include only renderable visible shapes.

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -11,7 +11,8 @@ class CreateAnimation(plugin.Creator):
     label = "Animation"
     family = "animation"
     icon = "male"
-    write_color_sets = False 
+
+    write_color_sets = False
 
     def __init__(self, *args, **kwargs):
         super(CreateAnimation, self).__init__(*args, **kwargs)

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -11,7 +11,7 @@ class CreateAnimation(plugin.Creator):
     label = "Animation"
     family = "animation"
     icon = "male"
-
+       
     write_color_sets = False
 
     def __init__(self, *args, **kwargs):

--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -11,7 +11,6 @@ class CreateAnimation(plugin.Creator):
     label = "Animation"
     family = "animation"
     icon = "male"
-       
     write_color_sets = False
 
     def __init__(self, *args, **kwargs):

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -12,13 +12,16 @@ class CreatePointCache(plugin.Creator):
     family = "pointcache"
     icon = "gears"
 
+    write_color_sets = False 
+
+
     def __init__(self, *args, **kwargs):
         super(CreatePointCache, self).__init__(*args, **kwargs)
 
         # Add animation data
         self.data.update(lib.collect_animation_data())
 
-        self.data["writeColorSets"] = False  # Vertex colors with the geometry.
+        self.data["writeColorSets"] = self.write_color_sets  # Vertex colors with the geometry.
         self.data["writeFaceSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -11,9 +11,8 @@ class CreatePointCache(plugin.Creator):
     label = "Point Cache"
     family = "pointcache"
     icon = "gears"
-
-    write_color_sets = False 
-
+    
+    write_color_sets = False
 
     def __init__(self, *args, **kwargs):
         super(CreatePointCache, self).__init__(*args, **kwargs)
@@ -21,7 +20,8 @@ class CreatePointCache(plugin.Creator):
         # Add animation data
         self.data.update(lib.collect_animation_data())
 
-        self.data["writeColorSets"] = self.write_color_sets  # Vertex colors with the geometry.
+        # Vertex colors with the geometry.
+        self.data["writeColorSets"] = self.write_color_sets  
         self.data["writeFaceSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -21,7 +21,7 @@ class CreatePointCache(plugin.Creator):
         self.data.update(lib.collect_animation_data())
 
         # Vertex colors with the geometry.
-        self.data["writeColorSets"] = self.write_color_sets  
+        self.data["writeColorSets"] = self.write_color_sets
         self.data["writeFaceSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -11,7 +11,6 @@ class CreatePointCache(plugin.Creator):
     label = "Point Cache"
     family = "pointcache"
     icon = "gears"
-    
     write_color_sets = False
 
     def __init__(self, *args, **kwargs):

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -90,9 +90,11 @@
         },
         "CreateAnimation": {
             "enabled": true,
+            "write_color_sets": false,
             "defaults": [
                 "Main"
             ]
+          
         },
         "CreateAss": {
             "enabled": true,

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -136,6 +136,7 @@
         },
         "CreatePointCache": {
             "enabled": true,
+            "write_color_sets": false,
             "defaults": [
                 "Main"
             ]

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -144,6 +144,31 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CreateAnimation",
+            "label": "Create Animation",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_color_sets",
+                    "label": "Write Color Sets"
+                },
+                {
+                    "type": "list",
+                    "key": "defaults",
+                    "label": "Default Subsets",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
             "type": "schema_template",
             "name": "template_create_plugin",
             "template_data": [
@@ -158,10 +183,6 @@
                 {
                     "key": "CreateMultiverseUsdOver",
                     "label": "Create Multiverse USD Override"
-                },
-                {
-                    "key": "CreateAnimation",
-                    "label": "Create Animation"
                 },
                 {
                     "key": "CreateAss",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -169,6 +169,32 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CreatePointCache",
+            "label": "Create Cache",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_color_sets",
+                    "label": "Write Color Sets"
+                },
+                {
+                    "type": "list",
+                    "key": "defaults",
+                    "label": "Default Subsets",
+                    "object_type": "text"
+                }
+            ]
+        },
+        
+        {
             "type": "schema_template",
             "name": "template_create_plugin",
             "template_data": [
@@ -207,10 +233,6 @@
                 {
                     "key": "CreateModel",
                     "label": "Create Model"
-                },
-                {
-                    "key": "CreatePointCache",
-                    "label": "Create Cache"
                 },
                 {
                     "key": "CreateRenderSetup",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -172,7 +172,7 @@
             "type": "dict",
             "collapsible": true,
             "key": "CreatePointCache",
-            "label": "Create Cache",
+            "label": "Create Point Cache",
             "checkbox_key": "enabled",
             "children": [
                 {


### PR DESCRIPTION
## Brief description
Add the switching on/off option for write color sets in Create Cache in Openpype settings
![image](https://user-images.githubusercontent.com/64118225/181245162-f466b5ec-bf0f-439d-a246-291641c97e3f.png)

## Description
Add the switching on/off option for write color sets in Create Cache in Openpype settings, which overrides the write color sets attributes in maya when creating point cache instance for the geometry. 
It is implemented for being consistent regarding to the same implementation of switching on/off options in Create Animation for maya.