### PR TITLE
General: Replace PypeLogger with Logger

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -1455,7 +1455,7 @@ def get_workfile_info(
 """
 ## Custom data storage:
 - Settings - OP settings overrides and local settings
-- Logging - logs from PypeLogger
+- Logging - logs from Logger
 - Webpublisher - jobs
 - Ftrack - events
 - Maya - Shaders

--- a/openpype/hosts/celaction/api/cli.py
+++ b/openpype/hosts/celaction/api/cli.py
@@ -14,7 +14,7 @@ from openpype.tools.utils import host_tools
 from openpype.pipeline import install_openpype_plugins
 
 
-log = Logger().get_logger("Celaction_cli_publisher")
+log = Logger.get_logger("Celaction_cli_publisher")
 
 publish_host = "celaction"
 

--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -8,7 +8,7 @@ import contextlib
 
 import pyblish.api
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,
@@ -20,7 +20,7 @@ from openpype.pipeline import (
 )
 import openpype.hosts.fusion
 
-log = Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 HOST_DIR = os.path.dirname(os.path.abspath(openpype.hosts.fusion.__file__))
 PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")

--- a/openpype/hosts/fusion/utility_scripts/__OpenPype_Menu__.py
+++ b/openpype/hosts/fusion/utility_scripts/__OpenPype_Menu__.py
@@ -1,13 +1,11 @@
 import os
 import sys
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import (
     install_host,
     registered_host,
 )
-
-log = Logger().get_logger(__name__)
 
 
 def main(env):
@@ -17,6 +15,7 @@ def main(env):
     # activate resolve from pype
     install_host(api)
 
+    log = Logger.get_logger(__name__)
     log.info(f"Registered host: {registered_host()}")
 
     menu.launch_openpype_menu()

--- a/openpype/hosts/hiero/api/events.py
+++ b/openpype/hosts/hiero/api/events.py
@@ -1,7 +1,6 @@
 import os
 import hiero.core.events
-from openpype.api import Logger
-from openpype.lib import register_event_callback
+from openpype.lib import Logger, register_event_callback
 from .lib import (
     sync_avalon_data_to_workfile,
     launch_workfiles_app,
@@ -11,7 +10,7 @@ from .lib import (
 from .tags import add_tags_to_workfile
 from .menu import update_menu_task_label
 
-log = Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 
 def startupCompleted(event):

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -21,7 +21,7 @@ from openpype.client import (
 )
 from openpype.settings import get_anatomy_settings
 from openpype.pipeline import legacy_io, Anatomy
-from openpype.api import Logger
+from openpype.lib import Logger
 from . import tags
 
 try:
@@ -34,7 +34,7 @@ except ImportError:
 # from opentimelineio import opentime
 # from pprint import pformat
 
-log = Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 self = sys.modules[__name__]
 self._has_been_setup = False

--- a/openpype/hosts/hiero/api/pipeline.py
+++ b/openpype/hosts/hiero/api/pipeline.py
@@ -6,7 +6,7 @@ import contextlib
 from collections import OrderedDict
 
 from pyblish import api as pyblish
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import (
     schema,
     register_creator_plugin_path,
@@ -18,7 +18,7 @@ from openpype.pipeline import (
 from openpype.tools.utils import host_tools
 from . import lib, menu, events
 
-log = Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 # plugin paths
 API_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/openpype/hosts/hiero/api/plugin.py
+++ b/openpype/hosts/hiero/api/plugin.py
@@ -9,11 +9,12 @@ from Qt import QtWidgets, QtCore
 import qargparse
 
 import openpype.api as openpype
+from openpype.lib import Logger
 from openpype.pipeline import LoaderPlugin, LegacyCreator
 from openpype.pipeline.context_tools import get_current_project_asset
 from . import lib
 
-log = openpype.Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 
 def load_stylesheet():

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -4,6 +4,7 @@ from maya import cmds
 
 import qargparse
 
+from openpype.lib import Logger
 from openpype.pipeline import (
     LegacyCreator,
     LoaderPlugin,
@@ -50,9 +51,7 @@ def get_reference_node(members, log=None):
     # Warn the user when we're taking the highest reference node
     if len(references) > 1:
         if not log:
-            from openpype.lib import PypeLogger
-
-            log = PypeLogger().get_logger(__name__)
+            log = Logger.get_logger(__name__)
 
         log.warning("More than one reference node found in "
                     "container, using highest reference node: "

--- a/openpype/hosts/nuke/plugins/load/actions.py
+++ b/openpype/hosts/nuke/plugins/load/actions.py
@@ -2,10 +2,10 @@
 
 """
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import load
 
-log = Logger().get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 
 class SetFrameRangeLoader(load.LoaderPlugin):

--- a/openpype/hosts/nuke/startup/clear_rendered.py
+++ b/openpype/hosts/nuke/startup/clear_rendered.py
@@ -1,10 +1,11 @@
 import os
 
-from openpype.api import Logger
-log = Logger().get_logger(__name__)
+from openpype.lib import Logger
 
 
 def clear_rendered(dir_path):
+    log = Logger.get_logger(__name__)
+
     for _f in os.listdir(dir_path):
         _f_path = os.path.join(dir_path, _f)
         log.info("Removing: `{}`".format(_f_path))

--- a/openpype/hosts/nuke/startup/write_to_read.py
+++ b/openpype/hosts/nuke/startup/write_to_read.py
@@ -2,8 +2,8 @@ import re
 import os
 import glob
 import nuke
-from openpype.api import Logger
-log = Logger().get_logger(__name__)
+from openpype.lib import Logger
+log = Logger.get_logger(__name__)
 
 SINGLE_FILE_FORMATS = ['avi', 'mp4', 'mxf', 'mov', 'mpg', 'mpeg', 'wmv', 'm4v',
                        'm2v']

--- a/openpype/hosts/tvpaint/worker/worker_job.py
+++ b/openpype/hosts/tvpaint/worker/worker_job.py
@@ -9,7 +9,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 
 import six
 
-from openpype.api import PypeLogger
+from openpype.lib import Logger
 from openpype.modules import ModulesManager
 
 
@@ -328,7 +328,7 @@ class TVPaintCommands:
     def log(self):
         """Access to logger object."""
         if self._log is None:
-            self._log = PypeLogger.get_logger(self.__class__.__name__)
+            self._log = Logger.get_logger(self.__class__.__name__)
         return self._log
 
     @property

--- a/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
+++ b/openpype/hosts/webpublisher/webserver_service/webpublish_routes.py
@@ -12,9 +12,7 @@ from openpype.client import (
     get_assets,
     OpenPypeMongoConnection,
 )
-from openpype.lib import (
-    PypeLogger,
-)
+from openpype.lib import Logger
 from openpype.lib.remote_publish import (
     get_task_data,
     ERROR_STATUS,
@@ -23,7 +21,7 @@ from openpype.lib.remote_publish import (
 from openpype.settings import get_project_settings
 from openpype_modules.webserver.base_routes import RestApiEndpoint
 
-log = PypeLogger.get_logger("WebpublishRoutes")
+log = Logger.get_logger("WebpublishRoutes")
 
 
 class ResourceRestApiEndpoint(RestApiEndpoint):

--- a/openpype/hosts/webpublisher/webserver_service/webserver_cli.py
+++ b/openpype/hosts/webpublisher/webserver_service/webserver_cli.py
@@ -7,7 +7,7 @@ import json
 import subprocess
 
 from openpype.client import OpenPypeMongoConnection
-from openpype.lib import PypeLogger
+from openpype.lib import Logger
 
 from .webpublish_routes import (
     RestApiResource,
@@ -28,7 +28,7 @@ from openpype.lib.remote_publish import (
 )
 
 
-log = PypeLogger.get_logger("webserver_gui")
+log = Logger.get_logger("webserver_gui")
 
 
 def run_webserver(*args, **kwargs):

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -24,7 +24,7 @@ from openpype.settings.constants import (
     METADATA_KEYS,
     M_DYNAMIC_KEY_LABEL
 )
-from . import PypeLogger
+from .log import Logger
 from .profiles_filtering import filter_profiles
 from .local_settings import get_openpype_username
 
@@ -138,7 +138,7 @@ def get_logger():
     """Global lib.applications logger getter."""
     global _logger
     if _logger is None:
-        _logger = PypeLogger.get_logger(__name__)
+        _logger = Logger.get_logger(__name__)
     return _logger
 
 
@@ -373,7 +373,7 @@ class ApplicationManager:
     """
 
     def __init__(self, system_settings=None):
-        self.log = PypeLogger.get_logger(self.__class__.__name__)
+        self.log = Logger.get_logger(self.__class__.__name__)
 
         self.app_groups = {}
         self.applications = {}
@@ -735,7 +735,7 @@ class LaunchHook:
 
         Always should be called
         """
-        self.log = PypeLogger().get_logger(self.__class__.__name__)
+        self.log = Logger.get_logger(self.__class__.__name__)
 
         self.launch_context = launch_context
 
@@ -877,7 +877,7 @@ class ApplicationLaunchContext:
 
         # Logger
         logger_name = "{}-{}".format(self.__class__.__name__, self.app_name)
-        self.log = PypeLogger.get_logger(logger_name)
+        self.log = Logger.get_logger(logger_name)
 
         self.executable = executable
 

--- a/openpype/lib/execute.py
+++ b/openpype/lib/execute.py
@@ -5,7 +5,7 @@ import platform
 import json
 import tempfile
 
-from .log import PypeLogger as Logger
+from .log import Logger
 from .vendor_bin_utils import find_executable
 
 # MSDN process creation flag (Windows only)
@@ -40,7 +40,7 @@ def execute(args,
 
     log_levels = ['DEBUG:', 'INFO:', 'ERROR:', 'WARNING:', 'CRITICAL:']
 
-    log = Logger().get_logger('execute')
+    log = Logger.get_logger('execute')
     log.info("Executing ({})".format(" ".join(args)))
     popen = subprocess.Popen(
         args,

--- a/openpype/lib/log.py
+++ b/openpype/lib/log.py
@@ -486,12 +486,18 @@ class Logger:
 
 
 class PypeLogger(Logger):
+    """Duplicate of 'Logger'.
+
+    Deprecated:
+        Class will be removed after release version 3.16.*
+    """
+
     @classmethod
     def get_logger(cls, *args, **kwargs):
         logger = Logger.get_logger(*args, **kwargs)
         # TODO uncomment when replaced most of places
-        # logger.warning((
-        #     "'openpype.lib.PypeLogger' is deprecated class."
-        #     " Please use 'openpype.lib.Logger' instead."
-        # ))
+        logger.warning((
+            "'openpype.lib.PypeLogger' is deprecated class."
+            " Please use 'openpype.lib.Logger' instead."
+        ))
         return logger

--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -6,11 +6,6 @@ import collections
 
 import six
 
-from .log import PypeLogger
-
-log = PypeLogger.get_logger(__name__)
-
-
 KEY_PATTERN = re.compile(r"(\{.*?[^{0]*\})")
 KEY_PADDING_PATTERN = re.compile(r"([^:]+)\S+[><]\S+")
 SUB_DICT_PATTERN = re.compile(r"([^\[\]]+)")

--- a/openpype/lib/remote_publish.py
+++ b/openpype/lib/remote_publish.py
@@ -66,7 +66,7 @@ def publish(log, close_plugin_name=None, raise_error=False):
     """Loops through all plugins, logs to console. Used for tests.
 
         Args:
-            log (OpenPypeLogger)
+            log (openpype.lib.Logger)
             close_plugin_name (str): name of plugin with responsibility to
                 close host app
     """
@@ -98,7 +98,7 @@ def publish_and_log(dbcon, _id, log, close_plugin_name=None, batch_id=None):
         Args:
             dbcon (OpenPypeMongoConnection)
             _id (str) - id of current job in DB
-            log (OpenPypeLogger)
+            log (openpype.lib.Logger)
             batch_id (str) - id sent from frontend
             close_plugin_name (str): name of plugin with responsibility to
                 close host app

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -13,7 +13,6 @@ from uuid import uuid4
 from abc import ABCMeta, abstractmethod
 import six
 
-import openpype
 from openpype.settings import (
     get_system_settings,
     SYSTEM_SETTINGS_KEY,
@@ -26,7 +25,12 @@ from openpype.settings.lib import (
     get_studio_system_settings_overrides,
     load_json_file
 )
-from openpype.lib import Logger
+
+from openpype.lib import (
+    Logger,
+    import_filepath,
+    import_module_from_dirpath
+)
 
 # Files that will be always ignored on modules import
 IGNORED_FILENAMES = (
@@ -278,12 +282,6 @@ def load_modules(force=False):
 
 
 def _load_modules():
-    # Import helper functions from lib
-    from openpype.lib import (
-        import_filepath,
-        import_module_from_dirpath
-    )
-
     # Key under which will be modules imported in `sys.modules`
     modules_key = "openpype_modules"
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -26,7 +26,7 @@ from openpype.settings.lib import (
     get_studio_system_settings_overrides,
     load_json_file
 )
-from openpype.lib import PypeLogger
+from openpype.lib import Logger
 
 # Files that will be always ignored on modules import
 IGNORED_FILENAMES = (
@@ -93,7 +93,7 @@ class _ModuleClass(object):
     def log(self):
         if self._log is None:
             super(_ModuleClass, self).__setattr__(
-                "_log", PypeLogger.get_logger(self.name)
+                "_log", Logger.get_logger(self.name)
             )
         return self._log
 
@@ -290,7 +290,7 @@ def _load_modules():
     # Change `sys.modules`
     sys.modules[modules_key] = openpype_modules = _ModuleClass(modules_key)
 
-    log = PypeLogger.get_logger("ModulesLoader")
+    log = Logger.get_logger("ModulesLoader")
 
     # Look for OpenPype modules in paths defined with `get_module_dirs`
     #   - dynamically imported OpenPype modules and addons
@@ -440,7 +440,7 @@ class OpenPypeModule:
     def __init__(self, manager, settings):
         self.manager = manager
 
-        self.log = PypeLogger.get_logger(self.name)
+        self.log = Logger.get_logger(self.name)
 
         self.initialize(settings)
 
@@ -1059,7 +1059,7 @@ class TrayModulesManager(ModulesManager):
     )
 
     def __init__(self):
-        self.log = PypeLogger.get_logger(self.__class__.__name__)
+        self.log = Logger.get_logger(self.__class__.__name__)
 
         self.modules = []
         self.modules_by_id = {}
@@ -1235,7 +1235,7 @@ def get_module_settings_defs():
 
     settings_defs = []
 
-    log = PypeLogger.get_logger("ModuleSettingsLoad")
+    log = Logger.get_logger("ModuleSettingsLoad")
 
     for raw_module in openpype_modules:
         for attr_name in dir(raw_module):

--- a/openpype/modules/deadline/deadline_module.py
+++ b/openpype/modules/deadline/deadline_module.py
@@ -3,7 +3,7 @@ import requests
 import six
 import sys
 
-from openpype.lib import requests_get, PypeLogger
+from openpype.lib import requests_get, Logger
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import IPluginPaths
 
@@ -58,7 +58,7 @@ class DeadlineModule(OpenPypeModule, IPluginPaths):
 
         """
         if not log:
-            log = PypeLogger.get_logger(__name__)
+            log = Logger.get_logger(__name__)
 
         argument = "{}/api/pools?NamesOnly=true".format(webservice)
         try:

--- a/openpype/modules/ftrack/ftrack_server/ftrack_server.py
+++ b/openpype/modules/ftrack/ftrack_server/ftrack_server.py
@@ -7,11 +7,9 @@ import traceback
 import ftrack_api
 
 from openpype.lib import (
-    PypeLogger,
+    Logger,
     modules_from_path
 )
-
-log = PypeLogger.get_logger(__name__)
 
 """
 # Required - Needed for connection to Ftrack
@@ -43,9 +41,12 @@ class FtrackServer:
                 server.run_server()
                 ..
         """
+
         # set Ftrack logging to Warning only - OPTIONAL
         ftrack_log = logging.getLogger("ftrack_api")
         ftrack_log.setLevel(logging.WARNING)
+
+        self.log = Logger.get_logger(__name__)
 
         self.stopped = True
         self.is_running = False
@@ -72,7 +73,7 @@ class FtrackServer:
             # Get all modules with functions
             modules, crashed = modules_from_path(path)
             for filepath, exc_info in crashed:
-                log.warning("Filepath load crashed {}.\n{}".format(
+                self.log.warning("Filepath load crashed {}.\n{}".format(
                     filepath, traceback.format_exception(*exc_info)
                 ))
 
@@ -87,7 +88,7 @@ class FtrackServer:
                         break
 
                 if not register_function:
-                    log.warning(
+                    self.log.warning(
                         "\"{}\" - Missing register method".format(filepath)
                     )
                     continue
@@ -97,7 +98,7 @@ class FtrackServer:
                 )
 
         if not register_functions:
-            log.warning((
+            self.log.warning((
                 "There are no events with `register` function"
                 " in registered paths: \"{}\""
             ).format("| ".join(paths)))
@@ -106,7 +107,7 @@ class FtrackServer:
             try:
                 register_func(self.session)
             except Exception:
-                log.warning(
+                self.log.warning(
                     "\"{}\" - register was not successful".format(filepath),
                     exc_info=True
                 )
@@ -141,7 +142,7 @@ class FtrackServer:
         self.session = session
         if load_files:
             if not self.handler_paths:
-                log.warning((
+                self.log.warning((
                     "Paths to event handlers are not set."
                     " Ftrack server won't launch."
                 ))
@@ -151,8 +152,8 @@ class FtrackServer:
             self.set_files(self.handler_paths)
 
             msg = "Registration of event handlers has finished!"
-            log.info(len(msg) * "*")
-            log.info(msg)
+            self.log.info(len(msg) * "*")
+            self.log.info(msg)
 
         # keep event_hub on session running
         self.session.event_hub.wait()

--- a/openpype/modules/ftrack/ftrack_server/socket_thread.py
+++ b/openpype/modules/ftrack/ftrack_server/socket_thread.py
@@ -5,8 +5,8 @@ import socket
 import threading
 import traceback
 import subprocess
-from openpype.api import Logger
-from openpype.lib import get_openpype_execute_args
+
+from openpype.lib import get_openpype_execute_args, Logger
 
 
 class SocketThread(threading.Thread):
@@ -16,7 +16,7 @@ class SocketThread(threading.Thread):
 
     def __init__(self, name, port, filepath, additional_args=[]):
         super(SocketThread, self).__init__()
-        self.log = Logger().get_logger(self.__class__.__name__)
+        self.log = Logger.get_logger(self.__class__.__name__)
         self.setName(name)
         self.name = name
         self.port = port

--- a/openpype/modules/ftrack/lib/ftrack_base_handler.py
+++ b/openpype/modules/ftrack/lib/ftrack_base_handler.py
@@ -6,7 +6,7 @@ import uuid
 import datetime
 import traceback
 import time
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.settings import get_project_settings
 
 import ftrack_api
@@ -52,7 +52,7 @@ class BaseHandler(object):
 
     def __init__(self, session):
         '''Expects a ftrack_api.Session instance'''
-        self.log = Logger().get_logger(self.__class__.__name__)
+        self.log = Logger.get_logger(self.__class__.__name__)
         if not(
             isinstance(session, ftrack_api.session.Session) or
             isinstance(session, ftrack_server.lib.SocketSession)

--- a/openpype/modules/ftrack/scripts/sub_event_processor.py
+++ b/openpype/modules/ftrack/scripts/sub_event_processor.py
@@ -4,6 +4,8 @@ import signal
 import socket
 import datetime
 
+import ftrack_api
+
 from openpype_modules.ftrack.ftrack_server.ftrack_server import FtrackServer
 from openpype_modules.ftrack.ftrack_server.lib import (
     SocketSession,
@@ -12,16 +14,11 @@ from openpype_modules.ftrack.ftrack_server.lib import (
 )
 from openpype.modules import ModulesManager
 
-from openpype.api import Logger
 from openpype.lib import (
+    Logger,
     get_openpype_version,
     get_build_version
 )
-
-
-import ftrack_api
-
-log = Logger().get_logger("Event processor")
 
 subprocess_started = datetime.datetime.now()
 
@@ -68,6 +65,8 @@ def register(session):
 
 
 def main(args):
+    log = Logger.get_logger("Event processor")
+
     port = int(args[-1])
     # Create a TCP/IP socket
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/openpype/modules/ftrack/scripts/sub_legacy_server.py
+++ b/openpype/modules/ftrack/scripts/sub_legacy_server.py
@@ -5,11 +5,11 @@ import signal
 import threading
 
 import ftrack_api
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.modules import ModulesManager
 from openpype_modules.ftrack.ftrack_server.ftrack_server import FtrackServer
 
-log = Logger().get_logger("Event Server Legacy")
+log = Logger.get_logger("Event Server Legacy")
 
 
 class TimerChecker(threading.Thread):

--- a/openpype/modules/ftrack/scripts/sub_user_server.py
+++ b/openpype/modules/ftrack/scripts/sub_user_server.py
@@ -2,6 +2,7 @@ import sys
 import signal
 import socket
 
+from openpype.lib import Logger
 from openpype_modules.ftrack.ftrack_server.ftrack_server import FtrackServer
 from openpype_modules.ftrack.ftrack_server.lib import (
     SocketSession,
@@ -9,9 +10,7 @@ from openpype_modules.ftrack.ftrack_server.lib import (
 )
 from openpype.modules import ModulesManager
 
-from openpype.api import Logger
-
-log = Logger().get_logger("FtrackUserServer")
+log = Logger.get_logger("FtrackUserServer")
 
 
 def main(args):

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -12,10 +12,11 @@ from ..lib import credentials
 from ..ftrack_module import FTRACK_MODULE_DIR
 from . import login_dialog
 
-from openpype.api import Logger, resources
+from openpype import resources
+from openpype.lib import Logger
 
 
-log = Logger().get_logger("FtrackModule")
+log = Logger.get_logger("FtrackModule")
 
 
 class FtrackTrayWrapper:

--- a/openpype/modules/log_viewer/tray/models.py
+++ b/openpype/modules/log_viewer/tray/models.py
@@ -1,6 +1,6 @@
 import collections
 from Qt import QtCore, QtGui
-from openpype.lib.log import PypeLogger
+from openpype.lib import Logger
 
 
 class LogModel(QtGui.QStandardItemModel):
@@ -41,14 +41,14 @@ class LogModel(QtGui.QStandardItemModel):
         self.dbcon = None
 
         # Crash if connection is not possible to skip this module
-        if not PypeLogger.initialized:
-            PypeLogger.initialize()
+        if not Logger.initialized:
+            Logger.initialize()
 
-        connection = PypeLogger.get_log_mongo_connection()
+        connection = Logger.get_log_mongo_connection()
         if connection:
-            PypeLogger.bootstrap_mongo_log()
-            database = connection[PypeLogger.log_database_name]
-            self.dbcon = database[PypeLogger.log_collection_name]
+            Logger.bootstrap_mongo_log()
+            database = connection[Logger.log_database_name]
+            self.dbcon = database[Logger.log_collection_name]
 
     def headerData(self, section, orientation, role):
         if (

--- a/openpype/modules/royalrender/api.py
+++ b/openpype/modules/royalrender/api.py
@@ -5,11 +5,8 @@ import os
 
 from openpype.settings import get_project_settings
 from openpype.lib.local_settings import OpenPypeSettingsRegistry
-from openpype.lib import PypeLogger, run_subprocess
+from openpype.lib import Logger, run_subprocess
 from .rr_job import RRJob, SubmitFile, SubmitterParameter
-
-
-log = PypeLogger.get_logger("RoyalRender")
 
 
 class Api:
@@ -19,6 +16,7 @@ class Api:
     RR_SUBMIT_API = 2
 
     def __init__(self, settings, project=None):
+        self.log = Logger.get_logger("RoyalRender")
         self._settings = settings
         self._initialize_rr(project)
 
@@ -137,7 +135,7 @@ class Api:
             rr_console += ".exe"
 
         args = [rr_console, file]
-        run_subprocess(" ".join(args), logger=log)
+        run_subprocess(" ".join(args), logger=self.log)
 
     def _submit_using_api(self, file):
         # type: (SubmitFile) -> None
@@ -159,11 +157,11 @@ class Api:
         rr_server = tcp.getRRServer()
 
         if len(rr_server) == 0:
-            log.info("Got RR IP address {}".format(rr_server))
+            self.log.info("Got RR IP address {}".format(rr_server))
 
         # TODO: Port is hardcoded in RR? If not, move it to Settings
         if not tcp.setServer(rr_server, 7773):
-            log.error(
+            self.log.error(
                 "Can not set RR server: {}".format(tcp.errorMessage()))
             raise RoyalRenderException(tcp.errorMessage())
 

--- a/openpype/modules/sync_server/providers/abstract_provider.py
+++ b/openpype/modules/sync_server/providers/abstract_provider.py
@@ -1,8 +1,8 @@
 import abc
 import six
-from openpype.api import Logger
+from openpype.lib import Logger
 
-log = Logger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -6,12 +6,11 @@ import concurrent.futures
 from concurrent.futures._base import CancelledError
 
 from .providers import lib
-from openpype.lib import PypeLogger
+from openpype.lib import Logger
 
 from .utils import SyncStatus, ResumableError
 
-
-log = PypeLogger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 async def upload(module, project_name, file, representation, provider_name,

--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -10,8 +10,6 @@ from openpype.lib import Logger
 
 from .utils import SyncStatus, ResumableError
 
-log = Logger.get_logger("SyncServer")
-
 
 async def upload(module, project_name, file, representation, provider_name,
                  remote_site_name, tree=None, preset=None):
@@ -237,6 +235,7 @@ class SyncServerThread(threading.Thread):
         Stopped when tray is closed.
     """
     def __init__(self, module):
+        self.log = Logger.get_logger(self.__class__.__name__)
         super(SyncServerThread, self).__init__()
         self.module = module
         self.loop = None
@@ -248,17 +247,17 @@ class SyncServerThread(threading.Thread):
         self.is_running = True
 
         try:
-            log.info("Starting Sync Server")
+            self.log.info("Starting Sync Server")
             self.loop = asyncio.new_event_loop()  # create new loop for thread
             asyncio.set_event_loop(self.loop)
             self.loop.set_default_executor(self.executor)
 
             asyncio.ensure_future(self.check_shutdown(), loop=self.loop)
             asyncio.ensure_future(self.sync_loop(), loop=self.loop)
-            log.info("Sync Server Started")
+            self.log.info("Sync Server Started")
             self.loop.run_forever()
         except Exception:
-            log.warning(
+            self.log.warning(
                 "Sync Server service has failed", exc_info=True
             )
         finally:
@@ -378,8 +377,9 @@ class SyncServerThread(threading.Thread):
                                                                  ))
                                     processed_file_path.add(file_path)
 
-                    log.debug("Sync tasks count {}".
-                              format(len(task_files_to_process)))
+                    self.log.debug("Sync tasks count {}".format(
+                        len(task_files_to_process)
+                    ))
                     files_created = await asyncio.gather(
                         *task_files_to_process,
                         return_exceptions=True)
@@ -398,28 +398,31 @@ class SyncServerThread(threading.Thread):
                                               error)
 
                 duration = time.time() - start_time
-                log.debug("One loop took {:.2f}s".format(duration))
+                self.log.debug("One loop took {:.2f}s".format(duration))
 
                 delay = self.module.get_loop_delay(project_name)
-                log.debug("Waiting for {} seconds to new loop".format(delay))
+                self.log.debug(
+                    "Waiting for {} seconds to new loop".format(delay)
+                )
                 self.timer = asyncio.create_task(self.run_timer(delay))
                 await asyncio.gather(self.timer)
 
             except ConnectionResetError:
-                log.warning("ConnectionResetError in sync loop, "
-                            "trying next loop",
-                            exc_info=True)
+                self.log.warning(
+                    "ConnectionResetError in sync loop, trying next loop",
+                    exc_info=True)
             except CancelledError:
                 # just stopping server
                 pass
             except ResumableError:
-                log.warning("ResumableError in sync loop, "
-                            "trying next loop",
-                            exc_info=True)
+                self.log.warning(
+                    "ResumableError in sync loop, trying next loop",
+                    exc_info=True)
             except Exception:
                 self.stop()
-                log.warning("Unhandled except. in sync loop, stopping server",
-                            exc_info=True)
+                self.log.warning(
+                    "Unhandled except. in sync loop, stopping server",
+                    exc_info=True)
 
     def stop(self):
         """Sets is_running flag to false, 'check_shutdown' shuts server down"""
@@ -432,16 +435,17 @@ class SyncServerThread(threading.Thread):
         while self.is_running:
             if self.module.long_running_tasks:
                 task = self.module.long_running_tasks.pop()
-                log.info("starting long running")
+                self.log.info("starting long running")
                 await self.loop.run_in_executor(None, task["func"])
-                log.info("finished long running")
+                self.log.info("finished long running")
                 self.module.projects_processed.remove(task["project_name"])
             await asyncio.sleep(0.5)
         tasks = [task for task in asyncio.all_tasks() if
                  task is not asyncio.current_task()]
         list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        log.debug(f'Finished awaiting cancelled tasks, results: {results}...')
+        self.log.debug(
+            f'Finished awaiting cancelled tasks, results: {results}...')
         await self.loop.shutdown_asyncgens()
         # to really make sure everything else has time to stop
         self.executor.shutdown(wait=True)
@@ -454,29 +458,32 @@ class SyncServerThread(threading.Thread):
 
     def reset_timer(self):
         """Called when waiting for next loop should be skipped"""
-        log.debug("Resetting timer")
+        self.log.debug("Resetting timer")
         if self.timer:
             self.timer.cancel()
             self.timer = None
 
     def _working_sites(self, project_name):
         if self.module.is_project_paused(project_name):
-            log.debug("Both sites same, skipping")
+            self.log.debug("Both sites same, skipping")
             return None, None
 
         local_site = self.module.get_active_site(project_name)
         remote_site = self.module.get_remote_site(project_name)
         if local_site == remote_site:
-            log.debug("{}-{} sites same, skipping".format(local_site,
-                                                          remote_site))
+            self.log.debug("{}-{} sites same, skipping".format(
+                local_site, remote_site))
             return None, None
 
         configured_sites = _get_configured_sites(self.module, project_name)
         if not all([local_site in configured_sites,
                     remote_site in configured_sites]):
-            log.debug("Some of the sites {} - {} is not ".format(local_site,
-                                                                 remote_site) +
-                      "working properly")
+            self.log.debug(
+                "Some of the sites {} - {} is not working properly".format(
+                    local_site, remote_site
+                )
+            )
+
             return None, None
 
         return local_site, remote_site

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -462,7 +462,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                 representation_id (string): MongoDB objectId value
                 site_name (string): 'gdrive', 'studio' etc.
         """
-        log.info("Pausing SyncServer for {}".format(representation_id))
+        self.log.info("Pausing SyncServer for {}".format(representation_id))
         self._paused_representations.add(representation_id)
         self.reset_site_on_representation(project_name, representation_id,
                                           site_name=site_name, pause=True)
@@ -479,7 +479,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                 representation_id (string): MongoDB objectId value
                 site_name (string): 'gdrive', 'studio' etc.
         """
-        log.info("Unpausing SyncServer for {}".format(representation_id))
+        self.log.info("Unpausing SyncServer for {}".format(representation_id))
         try:
             self._paused_representations.remove(representation_id)
         except KeyError:
@@ -518,7 +518,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             Args:
                 project_name (string): project_name name
         """
-        log.info("Pausing SyncServer for {}".format(project_name))
+        self.log.info("Pausing SyncServer for {}".format(project_name))
         self._paused_projects.add(project_name)
 
     def unpause_project(self, project_name):
@@ -530,7 +530,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             Args:
                 project_name (string):
         """
-        log.info("Unpausing SyncServer for {}".format(project_name))
+        self.log.info("Unpausing SyncServer for {}".format(project_name))
         try:
             self._paused_projects.remove(project_name)
         except KeyError:
@@ -558,14 +558,14 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
             It won't check anything, not uploading/downloading...
         """
-        log.info("Pausing SyncServer")
+        self.log.info("Pausing SyncServer")
         self._paused = True
 
     def unpause_server(self):
         """
             Unpause server
         """
-        log.info("Unpausing SyncServer")
+        self.log.info("Unpausing SyncServer")
         self._paused = False
 
     def is_paused(self):
@@ -876,7 +876,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
     #                             val = val[platform.system().lower()]
     #                     except KeyError:
     #                         st = "{}'s field value {} should be".format(key, val)  # noqa: E501
-    #                         log.error(st + " multiplatform dict")
+    #                         self.log.error(st + " multiplatform dict")
     #
     #                 item["namespace"] = item["namespace"].replace('{site}',
     #                                                               site_name)
@@ -1148,7 +1148,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         if self.enabled:
             self.sync_server_thread.start()
         else:
-            log.info("No presets or active providers. " +
+            self.log.info("No presets or active providers. " +
                      "Synchronization not possible.")
 
     def tray_exit(self):
@@ -1166,12 +1166,12 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         if not self.is_running:
             return
         try:
-            log.info("Stopping sync server server")
+            self.log.info("Stopping sync server server")
             self.sync_server_thread.is_running = False
             self.sync_server_thread.stop()
-            log.info("Sync server stopped")
+            self.log.info("Sync server stopped")
         except Exception:
-            log.warning(
+            self.log.warning(
                 "Error has happened during Killing sync server",
                 exc_info=True
             )
@@ -1256,7 +1256,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
             sync_project_settings[project_name] = proj_settings
         if not sync_project_settings:
-            log.info("No enabled and configured projects for sync.")
+            self.log.info("No enabled and configured projects for sync.")
         return sync_project_settings
 
     def get_sync_project_setting(self, project_name, exclude_locals=False,
@@ -1387,7 +1387,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         Returns:
             (list) of dictionaries
         """
-        log.debug("Check representations for : {}".format(project_name))
+        self.log.debug("Check representations for : {}".format(project_name))
         self.connection.Session["AVALON_PROJECT"] = project_name
         # retry_cnt - number of attempts to sync specific file before giving up
         retries_arr = self._get_retries_arr(project_name)
@@ -1466,9 +1466,10 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             }},
             {"$sort": {'priority': -1, '_id': 1}},
         ]
-        log.debug("active_site:{} - remote_site:{}".format(active_site,
-                                                           remote_site))
-        log.debug("query: {}".format(aggr))
+        self.log.debug("active_site:{} - remote_site:{}".format(
+            active_site, remote_site
+        ))
+        self.log.debug("query: {}".format(aggr))
         representations = self.connection.aggregate(aggr)
 
         return representations
@@ -1503,7 +1504,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         if get_local_site_id() not in (local_site, remote_site):
             # don't do upload/download for studio sites
-            log.debug("No local site {} - {}".format(local_site, remote_site))
+            self.log.debug("No local site {} - {}".format(local_site, remote_site))
             return SyncStatus.DO_NOTHING
 
         _, remote_rec = self._get_site_rec(sites, remote_site) or {}
@@ -1594,11 +1595,16 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             error_str = ''
 
         source_file = file.get("path", "")
-        log.debug("File for {} - {source_file} process {status} {error_str}".
-                  format(representation_id,
-                         status=status,
-                         source_file=source_file,
-                         error_str=error_str))
+        self.log.debug(
+            (
+                "File for {} - {source_file} process {status} {error_str}"
+            ).format(
+                representation_id,
+                status=status,
+                source_file=source_file,
+                error_str=error_str
+            )
+        )
 
     def _get_file_info(self, files, _id):
         """
@@ -1772,7 +1778,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                     break
         if not found:
             msg = "Site {} not found".format(site_name)
-            log.info(msg)
+            self.log.info(msg)
             raise ValueError(msg)
 
         update = {
@@ -1799,7 +1805,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                     break
         if not found:
             msg = "Site {} not found".format(site_name)
-            log.info(msg)
+            self.log.info(msg)
             raise ValueError(msg)
 
         if pause:
@@ -1834,7 +1840,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         reset_existing = False
         files = representation.get("files", [])
         if not files:
-            log.debug("No files for {}".format(representation_id))
+            self.log.debug("No files for {}".format(representation_id))
             return
 
         for repre_file in files:
@@ -1851,7 +1857,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
                         reset_existing = True
                     else:
                         msg = "Site {} already present".format(site_name)
-                        log.info(msg)
+                        self.log.info(msg)
                         raise SiteAlreadyPresentError(msg)
 
         if reset_existing:
@@ -1951,16 +1957,19 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
             self.widget = SyncServerWindow(self)
             no_errors = True
         except ValueError:
-            log.info("No system setting for sync. Not syncing.", exc_info=True)
+            self.log.info(
+                "No system setting for sync. Not syncing.", exc_info=True
+            )
         except KeyError:
-            log.info((
+            self.log.info((
                 "There are not set presets for SyncServer OR "
                 "Credentials provided are invalid, "
                 "no syncing possible").
                 format(str(self.sync_project_settings)), exc_info=True)
         except:
-            log.error("Uncaught exception durin start of SyncServer",
-                      exc_info=True)
+            self.log.error(
+                "Uncaught exception durin start of SyncServer",
+                exc_info=True)
         self.enabled = no_errors
         self.widget.show()
 

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -13,7 +13,7 @@ from openpype.settings import (
     get_project_settings,
     get_system_settings,
 )
-from openpype.lib import PypeLogger, get_local_site_id
+from openpype.lib import Logger, get_local_site_id
 from openpype.pipeline import AvalonMongoDB, Anatomy
 from openpype.settings.lib import (
     get_default_anatomy_settings,
@@ -28,7 +28,7 @@ from .utils import time_function, SyncStatus, SiteAlreadyPresentError
 from openpype.client import get_representations, get_representation_by_id
 
 
-log = PypeLogger.get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 class SyncServerModule(OpenPypeModule, ITrayModule):

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1504,7 +1504,9 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         if get_local_site_id() not in (local_site, remote_site):
             # don't do upload/download for studio sites
-            self.log.debug("No local site {} - {}".format(local_site, remote_site))
+            self.log.debug(
+                "No local site {} - {}".format(local_site, remote_site)
+            )
             return SyncStatus.DO_NOTHING
 
         _, remote_rec = self._get_site_rec(sites, remote_site) or {}

--- a/openpype/modules/sync_server/tray/app.py
+++ b/openpype/modules/sync_server/tray/app.py
@@ -2,15 +2,12 @@ from Qt import QtWidgets, QtCore, QtGui
 
 from openpype.tools.settings import style
 
-from openpype.lib import PypeLogger
 from openpype import resources
 
 from .widgets import (
     SyncProjectListWidget,
     SyncRepresentationSummaryWidget
 )
-
-log = PypeLogger().get_logger("SyncServer")
 
 
 class SyncServerWindow(QtWidgets.QDialog):

--- a/openpype/modules/sync_server/tray/delegates.py
+++ b/openpype/modules/sync_server/tray/delegates.py
@@ -1,8 +1,7 @@
 import os
 from Qt import QtCore, QtWidgets, QtGui
 
-from openpype.lib import PypeLogger
-from . import lib
+from openpype.lib import Logger
 
 from openpype.tools.utils.constants import (
     LOCAL_PROVIDER_ROLE,
@@ -16,7 +15,7 @@ from openpype.tools.utils.constants import (
     EDIT_ICON_ROLE
 )
 
-log = PypeLogger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 class PriorityDelegate(QtWidgets.QStyledItemDelegate):

--- a/openpype/modules/sync_server/tray/lib.py
+++ b/openpype/modules/sync_server/tray/lib.py
@@ -2,11 +2,6 @@ import attr
 import abc
 import six
 
-from openpype.lib import PypeLogger
-
-
-log = PypeLogger().get_logger("SyncServer")
-
 STATUS = {
     0: 'In Progress',
     1: 'Queued',

--- a/openpype/modules/sync_server/tray/models.py
+++ b/openpype/modules/sync_server/tray/models.py
@@ -9,8 +9,7 @@ import qtawesome
 
 from openpype.tools.utils.delegates import pretty_timestamp
 
-from openpype.lib import PypeLogger
-from openpype.api import get_local_site_id
+from openpype.lib import Logger, get_local_site_id
 from openpype.client import get_representation_by_id
 
 from . import lib
@@ -33,7 +32,7 @@ from openpype.tools.utils.constants import (
 )
 
 
-log = PypeLogger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 class _SyncRepresentationModel(QtCore.QAbstractTableModel):

--- a/openpype/modules/sync_server/tray/widgets.py
+++ b/openpype/modules/sync_server/tray/widgets.py
@@ -9,8 +9,7 @@ import qtawesome
 
 from openpype.tools.settings import style
 
-from openpype.api import get_local_site_id
-from openpype.lib import PypeLogger
+from openpype.lib import Logger, get_local_site_id
 
 from openpype.tools.utils.delegates import pretty_timestamp
 
@@ -36,7 +35,7 @@ from openpype.tools.utils.constants import (
     TRIES_ROLE
 )
 
-log = PypeLogger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer")
 
 
 class SyncProjectListWidget(QtWidgets.QWidget):

--- a/openpype/modules/sync_server/utils.py
+++ b/openpype/modules/sync_server/utils.py
@@ -1,6 +1,8 @@
 import time
-from openpype.api import Logger
-log = Logger().get_logger("SyncServer")
+
+from openpype.lib import Logger
+
+log = Logger.get_logger("SyncServer")
 
 
 class ResumableError(Exception):

--- a/openpype/modules/timers_manager/idle_threads.py
+++ b/openpype/modules/timers_manager/idle_threads.py
@@ -2,7 +2,7 @@ import time
 from Qt import QtCore
 from pynput import mouse, keyboard
 
-from openpype.lib import PypeLogger
+from openpype.lib import Logger
 
 
 class IdleItem:
@@ -31,7 +31,7 @@ class IdleManager(QtCore.QThread):
 
     def __init__(self):
         super(IdleManager, self).__init__()
-        self.log = PypeLogger.get_logger(self.__class__.__name__)
+        self.log = Logger.get_logger(self.__class__.__name__)
         self.signal_reset_timer.connect(self._reset_time)
 
         self.idle_item = IdleItem()

--- a/openpype/modules/timers_manager/rest_api.py
+++ b/openpype/modules/timers_manager/rest_api.py
@@ -1,9 +1,7 @@
 import json
 
 from aiohttp.web_response import Response
-from openpype.api import Logger
-
-log = Logger().get_logger("Event processor")
+from openpype.lib import Logger
 
 
 class TimersManagerModuleRestApi:
@@ -12,12 +10,18 @@ class TimersManagerModuleRestApi:
         happens in Workfile app.
     """
     def __init__(self, user_module, server_manager):
+        self.log = None
         self.module = user_module
         self.server_manager = server_manager
 
         self.prefix = "/timers_manager"
 
         self.register()
+
+    def log(self):
+        if self._log is None:
+            self._log = Logger.get_logger(self.__ckass__.__name__)
+        return self._log
 
     def register(self):
         self.server_manager.add_route(
@@ -47,7 +51,7 @@ class TimersManagerModuleRestApi:
                 "Payload must contain fields 'project_name,"
                 " 'asset_name' and 'task_name'"
             )
-            log.error(msg)
+            self.log.error(msg)
             return Response(status=400, message=msg)
 
         self.module.stop_timers()
@@ -73,7 +77,7 @@ class TimersManagerModuleRestApi:
                 "Payload must contain fields 'project_name, 'asset_name',"
                 " 'task_name'"
             )
-            log.warning(message)
+            self.log.warning(message)
             return Response(text=message, status=404)
 
         time = self.module.get_task_time(project_name, asset_name, task_name)

--- a/openpype/modules/timers_manager/rest_api.py
+++ b/openpype/modules/timers_manager/rest_api.py
@@ -18,6 +18,7 @@ class TimersManagerModuleRestApi:
 
         self.register()
 
+    @property
     def log(self):
         if self._log is None:
             self._log = Logger.get_logger(self.__ckass__.__name__)

--- a/openpype/modules/webserver/server.py
+++ b/openpype/modules/webserver/server.py
@@ -171,7 +171,9 @@ class WebServerThread(threading.Thread):
         ]
         list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        self.log.debug(f'Finished awaiting cancelled tasks, results: {results}...')
+        self.log.debug(
+            f'Finished awaiting cancelled tasks, results: {results}...'
+        )
         await self.loop.shutdown_asyncgens()
         # to really make sure everything else has time to stop
         await asyncio.sleep(0.07)

--- a/openpype/modules/webserver/server.py
+++ b/openpype/modules/webserver/server.py
@@ -4,16 +4,16 @@ import asyncio
 
 from aiohttp import web
 
-from openpype.lib import PypeLogger
+from openpype.lib import Logger
 from .cors_middleware import cors_middleware
-
-log = PypeLogger.get_logger("WebServer")
 
 
 class WebServerManager:
     """Manger that care about web server thread."""
 
     def __init__(self, port=None, host=None):
+        self._log = None
+
         self.port = port or 8079
         self.host = host or "localhost"
 
@@ -34,6 +34,12 @@ class WebServerManager:
         self.webserver_thread = WebServerThread(self)
 
     @property
+    def log(self):
+        if self._log is None:
+            self._log = Logger.get_logger(self.__class__.__name__)
+        return self._log
+
+    @property
     def url(self):
         return "http://{}:{}".format(self.host, self.port)
 
@@ -51,12 +57,12 @@ class WebServerManager:
         if not self.is_running:
             return
         try:
-            log.debug("Stopping Web server")
+            self.log.debug("Stopping Web server")
             self.webserver_thread.is_running = False
             self.webserver_thread.stop()
 
         except Exception:
-            log.warning(
+            self.log.warning(
                 "Error has happened during Killing Web server",
                 exc_info=True
             )
@@ -74,7 +80,10 @@ class WebServerManager:
 
 class WebServerThread(threading.Thread):
     """ Listener for requests in thread."""
+
     def __init__(self, manager):
+        self._log = None
+
         super(WebServerThread, self).__init__()
 
         self.is_running = False
@@ -83,6 +92,12 @@ class WebServerThread(threading.Thread):
         self.runner = None
         self.site = None
         self.tasks = []
+
+    @property
+    def log(self):
+        if self._log is None:
+            self._log = Logger.get_logger(self.__class__.__name__)
+        return self._log
 
     @property
     def port(self):
@@ -96,13 +111,13 @@ class WebServerThread(threading.Thread):
         self.is_running = True
 
         try:
-            log.info("Starting WebServer server")
+            self.log.info("Starting WebServer server")
             self.loop = asyncio.new_event_loop()  # create new loop for thread
             asyncio.set_event_loop(self.loop)
 
             self.loop.run_until_complete(self.start_server())
 
-            log.debug(
+            self.log.debug(
                 "Running Web server on URL: \"localhost:{}\"".format(self.port)
             )
 
@@ -110,7 +125,7 @@ class WebServerThread(threading.Thread):
             self.loop.run_forever()
 
         except Exception:
-            log.warning(
+            self.log.warning(
                 "Web Server service has failed", exc_info=True
             )
         finally:
@@ -118,7 +133,7 @@ class WebServerThread(threading.Thread):
 
         self.is_running = False
         self.manager.thread_stopped()
-        log.info("Web server stopped")
+        self.log.info("Web server stopped")
 
     async def start_server(self):
         """ Starts runner and TCPsite """
@@ -138,17 +153,17 @@ class WebServerThread(threading.Thread):
         while self.is_running:
             while self.tasks:
                 task = self.tasks.pop(0)
-                log.debug("waiting for task {}".format(task))
+                self.log.debug("waiting for task {}".format(task))
                 await task
-                log.debug("returned value {}".format(task.result))
+                self.log.debug("returned value {}".format(task.result))
 
             await asyncio.sleep(0.5)
 
-        log.debug("Starting shutdown")
+        self.log.debug("Starting shutdown")
         await self.site.stop()
-        log.debug("Site stopped")
+        self.log.debug("Site stopped")
         await self.runner.cleanup()
-        log.debug("Runner stopped")
+        self.log.debug("Runner stopped")
         tasks = [
             task
             for task in asyncio.all_tasks()
@@ -156,7 +171,7 @@ class WebServerThread(threading.Thread):
         ]
         list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        log.debug(f'Finished awaiting cancelled tasks, results: {results}...')
+        self.log.debug(f'Finished awaiting cancelled tasks, results: {results}...')
         await self.loop.shutdown_asyncgens()
         # to really make sure everything else has time to stop
         await asyncio.sleep(0.07)

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -14,9 +14,9 @@ from openpype.lib.path_templates import (
     TemplatesDict,
     FormatObject,
 )
-from openpype.lib.log import PypeLogger
+from openpype.lib.log import Logger
 
-log = PypeLogger.get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 
 class ProjectNotSet(Exception):

--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -5,7 +5,6 @@ import sys
 import json
 import time
 
-from openpype.lib import PypeLogger
 from openpype.api import get_app_environments_for_context
 from openpype.lib.plugin_tools import get_batch_asset_task_info
 from openpype.lib.remote_publish import (
@@ -27,9 +26,10 @@ class PypeCommands:
     """
     @staticmethod
     def launch_tray():
-        PypeLogger.set_process_name("Tray")
-
+        from openpype.lib import Logger
         from openpype.tools import tray
+
+        Logger.set_process_name("Tray")
 
         tray.main()
 
@@ -47,10 +47,12 @@ class PypeCommands:
     @staticmethod
     def add_modules(click_func):
         """Modules/Addons can add their cli commands dynamically."""
+
+        from openpype.lib import Logger
         from openpype.modules import ModulesManager
 
         manager = ModulesManager()
-        log = PypeLogger.get_logger("AddModulesCLI")
+        log = Logger.get_logger("CLI-AddModules")
         for module in manager.modules:
             try:
                 module.cli(click_func)
@@ -96,10 +98,10 @@ class PypeCommands:
         Raises:
             RuntimeError: When there is no path to process.
         """
+
+        from openpype.lib import Logger
         from openpype.modules import ModulesManager
         from openpype.pipeline import install_openpype_plugins
-
-        from openpype.api import Logger
         from openpype.tools.utils.host_tools import show_publish
         from openpype.tools.utils.lib import qt_app_context
 
@@ -107,7 +109,7 @@ class PypeCommands:
         import pyblish.api
         import pyblish.util
 
-        log = Logger.get_logger()
+        log = Logger.get_logger("CLI-publish")
 
         install_openpype_plugins()
 
@@ -195,11 +197,12 @@ class PypeCommands:
             targets (list): Pyblish targets
                 (to choose validator for example)
         """
+
         import pyblish.api
-        from openpype.api import Logger
         from openpype.lib import ApplicationManager
 
-        log = Logger.get_logger()
+        from openpype.lib import Logger
+        log = Logger.get_logger("CLI-remotepublishfromapp")
 
         log.info("remotepublishphotoshop command")
 
@@ -311,10 +314,11 @@ class PypeCommands:
         import pyblish.api
         import pyblish.util
 
+        from openpype.lib import Logger
         from openpype.pipeline import install_host
         from openpype.hosts.webpublisher import api as webpublisher
 
-        log = PypeLogger.get_logger()
+        log = Logger.get_logger("remotepublish")
 
         log.info("remotepublish command")
 

--- a/openpype/settings/entities/base_entity.py
+++ b/openpype/settings/entities/base_entity.py
@@ -15,7 +15,7 @@ from .exceptions import (
     EntitySchemaError
 )
 
-from openpype.lib import PypeLogger
+from openpype.lib import Logger
 
 
 @six.add_metaclass(ABCMeta)
@@ -478,7 +478,7 @@ class BaseItemEntity(BaseEntity):
     def log(self):
         """Auto created logger for debugging or warnings."""
         if self._log is None:
-            self._log = PypeLogger.get_logger(self.__class__.__name__)
+            self._log = Logger.get_logger(self.__class__.__name__)
         return self._log
 
     @abstractproperty


### PR DESCRIPTION
## Brief description
Code cleanup related to OpenPype logger.

## Description
Class `PypeLogger` should not be used anymore, is marked as deprecated and logs out warning message when `get_logger` is called. It's usage was replaced with `Logger`. Also was removed calling of the class which is not needed. In some cases was logger object moved into objects from global scope.

Most changes that could cause issues happened in sync server.

## Testing notes:
1. Logging should work as expected
2. SyncServer sync should work

Resolves https://github.com/pypeclub/OpenPype/issues/3581