### PR TITLE
Unreal: Define unreal as module and use host class

### DIFF
--- a/openpype/hosts/unreal/__init__.py
+++ b/openpype/hosts/unreal/__init__.py
@@ -1,24 +1,6 @@
-import os
-import openpype.hosts
-from openpype.lib.applications import Application
+from .module import UnrealModule
 
 
-def add_implementation_envs(env: dict, _app: Application) -> None:
-    """Modify environments to contain all required for implementation."""
-    # Set OPENPYPE_UNREAL_PLUGIN required for Unreal implementation
-
-    ue_plugin = "UE_5.0" if _app.name[:1] == "5" else "UE_4.7"
-    unreal_plugin_path = os.path.join(
-        os.path.dirname(os.path.abspath(openpype.hosts.__file__)),
-        "unreal", "integration", ue_plugin
-    )
-    if not env.get("OPENPYPE_UNREAL_PLUGIN"):
-        env["OPENPYPE_UNREAL_PLUGIN"] = unreal_plugin_path
-
-    # Set default environments if are not set via settings
-    defaults = {
-        "OPENPYPE_LOG_NO_COLORS": "True"
-    }
-    for key, value in defaults.items():
-        if not env.get(key):
-            env[key] = value
+__all__ = (
+    "UnrealModule",
+)

--- a/openpype/hosts/unreal/api/__init__.py
+++ b/openpype/hosts/unreal/api/__init__.py
@@ -19,6 +19,7 @@ from .pipeline import (
     show_tools_dialog,
     show_tools_popup,
     instantiate,
+    UnrealHost,
 )
 
 __all__ = [
@@ -36,5 +37,6 @@ __all__ = [
     "show_experimental_tools",
     "show_tools_dialog",
     "show_tools_popup",
-    "instantiate"
+    "instantiate",
+    "UnrealHost",
 ]

--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -14,6 +14,7 @@ from openpype.pipeline import (
 )
 from openpype.tools.utils import host_tools
 import openpype.hosts.unreal
+from openpypr.host import HostBase, ILoadHost
 
 import unreal  # noqa
 
@@ -27,6 +28,32 @@ PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
+
+
+class UnrealHost(HostBase, ILoadHost):
+    """Unreal host implementation.
+
+    For some time this class will re-use functions from module based
+    implementation for backwards compatibility of older unreal projects.
+    """
+
+    name = "unreal"
+
+    def install(self):
+        install()
+
+    def get_containers(self):
+        return ls()
+
+    def show_tools_popup(self):
+        """Show tools popup with actions leading to show other tools."""
+
+        show_tools_popup()
+
+    def show_tools_dialog(self):
+        """Show tools dialog with actions leading to show other tools."""
+
+        show_tools_dialog()
 
 
 def install():

--- a/openpype/hosts/unreal/integration/UE_4.7/Content/Python/init_unreal.py
+++ b/openpype/hosts/unreal/integration/UE_4.7/Content/Python/init_unreal.py
@@ -3,7 +3,9 @@ import unreal
 openpype_detected = True
 try:
     from openpype.pipeline import install_host
-    from openpype.hosts.unreal import api as openpype_host
+    from openpype.hosts.unreal.api import UnrealHost
+
+    openpype_host = UnrealHost()
 except ImportError as exc:
     openpype_host = None
     openpype_detected = False

--- a/openpype/hosts/unreal/integration/UE_5.0/Content/Python/init_unreal.py
+++ b/openpype/hosts/unreal/integration/UE_5.0/Content/Python/init_unreal.py
@@ -3,7 +3,9 @@ import unreal
 openpype_detected = True
 try:
     from openpype.pipeline import install_host
-    from openpype.hosts.unreal import api as openpype_host
+    from openpype.hosts.unreal.api import UnrealHost
+
+    openpype_host = UnrealHost()
 except ImportError as exc:
     openpype_host = None
     openpype_detected = False

--- a/openpype/hosts/unreal/module.py
+++ b/openpype/hosts/unreal/module.py
@@ -37,3 +37,6 @@ class UnrealModule(OpenPypeModule, IHostModule):
         return [
             os.path.join(UNREAL_ROOT_DIR, "hooks")
         ]
+
+    def get_workfile_extensions(self):
+        return [".uproject"]

--- a/openpype/hosts/unreal/module.py
+++ b/openpype/hosts/unreal/module.py
@@ -1,0 +1,39 @@
+import os
+from openpype.modules import OpenPypeModule
+from openpype.modules.interfaces import IHostModule
+
+UNREAL_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class UnrealModule(OpenPypeModule, IHostModule):
+    name = "unreal"
+    host_name = "unreal"
+
+    def initialize(self, module_settings):
+        self.enabled = True
+
+    def add_implementation_envs(self, env, app) -> None:
+        """Modify environments to contain all required for implementation."""
+        # Set OPENPYPE_UNREAL_PLUGIN required for Unreal implementation
+
+        ue_plugin = "UE_5.0" if app.name[:1] == "5" else "UE_4.7"
+        unreal_plugin_path = os.path.join(
+            UNREAL_ROOT_DIR, "integration", ue_plugin
+        )
+        if not env.get("OPENPYPE_UNREAL_PLUGIN"):
+            env["OPENPYPE_UNREAL_PLUGIN"] = unreal_plugin_path
+
+        # Set default environments if are not set via settings
+        defaults = {
+            "OPENPYPE_LOG_NO_COLORS": "True"
+        }
+        for key, value in defaults.items():
+            if not env.get(key):
+                env[key] = value
+
+    def get_launch_hook_paths(self, app):
+        if app.host_name != self.host_name:
+            return []
+        return [
+            os.path.join(UNREAL_ROOT_DIR, "hooks")
+        ]


### PR DESCRIPTION
## Brief description
Unreal is OpenPype module and it's implementation registered as object inherited from `HostBase`.

## Description
Unreal in `openpype.hosts` works as openpype module and unreal integration is registered using `UnrealHost` object instead of `openpype.hosts.unreal.api` module.

## Testing notes:
1. Unreal should initialize project as usually
2. Unreal should launch successfully
3. Integration works as did (with publishing)