### PR TITLE
Scene Inventory: Fix allow actions to change selection

### DIFF
--- a/openpype/tools/sceneinventory/view.py
+++ b/openpype/tools/sceneinventory/view.py
@@ -551,16 +551,16 @@ class SceneInventoryView(QtWidgets.QTreeView):
             "toggle": selection_model.Toggle,
         }[options.get("mode", "select")]
 
-        for item in iter_model_rows(model, 0):
-            item = item.data(InventoryModel.ItemRole)
+        for index in iter_model_rows(model, 0):
+            item = index.data(InventoryModel.ItemRole)
             if item.get("isGroupNode"):
                 continue
 
             name = item.get("objectName")
             if name in object_names:
-                self.scrollTo(item)  # Ensure item is visible
+                self.scrollTo(index)  # Ensure item is visible
                 flags = select_mode | selection_model.Rows
-                selection_model.select(item, flags)
+                selection_model.select(index, flags)
 
                 object_names.remove(name)
 


### PR DESCRIPTION
## Brief description

Scene Inventory actions allows to change the selection in the UI. That functionality however was broken and is fixed with this PR.

## Description

To test, here's an example Action that selects all containers of which the subsets belong to subset group `Deprecated`:

```python
from collections import defaultdict

from bson.objectid import ObjectId
from openpype.pipeline import InventoryAction, legacy_io
from openpype.client import get_representations, get_versions, get_subsets


def _by_id(docs):
    return {str(doc["_id"]): doc for doc in docs}


class CheckDeprecated(InventoryAction):
    """Select all containers that are 'Deprecated'

    Whenever a subset is added to a group named 'Deprecated' then this will
    identify those containers in the Scene Inventory and select them.

    """

    label = "Select deprecated"
    icon = "download"
    color = "#d8d8d8"

    def process(self, containers):

        from openpype.pipeline import registered_host
        host = registered_host()
        containers = list(host.ls())

        containers_by_repre_id = defaultdict(list)
        for container in containers:
            repre_id = ObjectId(container["representation"])
            containers_by_repre_id[repre_id].append(container)

        # Get subsets from representations
        project = legacy_io.active_project()
        repre_ids = list(containers_by_repre_id.keys())
        repre_docs = list(get_representations(project,
                                              representation_ids=repre_ids,
                                              fields=["parent"]))
        repre_docs_by_id = _by_id(repre_docs)
        version_ids = set([doc["parent"] for doc in repre_docs])
        version_docs = list(get_versions(project,
                                         version_ids=version_ids,
                                         fields=["parent"]))
        version_docs_by_id = _by_id(version_docs)

        subset_ids = set([doc["parent"] for doc in version_docs])
        subset_docs = list(get_subsets(project,
                                       subset_ids=subset_ids,
                                       fields=["data.subsetGroup"]))
        subset_docs_by_id = _by_id(subset_docs)

        deprecated_containers = []
        for container in containers:
            repre_doc = repre_docs_by_id[container["representation"]]
            version_doc = version_docs_by_id[str(repre_doc["parent"])]
            subset_doc = subset_docs_by_id[str(version_doc["parent"])]
            group = subset_doc["data"].get("subsetGroup")
            if group and group.lower() == "deprecated":
                # Subset is considered deprecated
                deprecated_containers.append(container["objectName"])

        return {
            "objectNames": deprecated_containers,
            "options": {"clear": True}
        }
```


## Additional info

I suspect this feature might have been broken for a very long time since likely no one really used it in production.

## Testing notes:

1. Run a DCC and open the inventory with content loaded
2. Run an Action that would return what to select (e.g. the example action above)
