### PR TITLE
Nuke: missing job dependency if multiple bake streams

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_nuke_deadline.py
@@ -114,6 +114,13 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
                 instance.data["deadlineSubmissionJob"] = resp.json()
                 instance.data["publishJobState"] = "Suspended"
 
+                # add to list of job Id
+                if not instance.data.get("bakingSubmissionJobs"):
+                    instance.data["bakingSubmissionJobs"] = []
+
+                instance.data["bakingSubmissionJobs"].append(
+                    resp.json()["_id"])
+
         # redefinition of families
         if "render.farm" in families:
             instance.data['family'] = 'write'

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -296,6 +296,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             for assembly_id in instance.data.get("assemblySubmissionJobs"):
                 payload["JobInfo"]["JobDependency{}".format(job_index)] = assembly_id  # noqa: E501
                 job_index += 1
+        elif instance.data.get("bakingSubmissionJobs"):
+            self.log.info("Adding baking submission jobs as dependencies...")
+            job_index = 0
+            for assembly_id in instance.data["bakingSubmissionJobs"]:
+                payload["JobInfo"]["JobDependency{}".format(job_index)] = assembly_id  # noqa: E501
+                job_index += 1
         else:
             payload["JobInfo"]["JobDependency0"] = job["_id"]
 


### PR DESCRIPTION
## Brief description
Multiple Deadline job dependencies are linked.

## Description
If Nuke multiple baking stream jobs are created, those are added as job dependency to the last python publishing job.

## Testing notes:
1. open nuke workfile in project with multiple baking stream configuration
2. publish render family instance to farm
3. Open Deadline Monitor and switch to Superuser mode
4. double click to `Publish - *` python job in submitted group of jobs
5. go to Dependencies and see there are multiple jobs.
![image](https://user-images.githubusercontent.com/40640033/186693392-03f4bc1b-d64f-467d-a03d-cc8d20295c59.png)
