### PR TITLE
Settings: Lock settings UI session

### DIFF
--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -453,13 +453,12 @@ class CacheValues:
             return {}
         return copy.deepcopy(self.data)
 
-    def update_data(self, data, version=None):
+    def update_data(self, data, version):
         self.data = data
         self.creation_time = datetime.datetime.now()
-        if version is not None:
-            self.version = version
+        self.version = version
 
-    def update_from_document(self, document, version=None):
+    def update_from_document(self, document, version):
         data = {}
         if document:
             if "data" in document:
@@ -468,9 +467,9 @@ class CacheValues:
                 value = document["value"]
                 if value:
                     data = json.loads(value)
+
         self.data = data
-        if version is not None:
-            self.version = version
+        self.version = version
 
     def to_json_string(self):
         return json.dumps(self.data or {})
@@ -1567,7 +1566,7 @@ class MongoLocalSettingsHandler(LocalSettingsHandler):
         """
         data = data or {}
 
-        self.local_settings_cache.update_data(data)
+        self.local_settings_cache.update_data(data, None)
 
         self.collection.replace_one(
             {
@@ -1590,6 +1589,6 @@ class MongoLocalSettingsHandler(LocalSettingsHandler):
                 "site_id": self.local_site_id
             })
 
-            self.local_settings_cache.update_from_document(document)
+            self.local_settings_cache.update_from_document(document, None)
 
         return self.local_settings_cache.data_copy()

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -447,6 +447,7 @@ class CacheValues:
         self.data = None
         self.creation_time = None
         self.version = None
+        self.settings_state = None
 
     def data_copy(self):
         if not self.data:
@@ -457,6 +458,9 @@ class CacheValues:
         self.data = data
         self.creation_time = datetime.datetime.now()
         self.version = version
+
+    def update_settings_state(self, settings_state):
+        self.settings_state = settings_state
 
     def update_from_document(self, document, version):
         data = {}

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -485,6 +485,9 @@ class CacheValues:
         delta = (datetime.datetime.now() - self.creation_time).seconds
         return delta > self.cache_lifetime
 
+    def set_outdated(self):
+        self.create_time = None
+
 
 class MongoSettingsHandler(SettingsHandler):
     """Settings handler that use mongo for storing and loading of settings."""

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -460,22 +460,22 @@ class SettingsHandler:
         pass
 
     @abstractmethod
-    def opened_ui(self):
+    def opened_settings_ui(self):
         """Callback called when settings UI is opened.
 
         Information about this machine must be available when
-        'get_last_opened_info' is called from anywhere until 'closed_ui' is
-        called again.
+        'get_last_opened_info' is called from anywhere until
+        'closed_settings_ui' is called again.
 
         Returns:
             SettingsStateInfo: Object representing information about this
-                machine. Must be passed to 'closed_ui' when finished.
+                machine. Must be passed to 'closed_settings_ui' when finished.
         """
 
         pass
 
     @abstractmethod
-    def closed_ui(self, info_obj):
+    def closed_settings_ui(self, info_obj):
         """Callback called when settings UI is closed.
 
         From the moment this method is called the information about this
@@ -486,8 +486,8 @@ class SettingsHandler:
         before changing any value.
 
         Args:
-            info_obj (SettingsStateInfo): Object created when 'opened_ui' was
-                called.
+            info_obj (SettingsStateInfo): Object created when
+                'opened_settings_ui' was called.
         """
 
         pass
@@ -1680,7 +1680,7 @@ class MongoSettingsHandler(SettingsHandler):
         }) or {}
         info_data = doc.get("info")
         if not info_data:
-            return SettingsStateInfo.create_new_empty(self._current_version)
+            return None
 
         # Fill not available information
         info_data["openpype_version"] = self._current_version
@@ -1688,7 +1688,7 @@ class MongoSettingsHandler(SettingsHandler):
         info_data["project_name"] = None
         return SettingsStateInfo.from_data(info_data)
 
-    def opened_ui(self):
+    def opened_settings_ui(self):
         doc_filter = {
             "type": "last_opened_settings_ui",
             "version": self._current_version
@@ -1711,7 +1711,7 @@ class MongoSettingsHandler(SettingsHandler):
             self.collection.insert_one(new_doc_data)
         return opened_info
 
-    def closed_ui(self, info_obj):
+    def closed_settings_ui(self, info_obj):
         doc_filter = {
             "type": "last_opened_settings_ui",
             "version": self._current_version

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -368,7 +368,7 @@ class SettingsHandler:
         """OpenPype versions that have any studio project anatomy overrides.
 
         Returns:
-            list<str>: OpenPype versions strings.
+            List[str]: OpenPype versions strings.
         """
         pass
 
@@ -379,7 +379,7 @@ class SettingsHandler:
         """OpenPype versions that have any studio project settings overrides.
 
         Returns:
-            list<str>: OpenPype versions strings.
+            List[str]: OpenPype versions strings.
         """
         pass
 
@@ -393,8 +393,39 @@ class SettingsHandler:
             project_name(str): Name of project.
 
         Returns:
-            list<str>: OpenPype versions strings.
+            List[str]: OpenPype versions strings.
         """
+
+        pass
+
+    @abstractmethod
+    def get_system_last_saved_info(self):
+        """State of last system settings overrides at the moment when called.
+
+        This method must provide most recent data so using cached data is not
+        the way.
+
+        Returns:
+            SettingsStateInfo: Information about system settings overrides.
+        """
+
+        pass
+
+    @abstractmethod
+    def get_project_last_saved_info(self, project_name):
+        """State of last project settings overrides at the moment when called.
+
+        This method must provide most recent data so using cached data is not
+        the way.
+
+        Args:
+            project_name (Union[None, str]): Project name for which state
+                should be returned.
+
+        Returns:
+            SettingsStateInfo: Information about project settings overrides.
+        """
+
         pass
 
 
@@ -427,7 +458,7 @@ class CacheValues:
         self.data = None
         self.creation_time = None
         self.version = None
-        self.settings_state = None
+        self.last_saved_info = None
 
     def data_copy(self):
         if not self.data:
@@ -439,8 +470,8 @@ class CacheValues:
         self.creation_time = datetime.datetime.now()
         self.version = version
 
-    def update_settings_state(self, settings_state):
-        self.settings_state = settings_state
+    def update_last_saved_info(self, last_saved_info):
+        self.last_saved_info = last_saved_info
 
     def update_from_document(self, document, version):
         data = {}
@@ -1288,6 +1319,7 @@ class MongoSettingsHandler(SettingsHandler):
                 self.project_anatomy_cache[project_name].update_from_document(
                     document, version
                 )
+
             else:
                 project_doc = get_project(project_name)
                 self.project_anatomy_cache[project_name].update_data(

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -22,6 +22,168 @@ from .constants import (
 )
 
 
+class SettingsStateInfo:
+    """Helper state information for Settings state.
+
+    Is used to hold information about last save and last opened UI. Keep
+    information about the time when that happened and on which machine under
+    which user.
+
+    To create currrent machine and time information use 'create_new' method.
+    """
+
+    timestamp_format = "%Y-%m-%d %H:%M:%S.%f"
+
+    def __init__(
+        self, timestamp, hostname, hostip, username, system_name, local_id
+    ):
+        self.timestamp = timestamp
+        self._timestamp_obj = datetime.datetime.strptime(
+            timestamp, self.timestamp_format
+        )
+        self.hostname = hostname
+        self.hostip = hostip
+        self.username = username
+        self.system_name = system_name
+        self.local_id = local_id
+
+    def copy(self):
+        return self.from_data(self.to_data())
+
+    @property
+    def timestamp_obj(self):
+        return self._timestamp_obj
+
+    @classmethod
+    def create_new(cls):
+        """Create information about this machine for current time."""
+
+        from openpype.lib.pype_info import get_workstation_info
+
+        now = datetime.datetime.now()
+        workstation_info = get_workstation_info()
+
+        return cls(
+            now.strftime(cls.timestamp_format),
+            workstation_info["hostname"],
+            workstation_info["hostip"],
+            workstation_info["username"],
+            workstation_info["system_name"],
+            workstation_info["local_id"]
+        )
+
+    @classmethod
+    def from_data(cls, data):
+        """Create object from data."""
+
+        return cls(
+            data["timestamp"],
+            data["hostname"],
+            data["hostip"],
+            data["username"],
+            data["system_name"],
+            data["local_id"]
+        )
+
+    def to_data(self):
+        return {
+            "timestamp": self.timestamp,
+            "hostname": self.hostname,
+            "hostip": self.hostip,
+            "username": self.username,
+            "system_name": self.system_name,
+            "local_id": self.local_id,
+        }
+
+    def __eq__(self, other):
+        if not isinstance(other, SettingsStateInfo):
+            return False
+
+        if other.timestamp_obj != self.timestamp_obj:
+            return False
+
+        return (
+            self.hostname == other.hostname
+            and self.hostip == other.hostip
+            and self.username == other.username
+            and self.system_name == other.system_name
+            and self.local_id == other.local_id
+        )
+
+
+class SettingsState:
+    """State of settings with last saved and last opened.
+
+    Args:
+        openpype_version (str): OpenPype version string.
+        settings_type (str): Type of settings. System or project settings.
+        last_saved_info (Union[None, SettingsStateInfo]): Information about
+            machine and time when were settings saved last time.
+        last_opened_info (Union[None, SettingsStateInfo]): This is settings UI
+            specific information similar to last saved describes who had opened
+            settings as last.
+        project_name (Union[None, str]): Identifier for project settings.
+    """
+
+    def __init__(
+        self,
+        openpype_version,
+        settings_type,
+        last_saved_info,
+        last_opened_info,
+        project_name=None
+    ):
+        self.openpype_version = openpype_version
+        self.settings_type = settings_type
+        self.last_saved_info = last_saved_info
+        self.last_opened_info = last_opened_info
+        self.project_name = project_name
+
+    def __eq__(self, other):
+        if not isinstance(other, SettingsState):
+            return False
+
+        return (
+            self.openpype_version == other.openpype_version
+            and self.settings_type == other.settings_type
+            and self.last_saved_info == other.last_saved_info
+            and self.last_opened_info == other.last_opened_info
+            and self.project_name == other.project_name
+        )
+
+    def copy(self):
+        return self.__class__(
+            self.openpype_version,
+            self.settings_type,
+            self.last_saved_info.copy(),
+            self.last_opened_info.copy(),
+            self.project_name
+        )
+
+    def on_save(self, openpype_version):
+        self.openpype_version = openpype_version
+        self.last_saved_info = SettingsStateInfo.create_new()
+
+    @classmethod
+    def from_document(cls, openpype_version, settings_type, document):
+        document = document or {}
+        last_saved_info = document.get("last_saved_info")
+        if last_saved_info:
+            last_saved_info = SettingsStateInfo.from_data(last_saved_info)
+
+        last_opened_info = document.get("last_opened_info")
+        if last_opened_info:
+            last_opened_info = SettingsStateInfo.from_data(last_opened_info)
+
+        return cls(
+            openpype_version,
+            settings_type,
+            last_saved_info,
+            last_opened_info,
+            document.get("project_name")
+        )
+
+
 @six.add_metaclass(ABCMeta)
 class SettingsHandler:
     @abstractmethod

--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -784,9 +784,9 @@ class MongoSettingsHandler(SettingsHandler):
             "last_saved_info": last_saved_info.to_document_data()
         }
         if not system_settings_doc:
-            self.collections.insert_one(new_system_settings_doc)
+            self.collection.insert_one(new_system_settings_doc)
         else:
-            self.collections.update_one(
+            self.collection.update_one(
                 {"_id": system_settings_doc["_id"]},
                 {"$set": new_system_settings_doc}
             )

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -92,6 +92,31 @@ def calculate_changes(old_value, new_value):
 
 
 @require_handler
+def get_system_last_saved_info():
+    return _SETTINGS_HANDLER.get_system_last_saved_info()
+
+
+@require_handler
+def get_project_last_saved_info(project_name):
+    return _SETTINGS_HANDLER.get_project_last_saved_info(project_name)
+
+
+@require_handler
+def get_last_opened_info():
+    return _SETTINGS_HANDLER.get_last_opened_info()
+
+
+@require_handler
+def opened_ui():
+    return _SETTINGS_HANDLER.opened_ui()
+
+
+@require_handler
+def closed_ui(info_obj):
+    return _SETTINGS_HANDLER.closed_ui(info_obj)
+
+
+@require_handler
 def save_studio_settings(data):
     """Save studio overrides of system settings.
 

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -107,13 +107,13 @@ def get_last_opened_info():
 
 
 @require_handler
-def opened_ui():
-    return _SETTINGS_HANDLER.opened_ui()
+def opened_settings_ui():
+    return _SETTINGS_HANDLER.opened_settings_ui()
 
 
 @require_handler
-def closed_ui(info_obj):
-    return _SETTINGS_HANDLER.closed_ui(info_obj)
+def closed_settings_ui(info_obj):
+    return _SETTINGS_HANDLER.closed_settings_ui(info_obj)
 
 
 @require_handler

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -121,6 +121,7 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
         self.user_role = user_role
 
         self.entity = None
+        self._edit_mode = None
 
         self._state = CategoryState.Idle
 
@@ -190,6 +191,21 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
             entity.__class__.__name__, entity.path, entity.value
         )
         raise TypeError("Unknown type: {}".format(label))
+
+    def set_edit_mode(self, enabled):
+        if enabled is self._edit_mode:
+            return
+
+        self.save_btn.setEnabled(enabled)
+        if enabled:
+            tooltip = (
+                "Someone else has opened settings UI."
+                "\nTry hit refresh to check if settings are already available."
+            )
+        else:
+            tooltip = "Save settings"
+
+        self.save_btn.setToolTip(tooltip)
 
     @property
     def state(self):
@@ -434,6 +450,9 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
         self.set_state(CategoryState.Idle)
 
     def save(self):
+        if not self._edit_mode:
+            return
+
         if not self.items_are_valid():
             return
 

--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -701,7 +701,7 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
             self.breadcrumbs_model.set_entity(None)
 
     def _on_reset_success(self):
-        self._reset_crashed = True
+        self._reset_crashed = False
         if not self.save_btn.isEnabled():
             self.save_btn.setEnabled(self._edit_mode)
 

--- a/openpype/tools/settings/settings/dialogs.py
+++ b/openpype/tools/settings/settings/dialogs.py
@@ -113,3 +113,67 @@ class SettingsUIOpenedElsewhere(BaseInfoDialog):
             take_control_btn,
             view_mode_btn
         ]
+
+
+class SettingsLastSavedChanged(BaseInfoDialog):
+    width = 500
+    height = 300
+
+    def __init__(self, info_obj, parent=None):
+        title = "Settings has changed"
+        message = (
+            "Settings has changed while you had opened this settings session."
+            "<br/><br/>It is <b>recommended to refresh settings</b>"
+            " and re-apply changes in the new session."
+        )
+        super(SettingsLastSavedChanged, self).__init__(
+            message, title, info_obj, parent
+        )
+
+    def _on_save(self):
+        self._result = 1
+        self.close()
+
+    def _on_close(self):
+        self._result = 0
+        self.close()
+
+    def get_buttons(self, parent):
+        close_btn = QtWidgets.QPushButton(
+            "Close", parent
+        )
+        save_btn = QtWidgets.QPushButton(
+            "Save anyway", parent
+        )
+
+        close_btn.clicked.connect(self._on_close)
+        save_btn.clicked.connect(self._on_save)
+
+        return [
+            close_btn,
+            save_btn
+        ]
+
+
+class SettingsControlTaken(BaseInfoDialog):
+    width = 500
+    height = 300
+
+    def __init__(self, info_obj, parent=None):
+        title = "Settings control taken"
+        message = (
+            "Someone took control over your settings."
+            "<br/><br/>It is not possible to save changes of currently"
+            " opened session. Copy changes you want to keep and hit refresh."
+        )
+        super(SettingsControlTaken, self).__init__(
+            message, title, info_obj, parent
+        )
+
+    def _on_confirm(self):
+        self.close()
+
+    def get_buttons(self, parent):
+        confirm_btn = QtWidgets.QPushButton("Understand", parent)
+        confirm_btn.clicked.connect(self._on_confirm)
+        return [confirm_btn]

--- a/openpype/tools/settings/settings/dialogs.py
+++ b/openpype/tools/settings/settings/dialogs.py
@@ -1,5 +1,7 @@
 from Qt import QtWidgets, QtCore
 
+from openpype.tools.utils.delegates import pretty_date
+
 
 class BaseInfoDialog(QtWidgets.QDialog):
     width = 600
@@ -34,12 +36,16 @@ class BaseInfoDialog(QtWidgets.QDialog):
             ("Host IP", info_obj.hostip),
             ("System name", info_obj.system_name),
             ("Local ID", info_obj.local_id),
-            ("Time Stamp", info_obj.timestamp),
         ):
             other_information_layout.addRow(
                 label,
                 QtWidgets.QLabel(value, other_information)
             )
+
+        timestamp_label = QtWidgets.QLabel(
+            pretty_date(info_obj.timestamp_obj), other_information
+        )
+        other_information_layout.addRow("Time", timestamp_label)
 
         footer_widget = QtWidgets.QWidget(self)
         buttons_widget = QtWidgets.QWidget(footer_widget)
@@ -64,9 +70,26 @@ class BaseInfoDialog(QtWidgets.QDialog):
         layout.addWidget(separator_widget_2, 0)
         layout.addWidget(footer_widget, 0)
 
+        timestamp_timer = QtCore.QTimer()
+        timestamp_timer.setInterval(1000)
+        timestamp_timer.timeout.connect(self._on_timestamp_timer)
+
+        self._timestamp_label = timestamp_label
+        self._timestamp_timer = timestamp_timer
+
     def showEvent(self, event):
         super(BaseInfoDialog, self).showEvent(event)
+        self._timestamp_timer.start()
         self.resize(self.width, self.height)
+
+    def closeEvent(self, event):
+        self._timestamp_timer.stop()
+        super(BaseInfoDialog, self).closeEvent(event)
+
+    def _on_timestamp_timer(self):
+        self._timestamp_label.setText(
+            pretty_date(self._info_obj.timestamp_obj)
+        )
 
     def result(self):
         return self._result

--- a/openpype/tools/settings/settings/dialogs.py
+++ b/openpype/tools/settings/settings/dialogs.py
@@ -1,0 +1,115 @@
+from Qt import QtWidgets, QtCore
+
+
+class BaseInfoDialog(QtWidgets.QDialog):
+    width = 600
+    height = 400
+
+    def __init__(self, message, title, info_obj, parent=None):
+        super(BaseInfoDialog, self).__init__(parent)
+        self._result = 0
+        self._info_obj = info_obj
+
+        self.setWindowTitle(title)
+
+        message_label = QtWidgets.QLabel(message, self)
+        message_label.setWordWrap(True)
+
+        separator_widget_1 = QtWidgets.QFrame(self)
+        separator_widget_2 = QtWidgets.QFrame(self)
+        for separator_widget in (
+            separator_widget_1,
+            separator_widget_2
+        ):
+            separator_widget.setObjectName("Separator")
+            separator_widget.setMinimumHeight(1)
+            separator_widget.setMaximumHeight(1)
+
+        other_information = QtWidgets.QWidget(self)
+        other_information_layout = QtWidgets.QFormLayout(other_information)
+        other_information_layout.setContentsMargins(0, 0, 0, 0)
+        for label, value in (
+            ("Username", info_obj.username),
+            ("Host name", info_obj.hostname),
+            ("Host IP", info_obj.hostip),
+            ("System name", info_obj.system_name),
+            ("Local ID", info_obj.local_id),
+            ("Time Stamp", info_obj.timestamp),
+        ):
+            other_information_layout.addRow(
+                label,
+                QtWidgets.QLabel(value, other_information)
+            )
+
+        footer_widget = QtWidgets.QWidget(self)
+        buttons_widget = QtWidgets.QWidget(footer_widget)
+
+        buttons_layout = QtWidgets.QHBoxLayout(buttons_widget)
+        buttons_layout.setContentsMargins(0, 0, 0, 0)
+        buttons = self.get_buttons(buttons_widget)
+        for button in buttons:
+            buttons_layout.addWidget(button, 1)
+
+        footer_layout = QtWidgets.QHBoxLayout(footer_widget)
+        footer_layout.setContentsMargins(0, 0, 0, 0)
+        footer_layout.addStretch(1)
+        footer_layout.addWidget(buttons_widget, 0)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(message_label, 0)
+        layout.addWidget(separator_widget_1, 0)
+        layout.addStretch(1)
+        layout.addWidget(other_information, 0, QtCore.Qt.AlignHCenter)
+        layout.addStretch(1)
+        layout.addWidget(separator_widget_2, 0)
+        layout.addWidget(footer_widget, 0)
+
+    def showEvent(self, event):
+        super(BaseInfoDialog, self).showEvent(event)
+        self.resize(self.width, self.height)
+
+    def result(self):
+        return self._result
+
+    def get_buttons(self, parent):
+        return []
+
+
+class SettingsUIOpenedElsewhere(BaseInfoDialog):
+    def __init__(self, info_obj, parent=None):
+        title = "Someone else has opened Settings UI"
+        message = (
+            "Someone else has opened Settings UI which could cause data loss."
+            " Please contact the person on the other side."
+            "<br/><br/>You can continue in <b>view-only mode</b>."
+            " All changes in view mode will be lost."
+            "<br/><br/>You can <b>take control</b> which will cause that"
+            " all changes of settings on the other side will be lost.<br/>"
+        )
+        super(SettingsUIOpenedElsewhere, self).__init__(
+            message, title, info_obj, parent
+        )
+
+    def _on_take_control(self):
+        self._result = 1
+        self.close()
+
+    def _on_view_mode(self):
+        self._result = 0
+        self.close()
+
+    def get_buttons(self, parent):
+        take_control_btn = QtWidgets.QPushButton(
+            "Take control", parent
+        )
+        view_mode_btn = QtWidgets.QPushButton(
+            "View only", parent
+        )
+
+        take_control_btn.clicked.connect(self._on_take_control)
+        view_mode_btn.clicked.connect(self._on_view_mode)
+
+        return [
+            take_control_btn,
+            view_mode_btn
+        ]

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -359,11 +359,12 @@ class SettingsUIOpenedElsewhere(QtWidgets.QDialog):
         self.setWindowTitle("Someone else has opened Settings UI")
 
         message_label = QtWidgets.QLabel((
-            "Someone else has opened Settings UI. That may cause data loss."
+            "Someone else has opened Settings UI which could cause data loss."
             " Please contact the person on the other side."
-            "<br/><br/>You can open the UI in view-only mode or take"
-            " the control which will cause settings on the other side"
-            " won't be able to save changes.<br/>"
+            "<br/><br/>You can open the UI in <b>view-only mode</b>."
+            " All changes in view mode will be lost."
+            "<br/><br/> You can <b>take the control</b> which will cause that"
+            " all changes of settings on the other side will be lost.<br/>"
         ), self)
         message_label.setWordWrap(True)
 
@@ -435,3 +436,7 @@ class SettingsUIOpenedElsewhere(QtWidgets.QDialog):
     def _on_view_mode(self):
         self._result = 0
         self.close()
+
+    def showEvent(self, event):
+        super(SettingsUIOpenedElsewhere, self).showEvent(event)
+        self.resize(600, 400)

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -105,6 +105,7 @@ class MainWidget(QtWidgets.QWidget):
 
     widget_width = 1000
     widget_height = 600
+    window_title = "OpenPype Settings"
 
     def __init__(self, user_role, parent=None, reset_on_show=True):
         super(MainWidget, self).__init__(parent)
@@ -122,7 +123,7 @@ class MainWidget(QtWidgets.QWidget):
         self._password_dialog = None
 
         self.setObjectName("SettingsMainWidget")
-        self.setWindowTitle("OpenPype Settings")
+        self.setWindowTitle(self.window_title)
 
         self.resize(self.widget_width, self.widget_height)
 
@@ -154,6 +155,11 @@ class MainWidget(QtWidgets.QWidget):
 
         self._shadow_widget = ShadowWidget("Working...", self)
         self._shadow_widget.setVisible(False)
+
+        controller.event_system.add_callback(
+            "edit.mode.changed",
+            self._edit_mode_changed
+        )
 
         header_tab_widget.currentChanged.connect(self._on_tab_changed)
         search_dialog.path_clicked.connect(self._on_search_path_clicked)
@@ -300,6 +306,12 @@ class MainWidget(QtWidgets.QWidget):
                 widget = self._header_tab_widget.currentWidget()
                 entity = widget.entity
             self._search_dialog.set_root_entity(entity)
+
+    def _edit_mode_changed(self, event):
+        title = self.window_title
+        if not event["edit_mode"]:
+            title += " [View only]"
+        self.setWindowTitle(title)
 
     def _on_tab_changed(self):
         self._update_search_dialog()

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -87,7 +87,6 @@ class SettingsController:
         )
 
     def update_last_opened_info(self):
-        print("update_last_opened_info")
         last_opened_info = get_last_opened_info()
         enabled = False
         if (

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -12,6 +12,7 @@ from openpype.settings.lib import (
     closed_settings_ui,
 )
 
+from .dialogs import SettingsUIOpenedElsewhere
 from .categories import (
     CategoryState,
     SystemWidget,
@@ -348,95 +349,3 @@ class MainWidget(QtWidgets.QWidget):
             return
 
         return super(MainWidget, self).keyPressEvent(event)
-
-
-class SettingsUIOpenedElsewhere(QtWidgets.QDialog):
-    def __init__(self, info_obj, parent=None):
-        super(SettingsUIOpenedElsewhere, self).__init__(parent)
-
-        self._result = 0
-
-        self.setWindowTitle("Someone else has opened Settings UI")
-
-        message_label = QtWidgets.QLabel((
-            "Someone else has opened Settings UI which could cause data loss."
-            " Please contact the person on the other side."
-            "<br/><br/>You can open the UI in <b>view-only mode</b>."
-            " All changes in view mode will be lost."
-            "<br/><br/> You can <b>take the control</b> which will cause that"
-            " all changes of settings on the other side will be lost.<br/>"
-        ), self)
-        message_label.setWordWrap(True)
-
-        separator_widget_1 = QtWidgets.QFrame(self)
-        separator_widget_2 = QtWidgets.QFrame(self)
-        for separator_widget in (
-            separator_widget_1,
-            separator_widget_2
-        ):
-            separator_widget.setObjectName("Separator")
-            separator_widget.setMinimumHeight(1)
-            separator_widget.setMaximumHeight(1)
-
-        other_information = QtWidgets.QWidget(self)
-        other_information_layout = QtWidgets.QFormLayout(other_information)
-        other_information_layout.setContentsMargins(0, 0, 0, 0)
-        for label, value in (
-            ("Username", info_obj.username),
-            ("Host name", info_obj.hostname),
-            ("Host IP", info_obj.hostip),
-            ("System name", info_obj.system_name),
-            ("Local ID", info_obj.local_id),
-            ("Time Stamp", info_obj.timestamp),
-        ):
-            other_information_layout.addRow(
-                label,
-                QtWidgets.QLabel(value, other_information)
-            )
-
-        footer_widget = QtWidgets.QWidget(self)
-        buttons_widget = QtWidgets.QWidget(footer_widget)
-
-        take_control_btn = QtWidgets.QPushButton(
-            "Take control", buttons_widget
-        )
-        view_mode_btn = QtWidgets.QPushButton(
-            "View only", buttons_widget
-        )
-
-        buttons_layout = QtWidgets.QHBoxLayout(buttons_widget)
-        buttons_layout.setContentsMargins(0, 0, 0, 0)
-        buttons_layout.addWidget(take_control_btn, 1)
-        buttons_layout.addWidget(view_mode_btn, 1)
-
-        footer_layout = QtWidgets.QHBoxLayout(footer_widget)
-        footer_layout.setContentsMargins(0, 0, 0, 0)
-        footer_layout.addStretch(1)
-        footer_layout.addWidget(buttons_widget, 0)
-
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.addWidget(message_label, 0)
-        layout.addWidget(separator_widget_1, 0)
-        layout.addStretch(1)
-        layout.addWidget(other_information, 0, QtCore.Qt.AlignHCenter)
-        layout.addStretch(1)
-        layout.addWidget(separator_widget_2, 0)
-        layout.addWidget(footer_widget, 0)
-
-        take_control_btn.clicked.connect(self._on_take_control)
-        view_mode_btn.clicked.connect(self._on_view_mode)
-
-    def result(self):
-        return self._result
-
-    def _on_take_control(self):
-        self._result = 1
-        self.close()
-
-    def _on_view_mode(self):
-        self._result = 0
-        self.close()
-
-    def showEvent(self, event):
-        super(SettingsUIOpenedElsewhere, self).showEvent(event)
-        self.resize(600, 400)


### PR DESCRIPTION
## Brief description
Handle opened sessions of settings UI and last saved settings, to avoid unwanted loss of settings values when multiple people are modifying setting at the same time.

## Description
First who opens settings will create lock in mongo (OP version specific lock). From that moment anyone who will open settings UI will see message saying that other session of settings is opened with information about username and machine where it's happening. The dialog give options to open settings in view only mode or take control over the settings. In view mode is save disabled and when control is taken the lock is changed to the user who did it. From that moment the previous locked user can't save with only option to reset settings, is shown with dialog and information about person who took the control.

Also was added one more information to saved overrides which is information about last save. That is also used before save to validate if last saved settings are the same as at the start of session. This is for cases when settings are modified out of settings UI. Lock does not work for project anatomy which is versionless and it's changes are not always propagated using settings handlers.

## Testing notes:
1. Open settings with `~openpype/tools/run_settings` script
2. Open other session of settings (script or from tray)
3. The second session should show a dialog
From this point you can "play" with possible scenarios and try to save or refresh settings.