### PR TITLE
Maya:  fix aov separator in Redshift

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -963,7 +963,7 @@ class RenderProductsRedshift(ARenderProducts):
 
         """
         prefix = super(RenderProductsRedshift, self).get_renderer_prefix()
-        prefix = "{}{}<aov>".format(prefix, self.aov_separator)
+        prefix = "{}{}<aov>".format(prefix, self.layer_data["aov_separator"])
         return prefix
 
     def get_render_products(self):

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -205,7 +205,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 .get('maya')\
                 .get('create')\
                 .get('CreateRender')\
-                .get('default_render_image_folder')
+                .get('default_render_image_folder') or ""
             # replace relative paths with absolute. Render products are
             # returned as list of dictionaries.
             publish_meta_path = None
@@ -318,7 +318,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "useReferencedAovs": render_instance.data.get(
                     "useReferencedAovs") or render_instance.data.get(
                         "vrayUseReferencedAovs") or False,
-                "aovSeparator": aov_separator
+                "aovSeparator": layer_render_products.layer_data.aov_separator  # noqa: E501
             }
 
             # Collect Deadline url if Deadline module is enabled


### PR DESCRIPTION
## Bug

Getting AOV separator for Redshift breaks render layer collection. This is fixing it, using the same default logic even for Redshift.