### PR TITLE
Maya: Warn correctly about nodes in render instance with unexpected names

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -102,21 +102,23 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
         }
 
         for layer in collected_render_layers:
-            try:
-                if layer.startswith("LAYER_"):
-                    # this is support for legacy mode where render layers
-                    # started with `LAYER_` prefix.
-                    expected_layer_name = re.search(
-                        r"^LAYER_(.*)", layer).group(1)
-                else:
-                    # new way is to prefix render layer name with instance
-                    # namespace.
-                    expected_layer_name = re.search(
-                        r"^.+:(.*)", layer).group(1)
-            except IndexError:
+            if layer.startswith("LAYER_"):
+                # this is support for legacy mode where render layers
+                # started with `LAYER_` prefix.
+                layer_name_pattern = r"^LAYER_(.*)"
+            else:
+                # new way is to prefix render layer name with instance
+                # namespace.
+                layer_name_pattern = r"^.+:(.*)"
+
+            # todo: We should have a more explicit way to link the renderlayer
+            match = re.match(layer_name_pattern, layer)
+            if not match:
                 msg = "Invalid layer name in set [ {} ]".format(layer)
                 self.log.warning(msg)
                 continue
+
+            expected_layer_name = match.group(1)
 
             self.log.info("processing %s" % layer)
             # check if layer is part of renderSetup

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -119,8 +119,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 continue
 
             expected_layer_name = match.group(1)
+            self.log.info("Processing '{}' as layer [ {} ]"
+                          "".format(layer, expected_layer_name))
 
-            self.log.info("processing %s" % layer)
             # check if layer is part of renderSetup
             if expected_layer_name not in maya_render_layers:
                 msg = "Render layer [ {} ] is not in " "Render Setup".format(


### PR DESCRIPTION
## Brief description

This is a fix for #3812 

## Description

This fixes the reported error and the node added incorrectly into the set is now logged with a warning. However, what the user originally tried in #3812 might still be unclear on how to solve correctly.

They should have done this: 🟢 
![openpype_valid_attach_to_rendering](https://user-images.githubusercontent.com/2439881/189229640-0ec94d2e-0aec-4f72-9d19-c7d409036731.png)

Instead of this: 🔴 
![openpype_invalid_attach_to_rendering](https://user-images.githubusercontent.com/2439881/189229695-15de2e0a-5249-4e5f-b599-2eaab7c6d67b.png)

Note how the `lookMain` that was intended to be attached to the layer is not a member of `_renderingMain:Main` (which represents the Main layer) and instead `lookMain` is a member of the `renderingMain` instance directly.

We might want improve the logging or workflow to ensure the User is more aware of what they did wrong, because this is what is logged as warning now:

![afbeelding](https://user-images.githubusercontent.com/2439881/189230192-d9458f81-71e4-4516-9380-28d1c932ec19.png)

In the current stage it DOES allow the user to continue and publish - but it won't attach the render to `lookMain`.

## Testing notes:
1. Add `lookMain` into `renderingMain`
2. Should now log warning instead of error with even more confusing error to end user - now at least the name is logged, etc.