### PR TITLE
RoyalRender: handle host name that is not set

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1459,6 +1459,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
         output = -1
         regexes = self.compile_list_of_regexes(in_list)
         for regex in regexes:
+            if not value:
+                continue
             if re.match(regex, value):
                 output = 1
                 break

--- a/openpype/plugins/publish/integrate_subset_group.py
+++ b/openpype/plugins/publish/integrate_subset_group.py
@@ -93,6 +93,6 @@ class IntegrateSubsetGroup(pyblish.api.InstancePlugin):
         return {
             "families": anatomy_data["family"],
             "tasks": task.get("name"),
-            "hosts": anatomy_data.get("app"),
+            "hosts": instance.context.data["hostName"],
             "task_types": task.get("type")
         }

--- a/openpype/plugins/publish/integrate_subset_group.py
+++ b/openpype/plugins/publish/integrate_subset_group.py
@@ -93,6 +93,6 @@ class IntegrateSubsetGroup(pyblish.api.InstancePlugin):
         return {
             "families": anatomy_data["family"],
             "tasks": task.get("name"),
-            "hosts": anatomy_data["app"],
+            "hosts": anatomy_data.get("app"),
             "task_types": task.get("type")
         }


### PR DESCRIPTION
## Description

Not setting `AVALON_APP_NAME` to proper configured host name resulted in crashes in  `extract_review` and `integrate_subset_gorups` that relied on `app` resp. `hostName` to be set in context.

This is not directly related to RoyalRender, only that RoyalRender publisher doesn't set this as it is oblivious about host name to be used.