### PR TITLE
Settings: Fix project overrides save

### DIFF
--- a/openpype/settings/handlers.py
+++ b/openpype/settings/handlers.py
@@ -957,7 +957,7 @@ class MongoSettingsHandler(SettingsHandler):
         if project_settings_doc:
             self.collection.update_one(
                 {"_id": project_settings_doc["_id"]},
-                new_project_settings_doc
+                {"$set": new_project_settings_doc}
             )
         else:
             self.collection.insert_one(new_project_settings_doc)


### PR DESCRIPTION
## Brief description
Fix broken save of project overrides.

## Description
There was wrong mongo operation when project overrides were saved to already existing overrides. This change is fixing it.

## Testing notes:
1. Save settings on a project
2. Save the settings again and it should not crash