### PR TITLE
Settings: Remove settings lock on tray exit

### DIFF
--- a/openpype/modules/settings_action.py
+++ b/openpype/modules/settings_action.py
@@ -23,6 +23,11 @@ class SettingsAction(OpenPypeModule, ITrayAction):
         """Initialization in tray implementation of ITrayAction."""
         self.create_settings_window()
 
+    def tray_exit(self):
+        # Close settings UI to remove settings lock
+        if self.settings_window:
+            self.settings_window.close()
+
     def on_action_trigger(self):
         """Implementation for action trigger of ITrayAction."""
         self.show_settings_window()

--- a/openpype/tools/settings/settings/dialogs.py
+++ b/openpype/tools/settings/settings/dialogs.py
@@ -39,7 +39,7 @@ class BaseInfoDialog(QtWidgets.QDialog):
         ):
             other_information_layout.addRow(
                 label,
-                QtWidgets.QLabel(value, other_information)
+                QtWidgets.QLabel(value or "N/A", other_information)
             )
 
         timestamp_label = QtWidgets.QLabel(


### PR DESCRIPTION
## Brief description
Remove settings lock on tray exit.

## Description
On tray exit is closed settings UI which should cause that settings lock is removed. This won't solve situations when tray crashes or is shut down by task manager but will solve most of possible issues connected to shutting down tray.

Also make sure that `None` value in machine information won't cause crashes.

## Testing notes:
1. Run OpenPype tray
2. In tray open studio settings (Tray > Admin > Studio Settings) - let them load
3. Close tray (Tray > Exit)
4. Open settings UI again (through tray or direct settings command) and no dialog should show

Resolves https://github.com/pypeclub/OpenPype/issues/3718