### PR TITLE
General: Hero version representations have full context

### DIFF
--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -313,13 +313,9 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
                 }
                 repre_context = template_filled.used_values
                 for key in self.db_representation_context_keys:
-                    if (
-                        key in repre_context or
-                        key not in anatomy_data
-                    ):
-                        continue
-
-                    repre_context[key] = anatomy_data[key]
+                    value = anatomy_data.get(key)
+                    if value is not None:
+                        repre_context[key] = value
 
                 # Prepare new repre
                 repre = copy.deepcopy(repre_info["representation"])


### PR DESCRIPTION
## Brief description
Add all keys from anatomy data to representation context even if it's already there.

## Description
Integrate hero versions skipped reusing of anatomy data values in repre context if the key was already there but e.g. for `project` or `task` the key can be there but not all subkeys were used. Was found out because project name was filled but project code was missing in representation context.

## Testing notes:
1. Publish hero version which does not use project code in templates
2. Check DB if representations contain project code in `context`