### PR TITLE
Maya: Publishing data key change

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_assembly.py
+++ b/openpype/hosts/maya/plugins/publish/collect_assembly.py
@@ -70,7 +70,7 @@ class CollectAssembly(pyblish.api.InstancePlugin):
             data[representation_id].append(instance_data)
 
         instance.data["scenedata"] = dict(data)
-        instance.data["hierarchy"] = list(set(hierarchy_nodes))
+        instance.data["nodesHierarchy"] = list(set(hierarchy_nodes))
 
     def get_file_rule(self, rule):
         return mel.eval('workspace -query -fileRuleEntry "{}"'.format(rule))

--- a/openpype/hosts/maya/plugins/publish/extract_assembly.py
+++ b/openpype/hosts/maya/plugins/publish/extract_assembly.py
@@ -33,7 +33,7 @@ class ExtractAssembly(openpype.api.Extractor):
             json.dump(instance.data["scenedata"], filepath, ensure_ascii=False)
 
         self.log.info("Extracting point cache ..")
-        cmds.select(instance.data["hierarchy"])
+        cmds.select(instance.data["nodesHierarchy"])
 
         # Run basic alembic exporter
         extract_alembic(file=hierarchy_path,

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
@@ -48,7 +48,7 @@ class ValidateAssemblyModelTransforms(pyblish.api.InstancePlugin):
         from openpype.hosts.maya.api import lib
 
         # Get all transforms in the loaded containers
-        container_roots = cmds.listRelatives(instance.data["hierarchy"],
+        container_roots = cmds.listRelatives(instance.data["nodesHierarchy"],
                                              children=True,
                                              type="transform",
                                              fullPath=True)


### PR DESCRIPTION
## Brief description
Change "hierarchy" key to "nodesHierarchy" in maya publishing.

## Description
The main issue is that `"hierarchy"` key is too generic key and is used on 2 places in a different way. Is used in Maya for storing hierarchy nodes and during editorial publishing to store asset hierarchy. The editorial key is used in Collect Resources which crashes when executed in Maya.

This breaks backwards compatibility if anyone else is using Maya's `"hierarchy"` key during publishing.

### Traceback
```
Traceback: 
Traceback (most recent call last):
  File "D:\REPO\OpenPype\.venv\lib\site-packages\pyblish\plugin.py", line 522, in __explicit_process
    runner(*args)
  File "D:\REPO\OpenPype\openpype\plugins\publish\collect_resources_path.py", line 82, in process
  File "D:\REPO\OpenPype\openpype\lib\path_templates.py", line 462, in __getitem__
    value.validate()
  File "D:\REPO\OpenPype\openpype\pipeline\anatomy.py", line 369, in validate
    self.invalid_types
openpype.pipeline.anatomy.AnatomyTemplateUnsolved: Anatomy template "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/v{version:0>3}" is unsolved. Keys with invalid DataType: `"hierarchy" <class 'list'>`.
```

## Additional info
The best would be to also change the editorial part to `assetHierarchy` or not store `hierarchy` directly to instance data at all but I don't 100% know where it comes from. Intuition guides me that it can not come only from publishing plugins but is also stored on instances themselves so every `instance.data.update(...)` is potential hazard.

## Testing notes:
1. Collect resources should work

Resolves https://github.com/pypeclub/OpenPype/issues/3807