### PR TITLE
General: Create project function moved to client code

### DIFF
--- a/openpype/client/__init__.py
+++ b/openpype/client/__init__.py
@@ -45,6 +45,11 @@ from .entities import (
     get_workfile_info,
 )
 
+from .operations import (
+    create_project,
+)
+
+
 __all__ = (
     "OpenPypeMongoConnection",
 
@@ -88,4 +93,6 @@ __all__ = (
     "get_thumbnail_id_from_source",
 
     "get_workfile_info",
+
+    "create_project",
 )

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -84,6 +84,7 @@ def deprecated(new_destination):
     return _decorator(func)
 
 
+@deprecated("openpype.client.operations.create_project")
 def create_project(
     project_name, project_code, library_project=False, dbcon=None
 ):
@@ -109,57 +110,9 @@ def create_project(
         dict: Created project document.
     """
 
-    from openpype.settings import ProjectSettings, SaveWarningExc
-    from openpype.pipeline import AvalonMongoDB
-    from openpype.pipeline.schema import validate
+    from openpype.client.operations import create_project
 
-    if get_project(project_name, fields=["name"]):
-        raise ValueError("Project with name \"{}\" already exists".format(
-            project_name
-        ))
-
-    if dbcon is None:
-        dbcon = AvalonMongoDB()
-
-    if not PROJECT_NAME_REGEX.match(project_name):
-        raise ValueError((
-            "Project name \"{}\" contain invalid characters"
-        ).format(project_name))
-
-    database = dbcon.database
-    project_doc = {
-        "type": "project",
-        "name": project_name,
-        "data": {
-            "code": project_code,
-            "library_project": library_project
-        },
-        "schema": CURRENT_DOC_SCHEMAS["project"]
-    }
-    # Insert document with basic data
-    database[project_name].insert_one(project_doc)
-    # Load ProjectSettings for the project and save it to store all attributes
-    #   and Anatomy
-    try:
-        project_settings_entity = ProjectSettings(project_name)
-        project_settings_entity.save()
-    except SaveWarningExc as exc:
-        print(str(exc))
-    except Exception:
-        database[project_name].delete_one({"type": "project"})
-        raise
-
-    project_doc = get_project(project_name)
-
-    try:
-        # Validate created project document
-        validate(project_doc)
-    except Exception:
-        # Remove project if is not valid
-        database[project_name].delete_one({"type": "project"})
-        raise
-
-    return project_doc
+    return create_project(project_name, project_code, library_project)
 
 
 def with_pipeline_io(func):

--- a/openpype/lib/avalon_context.py
+++ b/openpype/lib/avalon_context.py
@@ -108,6 +108,9 @@ def create_project(
 
     Returns:
         dict: Created project document.
+
+    Deprecated:
+        Function will be removed after release version 3.16.*
     """
 
     from openpype.client.operations import create_project

--- a/openpype/modules/ftrack/event_handlers_server/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_server/action_prepare_project.py
@@ -1,10 +1,8 @@
 import json
 import copy
 
-from openpype.client import get_project
-from openpype.api import ProjectSettings
-from openpype.lib import create_project
-from openpype.settings import SaveWarningExc
+from openpype.client import get_project, create_project
+from openpype.settings import ProjectSettings, SaveWarningExc
 
 from openpype_modules.ftrack.lib import (
     ServerAction,

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -1,10 +1,8 @@
 import json
 import copy
 
-from openpype.client import get_project
-from openpype.api import ProjectSettings
-from openpype.lib import create_project
-from openpype.settings import SaveWarningExc
+from openpype.client import get_project, create_project
+from openpype.settings import ProjectSettings, SaveWarningExc
 
 from openpype_modules.ftrack.lib import (
     BaseAction,

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -15,10 +15,10 @@ from openpype.client import (
     get_assets,
     get_asset_by_id,
     get_asset_by_name,
+    create_project,
 )
 from openpype.pipeline import AvalonMongoDB
-from openpype.api import get_project_settings
-from openpype.lib import create_project
+from openpype.settings import get_project_settings
 from openpype.modules.kitsu.utils.credentials import validate_credentials
 
 
@@ -278,7 +278,7 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
     project_doc = get_project(project_name)
     if not project_doc:
         print(f"Creating project '{project_name}'")
-        project_doc = create_project(project_name, project_name, dbcon=dbcon)
+        project_doc = create_project(project_name, project_name)
 
     # Project data and tasks
     project_data = project_doc["data"] or {}

--- a/openpype/tools/project_manager/project_manager/widgets.py
+++ b/openpype/tools/project_manager/project_manager/widgets.py
@@ -1,14 +1,13 @@
 import re
 
-from openpype.client import get_projects
+from openpype.client import get_projects, create_project
 from .constants import (
     NAME_ALLOWED_SYMBOLS,
     NAME_REGEX
 )
-from openpype.lib import create_project
 from openpype.client.operations import (
     PROJECT_NAME_ALLOWED_SYMBOLS,
-    PROJECT_NAME_REGEX
+    PROJECT_NAME_REGEX,
 )
 from openpype.style import load_stylesheet
 from openpype.pipeline import AvalonMongoDB
@@ -266,7 +265,7 @@ class CreateProjectDialog(QtWidgets.QDialog):
         project_name = self.project_name_input.text()
         project_code = self.project_code_input.text()
         library_project = self.library_project_input.isChecked()
-        create_project(project_name, project_code, library_project, self.dbcon)
+        create_project(project_name, project_code, library_project)
 
         self.done(1)
 


### PR DESCRIPTION
## Brief description
Function `create_project` was moved to `openpype.client.operations`.

## Description
Project creations is very specific operations which deserve special function. Function in lib was marked as deprecated with warning to new location. All existing usages in current codebase were replaced with new import location.

## Testing notes:
Creation of projects should work (e.g. from Ftrack or from Project Manager tool).