### PR TITLE
Maya: FBX support for update in reference loader

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -236,10 +236,16 @@ class ReferenceLoader(Loader):
                                            representation["context"]
                                                          ["project"]
                                                          ["name"])
+
+            params = {
+                "loadReference": reference_node,
+                "returnNewNodes": True
+            }
+            if file_type != "fbx":
+                params["type"] = file_type
+
             content = cmds.file(path,
-                                loadReference=reference_node,
-                                type=file_type,
-                                returnNewNodes=True)
+                                **params)
         except RuntimeError as exc:
             # When changing a reference to a file that has load errors the
             # command will raise an error even if the file is still loaded

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -209,7 +209,7 @@ class ReferenceLoader(Loader):
             "ma": "mayaAscii",
             "mb": "mayaBinary",
             "abc": "Alembic",
-            "fbx": "fbx"
+            "fbx": "FBX"
         }.get(representation["name"])
 
         assert file_type, "Unsupported representation: %s" % representation
@@ -236,16 +236,10 @@ class ReferenceLoader(Loader):
                                            representation["context"]
                                                          ["project"]
                                                          ["name"])
-
-            params = {
-                "loadReference": reference_node,
-                "returnNewNodes": True
-            }
-            if file_type != "fbx":
-                params["type"] = file_type
-
             content = cmds.file(path,
-                                **params)
+                                loadReference=reference_node,
+                                type=file_type,
+                                returnNewNodes=True)
         except RuntimeError as exc:
             # When changing a reference to a file that has load errors the
             # command will raise an error even if the file is still loaded

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -208,7 +208,8 @@ class ReferenceLoader(Loader):
         file_type = {
             "ma": "mayaAscii",
             "mb": "mayaBinary",
-            "abc": "Alembic"
+            "abc": "Alembic",
+            "fbx": "fbx"
         }.get(representation["name"])
 
         assert file_type, "Unsupported representation: %s" % representation

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -235,7 +235,7 @@ class ReferenceLoader(Loader):
             path = self.prepare_root_value(path,
                                            representation["context"]
                                                          ["project"]
-                                                         ["code"])
+                                                         ["name"])
             content = cmds.file(path,
                                 loadReference=reference_node,
                                 type=file_type,


### PR DESCRIPTION
## Brief description
Fixes a problem with Maya for which it is impossible to set hero version for Unreal Static Meshes.

## Description
It happens because Unreal Static Meshes are FBXs, and the FBX format was unsupported in the update function of the Reference Loader.

## Testing notes:
1. Publish a model as Unreal Static Mesh with hero version enabled for the `staticMesh` family.
2. Load the model as hero version *or* change to hero version for a loaded Static Mesh.