### PR TITLE
Standalone Publisher: Ignore empty labels, then still use name like other asset models

### DIFF
--- a/openpype/tools/standalonepublish/widgets/model_asset.py
+++ b/openpype/tools/standalonepublish/widgets/model_asset.py
@@ -81,7 +81,7 @@ class AssetModel(TreeModel):
         for asset in current_assets:
             # get label from data, otherwise use name
             data = asset.get("data", {})
-            label = data.get("label", asset["name"])
+            label = data.get("label") or asset["name"]
             tags = data.get("tags", [])
 
             # store for the asset for optimization


### PR DESCRIPTION
## Brief description

Match how other models ignore empty asset labels and then still show asset name.

## Description

We have some custom logic that can set custom labels on Assets - but it sets just an empty string when not set to anything - which didn't look pretty in Standalone Publisher. Other tools didn't have the issue.

![standalone_publisher_asset_labels](https://user-images.githubusercontent.com/2439881/188022569-cf5e6729-5088-40b6-bfbe-359bcf3d97ef.png)

## Testing notes:

1. Add a `asset["data"]["label"] = ""` to an asset
2. Show the asset in Standalone Publisher - should still look good.