### PR TITLE
PS, AE: Provide default variant value for workfile subset

### DIFF
--- a/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
+++ b/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
@@ -11,6 +11,8 @@ class AEWorkfileCreator(AutoCreator):
     identifier = "workfile"
     family = "workfile"
 
+    default_variant = "Main"
+
     def get_instance_attr_defs(self):
         return []
 
@@ -35,7 +37,6 @@ class AEWorkfileCreator(AutoCreator):
                 existing_instance = instance
                 break
 
-        variant = ''
         project_name = legacy_io.Session["AVALON_PROJECT"]
         asset_name = legacy_io.Session["AVALON_ASSET"]
         task_name = legacy_io.Session["AVALON_TASK"]
@@ -44,15 +45,17 @@ class AEWorkfileCreator(AutoCreator):
         if existing_instance is None:
             asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(
-                variant, task_name, asset_doc, project_name, host_name
+                self.default_variant, task_name, asset_doc,
+                project_name, host_name
             )
             data = {
                 "asset": asset_name,
                 "task": task_name,
-                "variant": variant
+                "variant": self.default_variant
             }
             data.update(self.get_dynamic_data(
-                variant, task_name, asset_doc, project_name, host_name
+                self.default_variant, task_name, asset_doc,
+                project_name, host_name
             ))
 
             new_instance = CreatedInstance(
@@ -69,7 +72,8 @@ class AEWorkfileCreator(AutoCreator):
         ):
             asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(
-                variant, task_name, asset_doc, project_name, host_name
+                self.default_variant, task_name, asset_doc,
+                project_name, host_name
             )
             existing_instance["asset"] = asset_name
             existing_instance["task"] = task_name

--- a/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
+++ b/openpype/hosts/aftereffects/plugins/create/workfile_creator.py
@@ -77,3 +77,4 @@ class AEWorkfileCreator(AutoCreator):
             )
             existing_instance["asset"] = asset_name
             existing_instance["task"] = task_name
+            existing_instance["subset"] = subset_name

--- a/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/aftereffects/plugins/publish/collect_workfile.py
@@ -11,6 +11,8 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
     label = "Collect After Effects Workfile Instance"
     order = pyblish.api.CollectorOrder + 0.1
 
+    default_variant = "Main"
+
     def process(self, context):
         existing_instance = None
         for instance in context:
@@ -71,7 +73,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         family = "workfile"
         subset = get_subset_name_with_asset_doc(
             family,
-            "",
+            self.default_variant,
             context.data["anatomyData"]["task"]["name"],
             context.data["assetEntity"],
             context.data["anatomyData"]["project"]["name"],

--- a/openpype/hosts/photoshop/plugins/create/workfile_creator.py
+++ b/openpype/hosts/photoshop/plugins/create/workfile_creator.py
@@ -75,3 +75,4 @@ class PSWorkfileCreator(AutoCreator):
             )
             existing_instance["asset"] = asset_name
             existing_instance["task"] = task_name
+            existing_instance["subset"] = subset_name

--- a/openpype/hosts/photoshop/plugins/create/workfile_creator.py
+++ b/openpype/hosts/photoshop/plugins/create/workfile_creator.py
@@ -11,6 +11,8 @@ class PSWorkfileCreator(AutoCreator):
     identifier = "workfile"
     family = "workfile"
 
+    default_variant = "Main"
+
     def get_instance_attr_defs(self):
         return []
 
@@ -35,7 +37,6 @@ class PSWorkfileCreator(AutoCreator):
                 existing_instance = instance
                 break
 
-        variant = ''
         project_name = legacy_io.Session["AVALON_PROJECT"]
         asset_name = legacy_io.Session["AVALON_ASSET"]
         task_name = legacy_io.Session["AVALON_TASK"]
@@ -43,15 +44,17 @@ class PSWorkfileCreator(AutoCreator):
         if existing_instance is None:
             asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(
-                variant, task_name, asset_doc, project_name, host_name
+                self.default_variant, task_name, asset_doc,
+                project_name, host_name
             )
             data = {
                 "asset": asset_name,
                 "task": task_name,
-                "variant": variant
+                "variant": self.default_variant
             }
             data.update(self.get_dynamic_data(
-                variant, task_name, asset_doc, project_name, host_name
+                self.default_variant, task_name, asset_doc,
+                project_name, host_name
             ))
 
             new_instance = CreatedInstance(
@@ -67,7 +70,8 @@ class PSWorkfileCreator(AutoCreator):
         ):
             asset_doc = get_asset_by_name(project_name, asset_name)
             subset_name = self.get_subset_name(
-                variant, task_name, asset_doc, project_name, host_name
+                self.default_variant, task_name, asset_doc,
+                project_name, host_name
             )
             existing_instance["asset"] = asset_name
             existing_instance["task"] = task_name

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -22,9 +22,11 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
                 break
 
         family = "workfile"
+        # context.data["variant"] might come only from collect_batch_data
+        variant = context.data.get("variant") or self.default_variant
         subset = get_subset_name_with_asset_doc(
             family,
-            self.default_variant,
+            variant,
             context.data["anatomyData"]["task"]["name"],
             context.data["assetEntity"],
             context.data["anatomyData"]["project"]["name"],

--- a/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_workfile.py
@@ -11,6 +11,8 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
     label = "Collect Workfile"
     hosts = ["photoshop"]
 
+    default_variant = "Main"
+
     def process(self, context):
         existing_instance = None
         for instance in context:
@@ -22,7 +24,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         family = "workfile"
         subset = get_subset_name_with_asset_doc(
             family,
-            "",
+            self.default_variant,
             context.data["anatomyData"]["task"]["name"],
             context.data["assetEntity"],
             context.data["anatomyData"]["project"]["name"],


### PR DESCRIPTION
## Brief description
Variant was omitted which resulted in trailing underscore if subset name was in format of `{family}_{Task}_{Variant}` (which is a case for one customer.)

## Description
Default value 'Main' hardcoded. 
Will only propagate in workfile subset (and final published name of workfile) if {variant} is used in subset name template. (By default it isn't.)

## Additional info
It could be potentially added to Settings if anyone requires. Currently not implemented to limit polluting Settings with unnecessary values.
This particular issue occurred only on one specific customer.

## Testing notes:
1. configure subset name template to `{family}_{Task}_{Variant}` in `project_settings/global/tools/creator/subset_name_profiles`
2. publish workfile
3. compare resulting workfile name in `publish` folder, it should contain `Main` value