### PR TITLE
Deadline: Global job pre load is not Pype 2 compatible

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -260,52 +260,6 @@ def pype_command_line(executable, arguments, workingDirectory):
     return executable, arguments, workingDirectory
 
 
-def pype(deadlinePlugin):
-    """Remaps `PYPE_METADATA_FILE` and `PYPE_PYTHON_EXE` environment vars.
-
-    `PYPE_METADATA_FILE` is used on farm to point to rendered data. This path
-    originates on platform from which this job was published. To be able to
-    publish on different platform, this path needs to be remapped.
-
-    `PYPE_PYTHON_EXE` can be used to specify custom location of python
-    interpreter to use for Pype. This is remappeda also if present even
-    though it probably doesn't make much sense.
-
-    Arguments:
-        deadlinePlugin: Deadline job plugin passed by Deadline
-
-    """
-    print(">>> Getting job ...")
-    job = deadlinePlugin.GetJob()
-    # PYPE should be here, not OPENPYPE - backward compatibility!!
-    pype_metadata = job.GetJobEnvironmentKeyValue("PYPE_METADATA_FILE")
-    pype_python = job.GetJobEnvironmentKeyValue("PYPE_PYTHON_EXE")
-    print(">>> Having backward compatible env vars {}/{}".format(pype_metadata,
-                                                                 pype_python))
-    # test if it is pype publish job.
-    if pype_metadata:
-        pype_metadata = RepositoryUtils.CheckPathMapping(pype_metadata)
-        if platform.system().lower() == "linux":
-            pype_metadata = pype_metadata.replace("\\", "/")
-
-        print("- remapping PYPE_METADATA_FILE: {}".format(pype_metadata))
-        job.SetJobEnvironmentKeyValue("PYPE_METADATA_FILE", pype_metadata)
-        deadlinePlugin.SetProcessEnvironmentVariable(
-            "PYPE_METADATA_FILE", pype_metadata)
-
-    if pype_python:
-        pype_python = RepositoryUtils.CheckPathMapping(pype_python)
-        if platform.system().lower() == "linux":
-            pype_python = pype_python.replace("\\", "/")
-
-        print("- remapping PYPE_PYTHON_EXE: {}".format(pype_python))
-        job.SetJobEnvironmentKeyValue("PYPE_PYTHON_EXE", pype_python)
-        deadlinePlugin.SetProcessEnvironmentVariable(
-            "PYPE_PYTHON_EXE", pype_python)
-
-    deadlinePlugin.ModifyCommandLineCallback += pype_command_line
-
-
 def __main__(deadlinePlugin):
     print("*** GlobalJobPreload start ...")
     print(">>> Getting job ...")
@@ -329,5 +283,3 @@ def __main__(deadlinePlugin):
         inject_render_job_id(deadlinePlugin)
     elif openpype_render_job == '1' or openpype_remote_job == '1':
         inject_openpype_environment(deadlinePlugin)
-    else:
-        pype(deadlinePlugin)  # backward compatibility with Pype2

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -234,32 +234,6 @@ def inject_render_job_id(deadlinePlugin):
     print(">>> Injection end.")
 
 
-def pype_command_line(executable, arguments, workingDirectory):
-    """Remap paths in comand line argument string.
-
-    Using Deadline rempper it will remap all path found in command-line.
-
-    Args:
-        executable (str): path to executable
-        arguments (str): arguments passed to executable
-        workingDirectory (str): working directory path
-
-    Returns:
-        Tuple(executable, arguments, workingDirectory)
-
-    """
-    print("-" * 40)
-    print("executable: {}".format(executable))
-    print("arguments: {}".format(arguments))
-    print("workingDirectory: {}".format(workingDirectory))
-    print("-" * 40)
-    print("Remapping arguments ...")
-    arguments = RepositoryUtils.CheckPathMapping(arguments)
-    print("* {}".format(arguments))
-    print("-" * 40)
-    return executable, arguments, workingDirectory
-
-
 def __main__(deadlinePlugin):
     print("*** GlobalJobPreload start ...")
     print(">>> Getting job ...")

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -34,7 +34,7 @@ def get_openpype_version_from_path(path, build=True):
 
     # if only builds are requested
     if build and not os.path.isfile(exe):  # noqa: E501
-        print(f"   ! path is not a build: {path}")
+        print("   ! path is not a build: {}".format(path))
         return None
 
     version = {}
@@ -70,11 +70,12 @@ def inject_openpype_environment(deadlinePlugin):
         # lets go over all available and find compatible build.
         requested_version = job.GetJobEnvironmentKeyValue("OPENPYPE_VERSION")
         if requested_version:
-            print((">>> Scanning for compatible requested "
-                  f"version {requested_version}"))
+            print((
+                ">>> Scanning for compatible requested version {}"
+            ).format(requested_version))
             install_dir = DirectoryUtils.SearchDirectoryList(dir_list)
             if install_dir:
-                print(f"--- Looking for OpenPype at: {install_dir}")
+                print("--- Looking for OpenPype at: {}".format(install_dir))
                 sub_dirs = [
                     f.path for f in os.scandir(install_dir)
                     if f.is_dir()
@@ -83,18 +84,20 @@ def inject_openpype_environment(deadlinePlugin):
                     version = get_openpype_version_from_path(subdir)
                     if not version:
                         continue
-                    print(f"  - found: {version} - {subdir}")
+                    print("  - found: {} - {}".format(version, subdir))
                     openpype_versions.append((version, subdir))
 
         exe = FileUtils.SearchFileList(exe_list)
         if openpype_versions:
             # if looking for requested compatible version,
             # add the implicitly specified to the list too.
-            print(f"Looking for OpenPype at: {os.path.dirname(exe)}")
+            print("Looking for OpenPype at: {}".format(os.path.dirname(exe)))
             version = get_openpype_version_from_path(
                 os.path.dirname(exe))
             if version:
-                print(f"  - found: {version} - {os.path.dirname(exe)}")
+                print("  - found: {} - {}".format(
+                    version, os.path.dirname(exe)
+                ))
                 openpype_versions.append((version, os.path.dirname(exe)))
 
         if requested_version:
@@ -106,8 +109,9 @@ def inject_openpype_environment(deadlinePlugin):
                         int(t) if t.isdigit() else t.lower()
                         for t in re.split(r"(\d+)", ver[0])
                     ])
-                print(("*** Latest available version found is "
-                       f"{openpype_versions[-1][0]}"))
+                print((
+                    "*** Latest available version found is {}"
+                ).format(openpype_versions[-1][0]))
             requested_major, requested_minor, _ = requested_version.split(".")[:3]  # noqa: E501
             compatible_versions = []
             for version in openpype_versions:
@@ -127,8 +131,9 @@ def inject_openpype_environment(deadlinePlugin):
                     int(t) if t.isdigit() else t.lower()
                     for t in re.split(r"(\d+)", ver[0])
                 ])
-            print(("*** Latest compatible version found is "
-                   f"{compatible_versions[-1][0]}"))
+            print((
+                "*** Latest compatible version found is {}"
+            ).format(compatible_versions[-1][0]))
             # create list of executables for different platform and let
             # Deadline decide.
             exe_list = [


### PR DESCRIPTION
## Brief description
OpenPype deadline global plugin is not Pype 2 compatible anymore.

## Description
Because of pype 2 compatibility the deadline prelaunch hook is always triggered which cause issues with jobs that are not for OpenPype because in that case Pype 2 logic starts.

Side change is to make the plugin Python 2 compatible.

## Testing notes:
1. Copy the plugin to deadline repository
2. Try submit a job without openpype
3. It should not crash

Resolves https://github.com/pypeclub/OpenPype/issues/3664