### PR TITLE
General: Naive implementation of document create, update, delete

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -6,38 +6,12 @@ that has project name as a context (e.g. on 'ProjectEntity'?).
 + We will need more specific functions doing wery specific queires really fast.
 """
 
-import os
 import collections
 
 import six
 from bson.objectid import ObjectId
 
-from .mongo import OpenPypeMongoConnection
-
-
-def _get_project_database():
-    db_name = os.environ.get("AVALON_DB") or "avalon"
-    return OpenPypeMongoConnection.get_mongo_client()[db_name]
-
-
-def get_project_connection(project_name):
-    """Direct access to mongo collection.
-
-    We're trying to avoid using direct access to mongo. This should be used
-    only for Create, Update and Remove operations until there are implemented
-    api calls for that.
-
-    Args:
-        project_name(str): Project name for which collection should be
-            returned.
-
-    Returns:
-        pymongo.Collection: Collection realated to passed project.
-    """
-
-    if not project_name:
-        raise ValueError("Invalid project name {}".format(str(project_name)))
-    return _get_project_database()[project_name]
+from .mongo import get_project_database, get_project_connection
 
 
 def _prepare_fields(fields, required_fields=None):
@@ -72,7 +46,7 @@ def _convert_ids(in_ids):
 
 
 def get_projects(active=True, inactive=False, fields=None):
-    mongodb = _get_project_database()
+    mongodb = get_project_database()
     for project_name in mongodb.collection_names():
         if project_name in ("system.indexes",):
             continue

--- a/openpype/client/mongo.py
+++ b/openpype/client/mongo.py
@@ -208,3 +208,28 @@ class OpenPypeMongoConnection:
             mongo_url, time.time() - t1
         ))
         return mongo_client
+
+
+def get_project_database():
+    db_name = os.environ.get("AVALON_DB") or "avalon"
+    return OpenPypeMongoConnection.get_mongo_client()[db_name]
+
+
+def get_project_connection(project_name):
+    """Direct access to mongo collection.
+
+    We're trying to avoid using direct access to mongo. This should be used
+    only for Create, Update and Remove operations until there are implemented
+    api calls for that.
+
+    Args:
+        project_name(str): Project name for which collection should be
+            returned.
+
+    Returns:
+        pymongo.Collection: Collection realated to passed project.
+    """
+
+    if not project_name:
+        raise ValueError("Invalid project name {}".format(str(project_name)))
+    return get_project_database()[project_name]

--- a/openpype/client/operations.py
+++ b/openpype/client/operations.py
@@ -1,0 +1,249 @@
+import uuid
+import copy
+from abc import ABCMeta, abstractmethod
+
+import six
+from bson.objectid import ObjectId
+from pymongo import DeleteOne, InsertOne, UpdateOne
+
+from .mongo import get_project_connection
+
+REMOVED_VALUE = object()
+
+
+@six.add_metaclass(ABCMeta)
+class AbstractOperation(object):
+    """Base operation class."""
+
+    def __init__(self, entity_type):
+        self._entity_type = entity_type
+        self._id = uuid.uuid4()
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def entity_type(self):
+        return self._entity_type
+
+    @abstractmethod
+    def to_mongo_operation(self):
+        pass
+
+
+class CreateOperation(AbstractOperation):
+    def __init__(self, project_name, entity_type, data):
+        super(CreateOperation, self).__init__(entity_type)
+
+        if not data:
+            data = {}
+        else:
+            data = copy.deepcopy(dict(data))
+
+        if "_id" not in data:
+            data["_id"] = ObjectId()
+        else:
+            data["_id"] = ObjectId(data["_id"])
+
+        self._entity_id = data["_id"]
+        self._data = data
+
+    def __setitem__(self, key, value):
+        self.set_value(key, value)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def set_value(self, key, value):
+        self.data[key] = value
+
+    def get(self, key, *args, **kwargs):
+        return self.data.get(key, *args, **kwargs)
+
+    @property
+    def entity_id(self):
+        return self._entity_id
+
+    @property
+    def data(self):
+        return self._data
+
+    def to_mongo_operation(self):
+        return InsertOne(copy.deepcopy(self._data))
+
+    def to_data(self):
+        return {
+            "operation": "create",
+            "entity_type": self.entity_type,
+            "data": copy.deepcopy(self.data)
+        }
+
+
+class UpdateOperation(AbstractOperation):
+    def __init__(self, project_name, entity_type, entity_id, update_fields):
+        super(CreateOperation, self).__init__(entity_type)
+
+        self._entity_id = ObjectId(entity_id)
+        self._update_fields = update_fields
+
+    @property
+    def entity_id(self):
+        return self._entity_id
+
+    @property
+    def update_fields(self):
+        return self._update_fields
+
+    def to_mongo_operation(self):
+        unset_data = {}
+        set_data = {}
+        for key, value in self._update_fields.items():
+            if value is REMOVED_VALUE:
+                unset_data[key] = value
+            else:
+                set_data[key] = value
+
+        op_data = {}
+        if unset_data:
+            op_data["$unset"] = unset_data
+        if set_data:
+            op_data["$set"] = set_data
+
+        if not op_data:
+            return None
+
+        return UpdateOne(
+            {"_id": self.entity_id},
+            op_data
+        )
+
+    def to_data(self):
+        fields = {}
+        for key, value in self._update_fields.items():
+            if value is REMOVED_VALUE:
+                value = None
+            fields[key] = value
+
+        return {
+            "operation": "update",
+            "entity_type": self.entity_type,
+            "entity_id": str(self.entity_id),
+            "fields": fields
+        }
+
+
+class DeleteOperation(AbstractOperation):
+    def __init__(self, entity_type, entity_id):
+        super(DeleteOperation, self).__init__(entity_type)
+
+        self._entity_id = ObjectId(entity_id)
+
+    @property
+    def entity_id(self):
+        return self._entity_id
+
+    def to_mongo_operation(self):
+        return DeleteOne({"_id": self.entity_id})
+
+    def to_data(self):
+        return {
+            "operation": "delete",
+            "entity_type": self.entity_type,
+            "entity_id": str(self.entity_id)
+        }
+
+
+class OperationsSession(object):
+    """Session storing operations that should happen in an order.
+
+    At this moment does not handle anything special can be sonsidered as
+    stupid list of operations that will happen after each other. If creation
+    of same entity is there multiple times it's handled in any way and document
+    values are not validated.
+
+    All operations must be related to single project.
+
+    Args:
+        project_name (str): Project name to which are operations related.
+    """
+
+    def __init__(self, project_name):
+        self._project_name = project_name
+        self._operations = []
+
+    @property
+    def project_name(self):
+        return self._project_name
+
+    def add(self, operation):
+        """Add operation to be processed.
+
+        Args:
+            operation (BaseOperation): Operation that should be processed.
+        """
+        if not isinstance(
+            operation,
+            (CreateOperation, UpdateOperation, DeleteOperation)
+        ):
+            raise TypeError("Expected Operation object got {}".format(
+                str(type(operation))
+            ))
+
+        self._operations.append(operation)
+
+    def append(self, operation):
+        """Add operation to be processed.
+
+        Args:
+            operation (BaseOperation): Operation that should be processed.
+        """
+
+        self.add(operation)
+
+    def extend(self, operations):
+        """Add operations to be processed.
+
+        Args:
+            operations (List[BaseOperation]): Operations that should be
+                processed.
+        """
+
+        for operation in operations:
+            self.add(operation)
+
+    def remove(self, operation):
+        """Remove operation."""
+
+        self._operations.remove(operation)
+
+    def clear(self):
+        """Clear all registered operations."""
+
+        self._operations = []
+
+    def to_data(self):
+        return {
+            "project_name": self.project_name,
+            "operations": [
+                operation.to_data()
+                for operation in self._operations
+            ]
+        }
+
+    def commit(self):
+        """Commit session operations."""
+
+        operations, self._operations = self._operations, []
+        if not operations:
+            return
+
+        bulk_writes = []
+        for operation in operations:
+            mongo_op = operation.to_mongo_operation()
+            if mongo_op is not None:
+                bulk_writes.append(mongo_op)
+
+        if bulk_writes:
+            collection = get_project_connection(self.project_name)
+            collection.bulk_write(bulk_writes)

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -5,8 +5,16 @@ import copy
 import clique
 import six
 
+from openpype.client.operations import (
+    OperationsSession,
+    new_subset_document,
+    new_version_doc,
+    new_representation_doc,
+    prepare_subset_update_data,
+    prepare_version_update_data,
+    prepare_representation_update_data,
+)
 from bson.objectid import ObjectId
-from pymongo import DeleteMany, ReplaceOne, InsertOne, UpdateOne
 import pyblish.api
 
 from openpype.client import (
@@ -282,9 +290,12 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         template_name = self.get_template_name(instance)
 
-        subset, subset_writes = self.prepare_subset(instance, project_name)
-        version, version_writes = self.prepare_version(
-            instance, subset, project_name
+        op_session = OperationsSession()
+        subset = self.prepare_subset(
+            instance, op_session, project_name
+        )
+        version = self.prepare_version(
+            instance, op_session, subset, project_name
         )
         instance.data["versionEntity"] = version
 
@@ -334,7 +345,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         # Transaction to reduce the chances of another publish trying to
         # publish to the same version number since that chance can greatly
         # increase if the file transaction takes a long time.
-        legacy_io.bulk_write(subset_writes + version_writes)
+        op_session.commit()
+
         self.log.info("Subset {subset[name]} and Version {version[name]} "
                       "written to database..".format(subset=subset,
                                                      version=version))
@@ -366,49 +378,49 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         # Finalize the representations now the published files are integrated
         # Get 'files' info for representations and its attached resources
-        representation_writes = []
         new_repre_names_low = set()
         for prepared in prepared_representations:
-            representation = prepared["representation"]
+            repre_doc = prepared["representation"]
+            repre_update_data = prepared["repre_doc_update_data"]
             transfers = prepared["transfers"]
             destinations = [dst for src, dst in transfers]
-            representation["files"] = self.get_files_info(
+            repre_doc["files"] = self.get_files_info(
                 destinations, sites=sites, anatomy=anatomy
             )
 
             # Add the version resource file infos to each representation
-            representation["files"] += resource_file_infos
+            repre_doc["files"] += resource_file_infos
 
             # Set up representation for writing to the database. Since
             # we *might* be overwriting an existing entry if the version
             # already existed we'll use ReplaceOnce with `upsert=True`
-            representation_writes.append(ReplaceOne(
-                filter={"_id": representation["_id"]},
-                replacement=representation,
-                upsert=True
-            ))
+            if repre_update_data is None:
+                op_session.create_entity(
+                    project_name, repre_doc["type"], repre_doc
+                )
+            else:
+                op_session.update_entity(
+                    project_name,
+                    repre_doc["type"],
+                    repre_doc["_id"],
+                    repre_update_data
+                )
 
-            new_repre_names_low.add(representation["name"].lower())
+            new_repre_names_low.add(repre_doc["name"].lower())
 
         # Delete any existing representations that didn't get any new data
         # if the instance is not set to append mode
         if not instance.data.get("append", False):
-            delete_names = set()
             for name, existing_repres in existing_repres_by_name.items():
                 if name not in new_repre_names_low:
                     # We add the exact representation name because `name` is
                     # lowercase for name matching only and not in the database
-                    delete_names.add(existing_repres["name"])
-            if delete_names:
-                representation_writes.append(DeleteMany(
-                    filter={
-                        "parent": version["_id"],
-                        "name": {"$in": list(delete_names)}
-                    }
-                ))
+                    op_session.delete_entity(
+                        project_name, "representation", existing_repres["_id"]
+                    )
 
-        # Write representations to the database
-        legacy_io.bulk_write(representation_writes)
+        self.log.debug("{}".format(op_session.to_data()))
+        op_session.commit()
 
         # Backwards compatibility
         # todo: can we avoid the need to store this?
@@ -419,13 +431,14 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         self.log.info("Registered {} representations"
                       "".format(len(prepared_representations)))
 
-    def prepare_subset(self, instance, project_name):
+    def prepare_subset(self, instance, op_session, project_name):
         asset_doc = instance.data["assetEntity"]
         subset_name = instance.data["subset"]
+        family = instance.data["family"]
         self.log.debug("Subset: {}".format(subset_name))
 
         # Get existing subset if it exists
-        subset_doc = get_subset_by_name(
+        existing_subset_doc = get_subset_by_name(
             project_name, subset_name, asset_doc["_id"]
         )
 
@@ -438,45 +451,40 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         if subset_group:
             data["subsetGroup"] = subset_group
 
-        bulk_writes = []
-        if subset_doc is None:
+        subset_id = None
+        if existing_subset_doc:
+            subset_id = existing_subset_doc["_id"]
+        subset_doc = new_subset_document(
+            subset_name, family, asset_doc["_id"], data, subset_id
+        )
+
+        if existing_subset_doc is None:
             # Create a new subset
             self.log.info("Subset '%s' not found, creating ..." % subset_name)
-            subset_doc = {
-                "_id": ObjectId(),
-                "schema": "openpype:subset-3.0",
-                "type": "subset",
-                "name": subset_name,
-                "data": data,
-                "parent": asset_doc["_id"]
-            }
-            bulk_writes.append(InsertOne(subset_doc))
+            op_session.create_entity(
+                project_name, subset_doc["type"], subset_doc
+            )
 
         else:
             # Update existing subset data with new data and set in database.
             # We also change the found subset in-place so we don't need to
             # re-query the subset afterwards
             subset_doc["data"].update(data)
-            bulk_writes.append(UpdateOne(
-                {"type": "subset", "_id": subset_doc["_id"]},
-                {"$set": {
-                    "data": subset_doc["data"]
-                }}
-            ))
+            update_data = prepare_subset_update_data(
+                existing_subset_doc, subset_doc
+            )
+            op_session.update_entity(
+                project_name,
+                subset_doc["type"],
+                subset_doc["_id"],
+                update_data
+            )
 
         self.log.info("Prepared subset: {}".format(subset_name))
-        return subset_doc, bulk_writes
+        return subset_doc
 
-    def prepare_version(self, instance, subset_doc, project_name):
+    def prepare_version(self, instance, op_session, subset_doc, project_name):
         version_number = instance.data["version"]
-
-        version_doc = {
-            "schema": "openpype:version-3.0",
-            "type": "version",
-            "parent": subset_doc["_id"],
-            "name": version_number,
-            "data": self.create_version_data(instance)
-        }
 
         existing_version = get_version_by_name(
             project_name,
@@ -484,23 +492,38 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             subset_doc["_id"],
             fields=["_id"]
         )
+        version_id = None
+        if existing_version:
+            version_id = existing_version["_id"]
+
+        version_data = self.create_version_data(instance)
+        version_doc = new_version_doc(
+            version_number,
+            subset_doc["_id"],
+            version_data,
+            version_id
+        )
 
         if existing_version:
             self.log.debug("Updating existing version ...")
-            version_doc["_id"] = existing_version["_id"]
+            update_data = prepare_version_update_data(
+                existing_version, version_doc
+            )
+            op_session.update_entity(
+                project_name,
+                version_doc["type"],
+                version_doc["_id"],
+                update_data
+            )
         else:
             self.log.debug("Creating new version ...")
-            version_doc["_id"] = ObjectId()
-
-        bulk_writes = [ReplaceOne(
-            filter={"_id": version_doc["_id"]},
-            replacement=version_doc,
-            upsert=True
-        )]
+            op_session.create_entity(
+                project_name, version_doc["type"], version_doc
+            )
 
         self.log.info("Prepared version: v{0:03d}".format(version_doc["name"]))
 
-        return version_doc, bulk_writes
+        return version_doc
 
     def prepare_representation(self, repre,
                                template_name,
@@ -696,10 +719,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         # Use previous representation's id if there is a name match
         existing = existing_repres_by_name.get(repre["name"].lower())
+        repre_id = None
         if existing:
             repre_id = existing["_id"]
-        else:
-            repre_id = ObjectId()
 
         # Store first transferred destination as published path data
         # - used primarily for reviews that are integrated to custom modules
@@ -713,20 +735,18 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         #       and the actual representation entity for the database
         data = repre.get("data", {})
         data.update({"path": published_path, "template": template})
-        representation = {
-            "_id": repre_id,
-            "schema": "openpype:representation-2.0",
-            "type": "representation",
-            "parent": version["_id"],
-            "name": repre["name"],
-            "data": data,
-
-            # Imprint shortcut to context for performance reasons.
-            "context": repre_context
-        }
+        repre_doc = new_representation_doc(
+            repre["name"], version["_id"], repre_context, data, repre_id
+        )
+        update_data = None
+        if repre_id is not None:
+            update_data = prepare_representation_update_data(
+                existing, repre_doc
+            )
 
         return {
-            "representation": representation,
+            "representation": repre_doc,
+            "repre_doc_update_data": update_data,
             "anatomy_data": template_data,
             "transfers": transfers,
             # todo: avoid the need for 'published_files' used by Integrate Hero


### PR DESCRIPTION
## Brief description
Simple variant of creating, updating and deleting of entities can be done without direct access to mongo documents.

## Description
Created basic operations for create, update and delete. All of them require project name and entity type, update and delete require entity id, creation requires full document and update requires changes of document.

There is almost none validation of documents even not on creation. That can be achieved by moving `schema.py` out of `openpype.pipeline` to top level. We should also consider that json schemas would be at the same folder.

## Additional info
There are missing docstrings and I didni't fully validated functionality, yet. Class and function/method names are not final. Any comments welcomed. There is no way to "replace or insert" operation. Not sure if we should allow that option/s.

## Possible enhancements
- schema validation of documents to create
- maybe also validate if created document is not duplicate of already existing document (by entity specific queries) before commit

## Testing notes:
At this moment are operations used only in new integrator.
1. Run publishing
2. Run publishing which will integrate to already existing version
3. Farm publishing which appends representations