### PR TITLE
Ftrack: Update ftrack api to 2.3.3

### DIFF
--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -7,6 +7,7 @@ import threading
 import datetime
 import time
 import queue
+import collections
 import appdirs
 import pymongo
 
@@ -309,7 +310,20 @@ class CustomEventHubSession(ftrack_api.session.Session):
 
         # Currently pending operations.
         self.recorded_operations = ftrack_api.operation.Operations()
-        self.record_operations = True
+
+        # OpenPype change - In new API are operations properties
+        new_api = hasattr(self.__class__, "record_operations")
+
+        if new_api:
+            self._record_operations = collections.defaultdict(
+                lambda: True
+            )
+            self._auto_populate = collections.defaultdict(
+                lambda: auto_populate
+            )
+        else:
+            self.record_operations = True
+            self.auto_populate = auto_populate
 
         self.cache_key_maker = cache_key_maker
         if self.cache_key_maker is None:
@@ -328,14 +342,15 @@ class CustomEventHubSession(ftrack_api.session.Session):
             if cache is not None:
                 self.cache.caches.append(cache)
 
+        if new_api:
+            self.merge_lock = threading.RLock()
+
         self._managed_request = None
         self._request = requests.Session()
         self._request.auth = ftrack_api.session.SessionAuthentication(
             self._api_key, self._api_user
         )
         self.request_timeout = timeout
-
-        self.auto_populate = auto_populate
 
         # Fetch server information and in doing so also check credentials.
         self._server_information = self._fetch_server_information()

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,7 +221,7 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "certifi"
-version = "2022.5.18.1"
+version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -456,19 +456,20 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "ftrack-python-api"
-version = "2.0.0"
+version = "2.3.3"
 description = "Python API for ftrack."
 category = "main"
 optional = false
-python-versions = ">=2.7.9, <4.0"
+python-versions = ">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, < 3.10"
 
 [package.dependencies]
+appdirs = ">=1,<2"
 arrow = ">=0.4.4,<1"
-clique = ">=1.2.0,<2"
+clique = "1.6.1"
 future = ">=0.16.0,<1"
 pyparsing = ">=2.0,<3"
 requests = ">=2,<3"
-six = ">=1,<2"
+six = ">=1.13.0,<2"
 termcolor = ">=1.1.0,<2"
 websocket-client = ">=0.40.0,<1"
 
@@ -1885,8 +1886,8 @@ cachetools = [
     {file = "cachetools-5.2.0.tar.gz", hash = "sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757"},
 ]
 certifi = [
-    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
-    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
@@ -2152,10 +2153,7 @@ frozenlist = [
     {file = "frozenlist-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:772965f773757a6026dea111a15e6e2678fbd6216180f82a48a40b27de1ee2ab"},
     {file = "frozenlist-1.3.0.tar.gz", hash = "sha256:ce6f2ba0edb7b0c1d8976565298ad2deba6f8064d2bebb6ffce2ca896eb35b0b"},
 ]
-ftrack-python-api = [
-    {file = "ftrack-python-api-2.0.0.tar.gz", hash = "sha256:dd6f02c31daf5a10078196dc9eac4671e4297c762fbbf4df98de668ac12281d9"},
-    {file = "ftrack_python_api-2.0.0-py2.py3-none-any.whl", hash = "sha256:d0df0f2df4b53947272f95e179ec98b477ee425bf4217b37bb59030ad989771e"},
-]
+ftrack-python-api = []
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ coolname = "*"
 clique = "1.6.*"
 Click = "^7"
 dnspython = "^2.1.0"
-ftrack-python-api = "2.0.*"
+ftrack-python-api = "^2.3.3"
 shotgun_api3 = {git = "https://github.com/shotgunsoftware/python-api.git", rev = "v3.3.3"}
 gazu = "^0.8.28"
 google-api-python-client = "^1.12.8" # sync server google support (should be separate?)


### PR DESCRIPTION
## Brief description
Update python ftrack api to 2.3.3.

## Description
Updated to newer version. This change required few small changes in code to work as did. It should work with both newer and older version. Also updated certifi.

## Testing notes:
1. Ftrack publishing should work
2. Ftrack event server should run ok (both server and user side)