### PR TITLE
fix the bug of failing to extract look when UDIMs format used in AiImage

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,7 +429,7 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                # get all the resolved files in Maya File Path Editor 
+                # get all the resolved files
                 metadata = files_metadata.get(source)
                 if metadata:
                     metadata = files_metadata[source]

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,7 +429,7 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                # get all the resolved files
+                # get all resolved files
                 metadata = files_metadata.get(source)
                 # if the files are unresolved from `source` 
                 # assume color space from the first file of 

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -430,11 +430,11 @@ class ExtractLook(openpype.api.Extractor):
                 color_space = "Raw"
             else:
                 try:
-                    if files_metadata[source]["color_space"]  == "Raw":
+                    if files_metadata[source]["color_space"] == "Raw":
                     # set color space to raw if we linearized it
                         color_space = "Raw"
                 except KeyError:
-                    #set color space to Raw if the attribute of the color space is raw.
+                    # set color space to Raw if the attribute of the color space is raw.
                     if cmds.getAttr(color_space_attr) == "Raw":
                         color_space = "Raw"
                 # Remap file node filename to destination

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,7 +429,7 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                # get all the resolved files 
+                # get all the resolved files in Maya File Path Editor 
                 src = files_metadata.get(source)
                 if src:
                     if files_metadata[source]["color_space"] == "Raw":

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -430,22 +430,25 @@ class ExtractLook(openpype.api.Extractor):
                 color_space = "Raw"
             else:
                 # get all the resolved files in Maya File Path Editor 
-                src = files_metadata.get(source)
-                if src:
-                    if files_metadata[source]["color_space"] == "Raw":
+                metadata = files_metadata.get(source)
+                if metadata:
+                    metadata = files_metadata[source]
+                    if metadata["color_space"] == "Raw":
                         # set color space to raw if we linearized it
                         color_space = "Raw"
                 else:
                     # if the files are unresolved from `source`
                     # assume color space from the first file of 
                     # the resource
-                    first_file = next(iter(resource.get("files", [])), None)
-                    if not first_file:
-                        continue
-                    filepath = os.path.normpath(first_file)
-                    # if the files are unresolved
-                    if files_metadata[filepath]["color_space"] == "Raw":
-                    # set color space to raw if we linearized it
+                    metadata = files_metadata.get(source)
+                    if not metadata:
+                        first_file = next(iter(resource.get("files", [])), None)
+                        if not first_file:
+                            continue
+                    first_filepath = os.path.normpath(first_file)
+                    metadata = files_metadata[first_filepath]
+                    if metadata["color_space"] == "Raw":
+                        # set color space to raw if we linearized it
                         color_space = "Raw"
                 # Remap file node filename to destination
                 remap[color_space_attr] = color_space

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,9 +429,14 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                if files_metadata[source]["color_space"] == "Raw":
+                try:
+                    if files_metadata[source]["color_space"]  == "Raw":
                     # set color space to raw if we linearized it
-                    color_space = "Raw"
+                        color_space = "Raw"
+                except KeyError:
+                    #set color space to Raw if the attribute of the color space is raw.
+                    if cmds.getAttr(color_space_attr) == "Raw":
+                        color_space = "Raw"
                 # Remap file node filename to destination
                 remap[color_space_attr] = color_space
             attr = resource["attribute"]

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -436,15 +436,12 @@ class ExtractLook(openpype.api.Extractor):
                         # set color space to raw if we linearized it
                         color_space = "Raw"
                 else:
-
                     # if the files are unresolved from `source`
                     # assume color space from the first file of 
                     # the resource
                     first_file = next(iter(resource.get("files", [])), None)
                     if not first_file:
-                        # No files for this resource? Can this happen? Should this error?
                         continue
-                        
                     filepath = os.path.normpath(first_file)
                     # if the files are unresolved
                     if files_metadata[filepath]["color_space"] == "Raw":

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,7 +429,7 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                #get all the resolved files 
+                # get all the resolved files 
                 src = files_metadata.get(source)
                 if src:
                     if files_metadata[source]["color_space"] == "Raw":

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -431,24 +431,17 @@ class ExtractLook(openpype.api.Extractor):
             else:
                 # get all the resolved files
                 metadata = files_metadata.get(source)
-                if metadata:
-                    metadata = files_metadata[source]
-                    if metadata["color_space"] == "Raw":
-                        # set color space to raw if we linearized it
-                        color_space = "Raw"
-                else:
-                    # if the files are unresolved from `source`
-                    # assume color space from the first file of 
-                    # the resource
-                    metadata = files_metadata.get(source)
-                    if not metadata:
-                        first_file = next(iter(resource.get(
-                            "files", [])), None)
-                        if not first_file:
-                            continue
+                # if the files are unresolved from `source`
+                # assume color space from the first file of 
+                # the resource
+                if not metadata:
+                    first_file = next(iter(resource.get(
+                        "files", [])), None)
+                    if not first_file:
+                        continue
                     first_filepath = os.path.normpath(first_file)
                     metadata = files_metadata[first_filepath]
-                    if metadata["color_space"] == "Raw":
+                if metadata["color_space"] == "Raw":
                         # set color space to raw if we linearized it
                         color_space = "Raw"
                 # Remap file node filename to destination

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,7 +429,17 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                color_space = "Raw"
+                #get all the resolved files 
+                src = files_metadata.get(source)
+                if src:
+                    if files_metadata[source]["color_space"] == "Raw":
+                        # set color space to raw if we linearized it
+                        color_space = "Raw"
+                else:
+                    # if the files are unresolved
+                    if files_metadata[filepath]["color_space"] == "Raw":
+                    # set color space to raw if we linearized it
+                        color_space = "Raw"
                 # Remap file node filename to destination
                 remap[color_space_attr] = color_space
             attr = resource["attribute"]

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,7 +429,6 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                # get all resolved files
                 metadata = files_metadata.get(source)
                 # if the files are unresolved from `source` 
                 # assume color space from the first file of 

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -436,6 +436,16 @@ class ExtractLook(openpype.api.Extractor):
                         # set color space to raw if we linearized it
                         color_space = "Raw"
                 else:
+
+                    # if the files are unresolved from `source`
+                    # assume color space from the first file of 
+                    # the resource
+                    first_file = next(iter(resource.get("files", [])), None)
+                    if not first_file:
+                        # No files for this resource? Can this happen? Should this error?
+                        continue
+                        
+                    filepath = os.path.normpath(first_file)
                     # if the files are unresolved
                     if files_metadata[filepath]["color_space"] == "Raw":
                     # set color space to raw if we linearized it

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -442,8 +442,8 @@ class ExtractLook(openpype.api.Extractor):
                     first_filepath = os.path.normpath(first_file)
                     metadata = files_metadata[first_filepath]
                 if metadata["color_space"] == "Raw":
-                        # set color space to raw if we linearized it
-                        color_space = "Raw"
+                    # set color space to raw if we linearized it
+                    color_space = "Raw"
                 # Remap file node filename to destination
                 remap[color_space_attr] = color_space
             attr = resource["attribute"]

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,14 +429,7 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
-                try:
-                    if files_metadata[source]["color_space"] == "Raw":
-                    # set color space to raw if we linearized it
-                        color_space = "Raw"
-                except KeyError:
-                    # set color space to Raw if its attribute is raw.
-                    if cmds.getAttr(color_space_attr) == "Raw":
-                        color_space = "Raw"
+                color_space = "Raw"
                 # Remap file node filename to destination
                 remap[color_space_attr] = color_space
             attr = resource["attribute"]

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -429,9 +429,10 @@ class ExtractLook(openpype.api.Extractor):
                 # node doesn't have color space attribute
                 color_space = "Raw"
             else:
+                # get the resolved files
                 metadata = files_metadata.get(source)
-                # if the files are unresolved from `source` 
-                # assume color space from the first file of 
+                # if the files are unresolved from `source`
+                # assume color space from the first file of
                 # the resource
                 if not metadata:
                     first_file = next(iter(resource.get(

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -434,7 +434,7 @@ class ExtractLook(openpype.api.Extractor):
                     # set color space to raw if we linearized it
                         color_space = "Raw"
                 except KeyError:
-                    # set color space to Raw if the attribute of the color space is raw.
+                    # set color space to Raw if its attribute is raw.
                     if cmds.getAttr(color_space_attr) == "Raw":
                         color_space = "Raw"
                 # Remap file node filename to destination

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -431,7 +431,7 @@ class ExtractLook(openpype.api.Extractor):
             else:
                 # get all the resolved files
                 metadata = files_metadata.get(source)
-                # if the files are unresolved from `source`
+                # if the files are unresolved from `source` 
                 # assume color space from the first file of 
                 # the resource
                 if not metadata:

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -442,7 +442,8 @@ class ExtractLook(openpype.api.Extractor):
                     # the resource
                     metadata = files_metadata.get(source)
                     if not metadata:
-                        first_file = next(iter(resource.get("files", [])), None)
+                        first_file = next(iter(resource.get(
+                            "files", [])), None)
                         if not first_file:
                             continue
                     first_filepath = os.path.normpath(first_file)


### PR DESCRIPTION
## Brief description
When the user added a texture with AiImage with UDIMs format and assign the look instance to the mesh with the texture, it will result to the KeyError when publishing the look.

## Root cause
the system cannot find the texture path when passing through the if-condition code: `if files_metadata[source]["color_space"] == "Raw"`. This error contributes to the Maya File Path Editor, which maya cannot resolve the udim path in AiImage.
![image](https://user-images.githubusercontent.com/64118225/183592572-8d9e2712-c809-4225-b747-d173a332db8a.png)

## Solution
~~Introduce exception handling to tell the system to reference the color_space attribute of the AiImage node itself to set up the color_space to raw specifically for the AiImage case.~~ 
UPDATE: Get the resolved files from `resource.get("source")` and tell the system to do the condition of `file_metadata[source]["color_space"] == "Raw"` to set color_space if the files are considered as resolved. If the files are considered as unresolved, the system would generally look at the filepath before self._process_texture(processing the texture) `file_metadata[filepath]["color_space"] == "Raw"`and set the color space
This is generally not the best way to deal with the issue/bug . Some conversations with Autodesk regarding to the Maya File Path Editor may be needed to "solve" this.