### PR TITLE
General: Thumbnail can use project roots

### DIFF
--- a/openpype/client/operations.py
+++ b/openpype/client/operations.py
@@ -24,6 +24,7 @@ CURRENT_SUBSET_SCHEMA = "openpype:subset-3.0"
 CURRENT_VERSION_SCHEMA = "openpype:version-3.0"
 CURRENT_REPRESENTATION_SCHEMA = "openpype:representation-2.0"
 CURRENT_WORKFILE_INFO_SCHEMA = "openpype:workfile-1.0"
+CURRENT_THUMBNAIL_SCHEMA = "openpype:thumbnail-1.0"
 
 
 def _create_or_convert_to_mongo_id(mongo_id):
@@ -192,6 +193,29 @@ def new_representation_doc(
 
         # Imprint shortcut to context for performance reasons.
         "context": context
+    }
+
+
+def new_thumbnail_doc(data=None, entity_id=None):
+    """Create skeleton data of thumbnail document.
+
+    Args:
+        data (Dict[str, Any]): Thumbnail document data.
+        entity_id (Union[str, ObjectId]): Predefined id of document. New id is
+            created if not passed.
+
+    Returns:
+        Dict[str, Any]: Skeleton of thumbnail document.
+    """
+
+    if data is None:
+        data = {}
+
+    return {
+        "_id": _create_or_convert_to_mongo_id(entity_id),
+        "type": "thumbnail",
+        "schema": CURRENT_THUMBNAIL_SCHEMA,
+        "data": data
     }
 
 

--- a/openpype/pipeline/thumbnail.py
+++ b/openpype/pipeline/thumbnail.py
@@ -4,6 +4,7 @@ import logging
 
 from openpype.client import get_project
 from . import legacy_io
+from .anatomy import Anatomy
 from .plugin_discover import (
     discover,
     register_plugin,
@@ -89,6 +90,7 @@ class TemplateResolver(ThumbnailResolver):
 
         project_name = self.dbcon.active_project()
         project = get_project(project_name, fields=["name", "data.code"])
+        anatomy = Anatomy(project_name)
 
         template_data = copy.deepcopy(
             thumbnail_entity["data"].get("template_data") or {}
@@ -100,7 +102,8 @@ class TemplateResolver(ThumbnailResolver):
             "project": {
                 "name": project["name"],
                 "code": project["data"].get("code")
-            }
+            },
+            "root": anatomy.roots
         })
 
         try:

--- a/openpype/pipeline/thumbnail.py
+++ b/openpype/pipeline/thumbnail.py
@@ -90,7 +90,6 @@ class TemplateResolver(ThumbnailResolver):
 
         project_name = self.dbcon.active_project()
         project = get_project(project_name, fields=["name", "data.code"])
-        anatomy = Anatomy(project_name)
 
         template_data = copy.deepcopy(
             thumbnail_entity["data"].get("template_data") or {}
@@ -103,8 +102,11 @@ class TemplateResolver(ThumbnailResolver):
                 "name": project["name"],
                 "code": project["data"].get("code")
             },
-            "root": anatomy.roots
         })
+        # Add anatomy roots if is in template
+        if "{root" in template:
+            anatomy = Anatomy(project_name)
+            template_data["root"] = anatomy.roots
 
         try:
             filepath = os.path.normpath(template.format(**template_data))

--- a/openpype/pipeline/thumbnail.py
+++ b/openpype/pipeline/thumbnail.py
@@ -73,17 +73,18 @@ class ThumbnailResolver(object):
 
 
 class TemplateResolver(ThumbnailResolver):
-
     priority = 90
 
     def process(self, thumbnail_entity, thumbnail_type):
-
-        if not os.environ.get("AVALON_THUMBNAIL_ROOT"):
-            return
-
         template = thumbnail_entity["data"].get("template")
         if not template:
             self.log.debug("Thumbnail entity does not have set template")
+            return
+
+        thumbnail_root_format_key = "{thumbnail_root}"
+        thumbnail_root = os.environ.get("AVALON_THUMBNAIL_ROOT") or ""
+        # Check if template require thumbnail root and if is avaiable
+        if thumbnail_root_format_key in template and not thumbnail_root:
             return
 
         project_name = self.dbcon.active_project()
@@ -95,7 +96,7 @@ class TemplateResolver(ThumbnailResolver):
         template_data.update({
             "_id": str(thumbnail_entity["_id"]),
             "thumbnail_type": thumbnail_type,
-            "thumbnail_root": os.environ.get("AVALON_THUMBNAIL_ROOT"),
+            "thumbnail_root": thumbnail_root,
             "project": {
                 "name": project["name"],
                 "code": project["data"].get("code")


### PR DESCRIPTION
## Brief description
It is not required to have filled `AVALON_THUMBNAIL_ROOT` to integrate thumbnail. The root can be replaced with project roots from anatomy.

## Description
The key `AVALON_THUMBNAIL_ROOT` is optional for thumbnail integration and thumbnail resolver. It is possible to use anatomy roots in thumbnail template as replacement. Anatomy roots are "loaded" only if template is using them - load of Anatomy could make loading slower.

Thumbnails integration is using client operations.

## Additional info
It would be good idea to make wrapper around thumbnail resolvers to reuse initilized objects instead of initialize them on use -> anatomy could be loaded only once.

## Testing notes:
1. Thumbnail integration works as before
    - integrate thumbnail happens and don't crash
    - the thumbnails are visible in loader
2. Usage of `{root[work]}` in thumbnail template is possible
    - can be tested same was as step 1.