### PR TITLE
Maya: `containerise` dont skip empty values

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -344,7 +344,7 @@ def containerise(name,
         ("id", AVALON_CONTAINER_ID),
         ("name", name),
         ("namespace", namespace),
-        ("loader", str(loader)),
+        ("loader", loader),
         ("representation", context["representation"]["_id"]),
     ]
 

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -350,7 +350,7 @@ def containerise(name,
 
     for key, value in data:
         cmds.addAttr(container, longName=key, dataType="string")
-        cmds.setAttr(container + "." + key, value, type="string")
+        cmds.setAttr(container + "." + key, str(value), type="string")
 
     main_container = cmds.ls(AVALON_CONTAINERS, type="objectSet")
     if not main_container:

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -349,14 +349,8 @@ def containerise(name,
     ]
 
     for key, value in data:
-
-        if isinstance(value, (int, float)):
-            cmds.addAttr(container, longName=key, attributeType="short")
-            cmds.setAttr(container + "." + key, value)
-
-        else:
-            cmds.addAttr(container, longName=key, dataType="string")
-            cmds.setAttr(container + "." + key, value, type="string")
+        cmds.addAttr(container, longName=key, dataType="string")
+        cmds.setAttr(container + "." + key, value, type="string")
 
     main_container = cmds.ls(AVALON_CONTAINERS, type="objectSet")
     if not main_container:

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -349,8 +349,6 @@ def containerise(name,
     ]
 
     for key, value in data:
-        if not value:
-            continue
 
         if isinstance(value, (int, float)):
             cmds.addAttr(container, longName=key, attributeType="short")


### PR DESCRIPTION
## Brief description

Maya host `containerise` was the only implementation that skipped imprinting values if the value was empty/None/zero (`if not value`). Instead of ever allowing to do so this now forces the required attributes to actually be generated on containerise.

Since all values should be string anyway I've also simplifies the logic that adds and sets the attributes.

## Additional info

I was investigating an issue where some loaded containers were missing `loader` and `representation` attributes and I'm unsure how that happened. However, this part of the code could have potentially done so without warnings/errors if `loader` or `representation` values were ever considered null.

## Testing notes:

1. Load containers into Maya
2. Everything should load as usual and be visible in the Scene Inventory, etc.