### PR TITLE
Nuke: color settings for render write node is working now

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -912,7 +912,7 @@ def get_render_path(node):
     avalon_knob_data = read_avalon_data(node)
 
     nuke_imageio_writes = get_imageio_node_setting(
-        node_class=avalon_knob_data["family"],
+        node_class=avalon_knob_data["families"],
         plugin_name=avalon_knob_data["creator"],
         subset=avalon_knob_data["subset"]
     )
@@ -1920,7 +1920,7 @@ class WorkfileSettings(object):
                 families.append(avalon_knob_data.get("families"))
 
             nuke_imageio_writes = get_imageio_node_setting(
-                node_class=avalon_knob_data["family"],
+                node_class=avalon_knob_data["families"],
                 plugin_name=avalon_knob_data["creator"],
                 subset=avalon_knob_data["subset"]
             )
@@ -2219,7 +2219,7 @@ def get_write_node_template_attr(node):
     avalon_knob_data = read_avalon_data(node)
     # get template data
     nuke_imageio_writes = get_imageio_node_setting(
-        node_class=avalon_knob_data["family"],
+        node_class=avalon_knob_data["families"],
         plugin_name=avalon_knob_data["creator"],
         subset=avalon_knob_data["subset"]
     )


### PR DESCRIPTION
## Brief description
Getting correct settings for write node was not working.

## Additional info
Key name in avalon data was defined as `family` but in reality in settings and in publishing plugins we are using `families`.

## Testing notes:
1. open nuke workfile and create render write node.
2. open settings and go to `project_anatomy/imageio/nuke/nodes/requiredNodes/0/knobs/6/value` and set to different colorspace setting.
3. Save settings and then go back to nuke and in openpype menu chose `Apply all`
4. colorspace on write node should change (this can only be seen inside the write node group)