### PR TITLE
Ftrack: More logs related to auto sync value change

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -697,13 +697,22 @@ class SyncToAvalonEvent(BaseEvent):
                 continue
 
             auto_sync = changes[CUST_ATTR_AUTO_SYNC]["new"]
-            if auto_sync == "1":
+            turned_on = auto_sync == "1"
+            ft_project = self.cur_project
+            username = self._get_username(session, event)
+            message = (
+                "Auto sync was turned {} for project \"{}\" by \"{}\"."
+            ).format(
+                "on" if turned_on else "off",
+                ft_project["full_name"],
+                username
+            )
+            if turned_on:
+                message += " Triggering syncToAvalon action."
+            self.log.debug(message)
+
+            if turned_on:
                 # Trigger sync to avalon action if auto sync was turned on
-                ft_project = self.cur_project
-                self.log.debug((
-                    "Auto sync was turned on for project <{}>."
-                    " Triggering syncToAvalon action."
-                ).format(ft_project["full_name"]))
                 selection = [{
                     "entityId": ft_project["id"],
                     "entityType": "show"
@@ -850,6 +859,26 @@ class SyncToAvalonEvent(BaseEvent):
 
         self.report()
         return True
+
+    def _get_username(self, session, event):
+        username = "Unknown"
+        event_source = event.get("source")
+        if not event_source:
+            return username
+        user_info = event_source.get("user")
+        if not user_info:
+            return username
+        user_id = user_info.get("id")
+        if not user_id:
+            return username
+
+        user_entity = session.query(
+            "User where id is {}".format(user_id)
+        ).first()
+        if user_entity:
+            username = user_entity["username"] or username
+        return username
+
 
     def process_removed(self):
         """


### PR DESCRIPTION
## Brief description
More information in logs when autosync is turned on/off.

## Description
Log information than auto sync was turned off and added infromation about username who triggered it.

## Testing notes:
1. Start ftrack event server
2. Change auto sync on a project
3. A log describing who turned on/off auto sync on which project should appear in process of ftrack event server