### PR TITLE
Blender: bugfix blender.api.ops for workfiles dialog

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -220,12 +220,9 @@ class LaunchQtApp(bpy.types.Operator):
                 self._app.store_window(self.bl_idname, window)
             self._window = window
 
-        if not isinstance(
-            self._window,
-            (QtWidgets.QMainWindow, QtWidgets.QDialog, ModuleType)
-        ):
+        if not isinstance(self._window, (QtWidgets.QWidget, ModuleType)):
             raise AttributeError(
-                "`window` should be a `QDialog or module`. Got: {}".format(
+                "`window` should be a `QWidget or module`. Got: {}".format(
                     str(type(window))
                 )
             )
@@ -249,9 +246,9 @@ class LaunchQtApp(bpy.types.Operator):
             self._window.setWindowFlags(on_top_flags)
             self._window.show()
 
-            if on_top_flags != origin_flags:
-                self._window.setWindowFlags(origin_flags)
-                self._window.show()
+            # if on_top_flags != origin_flags:
+            #     self._window.setWindowFlags(origin_flags)
+            #     self._window.show()
 
         return {'FINISHED'}
 


### PR DESCRIPTION
## Brief description
Bring back the Workfile Dialog in Blender Host since this commit: https://github.com/pypeclub/OpenPype/commit/55ff302d21a49b13281972129a944adcb998bf89 

## Description
see issue : https://github.com/pypeclub/OpenPype/issues/3592

## Testing notes:
1. Start with a task in Blender.
2. Open the workfiles dialog -> should now appear.