### PR TITLE
Scene Inventory: Add subsetGroup column

### DIFF
--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -34,7 +34,8 @@ from .lib import (
 class InventoryModel(TreeModel):
     """The model for the inventory"""
 
-    Columns = ["Name", "version", "count", "family", "loader", "objectName"]
+    Columns = ["Name", "version", "count", "family",
+               "subsetGroup", "loader", "objectName"]
 
     OUTDATED_COLOR = QtGui.QColor(235, 30, 30)
     CHILD_OUTDATED_COLOR = QtGui.QColor(200, 160, 30)
@@ -157,8 +158,13 @@ class InventoryModel(TreeModel):
                 # Family icon
                 return item.get("familyIcon", None)
 
+            column_name = self.Columns[index.column()]
+
+            if column_name == "subsetGroup" and item.get("subsetGroup"):
+                return qtawesome.icon("fa.object-group",
+                                      color=get_default_entity_icon_color())
+
             if item.get("isGroupNode"):
-                column_name = self.Columns[index.column()]
                 if column_name == "active_site":
                     provider = item.get("active_site_provider")
                     return self._site_icons.get(provider)
@@ -423,6 +429,7 @@ class InventoryModel(TreeModel):
             group_node["familyIcon"] = family_icon
             group_node["count"] = len(group_items)
             group_node["isGroupNode"] = True
+            group_node["subsetGroup"] = subset["data"].get("subsetGroup")
 
             if self.sync_enabled:
                 progress = get_progress_for_repre(

--- a/openpype/tools/sceneinventory/model.py
+++ b/openpype/tools/sceneinventory/model.py
@@ -35,7 +35,7 @@ class InventoryModel(TreeModel):
     """The model for the inventory"""
 
     Columns = ["Name", "version", "count", "family",
-               "subsetGroup", "loader", "objectName"]
+               "group", "loader", "objectName"]
 
     OUTDATED_COLOR = QtGui.QColor(235, 30, 30)
     CHILD_OUTDATED_COLOR = QtGui.QColor(200, 160, 30)
@@ -160,7 +160,7 @@ class InventoryModel(TreeModel):
 
             column_name = self.Columns[index.column()]
 
-            if column_name == "subsetGroup" and item.get("subsetGroup"):
+            if column_name == "group" and item.get("group"):
                 return qtawesome.icon("fa.object-group",
                                       color=get_default_entity_icon_color())
 
@@ -429,7 +429,7 @@ class InventoryModel(TreeModel):
             group_node["familyIcon"] = family_icon
             group_node["count"] = len(group_items)
             group_node["isGroupNode"] = True
-            group_node["subsetGroup"] = subset["data"].get("subsetGroup")
+            group_node["group"] = subset["data"].get("subsetGroup")
 
             if self.sync_enabled:
                 progress = get_progress_for_repre(

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -88,7 +88,7 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         view.setColumnWidth(1, 55)   # version
         view.setColumnWidth(2, 55)   # count
         view.setColumnWidth(3, 150)  # family
-        view.setColumnWidth(4, 120)  # subsetGroup
+        view.setColumnWidth(4, 120)  # group
         view.setColumnWidth(5, 150)  # loader
 
         # apply delegates

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -88,7 +88,8 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         view.setColumnWidth(1, 55)   # version
         view.setColumnWidth(2, 55)   # count
         view.setColumnWidth(3, 150)  # family
-        view.setColumnWidth(4, 100)  # namespace
+        view.setColumnWidth(4, 120)  # subsetGroup
+        view.setColumnWidth(5, 150)  # loader
 
         # apply delegates
         version_delegate = VersionDelegate(legacy_io, self)


### PR DESCRIPTION
## Brief description

This adds a `subsetGroup` column to the Scene Inventory / Manager.

## Description

We tend to group publishes in the Loader (shortcut: `ctrl + g`) to sometimes label things as "extras" or even group them to be "deprecated".
By showing the column in the Manager this is now also much easier to trace to that information.

![afbeelding](https://user-images.githubusercontent.com/2439881/184353831-631c1670-dfc3-48ac-981a-c41ef77e965b.png)

## Additional info

Code might be a bit messy - so please double check. 

The "icon" for the group is the default group icon. Originally in Avalon groups could be configured on the project to allow custom icons per groups, etc. but that's currently not supported in OpenPype as far as I know. Thus I had chosen for now to just hardcode the icon.

This would be extra useful as soon as better UX for filtering is added to tools - then we could also filter by subset group, etc.

## Testing notes:
1. Load some content with and without subset groups.
2. Check the scene inventory