### PR TITLE
Maya: Use project name instead of project code

### DIFF
--- a/openpype/hosts/maya/plugins/load/_load_animation.py
+++ b/openpype/hosts/maya/plugins/load/_load_animation.py
@@ -36,7 +36,7 @@ class AbcLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         # hero_001 (abc)
         # asset_counter{optional}
         file_url = self.prepare_root_value(self.fname,
-                                           context["project"]["code"])
+                                           context["project"]["name"])
         nodes = cmds.file(file_url,
                           namespace=namespace,
                           sharedReferenceFile=False,

--- a/openpype/hosts/maya/plugins/load/load_ass.py
+++ b/openpype/hosts/maya/plugins/load/load_ass.py
@@ -65,8 +65,9 @@ class AssProxyLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
             proxyPath = proxyPath_base + ".ma"
 
+            project_name = context["project"]["name"]
             file_url = self.prepare_root_value(proxyPath,
-                                               context["project"]["code"])
+                                               project_name)
 
             nodes = cmds.file(file_url,
                               namespace=namespace,
@@ -85,7 +86,7 @@ class AssProxyLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             proxyShape.dso.set(path)
             proxyShape.aiOverrideShaders.set(0)
 
-            settings = get_project_settings(os.environ['AVALON_PROJECT'])
+            settings = get_project_settings(project_name)
             colors = settings['maya']['load']['colors']
 
             c = colors.get(family)
@@ -128,7 +129,7 @@ class AssProxyLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             file_url = self.prepare_root_value(proxyPath,
                                                representation["context"]
                                                              ["project"]
-                                                             ["code"])
+                                                             ["name"])
             content = cmds.file(file_url,
                                 loadReference=reference_node,
                                 type="mayaAscii",

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -33,7 +33,7 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
 
         with lib.maintained_selection():
             file_url = self.prepare_root_value(self.fname,
-                                               context["project"]["code"])
+                                               context["project"]["name"])
             nodes = cmds.file(file_url,
                               namespace=namespace,
                               reference=True,

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -52,7 +52,7 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         with maintained_selection():
             cmds.loadPlugin("AbcImport.mll", quiet=True)
             file_url = self.prepare_root_value(self.fname,
-                                               context["project"]["code"])
+                                               context["project"]["name"])
             nodes = cmds.file(file_url,
                               namespace=namespace,
                               sharedReferenceFile=False,

--- a/openpype/hosts/maya/plugins/load/load_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_rig.py
@@ -54,7 +54,7 @@ class YetiRigLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         # load rig
         with lib.maintained_selection():
             file_url = self.prepare_root_value(self.fname,
-                                               context["project"]["code"])
+                                               context["project"]["name"])
             nodes = cmds.file(file_url,
                               namespace=namespace,
                               reference=True,


### PR DESCRIPTION
## Brief description
Use project name for root preparation instead of project code.

## Description
Using project code can cause that anatomy won't be created for right project so root values will be invalid.

## Testing notes:
1. Loading in Maya should work