### PR TITLE
General: Extract review aspect ratio scale is calculated by ffmpeg

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1390,9 +1390,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
             self.log.debug("height_half_pad: `{}`".format(height_half_pad))
 
             filters.extend([
-                "scale={}x{}:flags=lanczos".format(
-                    width_scale, height_scale
-                ),
+                (
+                    "scale={}x{}"
+                    ":flags=lanczos"
+                    ":force_original_aspect_ratio=decrease"
+                ).format(output_width, output_height),
                 "pad={}:{}:{}:{}:{}".format(
                     output_width, output_height,
                     width_half_pad, height_half_pad,

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1369,35 +1369,14 @@ class ExtractReview(pyblish.api.InstancePlugin):
             or input_width != output_width
             or pixel_aspect != 1
         ):
-            if input_res_ratio < output_res_ratio:
-                self.log.debug(
-                    "Input's resolution ratio is lower then output's"
-                )
-                width_scale = int(input_width * scale_factor_by_height)
-                width_half_pad = int((output_width - width_scale) / 2)
-                height_scale = output_height
-                height_half_pad = 0
-            else:
-                self.log.debug("Input is heigher then output")
-                width_scale = output_width
-                width_half_pad = 0
-                height_scale = int(input_height * scale_factor_by_width)
-                height_half_pad = int((output_height - height_scale) / 2)
-
-            self.log.debug("width_scale: `{}`".format(width_scale))
-            self.log.debug("width_half_pad: `{}`".format(width_half_pad))
-            self.log.debug("height_scale: `{}`".format(height_scale))
-            self.log.debug("height_half_pad: `{}`".format(height_half_pad))
-
             filters.extend([
                 (
                     "scale={}x{}"
                     ":flags=lanczos"
                     ":force_original_aspect_ratio=decrease"
                 ).format(output_width, output_height),
-                "pad={}:{}:{}:{}:{}".format(
+                "pad={}:{}:(ow-iw)/2:(oh-ih)/2:{}".format(
                     output_width, output_height,
-                    width_half_pad, height_half_pad,
                     overscan_color_value
                 ),
                 "setsar=1"


### PR DESCRIPTION
## Brief description
Ratio scaling calculations happens in ffmpeg instead of our python code.

## Description
It happened that `1080` after python float calculations becomes `1081` which cause a lot of troubles. The main reason why we did that was to keep aspect ratio but ffmpeg scale has `force_original_aspect_ratio` option which keep ration by decreasin or increasing (in our case decreasing) and calculate padding difference in ffmpeg too.

## Additional info
This is huge change and should be tested properly. Changes affect cases when scale is needed and when input and output have different aspect ratio (scale is needed).

## Testing notes:
Force extract review to output a video which has different aspect ratio (visible with an eye) then converted input. The output should have right resolution and should be padded the right way.