### PR TITLE
Maya: write color sets in  create_model

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_animation.py
+++ b/openpype/hosts/maya/plugins/create/create_animation.py
@@ -12,6 +12,7 @@ class CreateAnimation(plugin.Creator):
     family = "animation"
     icon = "male"
     write_color_sets = False
+    write_face_sets = False
 
     def __init__(self, *args, **kwargs):
         super(CreateAnimation, self).__init__(*args, **kwargs)
@@ -24,7 +25,7 @@ class CreateAnimation(plugin.Creator):
 
         # Write vertex colors with the geometry.
         self.data["writeColorSets"] = self.write_color_sets
-        self.data["writeFaceSets"] = False
+        self.data["writeFaceSets"] = self.write_face_sets
 
         # Include only renderable visible shapes.
         # Skips locators and empty transforms

--- a/openpype/hosts/maya/plugins/create/create_model.py
+++ b/openpype/hosts/maya/plugins/create/create_model.py
@@ -9,12 +9,12 @@ class CreateModel(plugin.Creator):
     family = "model"
     icon = "cube"
     defaults = ["Main", "Proxy", "_MD", "_HD", "_LD"]
-
+    write_color_sets = False
     def __init__(self, *args, **kwargs):
         super(CreateModel, self).__init__(*args, **kwargs)
 
         # Vertex colors with the geometry
-        self.data["writeColorSets"] = False
+        self.data["writeColorSets"] = self.write_color_sets
         self.data["writeFaceSets"] = False
 
         # Include attributes by attribute name or prefix

--- a/openpype/hosts/maya/plugins/create/create_model.py
+++ b/openpype/hosts/maya/plugins/create/create_model.py
@@ -10,12 +10,13 @@ class CreateModel(plugin.Creator):
     icon = "cube"
     defaults = ["Main", "Proxy", "_MD", "_HD", "_LD"]
     write_color_sets = False
+    write_face_sets = False
     def __init__(self, *args, **kwargs):
         super(CreateModel, self).__init__(*args, **kwargs)
 
         # Vertex colors with the geometry
         self.data["writeColorSets"] = self.write_color_sets
-        self.data["writeFaceSets"] = False
+        self.data["writeFaceSets"] = self.write_face_sets
 
         # Include attributes by attribute name or prefix
         self.data["attr"] = ""

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -12,6 +12,7 @@ class CreatePointCache(plugin.Creator):
     family = "pointcache"
     icon = "gears"
     write_color_sets = False
+    write_face_sets = False
 
     def __init__(self, *args, **kwargs):
         super(CreatePointCache, self).__init__(*args, **kwargs)
@@ -21,7 +22,8 @@ class CreatePointCache(plugin.Creator):
 
         # Vertex colors with the geometry.
         self.data["writeColorSets"] = self.write_color_sets
-        self.data["writeFaceSets"] = False  # Vertex colors with the geometry.
+        # Vertex colors with the geometry.
+        self.data["writeFaceSets"] = self.write_face_sets
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible
         self.data["includeParentHierarchy"] = False  # Include parent groups

--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -13,12 +13,15 @@ class CreateRig(plugin.Creator):
     label = "Rig"
     family = "rig"
     icon = "wheelchair"
+    write_color_sets = False
+    def __init__(self, *args, **kwargs):
+        super(CreateRig, self).__init__(*args, **kwargs)
+        self.data["writeColorSets"] = self.write_color_sets
 
     def process(self):
 
         with lib.undo_chunk():
             instance = super(CreateRig, self).process()
-
             self.log.info("Creating Rig instance set up ...")
             controls = cmds.sets(name="controls_SET", empty=True)
             pointcache = cmds.sets(name="out_SET", empty=True)

--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -18,6 +18,7 @@ class CreateRig(plugin.Creator):
     def __init__(self, *args, **kwargs):
         super(CreateRig, self).__init__(*args, **kwargs)
         self.data["writeColorSets"] = self.write_color_sets
+        self.data["writeFaceSets"] = False
 
     def process(self):
 

--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -14,11 +14,12 @@ class CreateRig(plugin.Creator):
     family = "rig"
     icon = "wheelchair"
     write_color_sets = False
+    write_face_sets = False
 
     def __init__(self, *args, **kwargs):
         super(CreateRig, self).__init__(*args, **kwargs)
         self.data["writeColorSets"] = self.write_color_sets
-        self.data["writeFaceSets"] = False
+        self.data["writeFaceSets"] = self.write_face_sets
 
     def process(self):
 

--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -14,6 +14,7 @@ class CreateRig(plugin.Creator):
     family = "rig"
     icon = "wheelchair"
     write_color_sets = False
+
     def __init__(self, *args, **kwargs):
         super(CreateRig, self).__init__(*args, **kwargs)
         self.data["writeColorSets"] = self.write_color_sets

--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -13,18 +13,12 @@ class CreateRig(plugin.Creator):
     label = "Rig"
     family = "rig"
     icon = "wheelchair"
-    write_color_sets = False
-    write_face_sets = False
-
-    def __init__(self, *args, **kwargs):
-        super(CreateRig, self).__init__(*args, **kwargs)
-        self.data["writeColorSets"] = self.write_color_sets
-        self.data["writeFaceSets"] = self.write_face_sets
 
     def process(self):
 
         with lib.undo_chunk():
             instance = super(CreateRig, self).process()
+
             self.log.info("Creating Rig instance set up ...")
             controls = cmds.sets(name="controls_SET", empty=True)
             pointcache = cmds.sets(name="out_SET", empty=True)

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -187,8 +187,6 @@
         },
         "CreateRig": {
             "enabled": true,
-            "write_color_sets": false,
-            "write_face_sets": false,
             "defaults": [
                 "Main",
                 "Sim",

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -102,6 +102,7 @@
         "CreateAnimation": {
             "enabled": true,
             "write_color_sets": false,
+            "write_face_sets": false,
             "defaults": [
                 "Main"
             ]
@@ -109,6 +110,7 @@
         "CreatePointCache": {
             "enabled": true,
             "write_color_sets": false,
+            "write_face_sets": false,
             "defaults": [
                 "Main"
             ]
@@ -164,6 +166,7 @@
         "CreateModel": {
             "enabled": true,
             "write_color_sets": false,
+            "write_face_sets": false,
             "defaults": [
                 "Main",
                 "Proxy",
@@ -185,6 +188,7 @@
         "CreateRig": {
             "enabled": true,
             "write_color_sets": false,
+            "write_face_sets": false,
             "defaults": [
                 "Main",
                 "Sim",

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -33,7 +33,7 @@
     },
     "RenderSettings": {
         "apply_render_settings": true,
-        "default_render_image_folder": "renders",
+        "default_render_image_folder": "",
         "aov_separator": "underscore",
         "reset_current_frame": false,
         "arnold_renderer": {

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -33,7 +33,7 @@
     },
     "RenderSettings": {
         "apply_render_settings": true,
-        "default_render_image_folder": "",
+        "default_render_image_folder": "renders",
         "aov_separator": "underscore",
         "reset_current_frame": false,
         "arnold_renderer": {
@@ -163,6 +163,7 @@
         },
         "CreateModel": {
             "enabled": true,
+            "write_color_sets": false,
             "defaults": [
                 "Main",
                 "Proxy",
@@ -183,6 +184,7 @@
         },
         "CreateRig": {
             "enabled": true,
+            "write_color_sets": false,
             "defaults": [
                 "Main",
                 "Sim",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -128,6 +128,11 @@
                     "label": "Write Color Sets"
                 },
                 {
+                    "type": "boolean",
+                    "key": "write_face_sets",
+                    "label": "Write Face Sets"
+                },
+                {
                     "type": "list",
                     "key": "defaults",
                     "label": "Default Subsets",
@@ -151,6 +156,11 @@
                     "type": "boolean",
                     "key": "write_color_sets",
                     "label": "Write Color Sets"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_face_sets",
+                    "label": "Write Face Sets"
                 },
                 {
                     "type": "list",
@@ -178,6 +188,11 @@
                     "label": "Write Color Sets"
                 },
                 {
+                    "type": "boolean",
+                    "key": "write_face_sets",
+                    "label": "Write Face Sets"
+                },
+                {
                     "type": "list",
                     "key": "defaults",
                     "label": "Default Subsets",
@@ -201,6 +216,11 @@
                     "type": "boolean",
                     "key": "write_color_sets",
                     "label": "Write Color Sets"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_face_sets",
+                    "label": "Write Face Sets"
                 },
                 {
                     "type": "list",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -138,6 +138,56 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "CreateModel",
+            "label": "Create Model",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_color_sets",
+                    "label": "Write Color Sets"
+                },
+                {
+                    "type": "list",
+                    "key": "defaults",
+                    "label": "Default Subsets",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CreateRig",
+            "label": "Create Rig",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "write_color_sets",
+                    "label": "Write Color Sets"
+                },
+                {
+                    "type": "list",
+                    "key": "defaults",
+                    "label": "Default Subsets",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "key": "CreatePointCache",
             "label": "Create Point Cache",
             "checkbox_key": "enabled",
@@ -160,7 +210,7 @@
                 }
             ]
         },
-        
+
         {
             "type": "schema_template",
             "name": "template_create_plugin",
@@ -198,20 +248,12 @@
                     "label": "Create Maya Scene"
                 },
                 {
-                    "key": "CreateModel",
-                    "label": "Create Model"
-                },
-                {
                     "key": "CreateRenderSetup",
                     "label": "Create Render Setup"
                 },
                 {
                     "key": "CreateReview",
                     "label": "Create Review"
-                },
-                {
-                    "key": "CreateRig",
-                    "label": "Create Rig"
                 },
                 {
                     "key": "CreateSetDress",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_create.json
@@ -173,36 +173,6 @@
         {
             "type": "dict",
             "collapsible": true,
-            "key": "CreateRig",
-            "label": "Create Rig",
-            "checkbox_key": "enabled",
-            "children": [
-                {
-                    "type": "boolean",
-                    "key": "enabled",
-                    "label": "Enabled"
-                },
-                {
-                    "type": "boolean",
-                    "key": "write_color_sets",
-                    "label": "Write Color Sets"
-                },
-                {
-                    "type": "boolean",
-                    "key": "write_face_sets",
-                    "label": "Write Face Sets"
-                },
-                {
-                    "type": "list",
-                    "key": "defaults",
-                    "label": "Default Subsets",
-                    "object_type": "text"
-                }
-            ]
-        },
-        {
-            "type": "dict",
-            "collapsible": true,
             "key": "CreatePointCache",
             "label": "Create Point Cache",
             "checkbox_key": "enabled",
@@ -274,6 +244,10 @@
                 {
                     "key": "CreateReview",
                     "label": "Create Review"
+                },
+                {
+                    "key": "CreateRig",
+                    "label": "Create Rig"
                 },
                 {
                     "key": "CreateSetDress",


### PR DESCRIPTION
## Brief description
Adding the on/off option of write color sets attributes in _create_rig.py_

Adding swtiching on/off clickbox to override the boolean option of write_color_sets_arttirbute in _create_model.py_ and  _create_rig.py_

![image](https://user-images.githubusercontent.com/64118225/185406917-fedd0494-e92c-451a-bb62-bd6e2219bf4f.png)
![image](https://user-images.githubusercontent.com/64118225/185407314-3296a7c8-35ae-40d4-bf44-586d61d65d2b.png)

