### PR TITLE
Maya: Fix typo in getPanel argument `with_focus` -> `withFocus`

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -128,7 +128,7 @@ class ExtractPlayblast(openpype.api.Extractor):
             # Update preset with current panel setting
             # if override_viewport_options is turned off
             if not override_viewport_options:
-                panel = cmds.getPanel(with_focus=True)
+                panel = cmds.getPanel(withFocus=True)
                 panel_preset = capture.parse_active_view()
                 preset.update(panel_preset)
                 cmds.setFocus(panel)

--- a/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
@@ -100,9 +100,9 @@ class ExtractThumbnail(openpype.api.Extractor):
         # camera.
         if preset.pop("isolate_view", False) and instance.data.get("isolate"):
             preset["isolate"] = instance.data["setMembers"]
-        
+
         # Show or Hide Image Plane
-        image_plane = instance.data.get("imagePlane", True)       
+        image_plane = instance.data.get("imagePlane", True)
         if "viewport_options" in preset:
             preset["viewport_options"]["imagePlane"] = image_plane
         else:
@@ -117,7 +117,7 @@ class ExtractThumbnail(openpype.api.Extractor):
             # Update preset with current panel setting
             # if override_viewport_options is turned off
             if not override_viewport_options:
-                panel = cmds.getPanel(with_focus=True)
+                panel = cmds.getPanel(withFocus=True)
                 panel_preset = capture.parse_active_view()
                 preset.update(panel_preset)
                 cmds.setFocus(panel)


### PR DESCRIPTION
## Brief description

This should fix #3752

## Testing notes:

Test against what's mentioned in the issue.