### PR TITLE
Webpublisher: timeout for PS studio processing

### DIFF
--- a/openpype/lib/remote_publish.py
+++ b/openpype/lib/remote_publish.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from datetime import datetime
 import collections
 
@@ -179,7 +178,11 @@ def publish_and_log(dbcon, _id, log, close_plugin_name=None, batch_id=None):
 
 
 def fail_batch(_id, dbcon, msg):
-    """Set current batch as failed as there is some problem."""
+    """Set current batch as failed as there is some problem.
+
+    Raises:
+        ValueError
+    """
     dbcon.update_one(
         {"_id": _id},
         {"$set":
@@ -267,7 +270,7 @@ def get_timeout(project_name, host_name, task_type):
     timeout_profiles = (get_project_settings(project_name)["webpublisher"]
                                                           ["timeout_profiles"])
     matching_item = filter_profiles(timeout_profiles, filter_data)
-    timeout = sys.maxsize
+    timeout = 3600
     if matching_item:
         timeout = matching_item["timeout"]
 

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -286,8 +286,6 @@ class PypeCommands:
                 launched_app.terminate()
                 msg = "Timeout reached"
                 fail_batch(_id, dbcon, msg)
-                raise ValueError("Timeout reached")
-
 
     @staticmethod
     def remotepublish(project, batch_path, user_email, targets=None):

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -171,7 +171,7 @@ class PypeCommands:
         log.info("Publish finished.")
 
     @staticmethod
-    def remotepublishfromapp(project, batch_path, host_name,
+    def remotepublishfromapp(project_name, batch_path, host_name,
                              user_email, targets=None):
         """Opens installed variant of 'host' and run remote publish there.
 
@@ -190,8 +190,8 @@ class PypeCommands:
         Runs publish process as user would, in automatic fashion.
 
         Args:
-            project (str): project to publish (only single context is expected
-                per call of remotepublish
+            project_name (str): project to publish (only single context is
+                expected per call of remotepublish
             batch_path (str): Path batch folder. Contains subfolders with
                 resources (workfile, another subfolder 'renders' etc.)
             host_name (str): 'photoshop'
@@ -232,7 +232,7 @@ class PypeCommands:
             fail_batch(_id, dbcon, msg)
             print("Another batch running, probably stuck, ask admin for help")
 
-        asset, task_name, task_type = get_batch_asset_task_info(
+        asset_name, task_name, task_type = get_batch_asset_task_info(
             task_data["context"])
 
         application_manager = ApplicationManager()
@@ -241,8 +241,8 @@ class PypeCommands:
 
         # must have for proper launch of app
         env = get_app_environments_for_context(
-            project,
-            asset,
+            project_name,
+            asset_name,
             task_name,
             app_name
         )
@@ -270,14 +270,14 @@ class PypeCommands:
         data = {
             "last_workfile_path": workfile_path,
             "start_last_workfile": True,
-            "project_name": project,
-            "asset_name": asset,
+            "project_name": project_name,
+            "asset_name": asset_name,
             "task_name": task_name
         }
 
         launched_app = application_manager.launch(app_name, **data)
 
-        timeout = get_timeout(project, host_name, task_type)
+        timeout = get_timeout(project_name, host_name, task_type)
 
         time_start = time.time()
         while launched_app.poll() is None:

--- a/openpype/settings/defaults/project_settings/webpublisher.json
+++ b/openpype/settings/defaults/project_settings/webpublisher.json
@@ -1,4 +1,13 @@
 {
+    "timeout_profiles": [
+        {
+            "hosts": [
+                "photoshop"
+            ],
+            "task_types": [],
+            "timeout": 600
+        }
+    ],
     "publish": {
         "CollectPublishedFiles": {
             "task_type_to_family": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
@@ -6,6 +6,38 @@
     "is_file": true,
     "children": [
         {
+            "type": "list",
+            "collapsible": true,
+            "use_label_wrap": true,
+            "key": "timeout_profiles",
+            "label": "Timeout profiles",
+            "object_type": {
+                "type": "dict",
+                "children": [
+                    {
+                        "key": "hosts",
+                        "label": "Host names",
+                        "type": "hosts-enum",
+                        "multiselection": true
+                    },
+                    {
+                        "key": "task_types",
+                        "label": "Task types",
+                        "type": "task-types-enum",
+                        "multiselection": true
+                    },
+                    {
+                        "type": "separator"
+                    },
+                    {
+                        "type": "number",
+                        "key": "timeout",
+                        "label": "Timeout (sec)"
+                    }
+                ]
+            }
+        },
+        {
             "type": "dict",
             "collapsible": true,
             "key": "publish",


### PR DESCRIPTION
## Brief description
Introduced configurable timeout for PS studio processing jobs.

## Description
Sometimes publishing job could get stuck on Photoshop side because some dialog requiring user interaction. This should limit that and kill the process.

In the code 1 hour limit is hardcoded if no configuration is found.

![Screenshot 2022-08-04 155208](https://user-images.githubusercontent.com/4457962/182865079-56faadca-9af4-45a1-a1d6-c6b38276f113.png)

## Testing notes:
1. Configure some small timeout in `project_settings/webpublisher/timeout_profiles`
2. Run studio processing job in PS that triggers user dialog