### PR TITLE
General: Move constants from lib to client

### DIFF
--- a/openpype/client/operations.py
+++ b/openpype/client/operations.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 import copy
 import collections
@@ -10,6 +11,11 @@ from pymongo import DeleteOne, InsertOne, UpdateOne
 from .mongo import get_project_connection
 
 REMOVED_VALUE = object()
+
+PROJECT_NAME_ALLOWED_SYMBOLS = "a-zA-Z0-9_"
+PROJECT_NAME_REGEX = re.compile(
+    "^[{}]+$".format(PROJECT_NAME_ALLOWED_SYMBOLS)
+)
 
 CURRENT_PROJECT_SCHEMA = "openpype:project-3.0"
 CURRENT_PROJECT_CONFIG_SCHEMA = "openpype:config-2.0"

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -1,6 +1,5 @@
 """Should be used only inside of hosts."""
 import os
-import re
 import copy
 import platform
 import logging
@@ -31,6 +30,7 @@ log = logging.getLogger("AvalonContext")
 
 
 # Backwards compatibility - should not be used anymore
+#   - Will be removed in OP 3.16.*
 CURRENT_DOC_SCHEMAS = {
     "project": CURRENT_PROJECT_SCHEMA,
     "asset": CURRENT_ASSET_DOC_SCHEMA,

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -14,6 +14,11 @@ from openpype.client import (
     get_last_version_by_subset_name,
     get_workfile_info,
 )
+from openpype.client.operations import (
+    CURRENT_ASSET_DOC_SCHEMA,
+    CURRENT_PROJECT_SCHEMA,
+    CURRENT_PROJECT_CONFIG_SCHEMA,
+)
 from .profiles_filtering import filter_profiles
 from .events import emit_event
 from .path_templates import StringTemplate
@@ -23,10 +28,11 @@ legacy_io = None
 log = logging.getLogger("AvalonContext")
 
 
+# Backwards compatibility - should not be used anymore
 CURRENT_DOC_SCHEMAS = {
-    "project": "openpype:project-3.0",
-    "asset": "openpype:asset-3.0",
-    "config": "openpype:config-2.0"
+    "project": CURRENT_PROJECT_SCHEMA,
+    "asset": CURRENT_ASSET_DOC_SCHEMA,
+    "config": CURRENT_PROJECT_CONFIG_SCHEMA
 }
 PROJECT_NAME_ALLOWED_SYMBOLS = "a-zA-Z0-9_"
 PROJECT_NAME_REGEX = re.compile(

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -18,6 +18,8 @@ from openpype.client.operations import (
     CURRENT_ASSET_DOC_SCHEMA,
     CURRENT_PROJECT_SCHEMA,
     CURRENT_PROJECT_CONFIG_SCHEMA,
+    PROJECT_NAME_ALLOWED_SYMBOLS,
+    PROJECT_NAME_REGEX,
 )
 from .profiles_filtering import filter_profiles
 from .events import emit_event
@@ -34,10 +36,6 @@ CURRENT_DOC_SCHEMAS = {
     "asset": CURRENT_ASSET_DOC_SCHEMA,
     "config": CURRENT_PROJECT_CONFIG_SCHEMA
 }
-PROJECT_NAME_ALLOWED_SYMBOLS = "a-zA-Z0-9_"
-PROJECT_NAME_REGEX = re.compile(
-    "^[{}]+$".format(PROJECT_NAME_ALLOWED_SYMBOLS)
-)
 
 
 class AvalonContextDeprecatedWarning(DeprecationWarning):

--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -18,6 +18,7 @@ from openpype.client import (
     get_archived_assets,
     get_asset_ids_with_subsets
 )
+from openpype.client.operations import CURRENT_ASSET_DOC_SCHEMA
 from openpype.pipeline import AvalonMongoDB, schema
 
 from openpype_modules.ftrack.lib import (
@@ -35,7 +36,6 @@ from openpype_modules.ftrack.lib.avalon_sync import (
     convert_to_fps,
     InvalidFpsValue
 )
-from openpype.lib import CURRENT_DOC_SCHEMAS
 
 
 class SyncToAvalonEvent(BaseEvent):
@@ -1236,7 +1236,7 @@ class SyncToAvalonEvent(BaseEvent):
             "_id": mongo_id,
             "name": name,
             "type": "asset",
-            "schema": CURRENT_DOC_SCHEMAS["asset"],
+            "schema": CURRENT_ASSET_DOC_SCHEMA,
             "parent": proj["_id"],
             "data": {
                 "ftrackId": ftrack_ent["id"],

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -14,6 +14,11 @@ from openpype.client import (
     get_versions,
     get_representations
 )
+from openpype.client.operations import (
+    CURRENT_ASSET_DOC_SCHEMA,
+    CURRENT_PROJECT_SCHEMA,
+    CURRENT_PROJECT_CONFIG_SCHEMA,
+)
 from openpype.api import (
     Logger,
     get_anatomy_settings
@@ -30,14 +35,6 @@ from pymongo import UpdateOne, ReplaceOne
 import ftrack_api
 
 log = Logger.get_logger(__name__)
-
-
-# Current schemas for avalon types
-CURRENT_DOC_SCHEMAS = {
-    "project": "openpype:project-3.0",
-    "asset": "openpype:asset-3.0",
-    "config": "openpype:config-2.0"
-}
 
 
 class InvalidFpsValue(Exception):
@@ -2063,7 +2060,7 @@ class SyncEntitiesFactory:
 
         item["_id"] = new_id
         item["parent"] = self.avalon_project_id
-        item["schema"] = CURRENT_DOC_SCHEMAS["asset"]
+        item["schema"] = CURRENT_ASSET_DOC_SCHEMA
         item["data"]["visualParent"] = avalon_parent
 
         new_id_str = str(new_id)
@@ -2198,8 +2195,8 @@ class SyncEntitiesFactory:
 
         project_item["_id"] = new_id
         project_item["parent"] = None
-        project_item["schema"] = CURRENT_DOC_SCHEMAS["project"]
-        project_item["config"]["schema"] = CURRENT_DOC_SCHEMAS["config"]
+        project_item["schema"] = CURRENT_PROJECT_SCHEMA
+        project_item["config"]["schema"] = CURRENT_PROJECT_CONFIG_SCHEMA
 
         self.ftrack_avalon_mapper[self.ft_project_id] = new_id
         self.avalon_ftrack_mapper[new_id] = self.ft_project_id

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -13,10 +13,8 @@ from openpype.client import (
     get_assets,
     get_asset_ids_with_subsets,
 )
-from openpype.lib import (
-    CURRENT_DOC_SCHEMAS,
-    PypeLogger,
-)
+from openpype.client.operations import CURRENT_ASSET_DOC_SCHEMA
+from openpype.lib import Logger
 
 from .constants import (
     IDENTIFIER_ROLE,
@@ -203,7 +201,7 @@ class HierarchyModel(QtCore.QAbstractItemModel):
     @property
     def log(self):
         if self._log is None:
-            self._log = PypeLogger.get_logger("ProjectManagerModel")
+            self._log = Logger.get_logger("ProjectManagerModel")
         return self._log
 
     @property
@@ -1961,7 +1959,7 @@ class AssetItem(BaseItem):
         }
         schema_name = (
             self._origin_asset_doc.get("schema")
-            or CURRENT_DOC_SCHEMAS["asset"]
+            or CURRENT_ASSET_DOC_SCHEMA
         )
 
         doc = {

--- a/openpype/tools/project_manager/project_manager/widgets.py
+++ b/openpype/tools/project_manager/project_manager/widgets.py
@@ -5,8 +5,8 @@ from .constants import (
     NAME_ALLOWED_SYMBOLS,
     NAME_REGEX
 )
-from openpype.lib import (
-    create_project,
+from openpype.lib import create_project
+from openpype.client.operations import (
     PROJECT_NAME_ALLOWED_SYMBOLS,
     PROJECT_NAME_REGEX
 )


### PR DESCRIPTION
## Brief description
Moved entity specific constants to client code or reuse those which are already there.

## Description
These constants are related to creation of new entities. Some of them were already available there. 

## Additional info
Hard to tell to which degree these constants are "constants" and should be defined at one place? They're connected to schema validations but schema validation is in pipeline part. I would say that logic related to validation of project entities should be moved to client side and rest should stay in pipeline. I would like to avoid changing it and discussing it in this PR as this is refactor PR.

Variable `PROJECT_NAME_ALLOWED_SYMBOLS` is not used in `avalon_context.py` but is imported from there in `__init__.py`. I would like to keep it until the backwards compatibility is removed.

## Testing notes:
Technically logic didn't change.
- project manager can create and update assets
- ftrack sync works