### PR TITLE
TrayPublisher: Fix wrong conflict merge

### DIFF
--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -92,6 +92,21 @@ class TrayPublishCreator(Creator):
         for instance in instances:
             self._remove_instance_from_context(instance)
 
+    def _store_new_instance(self, new_instance):
+        """Tray publisher specific method to store instance.
+
+        Instance is stored into "workfile" of traypublisher and also add it
+        to CreateContext.
+
+        Args:
+            new_instance (CreatedInstance): Instance that should be stored.
+        """
+
+        # Host implementation of storing metadata about instance
+        HostContext.add_instance(new_instance.data_to_store())
+        # Add instance to current context
+        self._add_instance_to_context(new_instance)
+
 
 class SettingsCreator(TrayPublishCreator):
     create_allow_context_change = True

--- a/openpype/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_editorial.py
@@ -75,20 +75,13 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
         self.log.info(f"instance_data: {instance_data}")
         subset_name = instance_data["subset"]
 
-        return self._create_instance(subset_name, instance_data)
-
-    def _create_instance(self, subset_name, data):
-
         # Create new instance
-        new_instance = CreatedInstance(self.family, subset_name, data, self)
+        new_instance = CreatedInstance(
+            self.family, subset_name, instance_data, self
+        )
         self.log.info(f"instance_data: {pformat(new_instance.data)}")
 
-        # Host implementation of storing metadata about instance
-        HostContext.add_instance(new_instance.data_to_store())
-        # Add instance to current context
-        self._add_instance_to_context(new_instance)
-
-        return new_instance
+        self._store_new_instance(new_instance)
 
     def get_instance_attr_defs(self):
         return [
@@ -299,8 +292,10 @@ or updating already created. Publishing will create OTIO file.
             "editorialSourcePath": media_path,
             "otioTimeline": otio.adapters.write_to_string(otio_timeline)
         })
-
-        self._create_instance(self.family, subset_name, data)
+        new_instance = CreatedInstance(
+            self.family, subset_name, data, self
+        )
+        self._store_new_instance(new_instance)
 
     def _create_otio_timeline(self, sequence_path, fps):
         """Creating otio timeline from sequence path
@@ -819,23 +814,6 @@ or updating already created. Publishing will create OTIO file.
                 f"Duplicate shot name: {name}! "
                 "Please check names in the input sequence files."
             )
-
-    def _create_instance(self, family, subset_name, instance_data):
-        """ CreatedInstance object creator
-
-        Args:
-            family (str): family name
-            subset_name (str): subset name
-            instance_data (dict): instance data
-        """
-        # Create new instance
-        new_instance = CreatedInstance(
-            family, subset_name, instance_data, self
-        )
-        # Host implementation of storing metadata about instance
-        HostContext.add_instance(new_instance.data_to_store())
-        # Add instance to current context
-        self._add_instance_to_context(new_instance)
 
     def get_pre_create_attr_defs(self):
         """ Creating pre-create attributes at creator plugin.

--- a/openpype/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_editorial.py
@@ -81,6 +81,8 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
         self._store_new_instance(new_instance)
 
+        return new_instance
+
     def get_instance_attr_defs(self):
         return [
             BoolDef(

--- a/openpype/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_editorial.py
@@ -29,8 +29,6 @@ from openpype.lib import (
     UILabelDef
 )
 
-from openpype.hosts.traypublisher.api.pipeline import HostContext
-
 
 CLIP_ATTR_DEFS = [
     EnumDef(


### PR DESCRIPTION
## Brief description
Tray publisher creator is missing `_store_new_instance` which was appended after new `HiddenCreator`.

## Description
Added `_store_new_instance` into tray publisher creator. Use `_store_new_instance` in editorial creators -> removed usage of `HostContext`.

## Testing notes:
1. Simple creators should work
2. Editorial should work