### PR TITLE
Maya: move set render settings menu entry

### DIFF
--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -100,13 +100,6 @@ def install():
         cmds.menuItem(divider=True)
 
         cmds.menuItem(
-            "Set Render Settings",
-            command=lambda *args: lib_rendersettings.RenderSettings().set_default_renderer_settings()    # noqa
-        )
-
-        cmds.menuItem(divider=True)
-
-        cmds.menuItem(
             "Work Files...",
             command=lambda *args: host_tools.show_workfiles(
                 parent=parent_widget
@@ -127,6 +120,12 @@ def install():
             "Set Colorspace",
             command=lambda *args: lib.set_colorspace(),
         )
+
+        cmds.menuItem(
+            "Set Render Settings",
+            command=lambda *args: lib_rendersettings.RenderSettings().set_default_renderer_settings()    # noqa
+        )
+
         cmds.menuItem(divider=True, parent=MENU_NAME)
         cmds.menuItem(
             "Build First Workfile",


### PR DESCRIPTION
## Brief description

[This PR added a new menu entry to **Set render settings**](https://github.com/pypeclub/OpenPype/pull/3097/files#diff-6776f55e08129abce6069879cab8e37160877468ca9276bbaabc631f28c1d3d8R102-R108) but our team felt it was in an odd location in the menu. Plus it messed with the muscle memory for the "Work files" menu entry they tend to click a lot.

## Description

Here's the change made by this PR:

**Before**

![before](https://user-images.githubusercontent.com/2439881/184650340-b266c00c-2d78-48d9-be1d-bcd1320b416c.png)

**After**

![after](https://user-images.githubusercontent.com/2439881/184650354-6b4841b0-1eee-4a7f-bfb3-038cd05c4dd4.png)

## Additional info

Also [mentioned on discord here](https://discord.com/channels/517362899170230292/517382145552154634/1008732362491838576)