### PR TITLE
Ftrack: Comment template can contain optional keys

### DIFF
--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -211,15 +211,28 @@ class StringTemplate(object):
                 if counted_symb > -1:
                     parts = tmp_parts.pop(counted_symb)
                     counted_symb -= 1
+                    # If part contains only single string keep value
+                    #   unchanged
                     if parts:
                         # Remove optional start char
                         parts.pop(0)
-                        if counted_symb < 0:
-                            out_parts = new_parts
-                        else:
-                            out_parts = tmp_parts[counted_symb]
-                        # Store temp parts
-                        out_parts.append(OptionalPart(parts))
+
+                    if not parts:
+                        value = "<>"
+                    elif (
+                        len(parts) == 1
+                        and isinstance(parts[0], six.string_types)
+                    ):
+                        value = "<{}>".format(parts[0])
+                    else:
+                        value = OptionalPart(parts)
+
+                    if counted_symb < 0:
+                        out_parts = new_parts
+                    else:
+                        out_parts = tmp_parts[counted_symb]
+                    # Store value
+                    out_parts.append(value)
                     continue
 
             if counted_symb < 0:
@@ -793,6 +806,7 @@ class OptionalPart:
         parts(list): Parts of template. Can contain 'str', 'OptionalPart' or
             'FormattingPart'.
     """
+
     def __init__(self, parts):
         self._parts = parts
 

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -9,9 +9,11 @@ Requires:
 """
 
 import sys
+import copy
 
 import six
 import pyblish.api
+from openpype.lib import StringTemplate
 
 
 class IntegrateFtrackNote(pyblish.api.InstancePlugin):
@@ -53,14 +55,10 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
 
         intent = instance.context.data.get("intent")
         intent_label = None
-        if intent and isinstance(intent, dict):
-            intent_val = intent.get("value")
-            intent_label = intent.get("label")
-        else:
-            intent_val = intent
-
-        if not intent_label:
-            intent_label = intent_val or ""
+        if intent:
+            value = intent["value"]
+            if value:
+                intent_label = intent["label"] or value
 
         # if intent label is set then format comment
         # - it is possible that intent_label is equal to "" (empty string)
@@ -96,6 +94,14 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
 
                 labels.append(label)
 
+        base_format_data = {
+            "host_name": host_name,
+            "app_name": app_name,
+            "app_label": app_label,
+            "source": instance.data.get("source", '')
+        }
+        if comment:
+            base_format_data["comment"] = comment
         for asset_version_data in asset_versions_data_by_id.values():
             asset_version = asset_version_data["asset_version"]
             component_items = asset_version_data["component_items"]
@@ -109,23 +115,31 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
             template = self.note_template
             if template is None:
                 template = self.note_with_intent_template
-            format_data = {
-                "intent": intent_label,
-                "comment": comment,
-                "host_name": host_name,
-                "app_name": app_name,
-                "app_label": app_label,
-                "published_paths": "<br/>".join(sorted(published_paths)),
-                "source": instance.data.get("source", '')
-            }
-            comment = template.format(**format_data)
-            if not comment:
+            format_data = copy.deepcopy(base_format_data)
+            format_data["published_paths"] = "<br/>".join(
+                sorted(published_paths)
+            )
+            if intent:
+                if "{intent}" in template:
+                    format_data["intent"] = intent_label
+                else:
+                    format_data["intent"] = intent
+
+            note_text = StringTemplate.format_template(template, format_data)
+            if not note_text.solved:
+                self.log.warning((
+                    "Note template require more keys then can be provided."
+                    "\nTemplate: {}\nData: {}"
+                ).format(template, format_data))
+                continue
+
+            if not note_text:
                 self.log.info((
                     "Note for AssetVersion {} would be empty. Skipping."
                     "\nTemplate: {}\nData: {}"
                 ).format(asset_version["id"], template, format_data))
                 continue
-            asset_version.create_note(comment, author=user, labels=labels)
+            asset_version.create_note(note_text, author=user, labels=labels)
 
             try:
                 session.commit()

--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -26,13 +26,14 @@
             "linux": []
         },
         "intent": {
+            "allow_empty_intent": true,
+            "empty_intent_label": "",
             "items": {
-                "-": "-",
                 "wip": "WIP",
                 "final": "Final",
                 "test": "Test"
             },
-            "default": "-"
+            "default": ""
         },
         "custom_attributes": {
             "show": {

--- a/openpype/settings/entities/schemas/system_schema/module_settings/schema_ftrack.json
+++ b/openpype/settings/entities/schemas/system_schema/module_settings/schema_ftrack.json
@@ -50,8 +50,15 @@
             "is_group": true,
             "children": [
                 {
-                    "type": "label",
-                    "label": "Intent"
+                    "type": "boolean",
+                    "key": "allow_empty_intent",
+                    "label": "Allow empty intent"
+                },
+                {
+                    "type": "text",
+                    "key": "empty_intent_label",
+                    "label": "Empty item label",
+                    "placeholder": "< Not set >"
                 },
                 {
                     "type": "dict-modifiable",
@@ -64,7 +71,8 @@
                 {
                     "key": "default",
                     "type": "text",
-                    "label": "Default Intent"
+                    "label": "Default Intent",
+                    "placeholder": "< First available >"
                 },
                 {
                     "type": "separator"

--- a/openpype/tools/pyblish_pype/window.py
+++ b/openpype/tools/pyblish_pype/window.py
@@ -523,6 +523,7 @@ class Window(QtWidgets.QDialog):
             instance_item.setData(enable_value, Roles.IsEnabledRole)
 
     def _add_intent_to_context(self):
+        context_value = None
         if (
             self.intent_model.has_items
             and "intent" not in self.controller.context.data
@@ -530,11 +531,17 @@ class Window(QtWidgets.QDialog):
             idx = self.intent_model.index(self.intent_box.currentIndex(), 0)
             intent_value = self.intent_model.data(idx, Roles.IntentItemValue)
             intent_label = self.intent_model.data(idx, QtCore.Qt.DisplayRole)
+            if intent_value:
+                context_value = {
+                    "value": intent_value,
+                    "label": intent_label
+                }
 
-            self.controller.context.data["intent"] = {
-                "value": intent_value,
-                "label": intent_label
-            }
+        # Unset intent if is set to empty value
+        if context_value is None:
+            self.controller.context.data.pop("intent", None)
+        else:
+            self.controller.context.data["intent"] = context_value
 
     def on_instance_toggle(self, index, state=None):
         """An item is requesting to be toggled"""


### PR DESCRIPTION
## Brief description
Reduced empty notes and descriptions during publishing when integrating to ftrack, intent can be nullable and `StringTemplate` support to keep less/greater symbols if don't contain any formatting `<...>` (`<br/>` is kept unchanged).

## Description
The main issue is that templates in most of cases consist from `{intent}: {comment}` which cause that result is `{-: }`. One reason is that intent can't be empty at this moment so it's filled with other symbol (e.g. `"-"`) and we're unable to know which part should be skipped if value is missing.

Intent can have nullable option so studio can tell that empty intent is possible and we can handle it in some way during publishing.

`StringTemplate` support to keep less/greater symbols if they do not contain any formatting. That is important for ftrack integrate note where html tags are used. If anybody would enter to template `"<<b>{asset}</b>><><br/>"` result after formatting would be `"<b>Bob</b><><br/>"` with `asset = "Bob"` and `"<><br/>"` if `asset` is not available. This is not a perfect solution for cases when someone would like to keep the symbols even between formatting but for current issue it's enough.

Integrate description skip integration if `comment` and `intent` are empty. Also template support optional keys. Integrate note can't skip if `comment` and `intent` are not available because are not only keys that can be used to fill the template but also support optional keys (was reason why `StringTemplate` needed modification).

## Additional info
This does not handle all cases because we can use optional keys only "one way". So for combination of `comment` and `intent` when template looks like `"{intent}: {comment}"` there are 2 possibilities how to enter optional keys `"<{intent}: >{comment}"` or `"{intent}<: {comment}>"` but we can't support both at a single time. I think that it would be possible with some "magical expression logic" (First letters make MEL, coinsidence?) in template `"<{intent}>{%: ?intent && comment%}<{comment}>"`.

## Testing notes:
1. Integrate description should skip if intent and comment are empty
2. It should be possible to use optional keys in both integrate description and integrate note