### PR TITLE
Ftrack status fix typo prgoress -> progress

### DIFF
--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -56,7 +56,7 @@
                     "Not Ready"
                 ],
                 "__ignore__": [
-                    "in prgoress",
+                    "in progress",
                     "omitted",
                     "on hold"
                 ]


### PR DESCRIPTION
## Brief description
there is a typo in the default status name in settings prgoress -> progress

![image](https://user-images.githubusercontent.com/352795/187486765-912ed4b9-3258-4fb0-843a-f7b23b726d47.png)

## Testing notes:
check the value was fixed in settings under `project_settings/ftrack/events/next_task_update`