### PR TITLE
General: Copied 'Extractor' plugin to publish pipeline

### DIFF
--- a/openpype/pipeline/publish/__init__.py
+++ b/openpype/pipeline/publish/__init__.py
@@ -17,6 +17,8 @@ from .publish_plugins import (
 
     RepairAction,
     RepairContextAction,
+
+    Extractor,
 )
 
 from .lib import (
@@ -57,6 +59,8 @@ __all__ = (
 
     "RepairAction",
     "RepairContextAction",
+
+    "Extractor",
 
     "DiscoverResult",
     "publish_plugins_discover",

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -8,7 +8,8 @@ from openpype.lib import BoolDef
 from .lib import (
     load_help_content_from_plugin,
     get_errored_instances_from_context,
-    get_errored_plugins_from_context
+    get_errored_plugins_from_context,
+    get_instance_staging_dir,
 )
 
 
@@ -241,3 +242,25 @@ class RepairContextAction(pyblish.api.Action):
         if plugin in errored_plugins:
             self.log.info("Attempting fix ...")
             plugin.repair(context)
+
+
+class Extractor(pyblish.api.InstancePlugin):
+    """Extractor base class.
+
+    The extractor base class implements a "staging_dir" function used to
+    generate a temporary directory for an instance to extract to.
+
+    This temporary directory is generated through `tempfile.mkdtemp()`
+
+    """
+
+    order = 2.0
+
+    def staging_dir(self, instance):
+        """Provide a temporary directory in which to store extracted files
+
+        Upon calling this method the staging directory is stored inside
+        the instance.data['stagingDir']
+        """
+
+        return get_instance_staging_dir(instance)

--- a/openpype/plugin.py
+++ b/openpype/plugin.py
@@ -85,7 +85,6 @@ class InstancePlugin(pyblish.api.InstancePlugin):
         super(InstancePlugin, self).__init__(*args, **kwargs)
 
 
-# NOTE: This class is used on so many places I gave up moving it
 class Extractor(pyblish.api.InstancePlugin):
     """Extractor base class.
 

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -8,10 +8,10 @@ import shutil
 
 import clique
 import six
-import pyblish
+import pyblish.api
 
-import openpype
-import openpype.api
+from openpype import resources, PACKAGE_DIR
+from openpype.pipeline import publish
 from openpype.lib import (
     run_openpype_process,
 
@@ -23,7 +23,7 @@ from openpype.lib import (
 )
 
 
-class ExtractBurnin(openpype.api.Extractor):
+class ExtractBurnin(publish.Extractor):
     """
     Extractor to create video with pre-defined burnins from
     existing extracted video representation.
@@ -400,7 +400,7 @@ class ExtractBurnin(openpype.api.Extractor):
 
         # Use OpenPype default font
         if not font_filepath:
-            font_filepath = openpype.api.resources.get_liberation_font_path()
+            font_filepath = resources.get_liberation_font_path()
 
         burnin_options["font"] = font_filepath
 
@@ -981,7 +981,7 @@ class ExtractBurnin(openpype.api.Extractor):
         """Return path to python script for burnin processing."""
         scriptpath = os.path.normpath(
             os.path.join(
-                openpype.PACKAGE_DIR,
+                PACKAGE_DIR,
                 "scripts",
                 "otio_burnin.py"
             )

--- a/openpype/plugins/publish/extract_otio_file.py
+++ b/openpype/plugins/publish/extract_otio_file.py
@@ -1,10 +1,11 @@
 import os
 import pyblish.api
-import openpype.api
 import opentimelineio as otio
 
+from openpype.pipeline import publish
 
-class ExtractOTIOFile(openpype.api.Extractor):
+
+class ExtractOTIOFile(publish.Extractor):
     """
     Extractor export OTIO file
     """

--- a/openpype/plugins/publish/extract_otio_review.py
+++ b/openpype/plugins/publish/extract_otio_review.py
@@ -18,7 +18,12 @@ import os
 import clique
 import opentimelineio as otio
 from pyblish import api
-import openpype
+
+from openpype.lib import (
+    get_ffmpeg_tool_path,
+    run_subprocess,
+)
+from openpype.pipeline import publish
 from openpype.pipeline.editorial import (
     otio_range_to_frame_range,
     trim_media_range,
@@ -28,7 +33,7 @@ from openpype.pipeline.editorial import (
 )
 
 
-class ExtractOTIOReview(openpype.api.Extractor):
+class ExtractOTIOReview(publish.Extractor):
     """
     Extract OTIO timeline into one concuted image sequence file.
 
@@ -334,7 +339,7 @@ class ExtractOTIOReview(openpype.api.Extractor):
             otio.time.TimeRange: trimmed available range
         """
         # get rendering app path
-        ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
         # create path  and frame start to destination
         output_path, out_frame_start = self._get_ffmpeg_output()
@@ -397,7 +402,7 @@ class ExtractOTIOReview(openpype.api.Extractor):
         ])
         # execute
         self.log.debug("Executing: {}".format(" ".join(command)))
-        output = openpype.api.run_subprocess(
+        output = run_subprocess(
             command, logger=self.log
         )
         self.log.debug("Output: {}".format(output))

--- a/openpype/plugins/publish/extract_otio_trimming_video.py
+++ b/openpype/plugins/publish/extract_otio_trimming_video.py
@@ -6,18 +6,24 @@ Requires:
 """
 
 import os
-from pyblish import api
-import openpype
 from copy import deepcopy
+
+import pyblish.api
+
+from openpype.lib import (
+    get_ffmpeg_tool_path,
+    run_subprocess,
+)
+from openpype.pipeline import publish
 from openpype.pipeline.editorial import frames_to_seconds
 
 
-class ExtractOTIOTrimmingVideo(openpype.api.Extractor):
+class ExtractOTIOTrimmingVideo(publish.Extractor):
     """
     Trimming video file longer then required lenght
 
     """
-    order = api.ExtractorOrder
+    order = pyblish.api.ExtractorOrder
     label = "Extract OTIO trim longer video"
     families = ["trim"]
     hosts = ["resolve", "hiero", "flame"]
@@ -70,7 +76,7 @@ class ExtractOTIOTrimmingVideo(openpype.api.Extractor):
 
         """
         # get rendering app path
-        ffmpeg_path = openpype.lib.get_ffmpeg_tool_path("ffmpeg")
+        ffmpeg_path = get_ffmpeg_tool_path("ffmpeg")
 
         # create path to destination
         output_path = self._get_ffmpeg_output(input_file_path)
@@ -96,7 +102,7 @@ class ExtractOTIOTrimmingVideo(openpype.api.Extractor):
 
         # execute
         self.log.debug("Executing: {}".format(" ".join(command)))
-        output = openpype.api.run_subprocess(
+        output = run_subprocess(
             command, logger=self.log
         )
         self.log.debug("Output: {}".format(output))

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -161,7 +161,7 @@ class ExtractReviewSlate(publish.Extractor):
 
             input_args.extend([
                 "-loop", "1",
-                "-i", openpype.lib.path_to_subprocess_arg(slate_path),
+                "-i", path_to_subprocess_arg(slate_path),
                 "-r", str(input_frame_rate),
                 "-frames:v", "1",
             ])

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -1,19 +1,22 @@
 import os
-from pprint import pformat
 import re
-import openpype.api
-import pyblish
+from pprint import pformat
+
+import pyblish.api
+
 from openpype.lib import (
     path_to_subprocess_arg,
+    run_subprocess,
     get_ffmpeg_tool_path,
     get_ffprobe_data,
     get_ffprobe_streams,
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
 )
+from openpype.pipeline import publish
 
 
-class ExtractReviewSlate(openpype.api.Extractor):
+class ExtractReviewSlate(publish.Extractor):
     """
     Will add slate frame at the start of the video files
     """
@@ -267,7 +270,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
             self.log.debug(
                 "Slate Executing: {}".format(slate_subprocess_cmd)
             )
-            openpype.api.run_subprocess(
+            run_subprocess(
                 slate_subprocess_cmd, shell=True, logger=self.log
             )
 
@@ -348,7 +351,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
                 "Executing concat filter: {}".format
                 (" ".join(concat_args))
             )
-            openpype.api.run_subprocess(
+            run_subprocess(
                 concat_args, logger=self.log
             )
 
@@ -533,7 +536,7 @@ class ExtractReviewSlate(openpype.api.Extractor):
         self.log.debug("Silent Slate Executing: {}".format(
             " ".join(slate_silent_args)
         ))
-        openpype.api.run_subprocess(
+        run_subprocess(
             slate_silent_args, logger=self.log
         )
 

--- a/openpype/plugins/publish/extract_trim_video_audio.py
+++ b/openpype/plugins/publish/extract_trim_video_audio.py
@@ -1,14 +1,16 @@
 import os
+from pprint import pformat
+
 import pyblish.api
-import openpype.api
 
 from openpype.lib import (
     get_ffmpeg_tool_path,
+    run_subprocess,
 )
-from pprint import pformat
+from openpype.pipeline import publish
 
 
-class ExtractTrimVideoAudio(openpype.api.Extractor):
+class ExtractTrimVideoAudio(publish.Extractor):
     """Trim with ffmpeg "mov" and "wav" files."""
 
     # must be before `ExtractThumbnailSP`
@@ -98,7 +100,7 @@ class ExtractTrimVideoAudio(openpype.api.Extractor):
 
             joined_args = " ".join(ffmpeg_args)
             self.log.info(f"Processing: {joined_args}")
-            openpype.api.run_subprocess(
+            run_subprocess(
                 ffmpeg_args, logger=self.log
             )
 


### PR DESCRIPTION
## Brief description
Copied `Extractor` from `openpype.plugin` to `openpype.pipeline.publish`.

## Description
This is first step to move `Extractor` class to different location. The plugin is used in almost each hosts and it will be safer and faster to do PRs for each of them to test them. In this PR were changed imports in global plugins.

## Testing notes:
- [x] Extract Burnin should work (any review publishing)
- [x] Extract otio file should work (editorial)
- [x] Extract otio review should work (editorial)
- [x] Extract otio trimming video should work (editorial)
- [x] Extract review slate should work (nuke)
- [x] Extract trim video/audio should work (standalone, tray publisher)