### PR TITLE
General: version string in subset name break file sequence collection in review

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -138,10 +138,10 @@ class ExtractPlayblast(openpype.api.Extractor):
         self.log.debug("playblast path  {}".format(path))
 
         collected_files = os.listdir(stagingdir)
-        pattern_frame = [r'\.(?P<index>(?P<padding>0*)\d+)\.\D+\d?$']
+        patterns = [clique.PATTERNS["frames"]]
         collections, remainder = clique.assemble(collected_files,
                                                  minimum_items=1,
-                                                 patterns=pattern_frame)
+                                                 patterns=patterns)
 
         self.log.debug("filename {}".format(filename))
         frame_collection = None

--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -138,9 +138,10 @@ class ExtractPlayblast(openpype.api.Extractor):
         self.log.debug("playblast path  {}".format(path))
 
         collected_files = os.listdir(stagingdir)
+        pattern_frame = [r'\.(?P<index>(?P<padding>0*)\d+)\.\D+\d?$']
         collections, remainder = clique.assemble(collected_files,
                                                  minimum_items=1,
-                                                 patterns=[r'\.(?P<index>(?P<padding>0*)\d+)\.\D+\d?$'])
+                                                 patterns=pattern_frame)
 
         self.log.debug("filename {}".format(filename))
         frame_collection = None

--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -139,7 +139,8 @@ class ExtractPlayblast(openpype.api.Extractor):
 
         collected_files = os.listdir(stagingdir)
         collections, remainder = clique.assemble(collected_files,
-                                                 minimum_items=1)
+                                                 minimum_items=1,
+                                                 patterns=[r'\.(?P<index>(?P<padding>0*)\d+)\.\D+\d?$'])
 
         self.log.debug("filename {}".format(filename))
         frame_collection = None


### PR DESCRIPTION
## Brief description
When there is a version string in subset name, like foo_bar_v004  and that subset name is used for review, clique  has trouble collecting playblasted sequences for it because it tries to parse version string as a frame number, resulting in multiple collections.

## Solutions
Defines the pattern of the filename in `clique.assemble()`
Instead of 
```
        collections, remainder = clique.assemble(collected_files,
                                                 minimum_items=1)
```
Uses
```
        pattern_frame = [r'\.(?P<index>(?P<padding>0*)\d+)\.\D+\d?$']
        collections, remainder = clique.assemble(collected_files,
                                                 minimum_items=1,
                                                 patterns=pattern_frame)
```