### PR TITLE
General: Benevolent context label collector

### DIFF
--- a/openpype/plugins/publish/collect_context_label.py
+++ b/openpype/plugins/publish/collect_context_label.py
@@ -1,5 +1,6 @@
 """
-Requires:
+Optional:
+    context     -> hostName (str)
     context     -> currentFile (str)
 Provides:
     context     -> label (str)
@@ -16,16 +17,16 @@ class CollectContextLabel(pyblish.api.ContextPlugin):
     label = "Context Label"
 
     def process(self, context):
+        host_name = context.data.get("hostName")
+        if not host_name:
+            host_name = pyblish.api.registered_hosts()[-1]
+        # Use host name as base for label
+        label = host_name.title()
 
-        # Get last registered host
-        host = pyblish.api.registered_hosts()[-1]
-
-        # Get scene name from "currentFile"
-        path = context.data.get("currentFile") or "<Unsaved>"
-        base = os.path.basename(path)
+        # Get scene name from "currentFile" and use basename as ending of label
+        path = context.data.get("currentFile")
+        if path:
+            label += " - {}".format(os.path.basename(path))
 
         # Set label
-        label = "{host} - {scene}".format(host=host.title(), scene=base)
-        if host == "standalonepublisher":
-            label = host.title()
         context.data["label"] = label

--- a/openpype/plugins/publish/collect_context_label.py
+++ b/openpype/plugins/publish/collect_context_label.py
@@ -17,6 +17,12 @@ class CollectContextLabel(pyblish.api.ContextPlugin):
     label = "Context Label"
 
     def process(self, context):
+        # Add ability to use custom context label
+        context_label = context.data.get("contextLabel")
+        if context_label:
+            context.data["label"] = context_label
+            return
+
         host_name = context.data.get("hostName")
         if not host_name:
             host_name = pyblish.api.registered_hosts()[-1]

--- a/openpype/plugins/publish/collect_context_label.py
+++ b/openpype/plugins/publish/collect_context_label.py
@@ -18,9 +18,11 @@ class CollectContextLabel(pyblish.api.ContextPlugin):
 
     def process(self, context):
         # Add ability to use custom context label
-        context_label = context.data.get("contextLabel")
-        if context_label:
-            context.data["label"] = context_label
+        label = context.data.get("label")
+        if label:
+            self.log.debug("Context label is already set to \"{}\"".format(
+                label
+            ))
             return
 
         host_name = context.data.get("hostName")
@@ -36,3 +38,6 @@ class CollectContextLabel(pyblish.api.ContextPlugin):
 
         # Set label
         context.data["label"] = label
+        self.log.debug("Context label is changed to \"{}\"".format(
+            label
+        ))

--- a/openpype/tools/publisher/publish_report_viewer/report_items.py
+++ b/openpype/tools/publisher/publish_report_viewer/report_items.py
@@ -79,7 +79,7 @@ class PublishReport:
 
         context_data = data["context"]
         context_data["name"] = "context"
-        context_data["label"] = context_data["label"] or "Context"
+        context_data["label"] = context_data.get("label") or "Context"
 
         logs = []
         plugins_items_by_id = {}

--- a/openpype/tools/publisher/widgets/publish_widget.py
+++ b/openpype/tools/publisher/widgets/publish_widget.py
@@ -335,14 +335,12 @@ class PublishFrame(QtWidgets.QFrame):
         if instance is None:
             new_name = (
                 context.data.get("label")
-                or getattr(context, "label", None)
                 or context.data.get("name")
                 or "Context"
             )
         else:
             new_name = (
                 instance.data.get("label")
-                or getattr(instance, "label", None)
                 or instance.data["name"]
             )
 

--- a/openpype/tools/pyblish_pype/control.py
+++ b/openpype/tools/pyblish_pype/control.py
@@ -244,7 +244,6 @@ class Controller(QtCore.QObject):
         self.context.optional = False
 
         self.context.data["publish"] = True
-        self.context.data["label"] = "Context"
         self.context.data["name"] = "context"
 
         self.context.data["host"] = reversed(pyblish.api.registered_hosts())

--- a/openpype/tools/pyblish_pype/model.py
+++ b/openpype/tools/pyblish_pype/model.py
@@ -613,10 +613,7 @@ class InstanceItem(QtGui.QStandardItem):
         if role == QtCore.Qt.DisplayRole:
             label = None
             if settings.UseLabel:
-                label = (
-                    self.instance.data.get("label")
-                    or getattr(self.instance, "label", None)
-                )
+                label = self.instance.data.get("label")
 
             if not label:
                 if self.is_context:

--- a/openpype/tools/pyblish_pype/model.py
+++ b/openpype/tools/pyblish_pype/model.py
@@ -596,11 +596,6 @@ class InstanceItem(QtGui.QStandardItem):
         instance._logs = []
         instance.optional = getattr(instance, "optional", True)
         instance.data["publish"] = instance.data.get("publish", True)
-        instance.data["label"] = (
-            instance.data.get("label")
-            or getattr(instance, "label", None)
-            or instance.data["name"]
-        )
 
         family = self.data(Roles.FamiliesRole)[0]
         self.setData(
@@ -616,9 +611,19 @@ class InstanceItem(QtGui.QStandardItem):
 
     def data(self, role=QtCore.Qt.DisplayRole):
         if role == QtCore.Qt.DisplayRole:
+            label = None
             if settings.UseLabel:
-                return self.instance.data["label"]
-            return self.instance.data["name"]
+                label = (
+                    self.instance.data.get("label")
+                    or getattr(self.instance, "label", None)
+                )
+
+            if not label:
+                if self.is_context:
+                    label = "Context"
+                else:
+                    label = self.instance.data["name"]
+            return label
 
         if role == QtCore.Qt.DecorationRole:
             icon_name = self.instance.data.get("icon") or "file"


### PR DESCRIPTION
## Brief description
Context label collector is more benevolent to available data.

## Description
Collector does not require `currentFile` to be filled and use just host name in that case. If context data contains `contextLabel` the plugin just set it as label of context and skip rest of logic, this was added to have ability define custom context label and skip the plugin logic. Result is that standalone publisher and tray publisher don't have to be explicitly named in the plugin.

Pyblish pype does not force to have `"label"` in `instance.data` and `context.data`.

## Testing notes:
1. Context label should be collected as did