### PR TITLE
Loader: Fix representation check per version logic

### DIFF
--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -584,9 +584,9 @@ class SubsetWidget(QtWidgets.QWidget):
             for repre_doc in repre_docs:
                 repre_ids.append(repre_doc["_id"])
 
+                # keep only version ids without representation with that name
                 version_id = repre_doc["parent"]
-                if version_id not in version_ids:
-                    version_ids.remove(version_id)
+                version_ids.remove(version_id)
 
             for version_id in version_ids:
                 joined_subset_names = ", ".join([

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -586,7 +586,7 @@ class SubsetWidget(QtWidgets.QWidget):
 
                 # keep only version ids without representation with that name
                 version_id = repre_doc["parent"]
-                version_ids.remove(version_id)
+                version_ids.discard(version_id)
 
             if version_ids:
                 # report versions that didn't have valid representation

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -567,12 +567,12 @@ class SubsetWidget(QtWidgets.QWidget):
 
             # Trigger
             project_name = self.dbcon.active_project()
-            subset_names_by_version_id = collections.defaultdict(set)
+            subset_name_by_version_id = dict()
             for item in items:
                 version_id = item["version_document"]["_id"]
-                subset_names_by_version_id[version_id].add(item["subset"])
+                subset_name_by_version_id[version_id] = item["subset"]
 
-            version_ids = set(subset_names_by_version_id.keys())
+            version_ids = set(subset_name_by_version_id.keys())
             repre_docs = get_representations(
                 project_name,
                 representation_names=[representation_name],
@@ -588,10 +588,11 @@ class SubsetWidget(QtWidgets.QWidget):
                 version_id = repre_doc["parent"]
                 version_ids.remove(version_id)
 
-            for version_id in version_ids:
+            if version_ids:
+                # report versions that didn't have valid representation
                 joined_subset_names = ", ".join([
-                    '"{}"'.format(subset)
-                    for subset in subset_names_by_version_id[version_id]
+                    '"{}"'.format(subset_name_by_version_id[version_id])
+                    for version_id in version_ids
                 ])
                 self.echo("Subsets {} don't have representation '{}'".format(
                     joined_subset_names, representation_name


### PR DESCRIPTION
## Brief description

Fix logic that reports whether a representation was found for the versions or not.

## Description

Noticed an odd if statement which looked like a bug:
```python
if version_id not in version_ids:
    version_ids.remove(version_id)
```

Which in the end resulted in all loaders to always log this:

> Subsets "subset" don't have representation 'representation'


So ended up investigating and refactoring the code.

## Testing notes:
1. Loaders should work as expected and report when representation isn't found.