### PR TITLE
Blender: ops refresh manager after process events

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -234,7 +234,7 @@ def lsattrs(attrs: Dict) -> List:
 def read(node: bpy.types.bpy_struct_meta_idprop):
     """Return user-defined attributes from `node`"""
 
-    data = dict(node.get(pipeline.AVALON_PROPERTY))
+    data = dict(node.get(pipeline.AVALON_PROPERTY, {}))
 
     # Ignore hidden/internal data
     data = {

--- a/openpype/hosts/blender/blender_addon/startup/init.py
+++ b/openpype/hosts/blender/blender_addon/startup/init.py
@@ -1,4 +1,10 @@
 from openpype.pipeline import install_host
 from openpype.hosts.blender import api
 
-install_host(api)
+
+def register():
+    install_host(api)
+
+
+def unregister():
+    pass


### PR DESCRIPTION
## Brief description
Blender host ops module enhancements : manager refresh after process events

## Description
- Manager (scene inventory) is refreshed after process events.
- _process_app_events registered once (before, this was multiple registered, each time OP dialogs was opened)
- TIMER_INTERVAL more longer to avoid lag with MacOs.
- OP Blender startup add-on fixed with required function register/unregister.

## Testing notes:
1. Open a task with out-to-date OP container asset.
2. Open the Manager dialog and update the asset.
3. Should get the Manager refreshed after the update.