### PR TITLE
Kitsu|Fix: Collect entities error cause of Python2

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
@@ -42,7 +42,9 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
             raise AssertionError("{} not found in kitsu!".format(entity_type))
 
         context.data["kitsu_entity"] = kitsu_entity
-        self.log.debug("Collect kitsu {}: {}".format(entity_type, kitsu_entity))
+        self.log.debug(
+            "Collect kitsu {}: {}".format(entity_type, kitsu_entity)
+        )
 
         if zou_task_data:
             kitsu_task = gazu.task.get_task(zou_task_data["id"])

--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
@@ -39,10 +39,10 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
             kitsu_entity = gazu.asset.get_asset(zou_asset_data["id"])
 
         if not kitsu_entity:
-            raise AssertionError(f"{entity_type} not found in kitsu!")
+            raise AssertionError("{} not found in kitsu!".format(entity_type))
 
         context.data["kitsu_entity"] = kitsu_entity
-        self.log.debug(f"Collect kitsu {entity_type}: {kitsu_entity}")
+        self.log.debug("Collect kitsu {}: {}".format(entity_type, kitsu_entity))
 
         if zou_task_data:
             kitsu_task = gazu.task.get_task(zou_task_data["id"])


### PR DESCRIPTION
Fix #3552

## Brief description
Some Python3 syntax was added in the `collect_kitsu_entities.py` file, leading Python2 softwares to fail.
