### PR TITLE
Nuke: support environment variables in gizmo menu

### DIFF
--- a/openpype/hosts/nuke/api/gizmo_menu.py
+++ b/openpype/hosts/nuke/api/gizmo_menu.py
@@ -56,7 +56,7 @@ class GizmoMenu():
                 if item_type == ("python" or "file"):
                     parent.addCommand(
                         item["title"],
-                        command=str(item["command"]),
+                        command=str(item["command"].format(**os.environ)),
                         icon=item.get("icon"),
                         shortcut=item.get("hotkey")
                     )


### PR DESCRIPTION
## Brief description
A little update to accept environment variables in the command part of the gizmo menu.

## Description
We can now use environment variables in the python command part of the gizmo menu definition

![image](https://user-images.githubusercontent.com/51854004/183075638-88865da0-2680-4b96-827b-9e62a0aa9e18.png)
