### PR TITLE
General: User keys during publishing

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/collect_username.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_username.py
@@ -13,7 +13,7 @@ import os
 import pyblish.api
 
 
-class CollectUsername(pyblish.api.ContextPlugin):
+class CollectUsernameForWebpublish(pyblish.api.ContextPlugin):
     """
         Translates user email to Ftrack username.
 
@@ -32,10 +32,8 @@ class CollectUsername(pyblish.api.ContextPlugin):
     hosts = ["webpublisher", "photoshop"]
     targets = ["remotepublish", "filespublish", "tvpaint_worker"]
 
-    _context = None
-
     def process(self, context):
-        self.log.info("CollectUsername")
+        self.log.info("{}".format(self.__class__.__name__))
         os.environ["FTRACK_API_USER"] = os.environ["FTRACK_BOT_API_USER"]
         os.environ["FTRACK_API_KEY"] = os.environ["FTRACK_BOT_API_KEY"]
 

--- a/openpype/modules/ftrack/plugins/publish/collect_username.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_username.py
@@ -65,5 +65,4 @@ class CollectUsernameForWebpublish(pyblish.api.ContextPlugin):
         burnin_name = username
         if '@' in burnin_name:
             burnin_name = burnin_name[:burnin_name.index('@')]
-        os.environ["WEBPUBLISH_OPENPYPE_USERNAME"] = burnin_name
         context.data["user"] = burnin_name

--- a/openpype/modules/ftrack/plugins/publish/collect_username.py
+++ b/openpype/modules/ftrack/plugins/publish/collect_username.py
@@ -1,5 +1,8 @@
 """Loads publishing context from json and continues in publish process.
 
+Should run before 'CollectAnatomyContextData' so the user on context is
+changed before it's stored to context anatomy data or instance anatomy data.
+
 Requires:
     anatomy -> context["anatomy"] *(pyblish.api.CollectorOrder - 0.11)
 
@@ -52,12 +55,14 @@ class CollectUsernameForWebpublish(pyblish.api.ContextPlugin):
             return
 
         session = ftrack_api.Session(auto_connect_event_hub=False)
-        user = session.query("User where email like '{}'".format(user_email))
+        user = session.query(
+            "User where email like '{}'".format(user_email)
+        ).first()
 
         if not user:
             raise ValueError(
                 "Couldn't find user with {} email".format(user_email))
-        user = user[0]
+
         username = user.get("username")
         self.log.debug("Resolved ftrack username:: {}".format(username))
         os.environ["FTRACK_API_USER"] = username

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -95,13 +95,15 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         Reviews might be large, so allow only adding link to message instead of
         uploading only.
         """
+
         fill_data = copy.deepcopy(instance.context.data["anatomyData"])
 
+        username = fill_data.get("user")
         fill_pairs = [
             ("asset", instance.data.get("asset", fill_data.get("asset"))),
             ("subset", instance.data.get("subset", fill_data.get("subset"))),
-            ("username", instance.data.get("username",
-                                           fill_data.get("username"))),
+            ("user", username),
+            ("username", username),
             ("app", instance.data.get("app", fill_data.get("app"))),
             ("family", instance.data.get("family", fill_data.get("family"))),
             ("version", str(instance.data.get("version",

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -112,13 +112,19 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         if review_path:
             fill_pairs.append(("review_filepath", review_path))
 
-        task_data = instance.data.get("task")
-        if not task_data:
-            task_data = fill_data.get("task")
-        for key, value in task_data.items():
-            fill_key = "task[{}]".format(key)
-            fill_pairs.append((fill_key, value))
-        fill_pairs.append(("task", task_data["name"]))
+        task_data = fill_data.get("task")
+        if task_data:
+            if (
+                "{task}" in message_templ
+                or "{Task}" in message_templ
+                or "{TASK}" in message_templ
+            ):
+                fill_pairs.append(("task", task_data["name"]))
+
+            else:
+                for key, value in task_data.items():
+                    fill_key = "task[{}]".format(key)
+                    fill_pairs.append((fill_key, value))
 
         self.log.debug("fill_pairs ::{}".format(fill_pairs))
         multiple_case_variants = prepare_template_data(fill_pairs)

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -488,13 +488,6 @@ class ExtractBurnin(openpype.api.Extractor):
             "frame_end_handle": frame_end_handle
         }
 
-        # use explicit username for webpublishes as rewriting
-        # OPENPYPE_USERNAME might have side effects
-        webpublish_user_name = os.environ.get("WEBPUBLISH_OPENPYPE_USERNAME")
-        if webpublish_user_name:
-            burnin_data["user"] = webpublish_user_name
-            burnin_data["username"] = webpublish_user_name
-
         self.log.debug(
             "Basic burnin_data: {}".format(json.dumps(burnin_data, indent=4))
         )

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -492,6 +492,7 @@ class ExtractBurnin(openpype.api.Extractor):
         # OPENPYPE_USERNAME might have side effects
         webpublish_user_name = os.environ.get("WEBPUBLISH_OPENPYPE_USERNAME")
         if webpublish_user_name:
+            burnin_data["user"] = webpublish_user_name
             burnin_data["username"] = webpublish_user_name
 
         self.log.debug(

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -135,7 +135,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     # the database even if not used by the destination template
     db_representation_context_keys = [
         "project", "asset", "task", "subset", "version", "representation",
-        "family", "hierarchy", "username", "output"
+        "family", "hierarchy", "username", "user", "output"
     ]
     skip_host_families = []
 

--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -46,7 +46,7 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
     ignored_representation_names = []
     db_representation_context_keys = [
         "project", "asset", "task", "subset", "representation",
-        "family", "hierarchy", "task", "username"
+        "family", "hierarchy", "task", "username", "user"
     ]
     # QUESTION/TODO this process should happen on server if crashed due to
     # permissions error on files (files were used or user didn't have perms)

--- a/openpype/plugins/publish/integrate_legacy.py
+++ b/openpype/plugins/publish/integrate_legacy.py
@@ -127,7 +127,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
     exclude_families = ["render.farm"]
     db_representation_context_keys = [
         "project", "asset", "task", "subset", "version", "representation",
-        "family", "hierarchy", "task", "username"
+        "family", "hierarchy", "task", "username", "user"
     ]
     default_template_name = "publish"
 


### PR DESCRIPTION
## Brief description
There is some bizzare usage mix of `"user"` and `"username"` keys during publishing. This change few places where it could cause issues.

## Description
In most of places is used `"user"` during publishing. This PR does not unify the mix of user and username but adds both options to places where only `"username"` was used. Renamed `CollectUsername` to `CollectUsernameForWebpublish`. Use query limits to get user. `WEBPUBLISH_OPENPYPE_USERNAME` is not set as user is already changed on context.

## Testing notes:
1. Webpublisher should still be able to fill user
2. Integrate slack can use `{user}` in template