### PR TITLE
General: Use client projects getter

### DIFF
--- a/openpype/modules/kitsu/utils/update_zou_with_op.py
+++ b/openpype/modules/kitsu/utils/update_zou_with_op.py
@@ -6,7 +6,11 @@ from typing import List
 import gazu
 from pymongo import UpdateOne
 
-from openpype.client import get_project, get_assets
+from openpype.client import (
+    get_projects,
+    get_project,
+    get_assets,
+)
 from openpype.pipeline import AvalonMongoDB
 from openpype.api import get_project_settings
 from openpype.modules.kitsu.utils.credentials import validate_credentials
@@ -37,7 +41,7 @@ def sync_zou(login: str, password: str):
     dbcon = AvalonMongoDB()
     dbcon.install()
 
-    op_projects = [p for p in dbcon.projects()]
+    op_projects = list(get_projects())
     for project_doc in op_projects:
         sync_zou_from_op_project(project_doc["name"], dbcon, project_doc)
 

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -6,7 +6,7 @@ import platform
 import copy
 from collections import deque, defaultdict
 
-
+from openpype.client import get_projects
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import ITrayModule
 from openpype.settings import (
@@ -913,7 +913,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         enabled_projects = []
 
         if self.enabled:
-            for project in self.connection.projects(projection={"name": 1}):
+            for project in get_projects(fields=["name"]):
                 project_name = project["name"]
                 if self.is_project_enabled(project_name):
                     enabled_projects.append(project_name)
@@ -1242,10 +1242,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
     def _prepare_sync_project_settings(self, exclude_locals):
         sync_project_settings = {}
         system_sites = self.get_all_site_configs()
-        project_docs = self.connection.projects(
-            projection={"name": 1},
-            only_active=True
-        )
+        project_docs = get_projects(fields=["name"])
         for project_doc in project_docs:
             project_name = project_doc["name"]
             sites = copy.deepcopy(system_sites)  # get all configured sites

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -10,6 +10,7 @@ from Qt import QtCore, QtGui
 import qtawesome
 
 from openpype.client import (
+    get_projects,
     get_project,
     get_assets,
 )
@@ -527,7 +528,7 @@ class LauncherModel(QtCore.QObject):
         current_project = self.project_name
         project_names = set()
         project_docs_by_name = {}
-        for project_doc in self._dbcon.projects(only_active=True):
+        for project_doc in get_projects():
             project_name = project_doc["name"]
             project_names.add(project_name)
             project_docs_by_name[project_name] = project_doc

--- a/openpype/tools/libraryloader/app.py
+++ b/openpype/tools/libraryloader/app.py
@@ -3,7 +3,7 @@ import sys
 from Qt import QtWidgets, QtCore, QtGui
 
 from openpype import style
-from openpype.client import get_project
+from openpype.client import get_projects, get_project
 from openpype.pipeline import AvalonMongoDB
 from openpype.tools.utils import lib as tools_lib
 from openpype.tools.loader.widgets import (
@@ -239,7 +239,7 @@ class LibraryLoaderWindow(QtWidgets.QDialog):
 
     def get_filtered_projects(self):
         projects = list()
-        for project in self.dbcon.projects():
+        for project in get_projects(fields=["name", "data.library_project"]):
             is_library = project.get("data", {}).get("library_project", False)
             if (
                 (is_library and self.show_libraries) or

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -8,6 +8,7 @@ from pymongo import UpdateOne, DeleteOne
 from Qt import QtCore, QtGui
 
 from openpype.client import (
+    get_projects,
     get_project,
     get_assets,
     get_asset_ids_with_subsets,
@@ -54,12 +55,8 @@ class ProjectModel(QtGui.QStandardItemModel):
             self._items_by_name[None] = none_project
             new_project_items.append(none_project)
 
-        project_docs = self.dbcon.projects(
-            projection={"name": 1},
-            only_active=True
-        )
         project_names = set()
-        for project_doc in project_docs:
+        for project_doc in get_projects(fields=["name"]):
             project_name = project_doc.get("name")
             if not project_name:
                 continue

--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -4,8 +4,9 @@ import sys
 from Qt import QtWidgets, QtCore
 import qtawesome
 
-from openpype.pipeline import legacy_io
 from openpype import style
+from openpype.client import get_projects
+from openpype.pipeline import legacy_io
 from openpype.tools.utils.delegates import VersionDelegate
 from openpype.tools.utils.lib import (
     qt_app_context,
@@ -195,8 +196,7 @@ def show(root=None, debug=False, parent=None, items=None):
 
         if not os.environ.get("AVALON_PROJECT"):
             any_project = next(
-                project for project in legacy_io.projects()
-                if project.get("active", True) is not False
+                project for project in get_projects()
             )
 
             project_name = any_project["name"]

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -3,6 +3,7 @@ import uuid
 from Qt import QtWidgets, QtCore, QtGui
 import qtawesome
 
+from openpype.client import get_projects
 from openpype.pipeline import AvalonMongoDB
 from openpype.style import get_objected_colors
 from openpype.tools.utils.widgets import ImageButton
@@ -783,8 +784,6 @@ class ProjectModel(QtGui.QStandardItemModel):
 
         self.setColumnCount(2)
 
-        self.dbcon = None
-
         self._only_active = only_active
         self._default_item = None
         self._items_by_name = {}
@@ -828,9 +827,6 @@ class ProjectModel(QtGui.QStandardItemModel):
             index = self.index(index.row(), 0, index.parent())
         return super(ProjectModel, self).flags(index)
 
-    def set_dbcon(self, dbcon):
-        self.dbcon = dbcon
-
     def refresh(self):
         # Change id of versions refresh
         self._version_refresh_id = uuid.uuid4()
@@ -846,31 +842,30 @@ class ProjectModel(QtGui.QStandardItemModel):
 
         self._default_item.setData("", PROJECT_VERSION_ROLE)
         project_names = set()
-        if self.dbcon is not None:
-            for project_doc in self.dbcon.projects(
-                projection={"name": 1, "data.active": 1},
-                only_active=self._only_active
-            ):
-                project_name = project_doc["name"]
-                project_names.add(project_name)
-                if project_name in self._items_by_name:
-                    item = self._items_by_name[project_name]
-                else:
-                    item = QtGui.QStandardItem(project_name)
+        for project_doc in get_projects(
+            inactive=not self._only_active,
+            fields=["name", "data.active"]
+        ):
+            project_name = project_doc["name"]
+            project_names.add(project_name)
+            if project_name in self._items_by_name:
+                item = self._items_by_name[project_name]
+            else:
+                item = QtGui.QStandardItem(project_name)
 
-                    self._items_by_name[project_name] = item
-                    new_items.append(item)
+                self._items_by_name[project_name] = item
+                new_items.append(item)
 
-                is_active = project_doc.get("data", {}).get("active", True)
-                item.setData(project_name, PROJECT_NAME_ROLE)
-                item.setData(is_active, PROJECT_IS_ACTIVE_ROLE)
-                item.setData("", PROJECT_VERSION_ROLE)
-                item.setData(False, PROJECT_IS_SELECTED_ROLE)
+            is_active = project_doc.get("data", {}).get("active", True)
+            item.setData(project_name, PROJECT_NAME_ROLE)
+            item.setData(is_active, PROJECT_IS_ACTIVE_ROLE)
+            item.setData("", PROJECT_VERSION_ROLE)
+            item.setData(False, PROJECT_IS_SELECTED_ROLE)
 
-                if not is_active:
-                    font = item.font()
-                    font.setItalic(True)
-                    item.setFont(font)
+            if not is_active:
+                font = item.font()
+                font.setItalic(True)
+                item.setFont(font)
 
         root_item = self.invisibleRootItem()
         for project_name in tuple(self._items_by_name.keys()):
@@ -1067,8 +1062,6 @@ class ProjectListWidget(QtWidgets.QWidget):
         self.project_model = project_model
         self.inactive_chk = inactive_chk
 
-        self.dbcon = None
-
     def set_entity(self, entity):
         self._entity = entity
 
@@ -1211,15 +1204,6 @@ class ProjectListWidget(QtWidgets.QWidget):
             selected_project = index.data(PROJECT_NAME_ROLE)
             break
 
-        if not self.dbcon:
-            try:
-                self.dbcon = AvalonMongoDB()
-                self.dbcon.install()
-            except Exception:
-                self.dbcon = None
-                self.current_project = None
-
-        self.project_model.set_dbcon(self.dbcon)
         self.project_model.refresh()
 
         self.project_proxy.sort(0)

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -3,6 +3,7 @@ from Qt import QtWidgets, QtCore
 import qtawesome
 
 from openpype.client import (
+    get_projects,
     get_project,
     get_asset_by_id,
 )
@@ -291,9 +292,7 @@ class AssetWidget(QtWidgets.QWidget):
     def _set_projects(self):
         project_names = list()
 
-        for doc in self.dbcon.projects(projection={"name": 1},
-                                       only_active=True):
-
+        for doc in get_projects(fields=["name"]):
             project_name = doc.get("name")
             if project_name:
                 project_names.append(project_name)
@@ -320,8 +319,7 @@ class AssetWidget(QtWidgets.QWidget):
     def on_project_change(self):
         projects = list()
 
-        for project in self.dbcon.projects(projection={"name": 1},
-                                           only_active=True):
+        for project in get_projects(fields=["name"]):
             projects.append(project['name'])
         project_name = self.combo_projects.currentText()
         if project_name in projects:

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -443,10 +443,6 @@ class FamilyConfigCache:
         if profiles:
             # Make sure connection is installed
             # - accessing attribute which does not have auto-install
-            self.dbcon.install()
-            database = getattr(self.dbcon, "database", None)
-            if database is None:
-                database = self.dbcon._database
             asset_doc = get_asset_by_name(
                 project_name, asset_name, fields=["data.tasks"]
             ) or {}

--- a/openpype/tools/utils/models.py
+++ b/openpype/tools/utils/models.py
@@ -3,6 +3,7 @@ import logging
 
 import Qt
 from Qt import QtCore, QtGui
+from openpype.client import get_projects
 from .constants import (
     PROJECT_IS_ACTIVE_ROLE,
     PROJECT_NAME_ROLE,
@@ -296,29 +297,29 @@ class ProjectModel(QtGui.QStandardItemModel):
             self._default_item = item
 
         project_names = set()
-        if self.dbcon is not None:
-            for project_doc in self.dbcon.projects(
-                projection={"name": 1, "data.active": 1},
-                only_active=self._only_active
-            ):
-                project_name = project_doc["name"]
-                project_names.add(project_name)
-                if project_name in self._items_by_name:
-                    item = self._items_by_name[project_name]
-                else:
-                    item = QtGui.QStandardItem(project_name)
+        project_docs = get_projects(
+            inactive=not self._only_active,
+            fields=["name", "data.active"]
+        )
+        for project_doc in project_docs:
+            project_name = project_doc["name"]
+            project_names.add(project_name)
+            if project_name in self._items_by_name:
+                item = self._items_by_name[project_name]
+            else:
+                item = QtGui.QStandardItem(project_name)
 
-                    self._items_by_name[project_name] = item
-                    new_items.append(item)
+                self._items_by_name[project_name] = item
+                new_items.append(item)
 
-                is_active = project_doc.get("data", {}).get("active", True)
-                item.setData(project_name, PROJECT_NAME_ROLE)
-                item.setData(is_active, PROJECT_IS_ACTIVE_ROLE)
+            is_active = project_doc.get("data", {}).get("active", True)
+            item.setData(project_name, PROJECT_NAME_ROLE)
+            item.setData(is_active, PROJECT_IS_ACTIVE_ROLE)
 
-                if not is_active:
-                    font = item.font()
-                    font.setItalic(True)
-                    item.setFont(font)
+            if not is_active:
+                font = item.font()
+                font.setItalic(True)
+                item.setFont(font)
 
         root_item = self.invisibleRootItem()
         for project_name in tuple(self._items_by_name.keys()):


### PR DESCRIPTION
## Brief description
Use `get_projects` from `openpype.client` instead of `projects` method from `AvalonMongoDB`.

## Description
Use `get_projects` function in code to query projects.

## Additional information
I didn't notice this method during query getter refactor.

## Testing notes:
Inactive projects should be hiddedn as expected
- [x] Settings should load projects
- [x] Sync server should load projects and sync properly
- [x] Library loader should show right projects (active library projects in hosts and all active projects from tray)
- [ ] Kitsu (zou) sync should work
- [x] Launcher is showing active projects
- [x] Project manager is showing active projects
- [x] Standalone publisher is showing active projects