### PR TITLE
Integrator: Don't force to have dot before frame

### DIFF
--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -541,8 +541,18 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             if any(os.path.isabs(fname) for fname in files):
                 raise KnownPublishError("Given file names contain full paths")
 
-            src_collection = clique.assemble(files)
+            src_collections, remainders = clique.assemble(files)
+            if len(files) < 2 or len(src_collections) != 1 or remainders:
+                raise KnownPublishError((
+                    "Files of representation does not contain proper"
+                    " sequence files.\nCollected collections: {}"
+                    "\nCollected remainders: {}"
+                ).format(
+                    ", ".join([str(col) for col in src_collections]),
+                    ", ".join([str(rem) for rem in remainders])
+                ))
 
+            src_collection = src_collections[0]
             destination_indexes = list(src_collection.indexes)
             # Use last frame for minimum padding
             #   - that should cover both 'udim' and 'frame' minimum padding

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -601,9 +601,11 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 template_filled = anatomy_filled[template_name]["path"]
                 dst_filepaths.append(template_filled)
                 if repre_context is None:
-                    repre_context = template_filled.used_value
+                    self.log.debug(
+                        "Template filled: {}".format(str(template_filled))
+                    )
+                    repre_context = template_filled.used_values
 
-            self.log.debug("Template filled: {}".format(str(template_filled)))
             # Make sure context contains frame
             # NOTE: Frame would not be available only if template does not
             #   contain '{frame}' in template -> Do we want support it?

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -613,7 +613,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 repre_context["frame"] = first_index_padded
 
             # Update the destination indexes and padding
-            dst_collection = clique.assemble(dst_filepaths)
+            dst_collection = clique.assemble(dst_filepaths)[0][0]
             dst_collection.padding = destination_padding
             if len(src_collection.indexes) != len(dst_collection.indexes):
                 raise KnownPublishError((


### PR DESCRIPTION
## Brief description
Creation of collection in new integrator does not require to have frame starting with dot.

## Description
It is not forced to use determined frame pattern in clique assemble. It seems to be added to support single file sequence which is not supported across multiple plugins so it's pointless and breaks a lot of current extractors output (or publish templates). Output sequence is created using anatomy format for each frame/udim.

## Testing notes:
It was discovered in TVPaint but it is also issue for AfterEffects.

Resolves https://github.com/pypeclub/OpenPype/issues/3608