### PR TITLE
Core: translated validate_containers.py into New publisher style

### DIFF
--- a/openpype/plugins/publish/help/validate_containers.xml
+++ b/openpype/plugins/publish/help/validate_containers.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Not up-to-date assets</title>
+<description>
+## Obsolete containers found
+
+Scene contains one or more obsolete loaded containers, eg. items loaded into scene by Loader.
+
+### How to repair?
+
+Use 'Scene Inventory' and update all highlighted old container to latest OR
+    refresh Publish and switch 'Validate Containers' toggle on 'Options' tab.
+
+    WARNING: Skipping this validator will result in publishing (and probably rendering) old version of loaded assets.
+</description>
+<detail>
+### __Detailed Info__ (optional)
+
+This validator protects you from rendering obsolete content, someone modified some referenced asset in this scene, eg.
+    by skipping this you would ignore changes to that asset.
+</detail>
+</error>
+</root>

--- a/openpype/plugins/publish/validate_containers.py
+++ b/openpype/plugins/publish/validate_containers.py
@@ -1,5 +1,9 @@
 import pyblish.api
 from openpype.pipeline.load import any_outdated_containers
+from openpype.pipeline import (
+    PublishXmlValidationError,
+    OptionalPyblishPluginMixin
+)
 
 
 class ShowInventory(pyblish.api.Action):
@@ -14,7 +18,9 @@ class ShowInventory(pyblish.api.Action):
         host_tools.show_scene_inventory()
 
 
-class ValidateContainers(pyblish.api.ContextPlugin):
+class ValidateContainers(OptionalPyblishPluginMixin,
+                         pyblish.api.ContextPlugin):
+
     """Containers are must be updated to latest version on publish."""
 
     label = "Validate Containers"
@@ -24,5 +30,9 @@ class ValidateContainers(pyblish.api.ContextPlugin):
     actions = [ShowInventory]
 
     def process(self, context):
+        if not self.is_active(context.data):
+            return
+
         if any_outdated_containers():
-            raise ValueError("There are outdated containers in the scene.")
+            msg = "There are outdated containers in the scene."
+            raise PublishXmlValidationError(self, msg)


### PR DESCRIPTION
## Brief description
`Validate Containers` could now be used in New Publisher as a optional plugin.
First sentence is brief description.


## Additional info
AE could be already using NP.


## Testing notes:
1. Try to publish in AE with New Publisher in the scene with obsolete loaded containers.