### PR TITLE
Webpublisher:change create flatten image into tri state

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
@@ -32,7 +32,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
     # TODO check if could be set globally, probably doesn't make sense when
     # flattened template cannot
     subset_template_name = ""
-    create_flatten_image = False
+    create_flatten_image = "no"
     # probably not possible to configure this globally
     flatten_subset_template = ""
 
@@ -98,13 +98,16 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
                     "Subset {} already created, skipping.".format(subset))
                 continue
 
-            instance = self._create_instance(context, layer, resolved_family,
-                                             asset_name, subset, task_name)
+            if self.create_flatten_image != "only":
+                instance = self._create_instance(context, layer,
+                                                 resolved_family,
+                                                 asset_name, subset, task_name)
+                created_instances.append(instance)
+
             existing_subset_names.append(subset)
             publishable_layers.append(layer)
-            created_instances.append(instance)
 
-        if self.create_flatten_image and publishable_layers:
+        if self.create_flatten_image != "no" and publishable_layers:
             self.log.debug("create_flatten_image")
             if not self.flatten_subset_template:
                 self.log.warning("No template for flatten image")
@@ -116,7 +119,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
 
             first_layer = publishable_layers[0]  # dummy layer
             first_layer.name = subset
-            family = created_instances[0].data["family"]  # inherit family
+            family = resolved_family  # inherit family
             instance = self._create_instance(context, first_layer,
                                              family,
                                              asset_name, subset, task_name)

--- a/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
@@ -109,7 +109,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
                     "Subset {} already created, skipping.".format(subset))
                 continue
 
-            if self.create_flatten_image != "only":
+            if self.create_flatten_image != "flatten_only":
                 instance = self._create_instance(context, layer,
                                                  resolved_family,
                                                  asset_name, subset, task_name)

--- a/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
@@ -9,13 +9,21 @@ from openpype.settings import get_project_settings
 
 
 class CollectColorCodedInstances(pyblish.api.ContextPlugin):
-    """Creates instances for configured color code of a layer.
+    """Creates instances for layers marked by configurable color.
 
     Used in remote publishing when artists marks publishable layers by color-
-    coding.
+    coding. Top level layers (group) must be marked by specific color to be
+    published as an instance of 'image' family.
 
     Can add group for all publishable layers to allow creation of flattened
     image. (Cannot contain special background layer as it cannot be grouped!)
+
+    Based on value `create_flatten_image` from Settings:
+    - "yes": create flattened 'image' subset of all publishable layers + create
+        'image' subset per publishable layer
+    - "only": create ONLY flattened 'image' subset of all publishable layers
+    - "no": do not create flattened 'image' subset at all,
+        only separate subsets per marked layer.
 
     Identifier:
         id (str): "pyblish.avalon.instance"
@@ -33,7 +41,6 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
     # flattened template cannot
     subset_template_name = ""
     create_flatten_image = "no"
-    # probably not possible to configure this globally
     flatten_subset_template = ""
 
     def process(self, context):

--- a/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_color_coded_instances.py
@@ -62,6 +62,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
 
         publishable_layers = []
         created_instances = []
+        family_from_settings = None
         for layer in layers:
             self.log.debug("Layer:: {}".format(layer))
             if layer.parents:
@@ -79,6 +80,9 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
             if not resolved_subset_template or not resolved_family:
                 self.log.debug("!!! Not found family or template, skip")
                 continue
+
+            if not family_from_settings:
+                family_from_settings = resolved_family
 
             fill_pairs = {
                 "variant": variant,
@@ -119,7 +123,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
 
             first_layer = publishable_layers[0]  # dummy layer
             first_layer.name = subset
-            family = resolved_family  # inherit family
+            family = family_from_settings  # inherit family
             instance = self._create_instance(context, first_layer,
                                              family,
                                              asset_name, subset, task_name)

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -8,7 +8,7 @@
     },
     "publish": {
         "CollectColorCodedInstances": {
-            "create_flatten_image": false,
+            "create_flatten_image": "no",
             "flatten_subset_template": "",
             "color_code_mapping": []
         },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -50,9 +50,9 @@
                             "type": "enum",
                             "multiselection": false,
                             "enum_items": [
-                                { "yes": "Yes" },
-                                { "no": "No" },
-                                { "only": "Only flatten" }
+                                { "flatten_with_images": "Flatten with images" },
+                                { "flatten_only": "Flatten only" },
+                                { "no": "No" }
                             ]
                         },
                         {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -45,9 +45,15 @@
                             "label": "Set color for publishable layers, set its resulting family and template for subset name. \nCan create flatten image from published instances.(Applicable only for remote publishing!)"
                         },
                         {
-                            "type": "boolean",
                             "key": "create_flatten_image",
-                            "label": "Create flatten image"
+                            "label": "Create flatten image",
+                            "type": "enum",
+                            "multiselection": false,
+                            "enum_items": [
+                                { "yes": "Yes" },
+                                { "no": "No" },
+                                { "only": "Only flatten" }
+                            ]
                         },
                         {
                             "type": "text",


### PR DESCRIPTION
## Brief description
`CollectColorCodedInstances` allows publish only flattened subset of 'image' family.

## Description
Previously it was possible to set in Settings to create flatten subset of 'image' family from published subsets. But separate layers marked by publishable colors were published also.
This PR brings more granularity, now it is possible to:
- create flattened 'image' subset of all publishable layers + create 'image' subset per publishable layer
- create ONLY flattened 'image' subset of all publishable layers
- not create flattened 'image' subset at all, only separate subsets per marked layer.


## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. set `project_settings/photoshop/publish/CollectColorCodedInstances/flatten_subset_template`
2. 
![Screenshot 2022-08-16 170951](https://user-images.githubusercontent.com/4457962/184914537-2bd1a997-c3b3-41e5-a70c-b0bc4cee31ad.png)

3. mark some top layers in PS to be published
4. check that only flatten subset was produced