### PR TITLE
Bugfix: Add OCIO as submodule to prepare for handling `maketx` color space conversion.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "tools/modules/powershell/PSWriteColor"]
     path = tools/modules/powershell/PSWriteColor
     url = https://github.com/EvotecIT/PSWriteColor.git
+[submodule "vendor/configs/OpenColorIO-Configs"]
+	path = vendor/configs/OpenColorIO-Configs
+	url = https://github.com/imageworks/OpenColorIO-Configs

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,3 @@
 [submodule "tools/modules/powershell/PSWriteColor"]
     path = tools/modules/powershell/PSWriteColor
     url = https://github.com/EvotecIT/PSWriteColor.git
-[submodule "vendor/configs/OpenColorIO-Configs"]
-	path = vendor/configs/OpenColorIO-Configs
-	url = https://github.com/imageworks/OpenColorIO-Configs

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -514,6 +514,9 @@ class ExtractLook(openpype.api.Extractor):
                 colorconvert = "--colorconvert sRGB linear"
             else:
                 colorconvert = ""
+
+            config_path = get_ocio_config_path("nuke-default")
+            color_config = "--colorconfig {0}".format(config_path)
             # Ensure folder exists
             if not os.path.exists(os.path.dirname(converted)):
                 os.makedirs(os.path.dirname(converted))
@@ -523,10 +526,11 @@ class ExtractLook(openpype.api.Extractor):
                 filepath,
                 converted,
                 # Include `source-hash` as string metadata
-                "-sattrib",
+                "--sattrib",
                 "sourceHash",
                 escape_space(texture_hash),
                 colorconvert,
+                color_config
             )
 
             return converted, COPY, texture_hash

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -27,6 +27,28 @@ def escape_space(path):
     return '"{}"'.format(path) if " " in path else path
 
 
+def get_ocio_config_path(profile_folder):
+    """Path to OpenPype vendorized OCIO.
+
+    Vendorized OCIO config file path is grabbed from the specific path
+    hierarchy specified below.
+
+    "{OPENPYPE_ROOT}/vendor/OpenColorIO-Configs/{profile_folder}/config.ocio"
+    Args:
+        profile_folder (str): Name of folder to grab config file from.
+
+    Returns:
+        str: Path to vendorized config file.
+    """
+    return os.path.join(
+        os.environ["OPENPYPE_ROOT"],
+        "vendor",
+        "OpenColorIO-Configs",
+        profile_folder,
+        "config.ocio"
+    )
+
+
 def find_paths_by_hash(texture_hash):
     """Find the texture hash key in the dictionary.
 
@@ -492,7 +514,6 @@ class ExtractLook(openpype.api.Extractor):
                 colorconvert = "--colorconvert sRGB linear"
             else:
                 colorconvert = ""
-
             # Ensure folder exists
             if not os.path.exists(os.path.dirname(converted)):
                 os.makedirs(os.path.dirname(converted))
@@ -534,25 +555,3 @@ class ExtractModelRenderSets(ExtractLook):
         self.scene_type = self.scene_type_prefix + self.scene_type
 
         return typ
-
-
-def get_ocio_config_path(profile_folder):
-    """Path to OpenPype vendorized OCIO.
-
-    Vendorized OCIO config file path is grabbed from the specific path
-    hierarchy specified below.
-
-    "{OPENPYPE_ROOT}/vendor/OpenColorIO-Configs/{profile_folder}/config.ocio"
-    Args:
-        profile_folder (str): Name of folder to grab config file from.
-
-    Returns:
-        str: Path to vendorized config file.
-    """
-    return os.path.join(
-        os.environ["OPENPYPE_ROOT"],
-        "vendor",
-        "OpenColorIO-Configs",
-        profile_folder,
-        "config.ocio"
-    )

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -43,6 +43,7 @@ def get_ocio_config_path(profile_folder):
     return os.path.join(
         os.environ["OPENPYPE_ROOT"],
         "vendor",
+        "config",
         "OpenColorIO-Configs",
         profile_folder,
         "config.ocio"

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -534,3 +534,25 @@ class ExtractModelRenderSets(ExtractLook):
         self.scene_type = self.scene_type_prefix + self.scene_type
 
         return typ
+
+
+def get_ocio_config_path(profile_folder):
+    """Path to OpenPype vendorized OCIO.
+
+    Vendorized OCIO config file path is grabbed from the specific path
+    hierarchy specified below.
+
+    "{OPENPYPE_ROOT}/vendor/OpenColorIO-Configs/{profile_folder}/config.ocio"
+    Args:
+        profile_folder (str): Name of folder to grab config file from.
+
+    Returns:
+        str: Path to vendorized config file.
+    """
+    return os.path.join(
+        os.environ["OPENPYPE_ROOT"],
+        "vendor",
+        "OpenColorIO-Configs",
+        profile_folder,
+        "config.ocio"
+    )

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -43,7 +43,7 @@ def get_ocio_config_path(profile_folder):
     return os.path.join(
         os.environ["OPENPYPE_ROOT"],
         "vendor",
-        "config",
+        "configs",
         "OpenColorIO-Configs",
         profile_folder,
         "config.ocio"
@@ -102,10 +102,11 @@ def maketx(source, destination, *args):
         # use oiio-optimized settings for tile-size, planarconfig, metadata
         "--oiio",
         "--filter lanczos3",
+        escape_space(source)
     ]
 
     cmd.extend(args)
-    cmd.extend(["-o", escape_space(destination), escape_space(source)])
+    cmd.extend(["-o", escape_space(destination)])
 
     cmd = " ".join(cmd)
 


### PR DESCRIPTION
## Brief description
`maketx` executable requires an `OCIO` config file path appended when using the `--colorconfig` flag.  This resolves #3584 and prepares for preventing `maketx` from crashing when publishing OpenPype `Look` instances.

## Description
Adding OCIO as a submodule and adding functionality to grab the OCIO config file path based on a profile folder parameter as the function argument.

Testing: 
1. Create some geo and OP model instance.
2. Publish it.
3. load model instance in.
4. Create shader, apply a test base color texture (that's in sRGB).
5. publish it. 

The publishing should produce a `.tx` file that's optimized for `MtoA`. (Make sure create .tx is enabled in the look creator)