### PR TITLE
General: Added helper getters to modules manager

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -562,6 +562,40 @@ class ModulesManager:
         self.initialize_modules()
         self.connect_modules()
 
+    def __getitem__(self, module_name):
+        return self.modules_by_name[module_name]
+
+    def get(self, module_name, default=None):
+        """Access module by name.
+
+        Args:
+            module_name (str): Name of module which should be returned.
+            default (Any): Default output if module is not available.
+
+        Returns:
+            Union[OpenPypeModule, None]: Module found by name or None.
+        """
+        return self.modules_by_name.get(module_name, default)
+
+    def get_enabled_module(self, module_name, default=None):
+        """Fast access to enabled module.
+
+        If module is available but is not enabled default value is returned.
+
+        Args:
+            module_name (str): Name of module which should be returned.
+            default (Any): Default output if module is not available or is
+                not enabled.
+
+        Returns:
+            Union[OpenPypeModule, None]: Enabled module found by name or None.
+        """
+
+        module = self.get(module_name)
+        if module is not None and module.enabled:
+            return module
+        return default
+
     def initialize_modules(self):
         """Import and initialize modules."""
         # Make sure modules are loaded


### PR DESCRIPTION
## Brief description
Added helper methods to ModulesManager to access modules by name.

## Description
Added dictionary like access to module by their names and special method to get module by name which also checks if is module enabled.

## Testing notes:
New methods on created object of `ModulesManager` in different cases (e.g. in Tray > Admin > Console).

```
from openpype.modules import ModulesManager

manager = ModulesManager()
print(manager["project_manager"])
print(manager.get("project_manager"))
print(manager.get_enabled_module("project_manager"))
```