### PR TITLE
Igniter: Fix status handling when version is already installed

### DIFF
--- a/igniter/install_dialog.py
+++ b/igniter/install_dialog.py
@@ -389,7 +389,7 @@ class InstallDialog(QtWidgets.QDialog):
 
     def _installation_finished(self):
         status = self._install_thread.result()
-        if status >= 0:
+        if status is not None and status >= 0:
             self._update_progress(100)
             QtWidgets.QApplication.processEvents()
             self.done(3)

--- a/igniter/install_dialog.py
+++ b/igniter/install_dialog.py
@@ -388,6 +388,9 @@ class InstallDialog(QtWidgets.QDialog):
         install_thread.start()
 
     def _installation_finished(self):
+        # TODO we should find out why status can be set to 'None'?
+        # - 'InstallThread.run' should handle all cases so not sure where
+        #       that come from
         status = self._install_thread.result()
         if status is not None and status >= 0:
             self._update_progress(100)


### PR DESCRIPTION
## Brief description
Fix unhandled cases when `status` is set to `None` when installation did not happen.

## Description
Fixed issue when install thread has status set to `None` because the version is already installed. That can happen in some cases.

## Additional info
This is reaction to happened traceback. I'm not sure how this happened so this is more or less quick fix. We should maybe find out where is the source of the issue?

### Traceback
```
*** No DB connection string specified.
--- launching setup UI ...
Traceback (most recent call last):
  File "C:\Users\petr.dvorak\Downloads\openpype-3.14.2-nightly.2-windows\openpype-3.14.2-nightly.2-windows\igniter\install_thread.py", line 150, in run
    bs.install_version(openpype_version)
  File "C:\Users\petr.dvorak\Downloads\openpype-3.14.2-nightly.2-windows\openpype-3.14.2-nightly.2-windows\igniter\bootstrap_repos.py", line 1449, in install_version
    "OpenPype already inside user data dir")
igniter.bootstrap_repos.OpenPypeVersionExists: OpenPype already inside user data dir
Traceback (most recent call last):
  File "C:\Users\petr.dvorak\Downloads\openpype-3.14.2-nightly.2-windows\openpype-3.14.2-nightly.2-windows\igniter\install_dialog.py", line 392, in _installation_finished
    if status >= 0:
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```