### PR TITLE
Maya: Fix types of default settings

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -99,6 +99,20 @@
             "enabled": true,
             "publish_mip_map": true
         },
+        "CreateAnimation": {
+            "enabled": true,
+            "write_color_sets": false,
+            "defaults": [
+                "Main"
+            ]
+        },
+        "CreatePointCache": {
+            "enabled": true,
+            "write_color_sets": false,
+            "defaults": [
+                "Main"
+            ]
+        },
         "CreateMultiverseUsd": {
             "enabled": true,
             "defaults": [
@@ -116,14 +130,6 @@
             "defaults": [
                 "Main"
             ]
-        },
-        "CreateAnimation": {
-            "enabled": true,
-            "write_color_sets": false,
-            "defaults": [
-                "Main"
-            ]
-          
         },
         "CreateAss": {
             "enabled": true,
@@ -161,13 +167,6 @@
                 "Main",
                 "Proxy",
                 "Sculpt"
-            ]
-        },
-        "CreatePointCache": {
-            "enabled": true,
-            "write_color_sets": false,
-            "defaults": [
-                "Main"
             ]
         },
         "CreateRenderSetup": {

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -42,14 +42,14 @@
             "multilayer_exr": true,
             "tiled": true,
             "aov_list": [],
-            "additional_options": {}
+            "additional_options": []
         },
         "vray_renderer": {
             "image_prefix": "maya/<scene>/<Layer>/<Layer>",
             "engine": "1",
             "image_format": "png",
             "aov_list": [],
-            "additional_options": {}
+            "additional_options": []
         },
         "redshift_renderer": {
             "image_prefix": "maya/<Scene>/<RenderLayer>/<RenderLayer>",
@@ -59,7 +59,7 @@
             "multilayer_exr": true,
             "force_combine": true,
             "aov_list": [],
-            "additional_options": {}
+            "additional_options": []
         }
     },
     "create": {

--- a/openpype/settings/defaults/project_settings/traypublisher.json
+++ b/openpype/settings/defaults/project_settings/traypublisher.json
@@ -294,8 +294,12 @@
         }
     },
     "BatchMovieCreator": {
-        "default_variants": ["Main"],
-        "default_tasks": ["Compositing"],
+        "default_variants": [
+            "Main"
+        ],
+        "default_tasks": [
+            "Compositing"
+        ],
         "extensions": [
             ".mov"
         ]


### PR DESCRIPTION
## Brief description
Default settings for maya RenderSettings use list instead of dictionary which is defined in settings schemas.

## Description
Resaved default settings using settings UI which reorganized formatting of few lines in default settings and fixed wrong types.

## Testing notes:
I hope nothing should change.