### PR TITLE
Nuke: Build template from workfile

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -29,12 +29,15 @@ from .lib import (
     add_publish_knob,
     WorkfileSettings,
     process_workfile_builder,
+    apply_template_nodes,
     launch_workfiles_app,
     check_inventory_versions,
     set_avalon_knob_data,
     read_avalon_data,
     Context
 )
+
+from . import workfile_template
 
 log = Logger.get_logger(__name__)
 
@@ -217,6 +220,17 @@ def _install_menu():
     menu.addCommand(
         "Build Workfile",
         lambda: BuildWorkfile().process()
+    )
+
+    menu.addSeparator()
+
+    menu.addCommand(
+        "Build Workfile and Apply Template",
+        lambda: apply_template_nodes(run_build=True)
+    )
+    menu.addCommand(
+        "Workfile to Template",
+        lambda: workfile_template.WorkfileTemplate().create_template()
     )
 
     menu.addSeparator()

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -190,9 +190,11 @@ class WorkfileTemplate():
                         if subset.startswith('model'):
                             load_create = 'CreateModel'
                         if subset.startswith('nukenodes'):
-                            load_create = 'LoadBackdropNodes'
+                            load_create = 'CreateBackdrop'
                         if subset.startswith('gizmo'):
-                            load_create = 'LoadGizmo'
+                            load_create = 'CreateGizmo'
+                        if subset.startswith('camera'):
+                            load_create = 'CreateCamera'
                 knob_load_create.setText(load_create)
                 knob_is_creator.setValue(True)
                 knob_subset.setText(str(node['avalon:subset'].value()))
@@ -233,6 +235,8 @@ class WorkfileTemplate():
             # Swap (and reconect) just created template node with it's source
             self._swap_nodes(node, template_node)
             # Delete the source node, we have template instead
+            # TODO deleting backdrop needs to delete
+            # what is "in" the backdrop as well
             nuke.delete(node)
 
     def _make_op_creator_nodes_from_temps(self):

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -104,7 +104,7 @@ class WorkfileTemplate():
         height_offset = target_node_height - source_node_height
         source_pos = (new_node.xpos(), new_node.ypos())
         target_pos = (target_node.xpos() + width_offset,
-                     target_node.ypos() + height_offset)
+                      target_node.ypos() + height_offset)
         input_nodes, output_nodes = self._get_connected_nodes(target_node)
         nukescripts.clear_selection_recursive()
         target_node.setSelected(True)

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -70,50 +70,52 @@ class WorkfileTemplate():
         the input index that is connected to 'node'.
         '''
 
-        inputNodes = [(i, node.input(i)) for i in range(node.inputs())]
-        outputNodes = []
+        input_nodes = [(i, node.input(i)) for i in range(node.inputs())]
+        output_nodes = []
         deps = nuke.dependentNodes(nuke.INPUTS | nuke.HIDDEN_INPUTS, node)
-        for depNode in deps:
-            for i in range(depNode.inputs()):
-                if depNode.input(i) == node:
-                    outputNodes.append((i, depNode))
-        return (inputNodes, outputNodes)
+        for dep_node in deps:
+            for i in range(dep_node.inputs()):
+                if dep_node.input(i) == node:
+                    output_nodes.append((i, dep_node))
+        return (input_nodes, output_nodes)
 
-    def _swap_nodes(self, targetNode, newNode):
+    def _swap_nodes(self, target_node, new_node):
         '''
         Mimics the Ctrl + Shift + drag-and-drop node functionality in Nuke.
 
-        'targetNode': The node (or node name) to be replaced.
-        'newNode': The node (or node name) that will replace it.
+        'target_node': The node (or node name) to be replaced.
+        'new_node': The node (or node name) that will replace it.
         '''
-        if isinstance(targetNode, str):
-            targetNode = nuke.toNode(targetNode)
-        if isinstance(newNode, str):
-            newNode = nuke.toNode(newNode)
-        if not (isinstance(targetNode, nuke.Node) and
-                isinstance(newNode, nuke.Node)):
+
+        # Convert node names to nodes
+        if isinstance(target_node, str):
+            target_node = nuke.toNode(target_node)
+        if isinstance(new_node, str):
+            new_node = nuke.toNode(new_node)
+        if not (isinstance(target_node, nuke.Node) and
+                isinstance(new_node, nuke.Node)):
             return
 
-        source_node_width = int(newNode.screenWidth() / 2)
-        source_node_height = int(newNode.screenHeight() / 2)
-        target_node_width = int(targetNode.screenWidth() / 2)
-        target_node_height = int(targetNode.screenHeight() / 2)
+        source_node_width = int(new_node.screenWidth() / 2)
+        source_node_height = int(new_node.screenHeight() / 2)
+        target_node_width = int(target_node.screenWidth() / 2)
+        target_node_height = int(target_node.screenHeight() / 2)
         width_offset = target_node_width - source_node_width
         height_offset = target_node_height - source_node_height
-        sourcePos = (newNode.xpos(), newNode.ypos())
-        targetPos = (targetNode.xpos() + width_offset,
-                     targetNode.ypos() + height_offset)
-        inputNodes, outputNodes = self._get_connected_nodes(targetNode)
+        source_pos = (new_node.xpos(), new_node.ypos())
+        target_pos = (target_node.xpos() + width_offset,
+                     target_node.ypos() + height_offset)
+        input_nodes, output_nodes = self._get_connected_nodes(target_node)
         nukescripts.clear_selection_recursive()
-        targetNode.setSelected(True)
+        target_node.setSelected(True)
         nuke.extractSelected()
-        targetNode.setSelected(False)
-        newNode.setXYpos(*targetPos)
-        targetNode.setXYpos(*sourcePos)
-        for inNode in inputNodes:
-            newNode.setInput(*inNode)
-        for index, node in outputNodes:
-            node.setInput(index, newNode)
+        target_node.setSelected(False)
+        new_node.setXYpos(*target_pos)
+        target_node.setXYpos(*source_pos)
+        for inNode in input_nodes:
+            new_node.setInput(*inNode)
+        for index, node in output_nodes:
+            node.setInput(index, new_node)
 
     def _make_temps_from_op_nodes(self, op_nodes):
         '''
@@ -143,7 +145,7 @@ class WorkfileTemplate():
                 'deadlineConcurrentTasks', 'suspend_publish'
                 'channels', 'first', 'last', 'use_limit'],
             'LoadClip':
-                ['avalon:version', 'avalon:frameStart', 'avalon:frameEnd'],
+                [],
             'LoadEffectsInputProcess':
                 ['name']
         }
@@ -165,7 +167,7 @@ class WorkfileTemplate():
             knob_is_template.setVisible(False)
             node_name = str(node['name'].value())
 
-            # Loader or Creator?
+            # Make Template node - NoOp
             if str(node['avalon:id'].value()) == 'pyblish.avalon.container':
                 # Node type is pyblish.avalon.container - Loader
                 template_node = nuke.nodes.NoOp(tile_color='0xff7f00ff')
@@ -190,10 +192,12 @@ class WorkfileTemplate():
                 knob_subset.setText(str(node['avalon:subset'].value()))
                 template_label = str(node['avalon:subset'].value())
 
+            # Name the Template node nicely
             template_node['name'].setValue('Template{}'.format(node_count))
             template_node['label'].setValue(template_label)
 
             # Store handpicked knobs and their values - from knobs_to_store
+            # Uses knob type number for later type conversion
             to_store = {}
             if knobs_to_store.get(load_create):
                 for knob_to_store in knobs_to_store[load_create]:
@@ -210,8 +214,8 @@ class WorkfileTemplate():
                             # Some knobs to be stored might not be present
                             log.debug('Node {}: knob to be stored not found'
                                       .format(node_name))
-
             knob_other.setText(str(to_store))
+
             # Add knobs to Template node
             template_node.addKnob(knob_tab)
             template_node.addKnob(knob_load_create)
@@ -220,7 +224,9 @@ class WorkfileTemplate():
             template_node.addKnob(knob_other)
             template_node.addKnob(knob_is_template)
 
+            # Swap (and reconect) just created template node with it's source
             self._swap_nodes(node, template_node)
+            # Delete the source node, we have template instead
             nuke.delete(node)
 
     def _make_op_creator_nodes_from_temps(self):
@@ -257,10 +263,14 @@ class WorkfileTemplate():
         op_nodes = self._get_op_nodes(selected_only=False)
         template_nodes = self._get_op_template_nodes()
 
+        # For all the template nodes, find corresponding template nodes
         for one_template in template_nodes:
+            # Template detail
             load_create = str(one_template['loaderCreator'].value())
             subset = str(one_template['subset'].value())
             is_op_creator = bool(one_template['is_op_creator'].value())
+
+            # Decode templated knobs and values
             knob_dict = {}
             try:
                 knob_dict = ast.literal_eval(
@@ -269,6 +279,7 @@ class WorkfileTemplate():
                 log.warning('Temp node {} knobs failed to parse.'.format(
                     one_template['name'].value()))
 
+            # Find corresponding OP node (target)
             target_node = None
             if is_op_creator:
                 # it is a creator, compare subsets
@@ -292,7 +303,9 @@ class WorkfileTemplate():
                         pass
 
             if target_node:
+                # We have a template and target OP node, swap it
                 self._swap_nodes(one_template, target_node)
+                # Try to set the OP node knobs by the stored template knobs
                 for knob_name, knob in knob_dict.items():
                     try:
                         knob_value = str(knob['value'])
@@ -311,8 +324,6 @@ class WorkfileTemplate():
                         log.debug("knob {} type conversion failed"
                                   .format(knob_name))
                 nuke.delete(one_template)
-
-        return True
 
     def create_template(self):
 

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -69,7 +69,7 @@ class WorkfileTemplate():
         The second contains its outputs, where each 'index' is
         the input index that is connected to 'node'.
         '''
-        
+
         inputNodes = [(i, node.input(i)) for i in range(node.inputs())]
         outputNodes = []
         deps = nuke.dependentNodes(nuke.INPUTS | nuke.HIDDEN_INPUTS, node)
@@ -86,9 +86,9 @@ class WorkfileTemplate():
         'targetNode': The node (or node name) to be replaced.
         'newNode': The node (or node name) that will replace it.
         '''
-        if isinstance(targetNode, basestring):
+        if isinstance(targetNode, str):
             targetNode = nuke.toNode(targetNode)
-        if isinstance(newNode, basestring):
+        if isinstance(newNode, str):
             newNode = nuke.toNode(newNode)
         if not (isinstance(targetNode, nuke.Node) and
                 isinstance(newNode, nuke.Node)):
@@ -229,7 +229,8 @@ class WorkfileTemplate():
         '''
 
         t_nodes = self._get_op_template_nodes()
-        t_creators = [node for node in t_nodes if node['is_op_creator'].value()]
+        t_creators = [node for node in t_nodes 
+                      if node['is_op_creator'].value()]
         asset = str(os.environ["AVALON_ASSET"])
         for temp_creator in t_creators:
             load_create = str(temp_creator['loaderCreator'].value())

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -183,10 +183,16 @@ class WorkfileTemplate():
                 try:
                     load_create = str(node['avalon:creator'].value())
                 except NameError:
-                    # Writing model via WriteGeo doesn't store creator
+                    # Some OP nodes are missing loader / creator name
                     load_create = ''
-                    if str(node['avalon:subset'].value()).startswith('model'):
-                        load_create = 'CreateModel'
+                    subset = str(node['avalon:subset'].value())
+                    if subset:
+                        if subset.startswith('model'):
+                            load_create = 'CreateModel'
+                        if subset.startswith('nukenodes'):
+                            load_create = 'LoadBackdropNodes'
+                        if subset.startswith('gizmo'):
+                            load_create = 'LoadGizmo'
                 knob_load_create.setText(load_create)
                 knob_is_creator.setValue(True)
                 knob_subset.setText(str(node['avalon:subset'].value()))

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -94,10 +94,10 @@ class WorkfileTemplate():
                 isinstance(newNode, nuke.Node)):
             return
 
-        source_node_width = newNode.screenWidth() / 2
-        source_node_height = newNode.screenHeight() / 2
-        target_node_width = targetNode.screenWidth() / 2
-        target_node_height = targetNode.screenHeight() / 2
+        source_node_width = int(newNode.screenWidth() / 2)
+        source_node_height = int(newNode.screenHeight() / 2)
+        target_node_width = int(targetNode.screenWidth() / 2)
+        target_node_height = int(targetNode.screenHeight() / 2)
         width_offset = target_node_width - source_node_width
         height_offset = target_node_height - source_node_height
         sourcePos = (newNode.xpos(), newNode.ypos())

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -1,0 +1,336 @@
+import ast
+import os
+import nuke
+import nukescripts
+
+from openpype.pipeline import discover_legacy_creator_plugins
+from openpype.api import Logger
+
+log = Logger.get_logger(__name__)
+
+
+class WorkfileTemplate():
+
+    def __init__(self):
+        pass
+
+    def _get_op_nodes(self, selected_only=True):
+        '''
+        Returns list of Nuke nodes that are OP loaders or creators.
+
+        Only returns nodes that have avalon:id knob
+        Optionally returns node only if it is selected
+        '''
+
+        nodes = []
+        for node in nuke.allNodes(recurseGroups=False):
+            if "OpenpypeDataGroup" in node.knobs():
+                try:
+                    if not selected_only:
+                        nodes.append(node)
+                    elif node['selected'].value():
+                        nodes.append(node)
+
+                except NameError:
+                    pass
+
+        if len(nodes) == 0:
+            log.warning('OP nodes not found')
+        else:
+            log.debug('OP nodes:')
+            for node in nodes:
+                log.debug(str(node['name'].value()))
+
+        return nodes
+
+    def _get_op_template_nodes(self):
+        '''
+        Returns list of Nuke nodes - templates for OP loaders or creators
+
+        Only returns Template nodes, recognized by hidden knob is_op_template
+        '''
+
+        nodes = []
+        for node in nuke.allNodes(filter='NoOp'):
+            if "is_op_template" in node.knobs():
+                nodes.append(node)
+
+        return nodes
+
+    def _get_connected_nodes(self, node):
+        '''
+        Returns a two-tuple of lists. Each list is made up of two-tuples in the
+        form ``(index, nodeObj)`` where 'index' is an input index and 'nodeObj'
+        is a Nuke node.
+
+        The first list contains the inputs to 'node', where each 'index' is the
+        input index of 'node' itself.
+
+        The second contains its outputs, where each 'index' is
+        the input index that is connected to 'node'.
+        '''
+        
+        inputNodes = [(i, node.input(i)) for i in range(node.inputs())]
+        outputNodes = []
+        deps = nuke.dependentNodes(nuke.INPUTS | nuke.HIDDEN_INPUTS, node)
+        for depNode in deps:
+            for i in range(depNode.inputs()):
+                if depNode.input(i) == node:
+                    outputNodes.append((i, depNode))
+        return (inputNodes, outputNodes)
+
+    def _swap_nodes(self, targetNode, newNode):
+        '''
+        Mimics the Ctrl + Shift + drag-and-drop node functionality in Nuke.
+
+        'targetNode': The node (or node name) to be replaced.
+        'newNode': The node (or node name) that will replace it.
+        '''
+        if isinstance(targetNode, basestring):
+            targetNode = nuke.toNode(targetNode)
+        if isinstance(newNode, basestring):
+            newNode = nuke.toNode(newNode)
+        if not (isinstance(targetNode, nuke.Node) and
+                isinstance(newNode, nuke.Node)):
+            return
+
+        source_node_width = newNode.screenWidth() / 2
+        source_node_height = newNode.screenHeight() / 2
+        target_node_width = targetNode.screenWidth() / 2
+        target_node_height = targetNode.screenHeight() / 2
+        width_offset = target_node_width - source_node_width
+        height_offset = target_node_height - source_node_height
+        sourcePos = (newNode.xpos(), newNode.ypos())
+        targetPos = (targetNode.xpos() + width_offset,
+                     targetNode.ypos() + height_offset)
+        inputNodes, outputNodes = self._get_connected_nodes(targetNode)
+        nukescripts.clear_selection_recursive()
+        targetNode.setSelected(True)
+        nuke.extractSelected()
+        targetNode.setSelected(False)
+        newNode.setXYpos(*targetPos)
+        targetNode.setXYpos(*sourcePos)
+        for inNode in inputNodes:
+            newNode.setInput(*inNode)
+        for index, node in outputNodes:
+            node.setInput(index, newNode)
+
+    def _make_temps_from_op_nodes(self, op_nodes):
+        '''
+        Converts OP nodes to template nodes
+
+        Template Nodes store
+            loader / Creator name
+            OP node subset
+            other selected knobs and their values as a string
+            knob indicating that node is a template node
+        '''
+
+        # Selected knobs to be stored
+        knobs_to_store = {
+            'CreateWriteRender': [
+                'publish', 'render', 'review',
+                'deadlinePriority', 'deadlineChunkSize',
+                'deadlineConcurrentTasks', 'suspend_publish'],
+            'CreateWritePrerender': [
+                'publish', 'render', 'review',
+                'deadlinePriority', 'deadlineChunkSize',
+                'deadlineConcurrentTasks', 'suspend_publish',
+                'channels', 'first', 'last', 'use_limit'],
+            'CreateWriteStill': [
+                'publish', 'render', 'review',
+                'deadlinePriority', 'deadlineChunkSize',
+                'deadlineConcurrentTasks', 'suspend_publish'
+                'channels', 'first', 'last', 'use_limit'],
+            'LoadClip':
+                ['avalon:version', 'avalon:frameStart', 'avalon:frameEnd'],
+            'LoadEffectsInputProcess':
+                ['name']
+        }
+
+        node_count = 0
+        for node in op_nodes:
+            node_count += 1
+            # Make knobs
+            knob_tab = nuke.Tab_Knob('OP Template')
+            knob_load_create = nuke.String_Knob('loaderCreator',
+                                                'Loader/Creator')
+            knob_is_creator = nuke.Boolean_Knob('is_op_creator', 'Creator')
+            knob_subset = nuke.String_Knob('subset', 'Subset')
+            knob_other = nuke.Multiline_Eval_String_Knob('other',
+                                                         'Other')
+            knob_is_template = nuke.Boolean_Knob('is_op_template',
+                                                 'Is Template')
+            knob_is_template.setValue(True)
+            knob_is_template.setVisible(False)
+            node_name = str(node['name'].value())
+
+            # Loader or Creator?
+            if str(node['avalon:id'].value()) == 'pyblish.avalon.container':
+                # Node type is pyblish.avalon.container - Loader
+                template_node = nuke.nodes.NoOp(tile_color='0xff7f00ff')
+                load_create = str(node['avalon:loader'].value())
+                knob_load_create.setText(load_create)
+                knob_is_creator.setValue(False)
+                knob_subset.setText(str(node['avalon:name'].value()))
+                template_label = str(node['avalon:loader'].value())
+                template_label += '\n' + str(node['avalon:name'].value())
+            else:
+                # Node type is pyblish.avalon.instance - Creator
+                template_node = nuke.nodes.NoOp(tile_color='0xff3d00ff')
+                try:
+                    load_create = str(node['avalon:creator'].value())
+                except NameError:
+                    # Writing model via WriteGeo doesn't store creator
+                    load_create = ''
+                    if str(node['avalon:subset'].value()).startswith('model'):
+                        load_create = 'CreateModel'
+                knob_load_create.setText(load_create)
+                knob_is_creator.setValue(True)
+                knob_subset.setText(str(node['avalon:subset'].value()))
+                template_label = str(node['avalon:subset'].value())
+
+            template_node['name'].setValue('Template{}'.format(node_count))
+            template_node['label'].setValue(template_label)
+
+            # Store handpicked knobs and their values - from knobs_to_store
+            to_store = {}
+            if knobs_to_store.get(load_create):
+                for knob_to_store in knobs_to_store[load_create]:
+                    my_knob = node.knob(str(knob_to_store))
+                    if my_knob:
+                        try:
+                            knob_type_num = nuke.knob(
+                                my_knob.fullyQualifiedName(), type=True)
+                            to_store[knob_to_store] = {
+                                'value': node[knob_to_store].value(),
+                                'type': knob_type_num
+                            }
+                        except NameError:
+                            # Some knobs to be stored might not be present
+                            log.debug('Node {}: knob to be stored not found'
+                                      .format(node_name))
+
+            knob_other.setText(str(to_store))
+            # Add knobs to Template node
+            template_node.addKnob(knob_tab)
+            template_node.addKnob(knob_load_create)
+            template_node.addKnob(knob_is_creator)
+            template_node.addKnob(knob_subset)
+            template_node.addKnob(knob_other)
+            template_node.addKnob(knob_is_template)
+
+            self._swap_nodes(node, template_node)
+            nuke.delete(node)
+
+    def _make_op_creator_nodes_from_temps(self):
+        '''
+        For each creator template creates OP node
+        '''
+
+        t_nodes = self._get_op_template_nodes()
+        t_creators = [node for node in t_nodes if node['is_op_creator'].value()]
+        asset = str(os.environ["AVALON_ASSET"])
+        for temp_creator in t_creators:
+            load_create = str(temp_creator['loaderCreator'].value())
+            subset = str(temp_creator['subset'].value())
+
+            # Get appropriate plugin class
+            creator_plugin = None
+            for creator in discover_legacy_creator_plugins():
+                if str(creator.__name__) != load_create:
+                    continue
+                creator_plugin = creator
+
+            if creator_plugin:
+                creator_plugin(subset, asset).process()
+            else:
+                log.warning('Creator plugin {} not found'.format(load_create))
+
+    def _template_connect(self):
+        '''
+        Swaps OP loaders or creators with corresponding template nodes,
+        delete Template nodes
+        '''
+
+        op_nodes = self._get_op_nodes(selected_only=False)
+        template_nodes = self._get_op_template_nodes()
+
+        for one_template in template_nodes:
+            load_create = str(one_template['loaderCreator'].value())
+            subset = str(one_template['subset'].value())
+            is_op_creator = bool(one_template['is_op_creator'].value())
+            knob_dict = {}
+            try:
+                knob_dict = ast.literal_eval(
+                    str(one_template['other'].value()))
+            except ValueError:
+                log.warning('Temp node {} knobs failed to parse.'.format(
+                    one_template['name'].value()))
+
+            target_node = None
+            if is_op_creator:
+                # it is a creator, compare subsets
+                for node in op_nodes:
+                    try:
+                        if subset == str(node['avalon:subset'].value()):
+                            target_node = node
+                            break
+                    except NameError:
+                        pass
+            else:
+                # it is a loader, compare subset and loader name
+                for node in op_nodes:
+                    try:
+                        if subset == str(node['avalon:name'].value()):
+                            node_loader = str(node['avalon:loader'].value())
+                            if load_create == node_loader:
+                                target_node = node
+                                break
+                    except NameError:
+                        pass
+
+            if target_node:
+                self._swap_nodes(one_template, target_node)
+                for knob_name, knob in knob_dict.items():
+                    try:
+                        knob_value = str(knob['value'])
+                        knob_type = int(knob['type'])
+                        if knob_type == 3:
+                            knob_value = int(knob_value)
+                        elif knob_type == 6:
+                            knob_value = bool(knob_value)
+                        elif knob_type == 8:
+                            knob_value = float(knob_value)
+                        target_node[knob_name].setValue(knob_value)
+                    except NameError:
+                        pass
+                nuke.delete(one_template)
+
+        return True
+
+    def create_template(self):
+
+        # get OP nodes
+        op_nodes = len(nuke.selectedNodes())
+        if op_nodes == 0:
+            # No nodes selected. Assume user wants to convert all OP nodes
+            op_nodes = self._get_op_nodes(selected_only=False)
+        else:
+            # Some nodes selected.
+            # Assume user wants to convert just selected nodes
+            log.info("Templating only {} selected nodes".format(op_nodes))
+            op_nodes = self._get_op_nodes(selected_only=True)
+
+        # Convert OP nodes to template nodes
+        self._make_temps_from_op_nodes(op_nodes)
+        log.info("Template created. Please save to location specified\
+                  by settings: workfile_builder - curstom_templates - path")
+
+    def apply_template(self):
+        # Make creators
+        self._make_op_creator_nodes_from_temps()
+
+        # Swap templates with loaders/creators
+        # Delete templates
+        self._template_connect()

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -229,7 +229,7 @@ class WorkfileTemplate():
         '''
 
         t_nodes = self._get_op_template_nodes()
-        t_creators = [node for node in t_nodes 
+        t_creators = [node for node in t_nodes
                       if node['is_op_creator'].value()]
         asset = str(os.environ["AVALON_ASSET"])
         for temp_creator in t_creators:

--- a/openpype/hosts/nuke/api/workfile_template.py
+++ b/openpype/hosts/nuke/api/workfile_template.py
@@ -298,14 +298,18 @@ class WorkfileTemplate():
                         knob_value = str(knob['value'])
                         knob_type = int(knob['type'])
                         if knob_type == 3:
-                            knob_value = int(knob_value)
+                            try:
+                                knob_value = int(knob_value)
+                            except ValueError:
+                                knob_value = int(float(knob_value))
                         elif knob_type == 6:
                             knob_value = bool(knob_value)
                         elif knob_type == 8:
                             knob_value = float(knob_value)
                         target_node[knob_name].setValue(knob_value)
-                    except NameError:
-                        pass
+                    except (NameError, ValueError):
+                        log.debug("knob {} type conversion failed"
+                                  .format(knob_name))
                 nuke.delete(one_template)
 
         return True


### PR DESCRIPTION
## Brief description
Following discussion https://github.com/pypeclub/OpenPype/discussions/2013
Similar to PR https://github.com/pypeclub/OpenPype/pull/3544, but allows making template from workfile in one go, and works with creators. 

There is already a mechanism for loading Nuke template scripts, even automatically on a first open. Nuke workfile Builder settings allow to create first workfile and run Builder on first launch. This PR allows to create template from workfile with one click. It connects loaders and creators, and applies (some) knob values from the template, for example  publishing and Deadline settings.

## Description
For propagating master shots, prepare the master shot, and when happy, convert it to the template Nuke script.
Save the template Nuke script to the location set up in the workfile builder settings, for example ```{root[work]}/{project[name]}/templates/{task[name]}.nk```. When artists launches the task with matching task name, your master script will autoload as version 1, complete with correct loaders and creators.

## Simple Template 
Showing two Loaders and one Write Render
![image](https://user-images.githubusercontent.com/45896205/184978758-0501eaf2-485e-41e2-997f-4dc29b12c6de.png)

## Shot with Template Applied
from above, at first open
![image](https://user-images.githubusercontent.com/45896205/184979652-6a2ec3a1-8bfd-4913-a4ee-2d813782b9b2.png)


## Tested Workfile Builder settings
Settings in json:
[WorkfileBuilder.json.txt](https://github.com/pypeclub/OpenPype/files/9362997/WorkfileBuilder.json.txt)

![image](https://user-images.githubusercontent.com/45896205/184978194-41378ac1-5776-45d4-881e-48fb045401ef.png)



## Testing notes:
1. Set up the Workfile Builder settings
2. Work on first Nuke task as usual. Save
3. Run ```OpenPype - Workfile to Template```. Note that if you select some nodes, only selection will be templated
4. Use Save as to save the template to the location specified by settings workfile_builder - curstom_templates - path
5. Launch Nuke in context of other task. If no version exists, template will auto apply
6. Alternatively, you can run ```OpenPype - Builde Workfile and Apply Template``` from the top menu
