### PR TITLE
AfterEffects: Define AfterEffects as module

### DIFF
--- a/openpype/hosts/aftereffects/__init__.py
+++ b/openpype/hosts/aftereffects/__init__.py
@@ -1,9 +1,6 @@
-def add_implementation_envs(env, _app):
-    """Modify environments to contain all required for implementation."""
-    defaults = {
-        "OPENPYPE_LOG_NO_COLORS": "True",
-        "WEBSOCKET_URL": "ws://localhost:8097/ws/"
-    }
-    for key, value in defaults.items():
-        if not env.get(key):
-            env[key] = value
+from .module import AfterEffectsModule
+
+
+__all__ = (
+    "AfterEffectsModule",
+)

--- a/openpype/hosts/aftereffects/api/workio.py
+++ b/openpype/hosts/aftereffects/api/workio.py
@@ -1,12 +1,11 @@
 """Host API required Work Files tool"""
 import os
 
-from openpype.pipeline import HOST_WORKFILE_EXTENSIONS
 from .launch_logic import get_stub
 
 
 def file_extensions():
-    return HOST_WORKFILE_EXTENSIONS["aftereffects"]
+    return [".aep"]
 
 
 def has_unsaved_changes():

--- a/openpype/hosts/aftereffects/module.py
+++ b/openpype/hosts/aftereffects/module.py
@@ -1,4 +1,3 @@
-import os
 from openpype.modules import OpenPypeModule
 from openpype.modules.interfaces import IHostModule
 

--- a/openpype/hosts/aftereffects/module.py
+++ b/openpype/hosts/aftereffects/module.py
@@ -1,0 +1,24 @@
+import os
+from openpype.modules import OpenPypeModule
+from openpype.modules.interfaces import IHostModule
+
+
+class AfterEffectsModule(OpenPypeModule, IHostModule):
+    name = "aftereffects"
+    host_name = "aftereffects"
+
+    def initialize(self, module_settings):
+        self.enabled = True
+
+    def add_implementation_envs(self, env, _app):
+        """Modify environments to contain all required for implementation."""
+        defaults = {
+            "OPENPYPE_LOG_NO_COLORS": "True",
+            "WEBSOCKET_URL": "ws://localhost:8097/ws/"
+        }
+        for key, value in defaults.items():
+            if not env.get(key):
+                env[key] = value
+
+    def get_workfile_extensions(self):
+        return [".aep"]


### PR DESCRIPTION
## Brief description
AfterEffects host is module.

## Description
Implemented `AfterEffectsModule` for resolve host which gives public information about the host.

## Testing notes:
- AE can be launched and is connected to side process (integration works)
- Last workfile is launched (not sure if it was possible?)