### PR TITLE
Maya look data contents fails with custom attribute on group

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -551,11 +551,9 @@ class CollectLook(pyblish.api.InstancePlugin):
                 if cmds.getAttr(attribute, type=True) == "message":
                     continue
                 node_attributes[attr] = cmds.getAttr(attribute)
-                
             # Only include if there are any properties we care about
             if not node_attributes:
                 continue
-            
             attributes.append({"name": node,
                                "uuid": lib.get_id(node),
                                "attributes": node_attributes})

--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -551,7 +551,11 @@ class CollectLook(pyblish.api.InstancePlugin):
                 if cmds.getAttr(attribute, type=True) == "message":
                     continue
                 node_attributes[attr] = cmds.getAttr(attribute)
-
+                
+            # Only include if there are any properties we care about
+            if not node_attributes:
+                continue
+            
             attributes.append({"name": node,
                                "uuid": lib.get_id(node),
                                "attributes": node_attributes})

--- a/openpype/hosts/maya/plugins/publish/validate_look_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_contents.py
@@ -76,12 +76,12 @@ class ValidateLookContents(pyblish.api.InstancePlugin):
                           "`relationships`" % instance.name)
             invalid.add(instance.name)
 
-        # Check if attributes are on a node with an ID, crucial for rebuild!
+        # Check if attributes are on a node with a name and an ID, crucial for rebuild!
         for attr_changes in lookdata["attributes"]:
-            if not attr_changes["uuid"]:
+            if not attr_changes["uuid"] and not attr_changes["name"]:
                 cls.log.error("Node '%s' has no cbId, please set the "
-                              "attributes to its children if it has any"
-                              % attr_changes["name"])
+                            "attributes to its children if it has any"
+                            % attr_changes["name"])
                 invalid.add(instance.name)
 
         return list(invalid)

--- a/openpype/hosts/maya/plugins/publish/validate_look_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_contents.py
@@ -76,16 +76,15 @@ class ValidateLookContents(pyblish.api.InstancePlugin):
                           "`relationships`" % instance.name)
             invalid.add(instance.name)
 
-        # Check if attributes are on a node with an ID, crucial for rebuild!
+        # Check if attributes are on a node with an attirbute and an ID, crucial for rebuild!
         for attr_changes in lookdata["attributes"]:
             if not attr_changes["uuid"] and not attr_changes["attributes"]:
                 cls.log.error("Node '%s' has no cbId, please set the "
-                            "attributes to its children if it has any"
-                            % attr_changes["name"])
+                              "attributes to its children if it has any"
+                              % attr_changes["name"])
                 invalid.add(instance.name)
 
         return list(invalid)
-
     @classmethod
     def validate_looks(cls, instance):
 

--- a/openpype/hosts/maya/plugins/publish/validate_look_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_contents.py
@@ -76,9 +76,9 @@ class ValidateLookContents(pyblish.api.InstancePlugin):
                           "`relationships`" % instance.name)
             invalid.add(instance.name)
 
-        # Check if attributes are on a node with a name and an ID, crucial for rebuild!
+        # Check if attributes are on a node with an ID, crucial for rebuild!
         for attr_changes in lookdata["attributes"]:
-            if not attr_changes["uuid"] and not attr_changes["name"]:
+            if not attr_changes["uuid"] and not attr_changes["attributes"]:
                 cls.log.error("Node '%s' has no cbId, please set the "
                             "attributes to its children if it has any"
                             % attr_changes["name"])

--- a/openpype/hosts/maya/plugins/publish/validate_look_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_contents.py
@@ -76,7 +76,7 @@ class ValidateLookContents(pyblish.api.InstancePlugin):
                           "`relationships`" % instance.name)
             invalid.add(instance.name)
 
-        # Check if attributes are on a node with an attirbute and an ID, crucial for rebuild!
+        # Check if attributes are on a node with an ID, crucial for rebuild!
         for attr_changes in lookdata["attributes"]:
             if not attr_changes["uuid"] and not attr_changes["attributes"]:
                 cls.log.error("Node '%s' has no cbId, please set the "


### PR DESCRIPTION
## Brief description
Solving the failure of validating look data contents when custom attributes are set up on group

## Solution
Set up the condition to tell the relative validating scripts to exclude the nodes with custom attributes from the invalid list, when the system is checking if the attributes are on nodes with IDs.
