### PR TITLE
General: Custom workfile template use env keys to fill path

### DIFF
--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -408,6 +408,9 @@ def get_custom_workfile_template(
     # add root dict
     anatomy_context_data["root"] = anatomy.roots
 
+    # extend anatomy context with os.environ
+    anatomy_context_data.update(os.environ)
+
     # get task type for the task in context
     current_task_type = anatomy_context_data["task"]["type"]
 

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -409,7 +409,7 @@ def get_custom_workfile_template(
     anatomy_context_data["root"] = anatomy.roots
 
     # extend anatomy context with os.environ
-    full_context_data = os.environ
+    full_context_data = os.environ.copy()
     full_context_data.update(anatomy_context_data)
 
     # get task type for the task in context

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -409,10 +409,11 @@ def get_custom_workfile_template(
     anatomy_context_data["root"] = anatomy.roots
 
     # extend anatomy context with os.environ
-    anatomy_context_data.update(os.environ)
+    full_context_data = os.environ
+    full_context_data.update(anatomy_context_data)
 
     # get task type for the task in context
-    current_task_type = anatomy_context_data["task"]["type"]
+    current_task_type = full_context_data["task"]["type"]
 
     # get path from matching profile
     matching_item = filter_profiles(
@@ -424,7 +425,7 @@ def get_custom_workfile_template(
     if matching_item:
         template = matching_item["path"][platform.system().lower()]
         return StringTemplate.format_strict_template(
-            template, anatomy_context_data
+            template, full_context_data
         ).normalized()
 
     return None

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -408,12 +408,8 @@ def get_custom_workfile_template(
     # add root dict
     anatomy_context_data["root"] = anatomy.roots
 
-    # extend anatomy context with os.environ
-    full_context_data = os.environ.copy()
-    full_context_data.update(anatomy_context_data)
-
     # get task type for the task in context
-    current_task_type = full_context_data["task"]["type"]
+    current_task_type = anatomy_context_data["task"]["type"]
 
     # get path from matching profile
     matching_item = filter_profiles(
@@ -423,6 +419,11 @@ def get_custom_workfile_template(
     # when path is available try to format it in case
     # there are some anatomy template strings
     if matching_item:
+        # extend anatomy context with os.environ to
+        # also allow formatting against env
+        full_context_data = os.environ.copy()
+        full_context_data.update(anatomy_context_data)
+
         template = matching_item["path"][platform.system().lower()]
         return StringTemplate.format_strict_template(
             template, full_context_data


### PR DESCRIPTION
## Brief description
Allow env vars to be parsed in workfile template path resolving

## Description
The current workfile template path resolving matches either an absolute path or just the anatomy context.
This extends the anatomy context used by the parser to also contain all the os.environ vars
using dict.update (so there's no conflict with keys)
Priority would be in environ then, which makes this flexible.

## Testing notes:
1. put an env var in the workfiles template path
2. seems to work!