### PR TITLE
Deadline: Submit publish job remove instance._log that has no use anymore

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -700,9 +700,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         self.context = context
         self.anatomy = instance.context.data["anatomy"]
 
-        if hasattr(instance, "_log"):
-            data['_log'] = instance._log
-
         asset = data.get("asset") or legacy_io.Session["AVALON_ASSET"]
         subset = data.get("subset")
 


### PR DESCRIPTION
## Brief description

[Remove `instance._log` legacy code that has no use anymore](https://github.com/pypeclub/OpenPype/commit/d00eb29ca1bd8fcda97a40a14f8ae03d171c4853)

## Description

Came up on [Discord here](https://discord.com/channels/517362899170230292/517382145552154634/1016662712614404147).

Original commit that added the code is [here](https://github.com/pypeclub/OpenPype/commit/5bceb794413381d7c1a1378de87cb9efaade4041).
Likely was related to [old logic in the Submit Publish Job](https://github.com/pypeclub/OpenPype/blame/b55dbc2bc29b040dedaad01adcbcba4d3ec54ee2/pype/plugins/global/publish/submit_publish_job.py#L438-L447) which is since long gone.

## Testing notes:

1. Publishing to Deadline with publish jobs
2. Publish jobs should behave as expected