### PR TITLE
Workfiles tool: Fix published workfile filtering

### DIFF
--- a/openpype/tools/workfiles/model.py
+++ b/openpype/tools/workfiles/model.py
@@ -299,7 +299,6 @@ class PublishFilesModel(QtGui.QStandardItemModel):
             self.project_name,
             asset_ids=[self._asset_id],
             fields=["_id", "name"]
-
         )
 
         subset_ids = [subset_doc["_id"] for subset_doc in subset_docs]
@@ -329,7 +328,9 @@ class PublishFilesModel(QtGui.QStandardItemModel):
         #   extension
         extensions = [ext.replace(".", "") for ext in self._file_extensions]
         repre_docs = get_representations(
-            self.project_name, version_ids, extensions
+            self.project_name,
+            version_ids=version_ids,
+            context_filters={"ext": extensions}
         )
 
         # Filter queried representations by task name if task is set


### PR DESCRIPTION
## Brief description
Published workfiles are again visible in workfiles tool.

## Description
Workfiles tool used wrong filtering for queries of published workfiles which caused that published workfiles are not visible in workfiles tool.

## Testing notes:
1. Open any host
2. Publish any workfile
3. Open workfiles tool
4. Check "Published" so published workfiles are visible
5. Your workfile should be visible there