### PR TITLE
Maya: Redshift Skip aov file format check for Cryptomatte

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -108,8 +108,9 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
         # Get the node attributes for current renderer
         attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS['default'])
+        # Prefix attribute can return None when a value was never set
         prefix = lib.get_attr_in_layer(cls.ImagePrefixes[renderer],
-                                       layer=layer)
+                                       layer=layer) or ""
         padding = lib.get_attr_in_layer("{node}.{padding}".format(**attrs),
                                         layer=layer)
 

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -201,7 +201,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                     labels = get_redshift_image_format_labels()
                     cls.log.error(
                         "AOV file format {} does not match global file format "
-                        "{}".format(labels[default_ext], labels[aov_ext])
+                        "{}".format(labels[aov_ext], labels[default_ext])
                     )
                     invalid = True
 

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -337,8 +337,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                 cmds.optionMenuGrp("vrayRenderElementSeparator",
                                    v=instance.data.get("aovSeparator", "_"))
                 cmds.setAttr(
-                    "{}.fileNameRenderElementSeparator".format(
-                        node),
+                    "{}.fileNameRenderElementSeparator".format(node),
                     instance.data.get("aovSeparator", "_"),
                     type="string"
                 )

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -199,10 +199,10 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
                 elif default_ext != aov_ext:
                     labels = get_redshift_image_format_labels()
-                    cls.log.error(("AOV file format is not the same "
-                                   "as the one set globally "
-                                   "{} != {}").format(labels[default_ext],
-                                                      labels[aov_ext]))
+                    cls.log.error(
+                        "AOV file format {} does not match global file format "
+                        "{}".format(labels[default_ext], labels[aov_ext])
+                    )
                     invalid = True
 
         if renderer == "renderman":

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -10,6 +10,12 @@ import openpype.api
 from openpype.hosts.maya.api import lib
 
 
+def get_redshift_image_format_labels():
+    """Return nice labels for Redshift image formats."""
+    var = "$g_redshiftImageFormatLabels"
+    return mel.eval("{0}={0}".format(var))
+
+
 class ValidateRenderSettings(pyblish.api.InstancePlugin):
     """Validates the global render settings
 
@@ -191,10 +197,11 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                     pass
 
                 elif default_ext != aov_ext:
+                    labels = get_redshift_image_format_labels()
                     cls.log.error(("AOV file format is not the same "
                                    "as the one set globally "
-                                   "{} != {}").format(default_ext,
-                                                      aov_ext))
+                                   "{} != {}").format(labels[default_ext],
+                                                      labels[aov_ext]))
                     invalid = True
 
         if renderer == "renderman":

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -180,14 +180,17 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
                         redshift_AOV_prefix
                     ))
                     invalid = True
-                # get aov format
-                aov_ext = cmds.getAttr(
-                    "{}.fileFormat".format(aov), asString=True)
 
-                default_ext = cmds.getAttr(
-                    "redshiftOptions.imageFormat", asString=True)
+                # check aov file format
+                aov_ext = cmds.getAttr("{}.fileFormat".format(aov))
+                default_ext = cmds.getAttr("redshiftOptions.imageFormat")
+                aov_type = cmds.getAttr("{}.aovType".format(aov))
+                if aov_type == "Cryptomatte":
+                    # redshift Cryptomatte AOV always uses "Cryptomatte (EXR)"
+                    # so we ignore validating file format for it.
+                    pass
 
-                if default_ext != aov_ext:
+                elif default_ext != aov_ext:
                     cls.log.error(("AOV file format is not the same "
                                    "as the one set globally "
                                    "{} != {}").format(default_ext,

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -302,6 +302,9 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             default = lib.RENDER_ATTRS['default']
             render_attrs = lib.RENDER_ATTRS.get(renderer, default)
 
+            # Repair animation must be enabled
+            cmds.setAttr("defaultRenderGlobals.animation", True)
+
             # Repair prefix
             if renderer != "renderman":
                 node = render_attrs["node"]


### PR DESCRIPTION
## Brief description

This fixes #3410 

## Description

The file format check for AOVs is skipped for Cryptomatte AOVs because Redshift always write it as "Cryptomatte (EXR)" format.

## Testing notes:
1. Set up scene with Redshift + Cryptomatte AOV and others
2. Ensure validation works as expected for file format (extension)