### PR TITLE
General: Python module appdirs from git

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -92,7 +92,14 @@ version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/ActiveState/appdirs.git"
+reference = "master"
+resolved_reference = "193a2cbba58cce2542882fcedd0e49f6763672ed"
 
 [[package]]
 name = "arrow"
@@ -1827,10 +1834,7 @@ ansicon = [
     {file = "ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec"},
     {file = "ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1"},
 ]
-appdirs = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
+appdirs = []
 arrow = [
     {file = "arrow-0.17.0-py2.py3-none-any.whl", hash = "sha256:e098abbd9af3665aea81bdd6c869e93af4feb078e98468dd351c383af187aac5"},
     {file = "arrow-0.17.0.tar.gz", hash = "sha256:ff08d10cda1d36c68657d6ad20d74fbea493d980f8b2d45344e00d6ed2bf6ed4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ aiohttp = "^3.7"
 aiohttp_json_rpc = "*" # TVPaint server
 acre = { git = "https://github.com/pypeclub/acre.git" }
 opentimelineio = { version = "0.14.0.dev1", source = "openpype" }
-appdirs = "^1.4.3"
+appdirs = { git = "https://github.com/ActiveState/appdirs.git", branch = "master" }
 blessed = "^1.17" # openpype terminal formatting
 coolname = "*"
 clique = "1.6.*"


### PR DESCRIPTION
## Brief description
Appdirs should work in any python build.

## Description
Appdirs module is in release using `pywin32` module but that may crash if is compiled for different python which is not handled properly in the module. That is not in `release` branch but not in `master` which should work the same way even wihout `pywin32`.

## Testing notes:
1. Update from version repository should work
2. Local machine name should be loaded
3. ..all other logic using appdirs should work too