### PR TITLE
General: Module interfaces cleanup

### DIFF
--- a/openpype/modules/__init__.py
+++ b/openpype/modules/__init__.py
@@ -2,7 +2,6 @@
 from .base import (
     OpenPypeModule,
     OpenPypeAddOn,
-    OpenPypeInterface,
 
     load_modules,
 
@@ -20,7 +19,6 @@ from .base import (
 __all__ = (
     "OpenPypeModule",
     "OpenPypeAddOn",
-    "OpenPypeInterface",
 
     "load_modules",
 

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -28,6 +28,14 @@ from openpype.settings.lib import (
 )
 from openpype.lib import PypeLogger
 
+from .interfaces import (
+    OpenPypeInterface,
+    IPluginPaths,
+    IHostModule,
+    ITrayModule,
+    ITrayService
+)
+
 # Files that will be always ignored on modules import
 IGNORED_FILENAMES = (
     "__pycache__",
@@ -391,29 +399,7 @@ def _load_modules():
                 log.error(msg, exc_info=True)
 
 
-class _OpenPypeInterfaceMeta(ABCMeta):
-    """OpenPypeInterface meta class to print proper string."""
 
-    def __str__(self):
-        return "<'OpenPypeInterface.{}'>".format(self.__name__)
-
-    def __repr__(self):
-        return str(self)
-
-
-@six.add_metaclass(_OpenPypeInterfaceMeta)
-class OpenPypeInterface:
-    """Base class of Interface that can be used as Mixin with abstract parts.
-
-    This is way how OpenPype module or addon can tell that has implementation
-    for specific part or for other module/addon.
-
-    Child classes of OpenPypeInterface may be used as mixin in different
-    OpenPype modules which means they have to have implemented methods defined
-    in the interface. By default interface does not have any abstract parts.
-    """
-
-    pass
 
 
 @six.add_metaclass(ABCMeta)
@@ -749,8 +735,6 @@ class ModulesManager:
                 and "actions" each containing list of paths.
         """
         # Output structure
-        from openpype_interfaces import IPluginPaths
-
         output = {
             "publish": [],
             "create": [],
@@ -807,8 +791,6 @@ class ModulesManager:
             list: List of creator plugin paths.
         """
         # Output structure
-        from openpype_interfaces import IPluginPaths
-
         output = []
         for module in self.get_enabled_modules():
             # Skip module that do not inherit from `IPluginPaths`
@@ -897,8 +879,6 @@ class ModulesManager:
                 host name set to passed 'host_name'.
         """
 
-        from openpype_interfaces import IHostModule
-
         for module in self.get_enabled_modules():
             if (
                 isinstance(module, IHostModule)
@@ -914,8 +894,6 @@ class ModulesManager:
             Iterable[str]: All available host names based on enabled modules
                 inheriting 'IHostModule'.
         """
-
-        from openpype_interfaces import IHostModule
 
         host_names = {
             module.host_name
@@ -1098,8 +1076,6 @@ class TrayModulesManager(ModulesManager):
         self.tray_menu(tray_menu)
 
     def get_enabled_tray_modules(self):
-        from openpype_interfaces import ITrayModule
-
         output = []
         for module in self.modules:
             if module.enabled and isinstance(module, ITrayModule):
@@ -1175,8 +1151,6 @@ class TrayModulesManager(ModulesManager):
             self._report["Tray menu"] = report
 
     def start_modules(self):
-        from openpype_interfaces import ITrayService
-
         report = {}
         time_start = time.time()
         prev_start_time = time_start

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -805,68 +805,6 @@ class ModulesManager:
                 output.extend(paths)
         return output
 
-    def collect_launch_hook_paths(self, app):
-        """Helper to collect application launch hooks.
-
-        It used to be based on 'ILaunchHookPaths' which is not true anymore.
-        Module just have to have implemented 'get_launch_hook_paths' method.
-
-        Args:
-            app (Application): Application object which can be used for
-                filtering of which launch hook paths are returned.
-
-        Returns:
-            list: Paths to launch hook directories.
-        """
-
-        str_type = type("")
-        expected_types = (list, tuple, set)
-
-        output = []
-        for module in self.get_enabled_modules():
-            # Skip module if does not have implemented 'get_launch_hook_paths'
-            func = getattr(module, "get_launch_hook_paths", None)
-            if func is None:
-                continue
-
-            func = module.get_launch_hook_paths
-            if hasattr(inspect, "signature"):
-                sig = inspect.signature(func)
-                expect_args = len(sig.parameters) > 0
-            else:
-                expect_args = len(inspect.getargspec(func)[0]) > 0
-
-            # Pass application argument if method expect it.
-            try:
-                if expect_args:
-                    hook_paths = func(app)
-                else:
-                    hook_paths = func()
-            except Exception:
-                self.log.warning(
-                    "Failed to call 'get_launch_hook_paths'",
-                    exc_info=True
-                )
-                continue
-
-            if not hook_paths:
-                continue
-
-            # Convert string to list
-            if isinstance(hook_paths, str_type):
-                hook_paths = [hook_paths]
-
-            # Skip invalid types
-            if not isinstance(hook_paths, expected_types):
-                self.log.warning((
-                    "Result of `get_launch_hook_paths`"
-                    " has invalid type {}. Expected {}"
-                ).format(type(hook_paths), expected_types))
-                continue
-
-            output.extend(hook_paths)
-        return output
-
     def get_host_module(self, host_name):
         """Find host module by host name.
 

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -9,7 +9,6 @@ from openpype.modules import OpenPypeModule
 from openpype_interfaces import (
     ITrayModule,
     IPluginPaths,
-    ILaunchHookPaths,
     ISettingsChangeListener
 )
 from openpype.settings import SaveWarningExc
@@ -21,7 +20,6 @@ class FtrackModule(
     OpenPypeModule,
     ITrayModule,
     IPluginPaths,
-    ILaunchHookPaths,
     ISettingsChangeListener
 ):
     name = "ftrack"
@@ -85,7 +83,8 @@ class FtrackModule(
         }
 
     def get_launch_hook_paths(self):
-        """Implementation of `ILaunchHookPaths`."""
+        """Implementation for applications launch hooks."""
+
         return os.path.join(FTRACK_MODULE_DIR, "launch_hooks")
 
     def modify_application_launch_arguments(self, application, env):

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -81,6 +81,13 @@ class ILaunchHookPaths(OpenPypeInterface):
 
     Expected result is list of paths.
     ["path/to/launch_hooks_dir"]
+
+    Deprecated:
+        This interface is not needed since OpenPype 3.14.*. Addon just have to
+        implement 'get_launch_hook_paths' which can expect Application object
+        or nothing as argument.
+
+        Interface class will be removed after 3.16.*.
     """
 
     @abstractmethod

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -1,8 +1,33 @@
-from abc import abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod, abstractproperty
+
+import six
 
 from openpype import resources
 
-from openpype.modules import OpenPypeInterface
+
+class _OpenPypeInterfaceMeta(ABCMeta):
+    """OpenPypeInterface meta class to print proper string."""
+
+    def __str__(self):
+        return "<'OpenPypeInterface.{}'>".format(self.__name__)
+
+    def __repr__(self):
+        return str(self)
+
+
+@six.add_metaclass(_OpenPypeInterfaceMeta)
+class OpenPypeInterface:
+    """Base class of Interface that can be used as Mixin with abstract parts.
+
+    This is way how OpenPype module or addon can tell OpenPype that contain
+    implementation for specific functionality.
+
+    Child classes of OpenPypeInterface may be used as mixin in different
+    OpenPype modules which means they have to have implemented methods defined
+    in the interface. By default interface does not have any abstract parts.
+    """
+
+    pass
 
 
 class IPluginPaths(OpenPypeInterface):

--- a/openpype/modules/shotgrid/shotgrid_module.py
+++ b/openpype/modules/shotgrid/shotgrid_module.py
@@ -3,7 +3,6 @@ import os
 from openpype_interfaces import (
     ITrayModule,
     IPluginPaths,
-    ILaunchHookPaths,
 )
 
 from openpype.modules import OpenPypeModule
@@ -11,9 +10,7 @@ from openpype.modules import OpenPypeModule
 SHOTGRID_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-class ShotgridModule(
-    OpenPypeModule, ITrayModule, IPluginPaths, ILaunchHookPaths
-):
+class ShotgridModule(OpenPypeModule, ITrayModule, IPluginPaths):
     leecher_manager_url = None
     name = "shotgrid"
     enabled = False

--- a/openpype/modules/slack/slack_module.py
+++ b/openpype/modules/slack/slack_module.py
@@ -1,14 +1,11 @@
 import os
 from openpype.modules import OpenPypeModule
-from openpype_interfaces import (
-    IPluginPaths,
-    ILaunchHookPaths
-)
+from openpype.modules.interfaces import IPluginPaths
 
 SLACK_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-class SlackIntegrationModule(OpenPypeModule, IPluginPaths, ILaunchHookPaths):
+class SlackIntegrationModule(OpenPypeModule, IPluginPaths):
     """Allows sending notification to Slack channels during publishing."""
 
     name = "slack"
@@ -18,7 +15,8 @@ class SlackIntegrationModule(OpenPypeModule, IPluginPaths, ILaunchHookPaths):
         self.enabled = slack_settings["enabled"]
 
     def get_launch_hook_paths(self):
-        """Implementation of `ILaunchHookPaths`."""
+        """Implementation for applications launch hooks."""
+
         return os.path.join(SLACK_MODULE_DIR, "launch_hooks")
 
     def get_plugin_paths(self):

--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -6,7 +6,6 @@ from openpype.client import get_asset_by_name
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import (
     ITrayService,
-    ILaunchHookPaths,
     IPluginPaths
 )
 from openpype.lib.events import register_event_callback
@@ -79,7 +78,6 @@ class ExampleTimersManagerConnector:
 class TimersManager(
     OpenPypeModule,
     ITrayService,
-    ILaunchHookPaths,
     IPluginPaths
 ):
     """ Handles about Timers.
@@ -185,12 +183,11 @@ class TimersManager(
         )
 
     def get_launch_hook_paths(self):
-        """Implementation of `ILaunchHookPaths`."""
+        """Implementation for applications launch hooks."""
 
-        return os.path.join(
-            TIMER_MODULE_DIR,
-            "launch_hooks"
-        )
+        return [
+            os.path.join(TIMER_MODULE_DIR, "launch_hooks")
+        ]
 
     def get_plugin_paths(self):
         """Implementation of `IPluginPaths`."""


### PR DESCRIPTION
## Brief description
Cleanup of openpype interfaces related to openpype modules.

## Description
Moved `OpenPypeInterface` into interfaces file as don't propagate it to `openpype.modules` api. Reduced usage of `ILaunchHookPaths` from modules as the interface is not needed anymore -> marked as deprecated. Function for collecting of launch hooks was moved to applications logic. Use direct import of interfaces -> replaced `from openpype_interfaces import ...` with `from openpype.modules.interfaces import ...`.

## Testing notes:
1. All modules should be imported and loaded
2. All launch hooks should be working as expected (e.g. slack should work in python 2 hosts)