### PR TITLE
SyncServer: Added cli commands for sync server

### DIFF
--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -4,6 +4,7 @@ import os
 import sys
 import json
 import time
+import signal
 
 
 class PypeCommands:
@@ -315,8 +316,12 @@ class PypeCommands:
         pytest.main(args)
 
     def syncserver(self, active_site):
-        """Start running sync_server in background."""
-        import signal
+        """Start running sync_server in background.
+
+        This functionality is available in directly in module cli commands.
+        `~/openpype_console module sync_server syncservice`
+        """
+
         os.environ["OPENPYPE_LOCAL_ID"] = active_site
 
         def signal_handler(sig, frame):


### PR DESCRIPTION
## Brief description
Addon has defined `syncservice` cli command.

## Description
Goal is to move cli commands from global commands to module specific commands. The previous implementation is kept so transition from one to other is smooth.

## Testing notes:
1. Running `~/openpype_console module sync_server syncservice -a <site name>` should work and do same thing as `~/openpype_console syncserver -a <site name>`