### PR TITLE
Hiero: retimed clip publishing is working

### DIFF
--- a/openpype/hosts/hiero/plugins/publish/precollect_instances.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_instances.py
@@ -318,10 +318,9 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
 
     @staticmethod
     def create_otio_time_range_from_timeline_item_data(track_item):
-        speed = track_item.playbackSpeed()
         timeline = phiero.get_current_sequence()
         frame_start = int(track_item.timelineIn())
-        frame_duration = int((track_item.duration() - 1) / speed)
+        frame_duration = int(track_item.duration())
         fps = timeline.framerate().toFloat()
 
         return hiero_export.create_otio_time_range(


### PR DESCRIPTION
## Brief description
Retimed clips for lest then 100% is working now.

## Description
Publishing is working as expected.

## Additional info
Precollect instances was falsely detecting timeline range for otio clip data.

## Testing notes:
1. open Hiero with testing project
2. create clip with retime for about 80% speed
3. Create publishable clip from the 2.
4. publish and see that Precollect intances will not fail