### PR TITLE
Maya: Hosts as modules

### DIFF
--- a/openpype/host/host.py
+++ b/openpype/host/host.py
@@ -19,8 +19,15 @@ class MissingMethodsError(ValueError):
         joined_missing = ", ".join(
             ['"{}"'.format(item) for item in missing_methods]
         )
+        if isinstance(host, HostBase):
+            host_name = host.name
+        else:
+            try:
+                host_name = host.__file__.replace("\\", "/").split("/")[-3]
+            except Exception:
+                host_name = str(host)
         message = (
-            "Host \"{}\" miss methods {}".format(host.name, joined_missing)
+            "Host \"{}\" miss methods {}".format(host_name, joined_missing)
         )
         super(MissingMethodsError, self).__init__(message)
 

--- a/openpype/hosts/maya/__init__.py
+++ b/openpype/hosts/maya/__init__.py
@@ -1,4 +1,5 @@
 import os
+from .module import OpenPypeMaya
 
 
 def add_implementation_envs(env, _app):
@@ -25,3 +26,9 @@ def add_implementation_envs(env, _app):
     for key, value in defaults.items():
         if not env.get(key):
             env[key] = value
+
+
+__all__ = (
+    "OpenPypeMaya",
+    "add_implementation_envs",
+)

--- a/openpype/hosts/maya/__init__.py
+++ b/openpype/hosts/maya/__init__.py
@@ -1,34 +1,6 @@
-import os
 from .module import OpenPypeMaya
-
-
-def add_implementation_envs(env, _app):
-    # Add requirements to PYTHONPATH
-    pype_root = os.environ["OPENPYPE_REPOS_ROOT"]
-    new_python_paths = [
-        os.path.join(pype_root, "openpype", "hosts", "maya", "startup")
-    ]
-    old_python_path = env.get("PYTHONPATH") or ""
-    for path in old_python_path.split(os.pathsep):
-        if not path:
-            continue
-
-        norm_path = os.path.normpath(path)
-        if norm_path not in new_python_paths:
-            new_python_paths.append(norm_path)
-
-    env["PYTHONPATH"] = os.pathsep.join(new_python_paths)
-
-    # Set default values if are not already set via settings
-    defaults = {
-        "OPENPYPE_LOG_NO_COLORS": "Yes"
-    }
-    for key, value in defaults.items():
-        if not env.get(key):
-            env[key] = value
 
 
 __all__ = (
     "OpenPypeMaya",
-    "add_implementation_envs",
 )

--- a/openpype/hosts/maya/api/workio.py
+++ b/openpype/hosts/maya/api/workio.py
@@ -2,11 +2,9 @@
 import os
 from maya import cmds
 
-from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
-
 
 def file_extensions():
-    return HOST_WORKFILE_EXTENSIONS["maya"]
+    return [".ma", ".mb"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/maya/module.py
+++ b/openpype/hosts/maya/module.py
@@ -42,3 +42,6 @@ class OpenPypeMaya(OpenPypeModule, IHostModule):
         return [
             os.path.join(MAYA_ROOT_DIR, "hooks")
         ]
+
+    def get_workfile_extensions(self):
+        return [".ma", ".mb"]

--- a/openpype/hosts/maya/module.py
+++ b/openpype/hosts/maya/module.py
@@ -1,0 +1,10 @@
+from openpype.modules import OpenPypeModule
+from openpype.modules.interfaces import IHostModule
+
+
+class OpenPypeMaya(OpenPypeModule, IHostModule):
+    name = "openpype_maya"
+    host_name = "maya"
+
+    def initialize(self, module_settings):
+        self.enabled = True

--- a/openpype/hosts/maya/module.py
+++ b/openpype/hosts/maya/module.py
@@ -35,3 +35,10 @@ class OpenPypeMaya(OpenPypeModule, IHostModule):
         for key, value in defaults.items():
             if not env.get(key):
                 env[key] = value
+
+    def get_launch_hook_paths(self, app):
+        if app.host_name != self.host_name:
+            return []
+        return [
+            os.path.join(MAYA_ROOT_DIR, "hooks")
+        ]

--- a/openpype/hosts/maya/module.py
+++ b/openpype/hosts/maya/module.py
@@ -1,5 +1,8 @@
+import os
 from openpype.modules import OpenPypeModule
 from openpype.modules.interfaces import IHostModule
+
+MAYA_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class OpenPypeMaya(OpenPypeModule, IHostModule):
@@ -8,3 +11,27 @@ class OpenPypeMaya(OpenPypeModule, IHostModule):
 
     def initialize(self, module_settings):
         self.enabled = True
+
+    def add_implementation_envs(self, env, _app):
+        # Add requirements to PYTHONPATH
+        new_python_paths = [
+            os.path.join(MAYA_ROOT_DIR, "startup")
+        ]
+        old_python_path = env.get("PYTHONPATH") or ""
+        for path in old_python_path.split(os.pathsep):
+            if not path:
+                continue
+
+            norm_path = os.path.normpath(path)
+            if norm_path not in new_python_paths:
+                new_python_paths.append(norm_path)
+
+        env["PYTHONPATH"] = os.pathsep.join(new_python_paths)
+
+        # Set default values if are not already set via settings
+        defaults = {
+            "OPENPYPE_LOG_NO_COLORS": "Yes"
+        }
+        for key, value in defaults.items():
+            if not env.get(key):
+                env[key] = value

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1508,8 +1508,10 @@ def prepare_app_environments(
     final_env = None
     # Add host specific environments
     if app.host_name and implementation_envs:
-        module = __import__("openpype.hosts", fromlist=[app.host_name])
-        host_module = getattr(module, app.host_name, None)
+        host_module = modules_manager.get_host_module(app.host_name)
+        if not host_module:
+            module = __import__("openpype.hosts", fromlist=[app.host_name])
+            host_module = getattr(module, app.host_name, None)
         add_implementation_envs = None
         if host_module:
             add_implementation_envs = getattr(

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -962,32 +962,24 @@ class ApplicationLaunchContext:
 
         # TODO load additional studio paths from settings
         import openpype
-        pype_dir = os.path.dirname(os.path.abspath(openpype.__file__))
+        openpype_dir = os.path.dirname(os.path.abspath(openpype.__file__))
 
-        # --- START: Backwards compatibility ---
-        hooks_dir = os.path.join(pype_dir, "hooks")
+        global_hooks_dir = os.path.join(openpype_dir, "hooks")
 
-        subfolder_names = ["global"]
-        if self.host_name:
-            subfolder_names.append(self.host_name)
-        for subfolder_name in subfolder_names:
-            path = os.path.join(hooks_dir, subfolder_name)
-            if (
-                os.path.exists(path)
-                and os.path.isdir(path)
-                and path not in paths
-            ):
-                paths.append(path)
-        # --- END: Backwards compatibility ---
-
-        subfolders_list = [
-            ["hooks"]
+        hooks_dirs = [
+            global_hooks_dir
         ]
         if self.host_name:
-            subfolders_list.append(["hosts", self.host_name, "hooks"])
+            # If host requires launch hooks and is module then launch hooks
+            #   should be collected using 'collect_launch_hook_paths'
+            #   - module have to implement 'get_launch_hook_paths'
+            host_module = self.modules_manager.get_host_module(self.host_name)
+            if not host_module:
+                hooks_dirs.append(os.path.join(
+                    openpype_dir, "hosts", self.host_name, "hooks"
+                ))
 
-        for subfolders in subfolders_list:
-            path = os.path.join(pype_dir, *subfolders)
+        for path in hooks_dirs:
             if (
                 os.path.exists(path)
                 and os.path.isdir(path)

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -996,7 +996,9 @@ class ApplicationLaunchContext:
                 paths.append(path)
 
         # Load modules paths
-        paths.extend(self.modules_manager.collect_launch_hook_paths())
+        paths.extend(
+            self.modules_manager.collect_launch_hook_paths(self.application)
+        )
 
         return paths
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -825,6 +825,45 @@ class ModulesManager:
             output.extend(hook_paths)
         return output
 
+    def get_host_module(self, host_name):
+        """Find host module by host name.
+
+        Args:
+            host_name (str): Host name for which is found host module.
+
+        Returns:
+            OpenPypeModule: Found host module by name.
+            None: There was not found module inheriting IHostModule which has
+                host name set to passed 'host_name'.
+        """
+
+        from openpype_interfaces import IHostModule
+
+        for module in self.get_enabled_modules():
+            if (
+                isinstance(module, IHostModule)
+                and module.host_name == host_name
+            ):
+                return module
+        return None
+
+    def get_host_names(self):
+        """List of available host names based on host modules.
+
+        Returns:
+            Iterable[str]: All available host names based on enabled modules
+                inheriting 'IHostModule'.
+        """
+
+        from openpype_interfaces import IHostModule
+
+        host_names = {
+            module.host_name
+            for module in self.get_enabled_modules()
+            if isinstance(module, IHostModule)
+        }
+        return host_names
+
     def print_report(self):
         """Print out report of time spent on modules initialization parts.
 

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -50,12 +50,32 @@ class IPluginPaths(OpenPypeInterface):
 class ILaunchHookPaths(OpenPypeInterface):
     """Module has launch hook paths to return.
 
+    Modules does not have to inherit from this interface (changed 8.11.2022).
+    Module just have to have implemented 'get_launch_hook_paths' to be able use
+    the advantage.
+
     Expected result is list of paths.
     ["path/to/launch_hooks_dir"]
     """
 
     @abstractmethod
-    def get_launch_hook_paths(self):
+    def get_launch_hook_paths(self, app):
+        """Paths to directory with application launch hooks.
+
+        Method can be also defined without arguments.
+        ```python
+        def get_launch_hook_paths(self):
+            return []
+        ```
+
+        Args:
+            app (Application): Application object which can be used for
+                filtering of which launch hook paths are returned.
+
+        Returns:
+            Iterable[str]: Path to directories where launch hooks can be found.
+        """
+
         pass
 
 
@@ -66,6 +86,7 @@ class ITrayModule(OpenPypeInterface):
     The module still must be usable if is not used in tray even if
     would do nothing.
     """
+
     tray_initialized = False
     _tray_manager = None
 
@@ -78,16 +99,19 @@ class ITrayModule(OpenPypeInterface):
         This is where GUIs should be loaded or tray specific parts should be
         prepared.
         """
+
         pass
 
     @abstractmethod
     def tray_menu(self, tray_menu):
         """Add module's action to tray menu."""
+
         pass
 
     @abstractmethod
     def tray_start(self):
         """Start procedure in Pype tray."""
+
         pass
 
     @abstractmethod
@@ -96,6 +120,7 @@ class ITrayModule(OpenPypeInterface):
 
         This is place where all threads should be shut.
         """
+
         pass
 
     def execute_in_main_thread(self, callback):
@@ -104,6 +129,7 @@ class ITrayModule(OpenPypeInterface):
             Some callbacks need to be processed on main thread (menu actions
             must be added on main thread or they won't get triggered etc.)
         """
+
         if not self.tray_initialized:
             # TODO Called without initialized tray, still main thread needed
             try:
@@ -128,6 +154,7 @@ class ITrayModule(OpenPypeInterface):
             msecs (int): Duration of message visibility in miliseconds.
                 Default is 10000 msecs, may differ by Qt version.
         """
+
         if self._tray_manager:
             self._tray_manager.show_tray_message(title, message, icon, msecs)
 
@@ -280,16 +307,19 @@ class ITrayService(ITrayModule):
 
     def set_service_running_icon(self):
         """Change icon of an QAction to green circle."""
+
         if self.menu_action:
             self.menu_action.setIcon(self.get_icon_running())
 
     def set_service_failed_icon(self):
         """Change icon of an QAction to red circle."""
+
         if self.menu_action:
             self.menu_action.setIcon(self.get_icon_failed())
 
     def set_service_idle_icon(self):
         """Change icon of an QAction to orange circle."""
+
         if self.menu_action:
             self.menu_action.setIcon(self.get_icon_idle())
 
@@ -303,6 +333,7 @@ class ISettingsChangeListener(OpenPypeInterface):
         "publish": ["path/to/publish_plugins"]
     }
     """
+
     @abstractmethod
     def on_system_settings_save(
         self, old_value, new_value, changes, new_value_metadata

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -361,3 +361,14 @@ class IHostModule(OpenPypeInterface):
         """Name of host which module represents."""
 
         pass
+
+    def get_workfile_extensions(self):
+        """Define workfile extensions for host.
+
+        Not all hosts support workfiles thus this is optional implementation.
+
+        Returns:
+            List[str]: Extensions used for workfiles with dot.
+        """
+
+        return []

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
 
 from openpype import resources
 
@@ -319,4 +319,14 @@ class ISettingsChangeListener(OpenPypeInterface):
     def on_project_anatomy_save(
         self, old_value, new_value, changes, project_name, new_value_metadata
     ):
+        pass
+
+
+class IHostModule(OpenPypeInterface):
+    """Module which also contain a host implementation."""
+
+    @abstractproperty
+    def host_name(self):
+        """Name of host which module represents."""
+
         pass


### PR DESCRIPTION
## Brief description
Hosts are OpenPype modules so they have more abilities and more defined structure.

## Description
First step to be able define hosts as OpenPype modules which can make them self contained parts. Added interface `IHostModule` which marks a module as host module so it can handle host related logic before a DCC or process, where host is integrated, is running. Host module must have set which host it represents with it name (`host_name`). Can define it's workfile extensions out of integration so it's available before DCC is running. As module it can handle some logic more dynamically without predetermined paths. For example can define path to launch hooks using `get_launch_hook_paths` or handle launch environments implementing `add_implementation_envs` as module method.

Changed how paths to prelaunch hooks are received. An object of application which is launched is passed as an argument to `get_launch_hook_paths` so it is possible to filter out if it make sense to add certain launch hook paths for passed application. Module does not have to inherit from `ILaunchHookPaths` to be able define launch hooks.

To demonstrate the functionality a maya implementation is now used as module.

## Testing notes:
1. Launch Maya
2. Last workfile should be used on launch (if exists and the feature is enabled)
3. Maya pre launch hooks should work (workspace mel is created)
4. OpenPype is integrated in launched maya