### PR TITLE
General: Switch from hero version to versioned works

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -1259,58 +1259,64 @@ def get_representations_parents(project_name, representations):
         dict[ObjectId, tuple]: Parents by representation id.
     """
 
-    repres_by_version_id = collections.defaultdict(list)
-    versions_by_version_id = {}
-    versions_by_subset_id = collections.defaultdict(list)
-    subsets_by_subset_id = {}
-    subsets_by_asset_id = collections.defaultdict(list)
+    repre_docs_by_version_id = collections.defaultdict(list)
+    version_docs_by_version_id = {}
+    version_docs_by_subset_id = collections.defaultdict(list)
+    subset_docs_by_subset_id = {}
+    subset_docs_by_asset_id = collections.defaultdict(list)
     output = {}
-    for representation in representations:
-        repre_id = representation["_id"]
+    for repre_doc in representations:
+        repre_id = repre_doc["_id"]
+        version_id = repre_doc["parent"]
         output[repre_id] = (None, None, None, None)
-        version_id = representation["parent"]
-        repres_by_version_id[version_id].append(representation)
+        repre_docs_by_version_id[version_id].append(repre_doc)
 
-    versions = get_versions(
-        project_name, version_ids=repres_by_version_id.keys()
+    version_docs = get_versions(
+        project_name,
+        version_ids=repre_docs_by_version_id.keys(),
+        hero=True
     )
-    for version in versions:
-        version_id = version["_id"]
-        subset_id = version["parent"]
-        versions_by_version_id[version_id] = version
-        versions_by_subset_id[subset_id].append(version)
+    for version_doc in version_docs:
+        version_id = version_doc["_id"]
+        subset_id = version_doc["parent"]
+        version_docs_by_version_id[version_id] = version_doc
+        version_docs_by_subset_id[subset_id].append(version_doc)
 
-    subsets = get_subsets(
-        project_name, subset_ids=versions_by_subset_id.keys()
+    subset_docs = get_subsets(
+        project_name, subset_ids=version_docs_by_subset_id.keys()
     )
-    for subset in subsets:
-        subset_id = subset["_id"]
-        asset_id = subset["parent"]
-        subsets_by_subset_id[subset_id] = subset
-        subsets_by_asset_id[asset_id].append(subset)
+    for subset_doc in subset_docs:
+        subset_id = subset_doc["_id"]
+        asset_id = subset_doc["parent"]
+        subset_docs_by_subset_id[subset_id] = subset_doc
+        subset_docs_by_asset_id[asset_id].append(subset_doc)
 
-    assets = get_assets(project_name, asset_ids=subsets_by_asset_id.keys())
-    assets_by_id = {
-        asset["_id"]: asset
-        for asset in assets
+    asset_docs = get_assets(
+        project_name, asset_ids=subset_docs_by_asset_id.keys()
+    )
+    asset_docs_by_id = {
+        asset_doc["_id"]: asset_doc
+        for asset_doc in asset_docs
     }
 
-    project = get_project(project_name)
+    project_doc = get_project(project_name)
 
-    for version_id, representations in repres_by_version_id.items():
-        asset = None
-        subset = None
-        version = versions_by_version_id.get(version_id)
-        if version:
-            subset_id = version["parent"]
-            subset = subsets_by_subset_id.get(subset_id)
-            if subset:
-                asset_id = subset["parent"]
-                asset = assets_by_id.get(asset_id)
+    for version_id, repre_docs in repre_docs_by_version_id.items():
+        asset_doc = None
+        subset_doc = None
+        version_doc = version_docs_by_version_id.get(version_id)
+        if version_doc:
+            subset_id = version_doc["parent"]
+            subset_doc = subset_docs_by_subset_id.get(subset_id)
+            if subset_doc:
+                asset_id = subset_doc["parent"]
+                asset_doc = asset_docs_by_id.get(asset_id)
 
-        for representation in representations:
-            repre_id = representation["_id"]
-            output[repre_id] = (version, subset, asset, project)
+        for repre_doc in repre_docs:
+            repre_id = repre_doc["_id"]
+            output[repre_id] = (
+                version_doc, subset_doc, asset_doc, project_doc
+            )
     return output
 
 

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -162,7 +162,15 @@ class LoadClip(plugin.NukeLoader):
             data_imprint = {}
             for k in add_keys:
                 if k == 'version':
-                    data_imprint[k] = context["version"]['name']
+                    version_doc = context["version"]
+                    if version_doc["type"] == "hero_version":
+                        version = "hero"
+                    else:
+                        version = version_doc.get("name")
+
+                    if version:
+                        data_imprint[k] = version
+
                 elif k == 'colorspace':
                     colorspace = repre["data"].get(k)
                     colorspace = colorspace or version_data.get(k)

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -222,13 +222,20 @@ def get_representation_context(representation):
             project_name, representation
         )
 
+    if not representation:
+        raise AssertionError("Representation was not found in database")
+
     version, subset, asset, project = get_representation_parents(
         project_name, representation
     )
-
-    assert all([representation, version, subset, asset, project]), (
-        "This is a bug"
-    )
+    if not version:
+        raise AssertionError("Version was not found in database")
+    if not subset:
+        raise AssertionError("Subset was not found in database")
+    if not asset:
+        raise AssertionError("Asset was not found in database")
+    if not project:
+        raise AssertionError("Project was not found in database")
 
     context = {
         "project": {

--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -1547,6 +1547,11 @@ def _load_representations_by_loader(loader, repre_contexts,
         return
 
     for repre_context in repre_contexts.values():
+        version_doc = repre_context["version"]
+        if version_doc["type"] == "hero_version":
+            version_name = "Hero"
+        else:
+            version_name = version_doc.get("name")
         try:
             if data_by_repre_id:
                 _id = repre_context["representation"]["_id"]
@@ -1564,7 +1569,7 @@ def _load_representations_by_loader(loader, repre_contexts,
                 None,
                 repre_context["representation"]["name"],
                 repre_context["subset"]["name"],
-                repre_context["version"]["name"]
+                version_name
             ))
 
         except Exception as exc:
@@ -1577,7 +1582,7 @@ def _load_representations_by_loader(loader, repre_contexts,
                 formatted_traceback,
                 repre_context["representation"]["name"],
                 repre_context["subset"]["name"],
-                repre_context["version"]["name"]
+                version_name
             ))
     return error_info
 


### PR DESCRIPTION
## Brief description
Fix switch from hero version functionaly in scene manager tool.

## Description
Bug was not related to scene manager tool but to client function `get_representation_parents` where were not handled hero versions thus it didn't find parents and crashed.

Side fixes related to loading of hero version in loader and in nuke's LoadClip. If loader crashed on loading of hero version it caused another crash when tried to show message with error becaue hero versions don't have name key in it. LoadClip crashed from same reason when added to scene "information" data.

## Testing notes:
1. Load Hero version to scene
2. Open scene manager tool
3. Run "Switch to version" which should work (if loader support it)

Resolves https://github.com/pypeclub/OpenPype/issues/3689