### PR TITLE
Fix general settings environment variables resolution

### DIFF
--- a/start.py
+++ b/start.py
@@ -270,8 +270,11 @@ def set_openpype_global_environments() -> None:
 
     general_env = get_general_environments()
 
+    # first resolve general environment because merge doesn't expect
+    # values to be list.
+    # TODO: switch to OpenPype environment functions
     merged_env = acre.merge(
-        acre.parse(general_env),
+        acre.compute(acre.parse(general_env), cleanup=False),
         dict(os.environ)
     )
     env = acre.compute(


### PR DESCRIPTION
# Fix

Fix how variables are resolved in general settings. This will now allow to define new variables and resolve them in one pass.

For example:

```
{
    "FOO": "something",
    "BAR": ["{FOO}", "else"]
}
```
will now resolve correctly. This was crashing OpenPype on start.

Resolves #3585 