### PR TITLE
General: Move creators plugin getter

### DIFF
--- a/openpype/hosts/blender/plugins/load/load_layout_blend.py
+++ b/openpype/hosts/blender/plugins/load/load_layout_blend.py
@@ -6,12 +6,12 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype import lib
 from openpype.pipeline import (
     legacy_create,
     get_representation_path,
     AVALON_CONTAINER_ID,
 )
+from openpype.pipeline.create import get_legacy_creator_by_name
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.pipeline import (
     AVALON_CONTAINERS,
@@ -157,7 +157,7 @@ class BlendLayoutLoader(plugin.AssetLoader):
                                 t.id = local_obj
 
             elif local_obj.type == 'EMPTY':
-                creator_plugin = lib.get_creator_by_name("CreateAnimation")
+                creator_plugin = get_legacy_creator_by_name("CreateAnimation")
                 if not creator_plugin:
                     raise ValueError("Creator plugin \"CreateAnimation\" was "
                                      "not found.")

--- a/openpype/hosts/blender/plugins/load/load_layout_json.py
+++ b/openpype/hosts/blender/plugins/load/load_layout_json.py
@@ -118,7 +118,7 @@ class JsonLayoutLoader(plugin.AssetLoader):
         # Camera creation when loading a layout is not necessary for now,
         # but the code is worth keeping in case we need it in the future.
         # # Create the camera asset and the camera instance
-        # creator_plugin = lib.get_creator_by_name("CreateCamera")
+        # creator_plugin = get_legacy_creator_by_name("CreateCamera")
         # if not creator_plugin:
         #     raise ValueError("Creator plugin \"CreateCamera\" was "
         #                      "not found.")

--- a/openpype/hosts/blender/plugins/load/load_rig.py
+++ b/openpype/hosts/blender/plugins/load/load_rig.py
@@ -6,12 +6,12 @@ from typing import Dict, List, Optional
 
 import bpy
 
-from openpype import lib
 from openpype.pipeline import (
     legacy_create,
     get_representation_path,
     AVALON_CONTAINER_ID,
 )
+from openpype.pipeline.create import get_legacy_creator_by_name
 from openpype.hosts.blender.api import (
     plugin,
     get_selection,
@@ -244,7 +244,7 @@ class BlendRigLoader(plugin.AssetLoader):
         objects = self._process(libpath, asset_group, group_name, action)
 
         if create_animation:
-            creator_plugin = lib.get_creator_by_name("CreateAnimation")
+            creator_plugin = get_legacy_creator_by_name("CreateAnimation")
             if not creator_plugin:
                 raise ValueError("Creator plugin \"CreateAnimation\" was "
                                  "not found.")

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -2,10 +2,10 @@ import os
 from maya import cmds
 
 from openpype.api import get_project_settings
-from openpype.lib import get_creator_by_name
-from openpype.pipeline import (
-    legacy_io,
+from openpype.pipeline import legacy_io
+from openpype.pipeline.create import (
     legacy_create,
+    get_legacy_creator_by_name,
 )
 import openpype.hosts.maya.api.plugin
 from openpype.hosts.maya.api.lib import maintained_selection
@@ -153,7 +153,9 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         self.log.info("Creating subset: {}".format(namespace))
 
         # Create the animation instance
-        creator_plugin = get_creator_by_name(self.animation_creator_name)
+        creator_plugin = get_legacy_creator_by_name(
+            self.animation_creator_name
+        )
         with maintained_selection():
             cmds.select([output, controls] + roots, noExpand=True)
             legacy_create(

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -769,7 +769,7 @@ def BuildWorkfile():
     return BuildWorkfile()
 
 
-@with_pipeline_io
+@deprecated("openpype.pipeline.create.get_legacy_creator_by_name")
 def get_creator_by_name(creator_name, case_sensitive=False):
     """Find creator plugin by name.
 
@@ -780,23 +780,13 @@ def get_creator_by_name(creator_name, case_sensitive=False):
 
     Returns:
         Creator: Return first matching plugin or `None`.
+
+    Deprecated:
+        Function will be removed after release version 3.16.*
     """
-    from openpype.pipeline import discover_legacy_creator_plugins
+    from openpype.pipeline.create import get_legacy_creator_by_name
 
-    # Lower input creator name if is not case sensitive
-    if not case_sensitive:
-        creator_name = creator_name.lower()
-
-    for creator_plugin in discover_legacy_creator_plugins():
-        _creator_name = creator_plugin.__name__
-
-        # Lower creator plugin name if is not case sensitive
-        if not case_sensitive:
-            _creator_name = _creator_name.lower()
-
-        if _creator_name == creator_name:
-            return creator_plugin
-    return None
+    return get_legacy_creator_by_name(creator_name, case_sensitive)
 
 
 @deprecated

--- a/openpype/pipeline/create/__init__.py
+++ b/openpype/pipeline/create/__init__.py
@@ -9,8 +9,10 @@ from .creator_plugins import (
     AutoCreator,
     HiddenCreator,
 
-    discover_creator_plugins,
     discover_legacy_creator_plugins,
+    get_legacy_creator_by_name,
+
+    discover_creator_plugins,
     register_creator_plugin,
     deregister_creator_plugin,
     register_creator_plugin_path,
@@ -38,8 +40,10 @@ __all__ = (
     "AutoCreator",
     "HiddenCreator",
 
-    "discover_creator_plugins",
     "discover_legacy_creator_plugins",
+    "get_legacy_creator_by_name",
+
+    "discover_creator_plugins",
     "register_creator_plugin",
     "deregister_creator_plugin",
     "register_creator_plugin_path",

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -458,6 +458,34 @@ def discover_legacy_creator_plugins():
     return plugins
 
 
+def get_legacy_creator_by_name(creator_name, case_sensitive=False):
+    """Find creator plugin by name.
+
+    Args:
+        creator_name (str): Name of creator class that should be returned.
+        case_sensitive (bool): Match of creator plugin name is case sensitive.
+            Set to `False` by default.
+
+    Returns:
+        Creator: Return first matching plugin or `None`.
+    """
+
+    # Lower input creator name if is not case sensitive
+    if not case_sensitive:
+        creator_name = creator_name.lower()
+
+    for creator_plugin in discover_legacy_creator_plugins():
+        _creator_name = creator_plugin.__name__
+
+        # Lower creator plugin name if is not case sensitive
+        if not case_sensitive:
+            _creator_name = _creator_name.lower()
+
+        if _creator_name == creator_name:
+            return creator_plugin
+    return None
+
+
 def register_creator_plugin(plugin):
     if issubclass(plugin, BaseCreator):
         register_plugin(BaseCreator, plugin)


### PR DESCRIPTION
## Brief description
Moved `get_creator_by_name` function into `openpype.pipeline.create.creator_plugins` and renamed to `get_legacy_creator_by_name`.

## Testing notes:
Creation during loading in Blender and Maya should work as before.