### PR TITLE
Added an event triggered when user connects to kitsu

### DIFF
--- a/openpype/modules/kitsu/utils/credentials.py
+++ b/openpype/modules/kitsu/utils/credentials.py
@@ -33,10 +33,8 @@ def validate_credentials(
     except gazu.exception.AuthFailedException:
         return False
 
-    emit_event("kitsu.user.logged", 
-           data={"username": login}, 
-           source="kitsu")
-           
+    emit_event("kitsu.user.logged", data={"username": login}, source="kitsu")
+
     return True
 
 

--- a/openpype/modules/kitsu/utils/credentials.py
+++ b/openpype/modules/kitsu/utils/credentials.py
@@ -8,9 +8,7 @@ from openpype.lib.local_settings import OpenPypeSecureRegistry
 from openpype.lib import emit_event
 
 
-def validate_credentials(
-    login: str, password: str, kitsu_url: str = None
-) -> bool:
+def validate_credentials(login: str, password: str, kitsu_url: str = None) -> bool:
     """Validate credentials by trying to connect to Kitsu host URL.
 
     Args:
@@ -105,12 +103,13 @@ def set_credentials_envs(login: str, password: str):
     os.environ["KITSU_LOGIN"] = login
     os.environ["KITSU_PWD"] = password
 
-def emit_on_kitsu_login(login:str):
-    """Notifies listeners that Kitsu module succesfully connected, 
+
+def emit_on_kitsu_login(login: str):
+    """Notifies listeners that Kitsu module succesfully connected,
     and passes them data
 
     Args:
         login (str): Kitsu username
     """
     event_data = {"username": login}
-    emit_event("kitsu.user.logged", data = event_data, source = "kitsu")
+    emit_event("kitsu.user.logged", data=event_data, source="kitsu")

--- a/openpype/modules/kitsu/utils/credentials.py
+++ b/openpype/modules/kitsu/utils/credentials.py
@@ -33,7 +33,10 @@ def validate_credentials(
     except gazu.exception.AuthFailedException:
         return False
 
-    emit_on_kitsu_login(login)
+    emit_event("kitsu.user.logged", 
+           data={"username": login}, 
+           source="kitsu")
+           
     return True
 
 
@@ -104,14 +107,3 @@ def set_credentials_envs(login: str, password: str):
     """
     os.environ["KITSU_LOGIN"] = login
     os.environ["KITSU_PWD"] = password
-
-
-def emit_on_kitsu_login(login: str):
-    """Notifies listeners that Kitsu module succesfully connected,
-    and passes them data
-
-    Args:
-        login (str): Kitsu username
-    """
-    event_data = {"username": login}
-    emit_event("kitsu.user.logged", data=event_data, source="kitsu")

--- a/openpype/modules/kitsu/utils/credentials.py
+++ b/openpype/modules/kitsu/utils/credentials.py
@@ -8,7 +8,9 @@ from openpype.lib.local_settings import OpenPypeSecureRegistry
 from openpype.lib import emit_event
 
 
-def validate_credentials(login: str, password: str, kitsu_url: str = None) -> bool:
+def validate_credentials(
+    login: str, password: str, kitsu_url: str = None
+) -> bool:
     """Validate credentials by trying to connect to Kitsu host URL.
 
     Args:

--- a/openpype/modules/kitsu/utils/credentials.py
+++ b/openpype/modules/kitsu/utils/credentials.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import gazu
 
 from openpype.lib.local_settings import OpenPypeSecureRegistry
+from openpype.lib import emit_event
 
 
 def validate_credentials(
@@ -32,6 +33,7 @@ def validate_credentials(
     except gazu.exception.AuthFailedException:
         return False
 
+    emit_on_kitsu_login(login)
     return True
 
 
@@ -102,3 +104,13 @@ def set_credentials_envs(login: str, password: str):
     """
     os.environ["KITSU_LOGIN"] = login
     os.environ["KITSU_PWD"] = password
+
+def emit_on_kitsu_login(login:str):
+    """Notifies listeners that Kitsu module succesfully connected, 
+    and passes them data
+
+    Args:
+        login (str): Kitsu username
+    """
+    event_data = {"username": login}
+    emit_event("kitsu.user.logged", data = event_data, source = "kitsu")


### PR DESCRIPTION
## Brief description
Added an event triggered when user connects to kitsu.

## Description
Thanks to this addition, other modules and addons can be notified when the user successfully connects to Kitsu via Kitsu module, and get data at the same time (Currently, only Kitsu login, but it's possible to pass more data if need be).

## Additional info
Listeners should subscribe to the event in tray_init using register_event_callback.
This method return value can be stored in a class level variable, which will be useful to unsubscribe to the event on tray_exit by calling the deregister method.

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. Create the on_kitsu_login(self, event) method in the class that should listen to the event. This method will be called when kitsu module calls the event.
2. Create a class level variable in which you'll store register_event_callback return value (let's say we called it on_kitsu_login_callback)
3. Subscribe to the event in tray_init using register_event_callback method
4. Unsubscribe to the event in tray_exit using the deregister method
5. Run OpenPype and connect  to Kitsu. If you successfully connected, the event should be triggered and your module or addon be notified. on_kitsu_login will therefore be called.