### PR TITLE
TrayPublisher: Define TrayPublisher as module

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -47,12 +47,6 @@ def standalonepublisher():
 
 
 @main.command()
-def traypublisher():
-    """Show new OpenPype Standalone publisher UI."""
-    PypeCommands().launch_traypublisher()
-
-
-@main.command()
 def tray():
     """Launch pype tray.
 

--- a/openpype/hosts/traypublisher/__init__.py
+++ b/openpype/hosts/traypublisher/__init__.py
@@ -1,0 +1,6 @@
+from .module import TrayPublishModule
+
+
+__all__ = (
+    "TrayPublishModule",
+)

--- a/openpype/hosts/traypublisher/module.py
+++ b/openpype/hosts/traypublisher/module.py
@@ -45,7 +45,7 @@ class TrayPublishModule(OpenPypeModule, IHostModule, ITrayAction):
 
     def run_traypublisher(self):
         args = get_openpype_execute_args(
-            "module", "traypublish_tool", "launch"
+            "module", self.name, "launch"
         )
         run_detached_process(args)
 

--- a/openpype/hosts/traypublisher/module.py
+++ b/openpype/hosts/traypublisher/module.py
@@ -1,25 +1,24 @@
 import os
+
+import click
+
 from openpype.lib import get_openpype_execute_args
 from openpype.lib.execute import run_detached_process
 from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayAction
+from openpype.modules.interfaces import ITrayAction, IHostModule
+
+TRAYPUBLISH_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-class TrayPublishAction(OpenPypeModule, ITrayAction):
+class TrayPublishModule(OpenPypeModule, IHostModule, ITrayAction):
     label = "New Publish (beta)"
     name = "traypublish_tool"
+    host_name = "traypublish"
 
     def initialize(self, modules_settings):
-        import openpype
         self.enabled = True
         self.publish_paths = [
-            os.path.join(
-                openpype.PACKAGE_DIR,
-                "hosts",
-                "traypublisher",
-                "plugins",
-                "publish"
-            )
+            os.path.join(TRAYPUBLISH_ROOT_DIR, "plugins", "publish")
         ]
         self._experimental_tools = None
 
@@ -29,7 +28,7 @@ class TrayPublishAction(OpenPypeModule, ITrayAction):
         self._experimental_tools = ExperimentalTools()
 
     def tray_menu(self, *args, **kwargs):
-        super(TrayPublishAction, self).tray_menu(*args, **kwargs)
+        super(TrayPublishModule, self).tray_menu(*args, **kwargs)
         traypublisher = self._experimental_tools.get("traypublisher")
         visible = False
         if traypublisher and traypublisher.enabled:
@@ -45,5 +44,7 @@ class TrayPublishAction(OpenPypeModule, ITrayAction):
         self.publish_paths.extend(publish_paths)
 
     def run_traypublisher(self):
-        args = get_openpype_execute_args("traypublisher")
+        args = get_openpype_execute_args(
+            "module", "traypublish_tool", "launch"
+        )
         run_detached_process(args)

--- a/openpype/hosts/traypublisher/module.py
+++ b/openpype/hosts/traypublisher/module.py
@@ -48,3 +48,20 @@ class TrayPublishModule(OpenPypeModule, IHostModule, ITrayAction):
             "module", "traypublish_tool", "launch"
         )
         run_detached_process(args)
+
+    def cli(self, click_group):
+        click_group.add_command(cli_main)
+
+
+@click.group(TrayPublishModule.name, help="TrayPublisher related commands.")
+def cli_main():
+    pass
+
+
+@cli_main.command()
+def launch():
+    """Launch TrayPublish tool UI."""
+
+    from openpype.tools import traypublisher
+
+    traypublisher.main()


### PR DESCRIPTION
## Brief description
Traypublisher host is now working as module.

## Description
Moved content of `traypublisher_action.py` into traypublisher host which can now behave as module. The module now also inherit from `IHostModule` and has custom cli commands. With new cli commands in the module was removed global cli command for traypublisher.

## Testing notes:
1. TrayPublisher action should still be visible in tray menu (if enabled in experimental tools)
2. TrayPublisher should launch when the action is triggered