### PR TITLE
Maya: Refactor moved usage of CreateRender settings

### DIFF
--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -60,8 +60,7 @@ class RenderSettings(object):
         try:
             aov_separator = self._aov_chars[(
                 self._project_settings["maya"]
-                                      ["create"]
-                                      ["CreateRender"]
+                                      ["RenderSettings"]
                                       ["aov_separator"]
             )]
         except KeyError:

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -203,8 +203,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             aov_dict = {}
             default_render_file = context.data.get('project_settings')\
                 .get('maya')\
-                .get('create')\
-                .get('CreateRender')\
+                .get('RenderSettings')\
                 .get('default_render_image_folder') or ""
             # replace relative paths with absolute. Render products are
             # returned as list of dictionaries.

--- a/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
@@ -41,6 +41,5 @@ class ValidateRenderImageRule(pyblish.api.InstancePlugin):
     def get_default_render_image_folder(instance):
         return instance.context.data.get('project_settings')\
             .get('maya') \
-            .get('create') \
-            .get('CreateRender') \
+            .get('RenderSettings') \
             .get('default_render_image_folder')

--- a/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
@@ -33,9 +33,13 @@ class ValidateRenderImageRule(pyblish.api.InstancePlugin):
 
     @classmethod
     def repair(cls, instance):
-        default = cls.get_default_render_image_folder(instance)
-        cmds.workspace(fileRule=("images", default))
-        cmds.workspace(saveWorkspace=True)
+
+        required_images_rule = cls.get_default_render_image_folder(instance)
+        current_images_rule = cmds.workspace(fileRuleEntry="images")
+
+        if current_images_rule != required_images_rule:
+            cmds.workspace(fileRule=("images", required_images_rule))
+            cmds.workspace(saveWorkspace=True)
 
     @staticmethod
     def get_default_render_image_folder(instance):

--- a/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
@@ -1,13 +1,7 @@
-import maya.mel as mel
-import pymel.core as pm
+from maya import cmds
 
 import pyblish.api
 import openpype.api
-
-
-def get_file_rule(rule):
-    """Workaround for a bug in python with cmds.workspace"""
-    return mel.eval('workspace -query -fileRuleEntry "{}"'.format(rule))
 
 
 class ValidateRenderImageRule(pyblish.api.InstancePlugin):
@@ -28,7 +22,7 @@ class ValidateRenderImageRule(pyblish.api.InstancePlugin):
     def process(self, instance):
 
         required_images_rule = self.get_default_render_image_folder(instance)
-        current_images_rule = get_file_rule("images")
+        current_images_rule = cmds.workspace(fileRuleEntry="images")
 
         assert current_images_rule == required_images_rule, (
             "Invalid workspace `images` file rule value: '{}'. "
@@ -40,8 +34,8 @@ class ValidateRenderImageRule(pyblish.api.InstancePlugin):
     @classmethod
     def repair(cls, instance):
         default = cls.get_default_render_image_folder(instance)
-        pm.workspace.fileRules["images"] = default
-        pm.system.Workspace.save()
+        cmds.workspace(fileRule=("images", default))
+        cmds.workspace(saveWorkspace=True)
 
     @staticmethod
     def get_default_render_image_folder(instance):

--- a/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_image_rule.py
@@ -11,7 +11,11 @@ def get_file_rule(rule):
 
 
 class ValidateRenderImageRule(pyblish.api.InstancePlugin):
-    """Validates "images" file rule is set to "renders/"
+    """Validates Maya Workpace "images" file rule matches project settings.
+
+    This validates against the configured default render image folder:
+        Studio Settings > Project > Maya >
+        Render Settings > Default render image folder.
 
     """
 
@@ -23,11 +27,13 @@ class ValidateRenderImageRule(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        default_render_file = self.get_default_render_image_folder(instance)
+        required_images_rule = self.get_default_render_image_folder(instance)
+        current_images_rule = get_file_rule("images")
 
-        assert get_file_rule("images") == default_render_file, (
-            "Workspace's `images` file rule must be set to: {}".format(
-                default_render_file
+        assert current_images_rule == required_images_rule, (
+            "Invalid workspace `images` file rule value: '{}'. "
+            "Must be set to: '{}'".format(
+                current_images_rule, required_images_rule
             )
         )
 

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -413,8 +413,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         # Gather needed data ------------------------------------------------
         default_render_file = instance.context.data.get('project_settings')\
             .get('maya')\
-            .get('create')\
-            .get('CreateRender')\
+            .get('RenderSettings')\
             .get('default_render_image_folder')
         filename = os.path.basename(filepath)
         comment = context.data.get("comment", "")

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -33,7 +33,7 @@
     },
     "RenderSettings": {
         "apply_render_settings": true,
-        "default_render_image_folder": "",
+        "default_render_image_folder": "renders",
         "aov_separator": "underscore",
         "reset_current_frame": false,
         "arnold_renderer": {


### PR DESCRIPTION
## Brief description

This is a draft untested PR to fix #3642 

## Description

Please test publishing from Maya with up-to-date saved settings.

## Testing 

1. Ensure render images file rule works as expected.
2. Ensure aov separator works as expected