### PR TITLE
Photoshop: resize saved images in ExtractReview for ffmpeg

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -144,7 +144,7 @@ class ExtractReview(openpype.api.Extractor):
         used as a source for thumbnail or review mov.
         """
         # 16384x16384 actually didn't work because int overflow
-        max_ffmpeg_size = 16000
+        max_ffmpeg_size = 8192
         Image.MAX_IMAGE_PIXELS = None
         first_url = os.path.join(staging_dir, processed_img_names[0])
         with Image.open(first_url) as im:

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -143,7 +143,8 @@ class ExtractReview(openpype.api.Extractor):
         Ffmpeg has max size 16384x16384. Saved image(s) must be resized to be
         used as a source for thumbnail or review mov.
         """
-        max_ffmpeg_size = 16384
+        # 16384x16384 actually didn't work because int overflow
+        max_ffmpeg_size = 16000
         Image.MAX_IMAGE_PIXELS = None
         first_url = os.path.join(staging_dir, processed_img_names[0])
         with Image.open(first_url) as im:

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -144,6 +144,7 @@ class ExtractReview(openpype.api.Extractor):
         used as a source for thumbnail or review mov.
         """
         max_ffmpeg_size = 16384
+        Image.MAX_IMAGE_PIXELS = None
         first_url = os.path.join(staging_dir, processed_img_names[0])
         with Image.open(first_url) as im:
             width, height = im.size

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -32,6 +32,7 @@
         },
         "ExtractReview": {
             "make_image_sequence": false,
+            "max_downscale_size": 8192,
             "jpg_options": {
                 "tags": []
             },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -187,6 +187,15 @@
                             "label": "Makes an image sequence instead of a flatten image"
                         },
                         {
+                            "type": "number",
+                            "key": "max_downscale_size",
+                            "label": "Maximum size of sources for review",
+                            "tooltip": "FFMpeg can only handle limited resolution for creation of review and/or thumbnail",
+                            "minimum": 300,
+                            "maximum": 16384,
+                            "decimal": 0
+                        },
+                        {
                             "type": "dict",
                             "collapsible": false,
                             "key": "jpg_options",


### PR DESCRIPTION
## Brief description
Ffmpeg cannot handle pictures higher than 16384x16384. 

## Description
Used PIL to resize to max size(with aspect ratio).

## Additional info
Implemented as a 'hotfix' to unblock customers production.
In the future this plugin should be refactored (to use general ExtractThumbnail and ExtractReview). That is currently blocked by not having oiio on all platforms.

## Testing notes:
1. publish workfile with larger resolution than 16384x16384 in PS