### PR TITLE
Support for mutliple installed versions - 3.13

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -122,7 +122,7 @@ class OpenPypeVersion(semver.VersionInfo):
         if self.staging:
             if kwargs.get("build"):
                 if "staging" not in kwargs.get("build"):
-                    kwargs["build"] = "{}-staging".format(kwargs.get("build"))
+                    kwargs["build"] = f"{kwargs.get('build')}-staging"
             else:
                 kwargs["build"] = "staging"
 
@@ -136,8 +136,7 @@ class OpenPypeVersion(semver.VersionInfo):
         return bool(result and self.staging == other.staging)
 
     def __repr__(self):
-        return "<{}: {} - path={}>".format(
-            self.__class__.__name__, str(self), self.path)
+        return f"<{self.__class__.__name__}: {str(self)} - path={self.path}>"
 
     def __lt__(self, other: OpenPypeVersion):
         result = super().__lt__(other)
@@ -232,10 +231,7 @@ class OpenPypeVersion(semver.VersionInfo):
         return openpype_version
 
     def __hash__(self):
-        if self.path:
-            return hash(self.path)
-        else:
-            return hash(str(self))
+        return hash(self.path) if self.path else hash(str(self))
 
     @staticmethod
     def is_version_in_dir(

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -514,10 +514,10 @@ class OpenPypeVersion(semver.VersionInfo):
             ValueError: if invalid path is specified.
 
         """
-        if not openpype_dir.exists() and not openpype_dir.is_dir():
-            raise ValueError("specified directory is invalid")
-
         _openpype_versions = []
+        if not openpype_dir.exists() and not openpype_dir.is_dir():
+            return _openpype_versions
+
         # iterate over directory in first level and find all that might
         # contain OpenPype.
         for item in openpype_dir.iterdir():

--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -21,6 +21,11 @@ class OpenPypeVersionNotFound(Exception):
     pass
 
 
+class OpenPypeVersionIncompatible(Exception):
+    """OpenPype version is not compatible with the installed one (build)."""
+    pass
+
+
 def should_add_certificate_path_to_mongo_url(mongo_url):
     """Check if should add ca certificate to mongo url.
 

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -443,3 +443,26 @@ def interactive():
         __version__, sys.version, sys.platform
     )
     code.interact(banner)
+
+
+@main.command()
+@click.option("--build", help="Print only build version",
+              is_flag=True, default=False)
+def version(build):
+    """Print OpenPype version."""
+
+    from openpype.version import __version__
+    from igniter.bootstrap_repos import BootstrapRepos, OpenPypeVersion
+    from pathlib import Path
+    import os
+
+    if getattr(sys, 'frozen', False):
+        local_version = BootstrapRepos.get_version(
+            Path(os.getenv("OPENPYPE_ROOT")))
+    else:
+        local_version = OpenPypeVersion.get_installed_version_str()
+
+    if build:
+        print(local_version)
+        return
+    print(f"{__version__} (booted: {local_version})")

--- a/openpype/modules/deadline/plugins/publish/submit_aftereffects_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_aftereffects_deadline.py
@@ -80,7 +80,8 @@ class AfterEffectsSubmitDeadline(
             "AVALON_TASK",
             "AVALON_APP_NAME",
             "OPENPYPE_DEV",
-            "OPENPYPE_LOG_NO_COLORS"
+            "OPENPYPE_LOG_NO_COLORS",
+            "OPENPYPE_VERSION"
         ]
         # Add mongo url if it's enabled
         if self._instance.context.data.get("deadlinePassMongoUrl"):

--- a/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_harmony_deadline.py
@@ -274,7 +274,8 @@ class HarmonySubmitDeadline(
             "AVALON_TASK",
             "AVALON_APP_NAME",
             "OPENPYPE_DEV",
-            "OPENPYPE_LOG_NO_COLORS"
+            "OPENPYPE_LOG_NO_COLORS",
+            "OPENPYPE_VERSION"
         ]
         # Add mongo url if it's enabled
         if self._instance.context.data.get("deadlinePassMongoUrl"):

--- a/openpype/modules/deadline/plugins/publish/submit_houdini_remote_publish.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_remote_publish.py
@@ -130,6 +130,7 @@ class HoudiniSubmitPublishDeadline(pyblish.api.ContextPlugin):
             # this application with so the Render Slave can build its own
             # similar environment using it, e.g. "houdini17.5;pluginx2.3"
             "AVALON_TOOLS",
+            "OPENPYPE_VERSION"
         ]
         # Add mongo url if it's enabled
         if context.data.get("deadlinePassMongoUrl"):

--- a/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_render_deadline.py
@@ -101,6 +101,7 @@ class HoudiniSubmitRenderDeadline(pyblish.api.InstancePlugin):
             # this application with so the Render Slave can build its own
             # similar environment using it, e.g. "maya2018;vray4.x;yeti3.1.9"
             "AVALON_TOOLS",
+            "OPENPYPE_VERSION"
         ]
         # Add mongo url if it's enabled
         if context.data.get("deadlinePassMongoUrl"):

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -525,7 +525,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             "AVALON_TASK",
             "AVALON_APP_NAME",
             "OPENPYPE_DEV",
-            "OPENPYPE_LOG_NO_COLORS"
+            "OPENPYPE_LOG_NO_COLORS",
+            "OPENPYPE_VERSION"
         ]
         # Add mongo url if it's enabled
         if instance.context.data.get("deadlinePassMongoUrl"):

--- a/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_remote_publish_deadline.py
@@ -102,7 +102,8 @@ class MayaSubmitRemotePublishDeadline(pyblish.api.InstancePlugin):
         keys = [
             "FTRACK_API_USER",
             "FTRACK_API_KEY",
-            "FTRACK_SERVER"
+            "FTRACK_SERVER",
+            "OPENPYPE_VERSION"
         ]
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **legacy_io.Session)

--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -261,7 +261,8 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             "PYBLISHPLUGINPATH",
             "NUKE_PATH",
             "TOOL_ENV",
-            "FOUNDRY_LICENSE"
+            "FOUNDRY_LICENSE",
+            "OPENPYPE_VERSION"
         ]
         # Add mongo url if it's enabled
         if instance.context.data.get("deadlinePassMongoUrl"):

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -141,7 +141,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         "OPENPYPE_USERNAME",
         "OPENPYPE_RENDER_JOB",
         "OPENPYPE_PUBLISH_JOB",
-        "OPENPYPE_MONGO"
+        "OPENPYPE_MONGO",
+        "OPENPYPE_VERSION"
     ]
 
     # custom deadline attributes

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -123,10 +123,10 @@ def inject_openpype_environment(deadlinePlugin):
                      "directory.").format(requested_version))
             # sort compatible versions nad pick the last one
             compatible_versions.sort(
-                    key=lambda ver: [
-                        int(t) if t.isdigit() else t.lower()
-                        for t in re.split(r"(\d+)", ver[0])
-                    ])
+                key=lambda ver: [
+                    int(t) if t.isdigit() else t.lower()
+                    for t in re.split(r"(\d+)", ver[0])
+                ])
             print(("*** Latest compatible version found is "
                    f"{compatible_versions[-1][0]}"))
             # create list of executables for different platform and let

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -10,9 +10,22 @@ import re
 from Deadline.Scripting import RepositoryUtils, FileUtils, DirectoryUtils
 
 
-def get_openpype_version_from_path(path):
+def get_openpype_version_from_path(path, build=True):
+    """Get OpenPype version from provided path.
+         path (str): Path to scan.
+         build (bool, optional): Get only builds, not sources
+
+    Returns:
+        str or None: version of OpenPype if found.
+
+    """
     version_file = os.path.join(path, "openpype", "version.py")
     if not os.path.isfile(version_file):
+        return None
+    # skip if the version is not build
+    if not build and \
+            (not os.path.isfile(os.path.join(path, "openpype_console")) or
+             not os.path.isfile(os.path.join(path, "openpype_console.exe"))):
         return None
     version = {}
     with open(version_file, "r") as vf:
@@ -101,7 +114,8 @@ def inject_openpype_environment(deadlinePlugin):
         if exe == "":
             raise RuntimeError(
                 "OpenPype executable was not found " +
-                "in the semicolon separated list \"" + exe_list + "\". " +
+                "in the semicolon separated list " +
+                "\"" + ";".join(exe_list) + "\". " +
                 "The path to the render executable can be configured " +
                 "from the Plugin Configuration in the Deadline Monitor.")
 

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -104,7 +104,7 @@ def inject_openpype_environment(deadlinePlugin):
                 openpype_versions.sort(
                     key=lambda ver: [
                         int(t) if t.isdigit() else t.lower()
-                        for t in re.split('(\d+)', ver[0])
+                        for t in re.split(r"(\d+)", ver[0])
                     ])
                 print(("*** Latest available version found is "
                        f"{openpype_versions[-1][0]}"))
@@ -125,7 +125,7 @@ def inject_openpype_environment(deadlinePlugin):
             compatible_versions.sort(
                     key=lambda ver: [
                         int(t) if t.isdigit() else t.lower()
-                        for t in re.split('(\d+)', ver[0])
+                        for t in re.split(r"(\d+)", ver[0])
                     ])
             print(("*** Latest compatible version found is "
                    f"{compatible_versions[-1][0]}"))

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -70,11 +70,11 @@ def inject_openpype_environment(deadlinePlugin):
         # lets go over all available and find compatible build.
         requested_version = job.GetJobEnvironmentKeyValue("OPENPYPE_VERSION")
         if requested_version:
-            print(("Scanning for compatible requested "
+            print((">>> Scanning for compatible requested "
                   f"version {requested_version}"))
             install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
             if install_dir:
-                print(f"Looking for OpenPype at: {install_dir}")
+                print(f"--- Looking for OpenPype at: {install_dir}")
                 sub_dirs = [
                     f.path for f in os.scandir(install_dir)
                     if f.is_dir()
@@ -83,7 +83,7 @@ def inject_openpype_environment(deadlinePlugin):
                     version = get_openpype_version_from_path(subdir)
                     if not version:
                         continue
-                    print(f" - found: {version} - {subdir}")
+                    print(f"  - found: {version} - {subdir}")
                     openpype_versions.append((version, subdir))
 
         exe = FileUtils.SearchFileList(exe_list)
@@ -94,14 +94,14 @@ def inject_openpype_environment(deadlinePlugin):
             version = get_openpype_version_from_path(
                 os.path.dirname(exe))
             if version:
-                print(f" - found: {version} - {os.path.dirname(exe)}")
+                print(f"  - found: {version} - {os.path.dirname(exe)}")
                 openpype_versions.append((version, os.path.dirname(exe)))
 
         if requested_version:
             # sort detected versions
             if openpype_versions:
                 openpype_versions.sort(key=lambda ver: ver[0])
-                print(("Latest available version found is "
+                print(("*** Latest available version found is "
                        f"{openpype_versions[-1][0]}"))
             requested_major, requested_minor, _ = requested_version.split(".")[:3]  # noqa: E501
             compatible_versions = []
@@ -118,7 +118,7 @@ def inject_openpype_environment(deadlinePlugin):
                      "directory.").format(requested_version))
             # sort compatible versions nad pick the last one
             compatible_versions.sort(key=lambda ver: ver[0])
-            print(("Latest compatible version found is "
+            print(("*** Latest compatible version found is "
                    f"{compatible_versions[-1][0]}"))
             # create list of executables for different platform and let
             # Deadline decide.

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -100,7 +100,12 @@ def inject_openpype_environment(deadlinePlugin):
         if requested_version:
             # sort detected versions
             if openpype_versions:
-                openpype_versions.sort(key=lambda ver: ver[0])
+                # use natural sorting
+                openpype_versions.sort(
+                    key=lambda ver: [
+                        int(t) if t.isdigit() else t.lower()
+                        for t in re.split('(\d+)', ver[0])
+                    ])
                 print(("*** Latest available version found is "
                        f"{openpype_versions[-1][0]}"))
             requested_major, requested_minor, _ = requested_version.split(".")[:3]  # noqa: E501
@@ -117,7 +122,11 @@ def inject_openpype_environment(deadlinePlugin):
                      "in Deadline or install it to configured "
                      "directory.").format(requested_version))
             # sort compatible versions nad pick the last one
-            compatible_versions.sort(key=lambda ver: ver[0])
+            compatible_versions.sort(
+                    key=lambda ver: [
+                        int(t) if t.isdigit() else t.lower()
+                        for t in re.split('(\d+)', ver[0])
+                    ])
             print(("*** Latest compatible version found is "
                    f"{compatible_versions[-1][0]}"))
             # create list of executables for different platform and let

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -23,7 +23,7 @@ def get_openpype_version_from_path(path, build=True):
     if not os.path.isfile(version_file):
         return None
     # skip if the version is not build
-    if not build and \
+    if build and \
             (not os.path.isfile(os.path.join(path, "openpype_console")) or
              not os.path.isfile(os.path.join(path, "openpype_console.exe"))):
         return None

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -63,7 +63,7 @@ def inject_openpype_environment(deadlinePlugin):
             print(("Scanning for compatible requested "
                   f"version {requested_version}"))
             install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
-            if dir:
+            if install_dir:
                 sub_dirs = [
                     f.path for f in os.scandir(install_dir)
                     if f.is_dir()
@@ -72,6 +72,7 @@ def inject_openpype_environment(deadlinePlugin):
                     version = get_openpype_version_from_path(subdir)
                     if not version:
                         continue
+                    print(f" - found: {version} - {subdir}")
                     openpype_versions.append((version, subdir))
 
         exe = FileUtils.SearchFileList(exe_list)
@@ -81,12 +82,15 @@ def inject_openpype_environment(deadlinePlugin):
             version = get_openpype_version_from_path(
                 os.path.dirname(exe))
             if version:
+                print(f" - found: {version} - {os.path.dirname(exe)}")
                 openpype_versions.append((version, os.path.dirname(exe)))
 
         if requested_version:
             # sort detected versions
             if openpype_versions:
                 openpype_versions.sort(key=lambda ver: ver[0])
+            print(("Latest available version found is "
+                   f"{openpype_versions[-1][0]}"))
             requested_major, requested_minor, _ = requested_version.split(".")[:3]  # noqa: E501
             compatible_versions = []
             for version in openpype_versions:
@@ -102,6 +106,8 @@ def inject_openpype_environment(deadlinePlugin):
                      "directory.").format(requested_version))
             # sort compatible versions nad pick the last one
             compatible_versions.sort(key=lambda ver: ver[0])
+            print(("Latest compatible version found is "
+                   f"{compatible_versions[-1][0]}"))
             # create list of executables for different platform and let
             # Deadline decide.
             exe_list = [

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.param
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.param
@@ -7,11 +7,20 @@ Index=0
 Default=OpenPype Plugin for Deadline
 Description=Not configurable
 
+[OpenPypeInstallationDirs]
+Type=multilinemultifolder
+Label=Directories where OpenPype versions are installed
+Category=OpenPype Installation Directories
+CategoryOrder=0
+Index=0
+Default=C:\Program Files (x86)\OpenPype
+Description=Path or paths to directories where multiple versions of OpenPype might be installed. Enter every such path on separate lines.
+
 [OpenPypeExecutable]
 Type=multilinemultifilename
 Label=OpenPype Executable
 Category=OpenPype Executables
-CategoryOrder=0
+CategoryOrder=1
 Index=0
 Default=
 Description=The path to the OpenPype executable. Enter alternative paths on separate lines.

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -76,7 +76,7 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
         # skip if the version is not build
         if not build and \
                 (not os.path.isfile(os.path.join(path, "openpype_console")) or
-                 not os.path.isfile(os.path.join(path, "openpype_console.exe"))):
+                 not os.path.isfile(os.path.join(path, "openpype_console.exe"))):  # noqa: E501
             return None
         version = {}
         with open(version_file, "r") as vf:

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -135,7 +135,7 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
                 openpype_versions.sort(
                     key=lambda ver: [
                         int(t) if t.isdigit() else t.lower()
-                        for t in re.split('(\d+)', ver[0])
+                        for t in re.split(r"(\d+)", ver[0])
                     ])
             requested_major, requested_minor, _ = requested_version.split(".")[:3]  # noqa: E501
             compatible_versions = []
@@ -153,7 +153,7 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
             compatible_versions.sort(
                     key=lambda ver: [
                         int(t) if t.isdigit() else t.lower()
-                        for t in re.split('(\d+)', ver[0])
+                        for t in re.split(r"(\d+)", ver[0])
                     ])
             # create list of executables for different platform and let
             # Deadline decide.

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -132,7 +132,11 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
         if requested_version:
             # sort detected versions
             if openpype_versions:
-                openpype_versions.sort(key=lambda ver: ver[0])
+                openpype_versions.sort(
+                    key=lambda ver: [
+                        int(t) if t.isdigit() else t.lower()
+                        for t in re.split('(\d+)', ver[0])
+                    ])
             requested_major, requested_minor, _ = requested_version.split(".")[:3]  # noqa: E501
             compatible_versions = []
             for version in openpype_versions:
@@ -146,7 +150,11 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
                                  "in Deadline or install it to configured "
                                  "directory.").format(requested_version))
             # sort compatible versions nad pick the last one
-            compatible_versions.sort(key=lambda ver: ver[0])
+            compatible_versions.sort(
+                    key=lambda ver: [
+                        int(t) if t.isdigit() else t.lower()
+                        for t in re.split('(\d+)', ver[0])
+                    ])
             # create list of executables for different platform and let
             # Deadline decide.
             exe_list = [

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -151,10 +151,10 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
                                  "directory.").format(requested_version))
             # sort compatible versions nad pick the last one
             compatible_versions.sort(
-                    key=lambda ver: [
-                        int(t) if t.isdigit() else t.lower()
-                        for t in re.split(r"(\d+)", ver[0])
-                    ])
+                key=lambda ver: [
+                    int(t) if t.isdigit() else t.lower()
+                    for t in re.split(r"(\d+)", ver[0])
+                ])
             # create list of executables for different platform and let
             # Deadline decide.
             exe_list = [

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -74,7 +74,7 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
         if not os.path.isfile(version_file):
             return None
         # skip if the version is not build
-        if not build and \
+        if build and \
                 (not os.path.isfile(os.path.join(path, "openpype_console")) or
                  not os.path.isfile(os.path.join(path, "openpype_console.exe"))):  # noqa: E501
             return None

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -13,6 +13,7 @@ from Deadline.Scripting import (
 
 import re
 import os
+import platform
 
 
 ######################################################################
@@ -70,14 +71,24 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
             str or None: version of OpenPype if found.
 
         """
+        # fix path for application bundle on macos
+        if platform.system().lower() == "darwin":
+            path = os.path.join(path, "Contents", "MacOS", "lib", "Python")
+
         version_file = os.path.join(path, "openpype", "version.py")
         if not os.path.isfile(version_file):
             return None
+
         # skip if the version is not build
-        if build and \
-                (not os.path.isfile(os.path.join(path, "openpype_console")) or
-                 not os.path.isfile(os.path.join(path, "openpype_console.exe"))):  # noqa: E501
+        exe = os.path.join(path, "openpype_console.exe")
+        if platform.system().lower() in ["linux", "darwin"]:
+            exe = os.path.join(path, "openpype_console")
+
+        # if only builds are requested
+        if build and not os.path.isfile(exe):  # noqa: E501
+            print(f"   ! path is not a build: {path}")
             return None
+
         version = {}
         with open(version_file, "r") as vf:
             exec(vf.read(), version)

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPype/OpenPype.py
@@ -61,9 +61,22 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
             ".*Progress: (\d+)%.*").HandleCallback += self.HandleProgress
 
     @staticmethod
-    def get_openpype_version_from_path(path):
+    def get_openpype_version_from_path(path, build=True):
+        """Get OpenPype version from provided path.
+             path (str): Path to scan.
+             build (bool, optional): Get only builds, not sources
+
+        Returns:
+            str or None: version of OpenPype if found.
+
+        """
         version_file = os.path.join(path, "openpype", "version.py")
         if not os.path.isfile(version_file):
+            return None
+        # skip if the version is not build
+        if not build and \
+                (not os.path.isfile(os.path.join(path, "openpype_console")) or
+                 not os.path.isfile(os.path.join(path, "openpype_console.exe"))):
             return None
         version = {}
         with open(version_file, "r") as vf:
@@ -136,7 +149,8 @@ class OpenPypeDeadlinePlugin(DeadlinePlugin):
         if exe == "":
             self.FailRender(
                 "OpenPype executable was not found " +
-                "in the semicolon separated list \"" + exe_list + "\". " +
+                "in the semicolon separated list " +
+                "\"" + ";".join(exe_list) + "\". " +
                 "The path to the render executable can be configured " +
                 "from the Plugin Configuration in the Deadline Monitor.")
         return exe

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ build_exe_options = dict(
 )
 
 bdist_mac_options = dict(
-    bundle_name="OpenPype",
+    bundle_name=f"OpenPype {__version__}",
     iconfile=mac_icon_path
 )
 

--- a/start.py
+++ b/start.py
@@ -187,9 +187,8 @@ else:
 if "--headless" in sys.argv:
     os.environ["OPENPYPE_HEADLESS_MODE"] = "1"
     sys.argv.remove("--headless")
-else:
-    if os.getenv("OPENPYPE_HEADLESS_MODE") != "1":
-        os.environ.pop("OPENPYPE_HEADLESS_MODE", None)
+elif os.getenv("OPENPYPE_HEADLESS_MODE") != "1":
+    os.environ.pop("OPENPYPE_HEADLESS_MODE", None)
 
 # Enabled logging debug mode when "--debug" is passed
 if "--verbose" in sys.argv:
@@ -203,8 +202,8 @@ if "--verbose" in sys.argv:
         value = sys.argv.pop(idx)
     else:
         raise RuntimeError((
-            "Expect value after \"--verbose\" argument. {}"
-        ).format(expected_values))
+            f"Expect value after \"--verbose\" argument. {expected_values}"
+        ))
 
     log_level = None
     low_value = value.lower()
@@ -225,8 +224,9 @@ if "--verbose" in sys.argv:
 
     if log_level is None:
         raise RuntimeError((
-            "Unexpected value after \"--verbose\" argument \"{}\". {}"
-        ).format(value, expected_values))
+            "Unexpected value after \"--verbose\" "
+            f"argument \"{value}\". {expected_values}"
+        ))
 
     os.environ["OPENPYPE_LOG_LEVEL"] = str(log_level)
 
@@ -336,34 +336,33 @@ def run_disk_mapping_commands(settings):
         destination = destination.rstrip('/')
         source = source.rstrip('/')
 
-        if low_platform == "windows":
-            args = ["subst", destination, source]
-        elif low_platform == "darwin":
-            scr = "do shell script \"ln -s {} {}\" with administrator privileges".format(source, destination)  # noqa: E501
+        if low_platform == "darwin":
+            scr = f'do shell script "ln -s {source} {destination}" with administrator privileges'  # noqa
+
             args = ["osascript", "-e", scr]
+        elif low_platform == "windows":
+            args = ["subst", destination, source]
         else:
             args = ["sudo", "ln", "-s", source, destination]
 
-        _print("disk mapping args:: {}".format(args))
+        _print(f"*** disk mapping arguments: {args}")
         try:
             if not os.path.exists(destination):
                 output = subprocess.Popen(args)
                 if output.returncode and output.returncode != 0:
-                    exc_msg = "Executing was not successful: \"{}\"".format(
-                        args)
+                    exc_msg = f'Executing was not successful: "{args}"'
 
                     raise RuntimeError(exc_msg)
         except TypeError as exc:
-            _print("Error {} in mapping drive {}, {}".format(str(exc),
-                                                             source,
-                                                             destination))
+            _print(
+                f"Error {str(exc)} in mapping drive {source}, {destination}")
             raise
 
 
 def set_avalon_environments():
     """Set avalon specific environments.
 
-    These are non modifiable environments for avalon workflow that must be set
+    These are non-modifiable environments for avalon workflow that must be set
     before avalon module is imported because avalon works with globals set with
     environment variables.
     """
@@ -508,7 +507,7 @@ def _process_arguments() -> tuple:
                 )
                 if m and m.group('version'):
                     use_version = m.group('version')
-                    _print(">>> Requested version [ {} ]".format(use_version))
+                    _print(f">>> Requested version [ {use_version} ]")
                     if "+staging" in use_version:
                         use_staging = True
                     break
@@ -614,8 +613,8 @@ def _determine_mongodb() -> str:
             try:
                 openpype_mongo = bootstrap.secure_registry.get_item(
                     "openPypeMongo")
-            except ValueError:
-                raise RuntimeError("Missing MongoDB url")
+            except ValueError as e:
+                raise RuntimeError("Missing MongoDB url") from e
 
     return openpype_mongo
 
@@ -816,11 +815,8 @@ def _bootstrap_from_code(use_version, use_staging):
                 use_version, use_staging
             )
             if version_to_use is None:
-                raise OpenPypeVersionNotFound(
-                    "Requested version \"{}\" was not found.".format(
-                        use_version
-                    )
-                )
+                raise OpenPypeVersionIncompatible(
+                    f"Requested version \"{use_version}\" was not found.")
         else:
             # Staging version should be used
             version_to_use = bootstrap.find_latest_openpype_version(
@@ -906,7 +902,7 @@ def _boot_validate_versions(use_version, local_version):
         use_version, openpype_versions
     )
     valid, message = bootstrap.validate_openpype_version(version_path)
-    _print("{}{}".format(">>> " if valid else "!!! ", message))
+    _print(f'{">>> " if valid else "!!! "}{message}')
 
 
 def _boot_print_versions(use_staging, local_version, openpype_root):
@@ -1043,7 +1039,7 @@ def boot():
         if not result[0]:
             _print(f"!!! Invalid version: {result[1]}")
             sys.exit(1)
-        _print(f"--- version is valid")
+        _print("--- version is valid")
     else:
         try:
             version_path = _bootstrap_from_code(use_version, use_staging)
@@ -1164,8 +1160,7 @@ def get_info(use_staging=None) -> list:
     formatted = []
     for info in inf:
         padding = (maximum - len(info[0])) + 1
-        formatted.append(
-            "... {}:{}[ {} ]".format(info[0], " " * padding, info[1]))
+        formatted.append(f'... {info[0]}:{" " * padding}[ {info[1]} ]')
     return formatted
 
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -193,15 +193,15 @@ if [ "$disable_submodule_update" == 1 ]; then
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # fix code signing issue
-    codesign --remove-signature "$openpype_root/build/OpenPype.app/Contents/MacOS/lib/Python"
+    codesign --remove-signature "$openpype_root/build/OpenPype $openpype_version.app/Contents/MacOS/lib/Python"
     if command -v create-dmg > /dev/null 2>&1; then
       create-dmg \
-        --volname "OpenPype Installer" \
+        --volname "OpenPype $openpype_version Installer" \
         --window-pos 200 120 \
         --window-size 600 300 \
         --app-drop-link 100 50 \
-        "$openpype_root/build/OpenPype-Installer.dmg" \
-        "$openpype_root/build/OpenPype.app"
+        "$openpype_root/build/OpenPype-Installer-$openpype_version.dmg" \
+        "$openpype_root/build/OpenPype $openpype_version.app"
     else
       echo -e "${BIYellow}!!!${RST} ${BIWhite}create-dmg${RST} command is not available."
     fi

--- a/tools/create_zip.py
+++ b/tools/create_zip.py
@@ -61,7 +61,7 @@ def _print(msg: str, message_type: int = 0) -> None:
     else:
         header = term.darkolivegreen3("--- ")
 
-    print("{}{}".format(header, msg))
+    print(f"{header}{msg}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature

This PR is adding support for multiple installed versions (builds) on the same system. It will allow easy rollback and testing on farms and without disrupting existing running sessions.

On Deadline, it is now passing OpenPype version as `OPENPYPE_VERSION` to the job. If this environment variable is found on the job, Deadline will try to find compatible version build to use for launching that version of OpenPype. So if job was submitted from OpenPype version `3.12.2` Deadline will try to find any build that matches `3.12` and will use the latest available. Deadline will try to find it in directories specified in `OpenPypeInstallationDirs` configuration option.

It relies on functionality implemented here #3445.

## Deployment Notes

Since #3445 you can have multiple versions of OpenPype installed on Windows. This was possible even before with Linux, but it was missing logic that will load only versions from the update zips/repository compatible with the currently running build.

So with this PR, running build will "see" only versions compatible with it and will use only them. For Deadline, where this process is reversed - you know what version was used to create the submission and you need to find correct build to launch it, you need to put builds under some common directory do OpenPype can detect them. On Windows, this is by default `C:\Program Files (x86)\OpenPype` but it can be any directory following logic that its direct subdirectories should contain separate build available. So with Deadline, you need to point it to the directory with following structure: `/some/op/dir/3.12.2-nightly.2`, `/some/op/dir/3.13.0` and so on.


## Testing

For proper testing, you need to create few "mock" build versions of OpenPype. It should be enough to change `openpype/version.py` and running `tools/build.ps1|sh` and after each run store produced version somewhere.

### Visibility of compatible versions
OpenPype should by default see only versions compatible with the running build. So issuing command like:

```powershell
.\.poetry\bin\poetry.exe run python start.py --list-versions
```
or
```powershell
& "C:\Program Files (x86)\OpenPype\3.12.2-nightly.3\openpype_console.exe" --list-versions
```
should show only versions compatible with that particular build.

### Deadline
When testing, don't forget to update Deadline plugins in Deadline repository.

You need to configure OpenPype Deadline plugin:

![image](https://user-images.githubusercontent.com/33513211/180769994-6bed5780-359a-43ea-9d2c-1e3bdef58d0d.png)

Add path to **OpenPype Installation Directories**. This is path-per-line, first found is used.

Jobs submitted to Deadline should have set `OPENPYPE_VERSION` to correct one. In job log, you should find messages about version resolution. 

### Implementation steps:

- [X] change Inno Setup to allow multiple versions intalled on Windows #3445 
- [X] implement compatibility checks to functions detecting OP versions
- [x] change unzipping and tools to look into version folders in user data folder
- [x] mark as deprecated looking for versions in common folder
- [x] fix unit tests
- [x] implement version selector in the Deadline global event / OP plugin[^draft]

[^draft]: This would go over all specified path to OpenPype in Deadline and try to find requested version among them.

🧑‍🏭 **TODO:** find out how to deal with multiple installations on mac.

Resolves #3415
Resolves #3416
Resolves #3439