### PR TITLE
Kitsu: Project with no dedicated task types use defaults

### DIFF
--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -276,7 +276,7 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
         project_doc = create_project(project_name, project_name, dbcon=dbcon)
 
     # Project data and tasks
-    project_data = project["data"] or {}
+    project_data = project_doc["data"] or {}
 
     # Build project code and update Kitsu
     project_code = project.get("code")
@@ -305,6 +305,7 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
                 "config.tasks": {
                     t["name"]: {"short_name": t.get("short_name", t["name"])}
                     for t in gazu.task.all_task_types_for_project(project)
+                    or gazu.task.all_task_types()
                 },
                 "data": project_data,
             }


### PR DESCRIPTION
## Brief description
In Kitsu, you can assign task types to a Project. If none are assigned, the project takes all existing tasks as default. 
In OP, it doesn't behaves like that, it could assign an empty tasks list, which is not correct.

This fixes it.