### PR TITLE
Settings: Fix settings for inactive projects 

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -58,7 +58,7 @@ def get_projects(active=True, inactive=False, fields=None):
             yield project_doc
 
 
-def get_project(project_name, active=True, inactive=False, fields=None):
+def get_project(project_name, active=True, inactive=True, fields=None):
     # Skip if both are disabled
     if not active and not inactive:
         return None


### PR DESCRIPTION
## Brief description

This fixes Settings reading and saving for inactive projects.

**:warning: NOTE: This makes `openpype.client.get_project` argument `inactive` default to True.**
_And `openpype.client.get_projects` argument `inactive` still defaults to False like before._

I felt that was a much more logical default value for a function whose sole function is to get a single project by name - it should just return it if found by default. Having this filtered by default would also break a lot of other code too if you would be working inside the DCC and the project would be set to inactive.

## Description

The Project Settings did not read the project settings (anatomy data) for an inactive project and thus the UI would just show the default values.

Saving the settings for an inactive project would error:

![openpype_settings_inactive_project_error](https://user-images.githubusercontent.com/2439881/188017457-192cc8c6-1f14-4600-9982-4586996a3249.png)

```python
Traceback (most recent call last):
  File "S:\openpype\OpenPype\openpype\tools\settings\settings\categories.py", line 441, in save
    self.entity.save()
  File "S:\openpype\OpenPype\openpype\settings\entities\root_entities.py", line 410, in save
    self._save_project_values()
  File "S:\openpype\OpenPype\openpype\settings\entities\root_entities.py", line 887, in _save_project_values
    self._save_studio_values()
  File "S:\openpype\OpenPype\openpype\settings\entities\root_entities.py", line 875, in _save_studio_values
    save_project_anatomy(self.project_name, project_anatomy)
  File "S:\openpype\OpenPype\openpype\settings\lib.py", line 49, in wrapper
    return func(*args, **kwargs)
  File "S:\openpype\OpenPype\openpype\settings\lib.py", line 261, in save_project_anatomy
    _SETTINGS_HANDLER.save_project_anatomy(project_name, anatomy_data)
  File "S:\openpype\OpenPype\openpype\settings\handlers.py", line 581, in save_project_anatomy
    self._save_project_anatomy_data(project_name, data_cache)
  File "S:\openpype\OpenPype\openpype\settings\handlers.py", line 613, in _save_project_anatomy_data
    ).format(project_name))
ValueError: Project document of project "test" does not exists. Create project first.
```

## Additional info

I tried fixing it locally in Settings handlers [here](https://github.com/pypeclub/OpenPype/blob/9721df1574b31935c6071876644676323caf9e9c/openpype/settings/handlers.py#L887) and [here](https://github.com/pypeclub/OpenPype/blob/9721df1574b31935c6071876644676323caf9e9c/openpype/settings/handlers.py#L1472) but turning it into `get_project(project_name, inactive=True)`. 

That did fix the querying and viewing of the settings in the UI but still disallowed saving the project correctly.

Also reported on [OpenPype Discord here](https://discord.com/channels/517362899170230292/563751989075378201/1015003802925023232).

## Testing notes:

1. Set Project Setting `project_anatomy/attributes/active` to False.
2. Try to refresh the settings UI for that project
3. Try to save the settings for that project.
4. Ensure other code relying on `get_project` also still behaves as intended