### PR TITLE
General: New Integrator small fixes

### DIFF
--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -556,14 +556,15 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 continue
             template_data[anatomy_key] = value
 
-        if repre.get('stagingDir'):
-            stagingdir = repre['stagingDir']
-        else:
+        stagingdir = repre.get("stagingDir")
+        if not stagingdir:
             # Fall back to instance staging dir if not explicitly
             # set for representation in the instance
-            self.log.debug("Representation uses instance staging dir: "
-                           "{}".format(instance_stagingdir))
+            self.log.debug((
+                "Representation uses instance staging dir: {}"
+            ).format(instance_stagingdir))
             stagingdir = instance_stagingdir
+
         if not stagingdir:
             raise KnownPublishError(
                 "No staging directory set for representation: {}".format(repre)

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -577,11 +577,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
             src_collection = assemble(files)
 
-            # If the representation has `frameStart` set it renumbers the
-            # frame indices of the published collection. It will start from
-            # that `frameStart` index instead. Thus if that frame start
-            # differs from the collection we want to shift the destination
-            # frame indices from the source collection.
             destination_indexes = list(src_collection.indexes)
             # Use last frame for minimum padding
             #   - that should cover both 'udim' and 'frame' minimum padding
@@ -595,16 +590,19 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 if template_padding > destination_padding:
                     destination_padding = template_padding
 
-                if repre.get("frameStart") is not None:
-                    index_frame_start = int(repre.get("frameStart"))
-
+                # If the representation has `frameStart` set it renumbers the
+                # frame indices of the published collection. It will start from
+                # that `frameStart` index instead. Thus if that frame start
+                # differs from the collection we want to shift the destination
+                # frame indices from the source collection.
+                repre_frame_start = repre.get("frameStart")
+                if repre_frame_start is not None:
+                    index_frame_start = int(repre["frameStart"])
                     # Shift destination sequence to the start frame
-                    src_start_frame = next(iter(src_collection.indexes))
-                    shift = index_frame_start - src_start_frame
-                    if shift:
-                        destination_indexes = [
-                            frame + shift for frame in destination_indexes
-                        ]
+                    destination_indexes = [
+                        index_frame_start + idx
+                        for idx in range(len(destination_indexes))
+                    ]
 
             # To construct the destination template with anatomy we require
             # a Frame or UDIM tile set for the template data. We use the first

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -700,14 +700,12 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         else:
             repre_id = ObjectId()
 
-        # Backwards compatibility:
         # Store first transferred destination as published path data
-        # todo: can we remove this?
-        # todo: We shouldn't change data that makes its way back into
-        #       instance.data[] until we know the publish actually succeeded
-        #       otherwise `published_path` might not actually be valid?
+        # - used primarily for reviews that are integrated to custom modules
+        # TODO we should probably store all integrated files
+        #   related to the representation?
         published_path = transfers[0][1]
-        repre["published_path"] = published_path  # Backwards compatibility
+        repre["published_path"] = published_path
 
         # todo: `repre` is not the actual `representation` entity
         #       we should simplify/clarify difference between data above

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -9,12 +9,12 @@ from bson.objectid import ObjectId
 from pymongo import DeleteMany, ReplaceOne, InsertOne, UpdateOne
 import pyblish.api
 
-import openpype.api
 from openpype.client import (
     get_representations,
     get_subset_by_name,
     get_version_by_name,
 )
+from openype.lib import source_hash
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.lib.file_transaction import FileTransaction
 from openpype.pipeline import legacy_io
@@ -834,6 +834,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
     def get_profile_filter_criteria(self, instance):
         """Return filter criteria for `filter_profiles`"""
+
         # Anatomy data is pre-filled by Collectors
         anatomy_data = instance.data["anatomyData"]
 
@@ -864,6 +865,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             path: modified path if possible, or unmodified path
             + warning logged
         """
+
         success, rootless_path = anatomy.find_root_template_from_path(path)
         if success:
             path = rootless_path
@@ -885,6 +887,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             output_resources: array of dictionaries to be added to 'files' key
             in representation
         """
+
         file_infos = []
         for file_path in destinations:
             file_info = self.prepare_file_info(file_path, anatomy, sites=sites)
@@ -904,10 +907,11 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         Returns:
             dict: file info dictionary
         """
+
         return {
             "_id": ObjectId(),
             "path": self.get_rootless_path(anatomy, path),
             "size": os.path.getsize(path),
-            "hash": openpype.api.source_hash(path),
+            "hash": source_hash(path),
             "sites": sites
         }

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -78,12 +78,6 @@ def get_frame_padded(frame, padding):
     return "{frame:0{padding}d}".format(padding=padding, frame=frame)
 
 
-def get_first_frame_padded(collection):
-    """Return first frame as padded number from `clique.Collection`"""
-    start_frame = next(iter(collection.indexes))
-    return get_frame_padded(start_frame, padding=collection.padding)
-
-
 class IntegrateAsset(pyblish.api.InstancePlugin):
     """Register publish in the database and transfer files to destinations.
 
@@ -588,7 +582,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             # differs from the collection we want to shift the destination
             # frame indices from the source collection.
             destination_indexes = list(src_collection.indexes)
-            destination_padding = len(get_first_frame_padded(src_collection))
+            # Use last frame for minimum padding
+            #   - that should cover both 'udim' and 'frame' minimum padding
+            destination_padding = len(str(destination_indexes[-1]))
             if repre.get("frameStart") is not None and not is_udim:
                 index_frame_start = int(repre.get("frameStart"))
 

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -14,7 +14,7 @@ from openpype.client import (
     get_subset_by_name,
     get_version_by_name,
 )
-from openype.lib import source_hash
+from openpype.lib import source_hash
 from openpype.lib.profiles_filtering import filter_profiles
 from openpype.lib.file_transaction import FileTransaction
 from openpype.pipeline import legacy_io

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -526,7 +526,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         template_data = copy.deepcopy(instance.data["anatomyData"])
 
         # required representation keys
-        files = repre['files']
+        files = repre["files"]
         template_data["representation"] = repre["name"]
         template_data["ext"] = repre["ext"]
 
@@ -564,11 +564,12 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             )
 
         self.log.debug("Anatomy template name: {}".format(template_name))
-        anatomy = instance.context.data['anatomy']
+        anatomy = instance.context.data["anatomy"]
         publish_template_category = anatomy.templates[template_name]
         template = os.path.normpath(publish_template_category["path"])
 
         is_udim = bool(repre.get("udim"))
+
         is_sequence_representation = isinstance(files, (list, tuple))
         if is_sequence_representation:
             # Collection of files (sequence)
@@ -704,13 +705,13 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         #       we should simplify/clarify difference between data above
         #       and the actual representation entity for the database
         data = repre.get("data", {})
-        data.update({'path': published_path, 'template': template})
+        data.update({"path": published_path, "template": template})
         representation = {
             "_id": repre_id,
             "schema": "openpype:representation-2.0",
             "type": "representation",
             "parent": version["_id"],
-            "name": repre['name'],
+            "name": repre["name"],
             "data": data,
 
             # Imprint shortcut to context for performance reasons.
@@ -718,7 +719,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         }
 
         if is_sequence_representation and repre.get("frameStart") is not None:
-            representation['context']['frame'] = template_data["frame"]
+            representation["context"]["frame"] = template_data["frame"]
 
         return {
             "representation": representation,
@@ -779,7 +780,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 version_data[key] = instance.data[key]
 
         # Include instance.data[versionData] directly
-        version_data_instance = instance.data.get('versionData')
+        version_data_instance = instance.data.get("versionData")
         if version_data_instance:
             version_data.update(version_data_instance)
 

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -621,6 +621,13 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             anatomy_filled = anatomy.format(template_data)
             template_filled = anatomy_filled[template_name]["path"]
             repre_context = template_filled.used_values
+
+            # Make sure context contains frame
+            # NOTE: Frame would not be available only if template does not
+            #   contain '{frame}' in template -> Do we want support it?
+            if not is_udim:
+                repre_context["frame"] = first_index_padded
+
             self.log.debug("Template filled: {}".format(str(template_filled)))
             dst_collection = assemble([os.path.normpath(template_filled)])
 
@@ -717,9 +724,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             # Imprint shortcut to context for performance reasons.
             "context": repre_context
         }
-
-        if is_sequence_representation and repre.get("frameStart") is not None:
-            representation["context"]["frame"] = template_data["frame"]
 
         return {
             "representation": representation,

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -686,9 +686,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             # Also add these values to the context even if not used by the
             # destination template
             value = template_data.get(key)
-            if not value:
-                continue
-            repre_context[key] = template_data[key]
+            if value is not None:
+                repre_context[key] = value
 
         # Explicitly store the full list even though template data might
         # have a different value because it uses just a single udim tile

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -548,13 +548,12 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         }.items():
             # Allow to take value from representation
             # if not found also consider instance.data
-            if key in repre:
-                value = repre[key]
-            elif key in instance.data:
-                value = instance.data[key]
-            else:
-                continue
-            template_data[anatomy_key] = value
+            value = repre.get(key)
+            if value is None:
+                value = instance.data.get(key)
+
+            if value is not None:
+                template_data[anatomy_key] = value
 
         stagingdir = repre.get("stagingDir")
         if not stagingdir:

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -168,7 +168,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     # the database even if not used by the destination template
     db_representation_context_keys = [
         "project", "asset", "task", "subset", "version", "representation",
-        "family", "hierarchy", "username"
+        "family", "hierarchy", "username", "output"
     ]
     skip_host_families = []
 
@@ -726,11 +726,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             # Imprint shortcut to context for performance reasons.
             "context": repre_context
         }
-
-        # todo: simplify/streamline which additional data makes its way into
-        #       the representation context
-        if repre.get("outputName"):
-            representation["context"]["output"] = repre['outputName']
 
         if is_sequence_representation and repre.get("frameStart") is not None:
             representation['context']['frame'] = template_data["frame"]


### PR DESCRIPTION
## Brief description
Fixed few smaller issues in integrator and cleaned up code and comments.

## Description
Minimum frame padding is defined by last frame of sequence instead of first frame (999 vs. 1000). Frame padding fom anatomy template is always considered when `frame` should be filled. Replaced `AssertionError`s with `KnownPublishError`. Added `"output"` to representation context keys and removed explicit set of it at the end. Make sure that representation context has filled first frame during sequence processing. Removed comments marking logic as backwards compatibility which is still fully required and does not have any replacement.

## Testing notes:
- Integration should work
- Integrated representation filenames should at all costs have filled frame with padding from anatomy templates or lenght of last frame (in case anatomy templates padding is 4 but last frame is e.g. "10000" - in that case padding should be 5)
    - even if frames of input filepaths have padding of 6