### PR TITLE
General: Extract Review can scale with pixel aspect ratio

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -85,6 +85,7 @@
                             ],
                             "width": 0,
                             "height": 0,
+                            "scale_pixel_aspect": true,
                             "bg_color": [
                                 0,
                                 0,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -321,6 +321,15 @@
                                         },
                                         {
                                             "type": "label",
+                                            "label": "Rescale input when it's pixel aspect ratio is not 1. Usefull for anamorph reviews."
+                                        },
+                                        {
+                                            "key": "scale_pixel_aspect",
+                                            "label": "Scale pixel aspect",
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "label",
                                             "label": "Background color is used only when input have transparency and Alpha is higher than 0."
                                         },
                                         {


### PR DESCRIPTION
## Brief description
This [PR](https://github.com/pypeclub/OpenPype/pull/3620) removed ability to scale source using pixel aspect ratio which is fixed here.

## Description
Next paragraf is more elaborate text with more info. This will be displayed for example in collapsed form under the first sentence in a changelog.

## Additional info
The rest will be ignored in changelog and should contain any additional
technical information.

## Testing notes:
1. Make sure `project_settings/global/publish/ExtractReview/profiles/0/outputs/h264/scale_pixel_aspect` is set to true
2. Publish something with pixel aspect ratio different then 1
- from what I know it's possible from nuke or editorial
- e.g. anamorphic image (pixel aspect is 2 so 100x100 should have resolution 200x100)
3. Check output which should be scaled as expected

Resolves https://github.com/pypeclub/OpenPype/issues/3641