### PR TITLE
Refactor `get_output_link_versions` to query id instead of input

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -819,7 +819,7 @@ def get_output_link_versions(project_name, version_id, fields=None):
     # Does make sense to look for hero versions?
     query_filter = {
         "type": "version",
-        "data.inputLinks.input": version_id
+        "data.inputLinks.id": version_id
     }
     return conn.find(query_filter, _prepare_fields(fields))
 


### PR DESCRIPTION
## Brief description

This fixes `get_output_link_versions` query.

Now it search for `data.inputLinks.id` instead of `data.inputLinks.input`

## Description

With this change the Outputs in the Loader are now also correctly shown:

![afbeelding](https://user-images.githubusercontent.com/2439881/183625387-43e920f6-d44e-4eaa-888c-f7607caa3320.png)

## Additional info

Note: The old logic is likely due to how the ids were stored previously. So we might want to add backwards compatibility similar to [how the SimpleLinkView does for inputs here](https://github.com/pypeclub/OpenPype/blob/a04840eadfc7e0be3d69e7a0c2dd13bd9109393b/openpype/tools/assetlinks/widgets.py#L64-L68).

Or if that "old style" is **ancient legacy** we can also remove the backwards compatibility there and only consider entries with `id` data present for inputs.

---

This will be a useful fix once #3629 is merged as well. It'll allow you to trace easily from a specific version in what publishes it's used down the line.