### PR TITLE
SyncServer: use query functions

### DIFF
--- a/openpype/modules/sync_server/providers/abstract_provider.py
+++ b/openpype/modules/sync_server/providers/abstract_provider.py
@@ -62,7 +62,7 @@ class AbstractProvider:
 
     @abc.abstractmethod
     def upload_file(self, source_path, path,
-                    server, collection, file, representation, site,
+                    server, project_name, file, representation, site,
                     overwrite=False):
         """
             Copy file from 'source_path' to 'target_path' on provider.
@@ -75,7 +75,7 @@ class AbstractProvider:
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str): name of project_name
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -87,7 +87,7 @@ class AbstractProvider:
 
     @abc.abstractmethod
     def download_file(self, source_path, local_path,
-                      server, collection, file, representation, site,
+                      server, project_name, file, representation, site,
                       overwrite=False):
         """
             Download file from provider into local system
@@ -99,7 +99,7 @@ class AbstractProvider:
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name

--- a/openpype/modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/sync_server/providers/dropbox.py
@@ -224,7 +224,7 @@ class DropboxHandler(AbstractProvider):
         return False
 
     def upload_file(self, source_path, path,
-                    server, collection, file, representation, site,
+                    server, project_name, file, representation, site,
                     overwrite=False):
         """
             Copy file from 'source_path' to 'target_path' on provider.
@@ -237,7 +237,7 @@ class DropboxHandler(AbstractProvider):
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -290,7 +290,7 @@ class DropboxHandler(AbstractProvider):
                         cursor.offset = f.tell()
 
         server.update_db(
-            collection=collection,
+            project_name=project_name,
             new_file_id=None,
             file=file,
             representation=representation,
@@ -301,7 +301,7 @@ class DropboxHandler(AbstractProvider):
         return path
 
     def download_file(self, source_path, local_path,
-                      server, collection, file, representation, site,
+                      server, project_name, file, representation, site,
                       overwrite=False):
         """
             Download file from provider into local system
@@ -313,7 +313,7 @@ class DropboxHandler(AbstractProvider):
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -337,7 +337,7 @@ class DropboxHandler(AbstractProvider):
         self.dbx.files_download_to_file(local_path, source_path)
 
         server.update_db(
-            collection=collection,
+            project_name=project_name,
             new_file_id=None,
             file=file,
             representation=representation,

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -251,7 +251,7 @@ class GDriveHandler(AbstractProvider):
                 return folder_id
 
     def upload_file(self, source_path, path,
-                    server, collection, file, representation, site,
+                    server, project_name, file, representation, site,
                     overwrite=False):
         """
             Uploads single file from 'source_path' to destination 'path'.
@@ -264,7 +264,7 @@ class GDriveHandler(AbstractProvider):
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -324,7 +324,7 @@ class GDriveHandler(AbstractProvider):
             while response is None:
                 if server.is_representation_paused(representation['_id'],
                                                    check_parents=True,
-                                                   project_name=collection):
+                                                   project_name=project_name):
                     raise ValueError("Paused during process, please redo.")
                 if status:
                     status_val = float(status.progress())
@@ -333,7 +333,7 @@ class GDriveHandler(AbstractProvider):
                     last_tick = time.time()
                     log.debug("Uploaded %d%%." %
                               int(status_val * 100))
-                    server.update_db(collection=collection,
+                    server.update_db(project_name=project_name,
                                      new_file_id=None,
                                      file=file,
                                      representation=representation,
@@ -358,7 +358,7 @@ class GDriveHandler(AbstractProvider):
         return response['id']
 
     def download_file(self, source_path, local_path,
-                      server, collection, file, representation, site,
+                      server, project_name, file, representation, site,
                       overwrite=False):
         """
             Downloads single file from 'source_path' (remote) to 'local_path'.
@@ -372,7 +372,7 @@ class GDriveHandler(AbstractProvider):
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -410,7 +410,7 @@ class GDriveHandler(AbstractProvider):
             while response is None:
                 if server.is_representation_paused(representation['_id'],
                                                    check_parents=True,
-                                                   project_name=collection):
+                                                   project_name=project_name):
                     raise ValueError("Paused during process, please redo.")
                 if status:
                     status_val = float(status.progress())
@@ -419,7 +419,7 @@ class GDriveHandler(AbstractProvider):
                     last_tick = time.time()
                     log.debug("Downloaded %d%%." %
                               int(status_val * 100))
-                    server.update_db(collection=collection,
+                    server.update_db(project_name=project_name,
                                      new_file_id=None,
                                      file=file,
                                      representation=representation,

--- a/openpype/modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/sync_server/providers/local_drive.py
@@ -111,7 +111,8 @@ class LocalDriveHandler(AbstractProvider):
             Download a file form 'source_path' to 'local_path'
         """
         return self.upload_file(source_path, local_path,
-                                server, project_name, file, representation, site,
+                                server, project_name, file,
+                                representation, site,
                                 overwrite, direction="Download")
 
     def delete_file(self, path):

--- a/openpype/modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/sync_server/providers/local_drive.py
@@ -82,7 +82,7 @@ class LocalDriveHandler(AbstractProvider):
         return editable
 
     def upload_file(self, source_path, target_path,
-                    server, collection, file, representation, site,
+                    server, project_name, file, representation, site,
                     overwrite=False, direction="Upload"):
         """
             Copies file from 'source_path' to 'target_path'
@@ -95,7 +95,7 @@ class LocalDriveHandler(AbstractProvider):
             thread = threading.Thread(target=self._copy,
                                       args=(source_path, target_path))
             thread.start()
-            self._mark_progress(collection, file, representation, server,
+            self._mark_progress(project_name, file, representation, server,
                                 site, source_path, target_path, direction)
         else:
             if os.path.exists(target_path):
@@ -105,13 +105,13 @@ class LocalDriveHandler(AbstractProvider):
         return os.path.basename(target_path)
 
     def download_file(self, source_path, local_path,
-                      server, collection, file, representation, site,
+                      server, project_name, file, representation, site,
                       overwrite=False):
         """
             Download a file form 'source_path' to 'local_path'
         """
         return self.upload_file(source_path, local_path,
-                                server, collection, file, representation, site,
+                                server, project_name, file, representation, site,
                                 overwrite, direction="Download")
 
     def delete_file(self, path):
@@ -188,7 +188,7 @@ class LocalDriveHandler(AbstractProvider):
         except shutil.SameFileError:
             print("same files, skipping")
 
-    def _mark_progress(self, collection, file, representation, server, site,
+    def _mark_progress(self, project_name, file, representation, server, site,
                        source_path, target_path, direction):
         """
             Updates progress field in DB by values 0-1.
@@ -204,7 +204,7 @@ class LocalDriveHandler(AbstractProvider):
                 status_val = target_file_size / source_file_size
                 last_tick = time.time()
                 log.debug(direction + "ed %d%%." % int(status_val * 100))
-                server.update_db(collection=collection,
+                server.update_db(project_name=project_name,
                                  new_file_id=None,
                                  file=file,
                                  representation=representation,

--- a/openpype/modules/sync_server/providers/sftp.py
+++ b/openpype/modules/sync_server/providers/sftp.py
@@ -222,7 +222,7 @@ class SFTPHandler(AbstractProvider):
         return os.path.basename(path)
 
     def upload_file(self, source_path, target_path,
-                    server, collection, file, representation, site,
+                    server, project_name, file, representation, site,
                     overwrite=False):
         """
             Uploads single file from 'source_path' to destination 'path'.
@@ -235,7 +235,7 @@ class SFTPHandler(AbstractProvider):
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -256,7 +256,7 @@ class SFTPHandler(AbstractProvider):
         thread = threading.Thread(target=self._upload,
                                   args=(source_path, target_path))
         thread.start()
-        self._mark_progress(collection, file, representation, server,
+        self._mark_progress(project_name, file, representation, server,
                             site, source_path, target_path, "upload")
 
         return os.path.basename(target_path)
@@ -267,7 +267,7 @@ class SFTPHandler(AbstractProvider):
         conn.put(source_path, target_path)
 
     def download_file(self, source_path, target_path,
-                      server, collection, file, representation, site,
+                      server, project_name, file, representation, site,
                       overwrite=False):
         """
             Downloads single file from 'source_path' (remote) to 'target_path'.
@@ -281,7 +281,7 @@ class SFTPHandler(AbstractProvider):
 
             arguments for saving progress:
             server (SyncServer): server instance to call update_db on
-            collection (str): name of collection
+            project_name (str):
             file (dict): info about uploaded file (matches structure from db)
             representation (dict): complete repre containing 'file'
             site (str): site name
@@ -302,7 +302,7 @@ class SFTPHandler(AbstractProvider):
         thread = threading.Thread(target=self._download,
                                   args=(source_path, target_path))
         thread.start()
-        self._mark_progress(collection, file, representation, server,
+        self._mark_progress(project_name, file, representation, server,
                             site, source_path, target_path, "download")
 
         return os.path.basename(target_path)
@@ -425,7 +425,7 @@ class SFTPHandler(AbstractProvider):
                 pysftp.exceptions.ConnectionException):
             log.warning("Couldn't connect", exc_info=True)
 
-    def _mark_progress(self, collection, file, representation, server, site,
+    def _mark_progress(self, project_name, file, representation, server, site,
                        source_path, target_path, direction):
         """
             Updates progress field in DB by values 0-1.
@@ -446,7 +446,7 @@ class SFTPHandler(AbstractProvider):
                 status_val = target_file_size / source_file_size
                 last_tick = time.time()
                 log.debug(direction + "ed %d%%." % int(status_val * 100))
-                server.update_db(collection=collection,
+                server.update_db(project_name=project_name,
                                  new_file_id=None,
                                  file=file,
                                  representation=representation,

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -54,8 +54,9 @@ async def upload(module, project_name, file, representation, provider_name,
 
         file_path = file.get("path", "")
         try:
-            local_file_path, remote_file_path = resolve_paths(module,
-                file_path, project_name, remote_site_name, remote_handler
+            local_file_path, remote_file_path = resolve_paths(
+                module, file_path, project_name,
+                remote_site_name, remote_handler
             )
         except Exception as exp:
             print(exp)
@@ -270,8 +271,8 @@ class SyncServerThread(threading.Thread):
                 - gets list of collections in DB
                 - gets list of active remote providers (has configuration,
                     credentials)
-                - for each project_name it looks for representations that should
-                    be synced
+                - for each project_name it looks for representations that
+                  should be synced
                 - synchronize found collections
                 - update representations - fills error messages for exceptions
                 - waits X seconds and repeat

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -25,7 +25,7 @@ from .providers import lib
 
 from .utils import time_function, SyncStatus, SiteAlreadyPresentError
 
-from openpype.client import get_representations
+from openpype.client import get_representations, get_representation_by_id
 
 
 log = PypeLogger.get_logger("SyncServer")
@@ -1591,11 +1591,12 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                 not 'force'
             ValueError - other errors (repre not found, misconfiguration)
         """
-        representations = get_representations(collection, [representation_id])
-        if not representations:
+        representation = get_representation_by_id(collection,
+                                                  representation_id)
+        if not representation:
             raise ValueError("Representation {} not found in {}".
                              format(representation_id, collection))
-        representation = representations[0]
+
         if side and site_name:
             raise ValueError("Misconfiguration, only one of side and " +
                              "site_name arguments should be passed.")
@@ -1807,15 +1808,14 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         provider_name = self.get_provider_for_site(site=site_name)
 
         if provider_name == 'local_drive':
-            representations = list(get_representations(collection,
-                                                       [representation_id],
-                                                       fields=["files"]))
-            if not representations:
+            representation = get_representation_by_id(collection,
+                                                      representation_id,
+                                                      fields=["files"])
+            if not representation:
                 self.log.debug("No repre {} found".format(
                     representation_id))
                 return
 
-            representation = representations.pop()
             local_file_path = ''
             for file in representation.get("files"):
                 local_file_path = self.get_local_file_path(collection,

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1611,6 +1611,10 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         elem = {"name": site_name}
 
+        query = {
+            "_id": ObjectId(representation_id)
+        }
+
         if file_id:  # reset site for particular file
             self._reset_site_for_file(collection, query,
                                       elem, file_id, site_name)

--- a/openpype/modules/sync_server/tray/models.py
+++ b/openpype/modules/sync_server/tray/models.py
@@ -11,6 +11,7 @@ from openpype.tools.utils.delegates import pretty_timestamp
 
 from openpype.lib import PypeLogger
 from openpype.api import get_local_site_id
+from openpype.client import get_representation_by_id
 
 from . import lib
 
@@ -919,8 +920,7 @@ class SyncRepresentationSummaryModel(_SyncRepresentationModel):
 
         repre_id = self.data(index, Qt.UserRole)
 
-        representation = list(self.dbcon.find({"type": "representation",
-                                               "_id": repre_id}))
+        representation = get_representation_by_id(self.project, repre_id)
         if representation:
             self.sync_server.update_db(self.project, None, None,
                                        representation.pop(),
@@ -1357,11 +1357,10 @@ class SyncRepresentationDetailModel(_SyncRepresentationModel):
         file_id = self.data(index, Qt.UserRole)
 
         updated_file = None
-        # conversion from cursor to list
-        representations = list(self.dbcon.find({"type": "representation",
-                                               "_id": self._id}))
+        representation = get_representation_by_id(self.project, self._id)
+        if not representation:
+            return
 
-        representation = representations.pop()
         for repre_file in representation["files"]:
             if repre_file["_id"] == file_id:
                 updated_file = repre_file

--- a/openpype/modules/sync_server/tray/models.py
+++ b/openpype/modules/sync_server/tray/models.py
@@ -441,7 +441,7 @@ class SyncRepresentationSummaryModel(_SyncRepresentationModel):
         full text filtering.
 
         Allows pagination, most of heavy lifting is being done on DB side.
-        Single model matches to single collection. When project is changed,
+        Single model matches to single project. When project is changed,
         model is reset and refreshed.
 
         Args:

--- a/openpype/modules/sync_server/tray/models.py
+++ b/openpype/modules/sync_server/tray/models.py
@@ -923,7 +923,7 @@ class SyncRepresentationSummaryModel(_SyncRepresentationModel):
         representation = get_representation_by_id(self.project, repre_id)
         if representation:
             self.sync_server.update_db(self.project, None, None,
-                                       representation.pop(),
+                                       representation,
                                        get_local_site_id(),
                                        priority=value)
         self.is_editing = False


### PR DESCRIPTION
## Brief description
Preparation for v4 transition.

## Description
Replaced regular `find` functions with `get_representations` query whenever possible.

## Additional info
There is a couple of places where appropriate query doesn't exist in entities. 
There is also quite a few MongoDB dependent aggregates, piece meal updates of representation documents. It doesn't make sense to prepare intermediate step for these, they will need to be updated when transition to v4 will be imminent.

## Testing notes:
1. Enable SiteSync module, everything should work as before