### PR TITLE
Ftrack: Add more metadata to ftrack components

### DIFF
--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -115,6 +115,7 @@ from .transcoding import (
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
     convert_ffprobe_fps_value,
+    convert_ffprobe_fps_to_float,
 )
 from .avalon_context import (
     CURRENT_DOC_SCHEMAS,
@@ -287,6 +288,7 @@ __all__ = [
     "get_ffmpeg_codec_args",
     "get_ffmpeg_format_args",
     "convert_ffprobe_fps_value",
+    "convert_ffprobe_fps_to_float",
 
     "CURRENT_DOC_SCHEMAS",
     "PROJECT_NAME_ALLOWED_SYMBOLS",

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -938,3 +938,40 @@ def convert_ffprobe_fps_value(str_value):
         fps = int(fps)
 
     return str(fps)
+
+
+def convert_ffprobe_fps_to_float(value):
+    """Convert string value of frame rate to float.
+
+    Copy of 'convert_ffprobe_fps_value' which raises exceptions on invalid
+    value, does not convert value to string and does not return "Unknown"
+    string.
+
+    Args:
+        value (str): Value to be converted.
+
+    Returns:
+        Float: Converted frame rate in float. If divisor in value is '0' then
+            '0.0' is returned.
+
+    Raises:
+        ValueError: Passed value is invalid for conversion.
+    """
+
+    if not value:
+        raise ValueError("Got empty value.")
+
+    items = value.split("/")
+    if len(items) == 1:
+        return float(items[0])
+
+    if len(items) > 2:
+        raise ValueError((
+            "FPS expression contains multiple dividers \"{}\"."
+        ).format(value))
+
+    dividend = float(items.pop(0))
+    divisor = float(items.pop(0))
+    if divisor == 0.0:
+        return 0.0
+    return dividend / divisor

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -3,7 +3,10 @@ import json
 import copy
 import pyblish.api
 
-from openpype.lib import get_ffprobe_streams
+from openpype.lib.transcoding import (
+    get_ffprobe_streams,
+    convert_ffprobe_fps_to_float,
+)
 from openpype.lib.profiles_filtering import filter_profiles
 
 
@@ -78,11 +81,6 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 "Family \"{}\" does not match any asset type mapping"
             ).format(family))
             return
-
-        # Prepare FPS
-        instance_fps = instance.data.get("fps")
-        if instance_fps is None:
-            instance_fps = instance.context.data["fps"]
 
         status_name = self._get_asset_version_status_name(instance)
 
@@ -168,10 +166,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             # Add item to component list
             component_list.append(thumbnail_item)
 
-        if (
-            not review_representations
-            and first_thumbnail_component is not None
-        ):
+        if first_thumbnail_component is not None:
             width = first_thumbnail_component_repre.get("width")
             height = first_thumbnail_component_repre.get("height")
             if not width or not height:
@@ -253,20 +248,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                     first_thumbnail_component[
                         "asset_data"]["name"] = extended_asset_name
 
-            frame_start = repre.get("frameStartFtrack")
-            frame_end = repre.get("frameEndFtrack")
-            if frame_start is None or frame_end is None:
-                frame_start = instance.data["frameStart"]
-                frame_end = instance.data["frameEnd"]
-
-            # Frame end of uploaded video file should be duration in frames
-            # - frame start is always 0
-            # - frame end is duration in frames
-            duration = frame_end - frame_start + 1
-
-            fps = repre.get("fps")
-            if fps is None:
-                fps = instance_fps
+            component_meta = self._prepare_component_metadata(
+                instance, repre, repre_path, True
+            )
 
             # Change location
             review_item["component_path"] = repre_path
@@ -275,11 +259,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 # Default component name is "main".
                 "name": "ftrackreview-mp4",
                 "metadata": {
-                    "ftr_meta": json.dumps({
-                        "frameIn": 0,
-                        "frameOut": int(duration),
-                        "frameRate": float(fps)
-                    })
+                    "ftr_meta": json.dumps(component_meta)
                 }
             }
 
@@ -339,9 +319,17 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             ):
                 other_item["asset_data"]["name"] = extended_asset_name
 
-            other_item["component_data"] = {
+            component_meta = self._prepare_component_metadata(
+                instance, repre, published_path, False
+            )
+            component_data = {
                 "name": repre["name"]
             }
+            if component_meta:
+                component_data["metadata"] = {
+                    "ftr_meta": json.dumps(component_meta)
+                }
+            other_item["component_data"] = component_data
             other_item["component_location_name"] = unmanaged_location_name
             other_item["component_path"] = published_path
             component_list.append(other_item)
@@ -424,3 +412,106 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             return None
 
         return matching_profile["status"] or None
+
+    def _prepare_component_metadata(
+        self, instance, repre, component_path, is_review
+    ):
+        extension = os.path.splitext(component_path)[-1]
+        streams = []
+        try:
+            streams = get_ffprobe_streams(component_path)
+        except Exception:
+            self.log.debug((
+                "Failed to retrieve information about intput {}"
+            ).format(component_path))
+
+        # Find video streams
+        video_streams = [
+            stream
+            for stream in streams
+            if stream["codec_type"] == "video"
+        ]
+        # Skip if there are not video streams
+        #   - exr is special case which can have issues with reading through
+        #       ffmpegh but we want to set fps for it
+        if not video_streams and extension not in [".exr"]:
+            return {}
+
+        stream_width = None
+        stream_height = None
+        stream_fps = None
+        frame_out = None
+        for video_stream in video_streams:
+            input_framerate = video_stream.get("r_frame_rate")
+            duration = video_stream.get("duration")
+            tmp_width = video_stream.get("width")
+            tmp_height = video_stream.get("height")
+            if input_framerate is None or duration is None:
+                if tmp_width and tmp_height:
+                    stream_width = int(tmp_width)
+                    stream_height = int(tmp_height)
+                continue
+            try:
+                stream_fps = convert_ffprobe_fps_to_float(
+                    input_framerate
+                )
+            except ValueError:
+                self.log.warning((
+                    "Could not convert ffprobe fps to float \"{}\""
+                ).format(input_framerate))
+                continue
+
+            stream_width = tmp_width
+            stream_height = tmp_height
+
+            self.log.debug("FPS from stream is {} and duration is {}".format(
+                input_framerate, duration
+            ))
+            frame_out = float(duration) * stream_fps
+            break
+
+        # Prepare FPS
+        instance_fps = instance.data.get("fps")
+        if instance_fps is None:
+            instance_fps = instance.context.data["fps"]
+
+        if not is_review:
+            output = {}
+            fps = stream_fps or instance_fps
+            if fps:
+                output["frameRate"] = fps
+
+            if stream_width and stream_height:
+                output["width"] = int(stream_width)
+                output["height"] = int(stream_height)
+            return output
+
+        frame_start = repre.get("frameStartFtrack")
+        frame_end = repre.get("frameEndFtrack")
+        if frame_start is None or frame_end is None:
+            frame_start = instance.data["frameStart"]
+            frame_end = instance.data["frameEnd"]
+
+        fps = None
+        repre_fps = repre.get("fps")
+        if repre_fps is not None:
+            repre_fps = float(repre_fps)
+
+        fps = stream_fps or repre_fps or instance_fps
+
+        # Frame end of uploaded video file should be duration in frames
+        # - frame start is always 0
+        # - frame end is duration in frames
+        if not frame_out:
+            frame_out = frame_end - frame_start + 1
+
+        # Ftrack documentation says that it is required to have
+        #   'width' and 'height' in review component. But with those values
+        #   review video does not play.
+        component_meta = {
+            "frameIn": 0,
+            "frameOut": frame_out,
+            "frameRate": float(fps)
+        }
+
+        return component_meta

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -302,6 +302,13 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             component_data = copy_src_item["component_data"]
             component_name = component_data["name"]
             component_data["name"] = component_name + "_src"
+            component_meta = self._prepare_component_metadata(
+                instance, repre, copy_src_item["component_path"], False
+            )
+            if component_meta:
+                component_data["metadata"] = {
+                    "ftr_meta": json.dumps(component_meta)
+                }
             component_list.append(copy_src_item)
 
         # Add others representations as component
@@ -442,14 +449,15 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         stream_fps = None
         frame_out = None
         for video_stream in video_streams:
-            input_framerate = video_stream.get("r_frame_rate")
-            duration = video_stream.get("duration")
             tmp_width = video_stream.get("width")
             tmp_height = video_stream.get("height")
+            if tmp_width and tmp_height:
+                stream_width = tmp_width
+                stream_height = tmp_height
+
+            input_framerate = video_stream.get("r_frame_rate")
+            duration = video_stream.get("duration")
             if input_framerate is None or duration is None:
-                if tmp_width and tmp_height:
-                    stream_width = int(tmp_width)
-                    stream_height = int(tmp_height)
                 continue
             try:
                 stream_fps = convert_ffprobe_fps_to_float(

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -360,6 +360,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
                     os.unlink(f)
 
             new_repre.update({
+                "fps": temp_data["fps"],
                 "name": "{}_{}".format(output_name, output_ext),
                 "outputName": output_name,
                 "outputDef": output_def,


### PR DESCRIPTION
## Brief description
Add more metadata to ftrack components even for those which are not for review.

## Description
Add fps, width, height to components that can potentially be able to use it in CineCync. To achieve that I'm using ffprobe to read information about published path. If ffprobe crashes the component won't have any metadata otherwise fps (or `frameRate` is added.

Fixed issue when there are both `ftrackreview-mp4` and `ftrackreview-image` which could cause the thumbnail is showed in play instead of video. When both are available the `ftrackreview-image` is renamed to thumbnail.

## Additional information
We have no information about representation, is it an image or video with width, height and fps and sometimes when the information is there it is sometimes copied from source representation which changed so the data are not relevant.

## Testing notes:
1. Publish something that produces reviewable and create source filepath components in ftrack
2. Check all created components in ftrack, they should have metadata about `frameRate`, `width` and `height` (workfile probably won't)