### PR TITLE
General: Logger tweaks

### DIFF
--- a/openpype/modules/sync_server/providers/abstract_provider.py
+++ b/openpype/modules/sync_server/providers/abstract_provider.py
@@ -10,6 +10,8 @@ class AbstractProvider:
     CODE = ''
     LABEL = ''
 
+    _log = None
+
     def __init__(self, project_name, site_name, tree=None, presets=None):
         self.presets = None
         self.active = False
@@ -18,6 +20,12 @@ class AbstractProvider:
         self.presets = presets
 
         super(AbstractProvider, self).__init__()
+
+    @property
+    def log(self):
+        if self._log is None:
+            self._log = Logger.get_logger(self.__class__.__name__)
+        return self._log
 
     @abc.abstractmethod
     def is_active(self):
@@ -199,11 +207,11 @@ class AbstractProvider:
                 path = anatomy.fill_root(path)
             except KeyError:
                 msg = "Error in resolving local root from anatomy"
-                log.error(msg)
+                self.log.error(msg)
                 raise ValueError(msg)
         except IndexError:
             msg = "Path {} contains unfillable placeholder"
-            log.error(msg)
+            self.log.error(msg)
             raise ValueError(msg)
 
         return path

--- a/openpype/modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/sync_server/providers/dropbox.py
@@ -2,11 +2,8 @@ import os
 
 import dropbox
 
-from openpype.api import Logger
 from .abstract_provider import AbstractProvider
 from ..utils import EditableScopes
-
-log = Logger().get_logger("SyncServer")
 
 
 class DropboxHandler(AbstractProvider):
@@ -20,26 +17,26 @@ class DropboxHandler(AbstractProvider):
         self.dbx = None
 
         if not self.presets:
-            log.info(
+            self.log.info(
                 "Sync Server: There are no presets for {}.".format(site_name)
             )
             return
 
         if not self.presets["enabled"]:
-            log.debug("Sync Server: Site {} not enabled for {}.".
+            self.log.debug("Sync Server: Site {} not enabled for {}.".
                       format(site_name, project_name))
             return
 
         token = self.presets.get("token", "")
         if not token:
             msg = "Sync Server: No access token for dropbox provider"
-            log.info(msg)
+            self.log.info(msg)
             return
 
         team_folder_name = self.presets.get("team_folder_name", "")
         if not team_folder_name:
             msg = "Sync Server: No team folder name for dropbox provider"
-            log.info(msg)
+            self.log.info(msg)
             return
 
         acting_as_member = self.presets.get("acting_as_member", "")
@@ -47,7 +44,7 @@ class DropboxHandler(AbstractProvider):
             msg = (
                 "Sync Server: No acting member for dropbox provider"
             )
-            log.info(msg)
+            self.log.info(msg)
             return
 
         try:
@@ -55,7 +52,7 @@ class DropboxHandler(AbstractProvider):
                 token, acting_as_member, team_folder_name
             )
         except Exception as e:
-            log.info("Could not establish dropbox object: {}".format(e))
+            self.log.info("Could not establish dropbox object: {}".format(e))
             return
 
         super(AbstractProvider, self).__init__()
@@ -448,7 +445,7 @@ class DropboxHandler(AbstractProvider):
                 path = anatomy.fill_root(path)
             except KeyError:
                 msg = "Error in resolving local root from anatomy"
-                log.error(msg)
+                self.log.error(msg)
                 raise ValueError(msg)
 
         return path

--- a/openpype/modules/sync_server/providers/sftp.py
+++ b/openpype/modules/sync_server/providers/sftp.py
@@ -4,10 +4,10 @@ import time
 import threading
 import platform
 
-from openpype.api import Logger
-from openpype.api import get_system_settings
+from openpype.lib import Logger
+from openpype.settings import get_system_settings
 from .abstract_provider import AbstractProvider
-log = Logger().get_logger("SyncServer")
+log = Logger.get_logger("SyncServer-SFTPHandler")
 
 pysftp = None
 try:
@@ -43,8 +43,9 @@ class SFTPHandler(AbstractProvider):
 
         self.presets = presets
         if not self.presets:
-            log.warning("Sync Server: There are no presets for {}.".
-                        format(site_name))
+            self.log.warning(
+                "Sync Server: There are no presets for {}.".format(site_name)
+            )
             return
 
         # store to instance for reconnect
@@ -423,7 +424,7 @@ class SFTPHandler(AbstractProvider):
             return pysftp.Connection(**conn_params)
         except (paramiko.ssh_exception.SSHException,
                 pysftp.exceptions.ConnectionException):
-            log.warning("Couldn't connect", exc_info=True)
+            self.log.warning("Couldn't connect", exc_info=True)
 
     def _mark_progress(self, project_name, file, representation, server, site,
                        source_path, target_path, direction):
@@ -445,7 +446,7 @@ class SFTPHandler(AbstractProvider):
                     time.time() - last_tick >= server.LOG_PROGRESS_SEC:
                 status_val = target_file_size / source_file_size
                 last_tick = time.time()
-                log.debug(direction + "ed %d%%." % int(status_val * 100))
+                self.log.debug(direction + "ed %d%%." % int(status_val * 100))
                 server.update_db(project_name=project_name,
                                  new_file_id=None,
                                  file=file,

--- a/openpype/modules/timers_manager/rest_api.py
+++ b/openpype/modules/timers_manager/rest_api.py
@@ -10,7 +10,7 @@ class TimersManagerModuleRestApi:
         happens in Workfile app.
     """
     def __init__(self, user_module, server_manager):
-        self.log = None
+        self._log = None
         self.module = user_module
         self.server_manager = server_manager
 

--- a/openpype/modules/webserver/webserver_module.py
+++ b/openpype/modules/webserver/webserver_module.py
@@ -53,9 +53,12 @@ class WebServerModule(OpenPypeModule, ITrayService):
             try:
                 module.webserver_initialization(self.server_manager)
             except Exception:
-                self.log.warning((
-                    "Failed to connect module \"{}\" to webserver."
-                ).format(module.name))
+                self.log.warning(
+                    (
+                        "Failed to connect module \"{}\" to webserver."
+                    ).format(module.name),
+                    exc_info=True
+                )
 
     def tray_init(self):
         self.create_server_manager()


### PR DESCRIPTION
## Brief description
Fix logger issue in timers manager and modify logs in sync server.

## Description
Timers manager rest api codebase is using wront attribute name during initialization for logger. Sync server provides have their own loggers so they don't have to use loggers in global scope.

## Testing notes:
1. TimersManager can register webserver callbacks
    - can start/stop timer from host (e.g. on task change in workfiles tool)
2. Sync server provides should not crash and still can log