### PR TITLE
Maya+Ftrack: Change typo in family name `mayaascii` -> `mayaAscii`

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -74,11 +74,14 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         version_number = int(instance_version)
 
         family = instance.data["family"]
-        family_low = family.lower()
 
+        # Perform case-insensitive family mapping
+        family_low = family.lower()
         asset_type = instance.data.get("ftrackFamily")
-        if not asset_type and family_low in self.family_mapping:
-            asset_type = self.family_mapping[family_low]
+        if not asset_type:
+            for map_family, map_value in self.family_mapping.items():
+                if map_family.lower() == family_low:
+                    asset_type = map_value
 
         if not asset_type:
             asset_type = "upload"

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -89,15 +89,6 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         self.log.debug(
             "Family: {}\nMapping: {}".format(family_low, self.family_mapping)
         )
-
-        # Ignore this instance if neither "ftrackFamily" or a family mapping is
-        # found.
-        if not asset_type:
-            self.log.info((
-                "Family \"{}\" does not match any asset type mapping"
-            ).format(family))
-            return
-
         status_name = self._get_asset_version_status_name(instance)
 
         # Base of component item data

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -35,7 +35,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
     family_mapping = {
         "camera": "cam",
         "look": "look",
-        "mayaascii": "scene",
+        "mayaAscii": "scene",
         "model": "geo",
         "rig": "rig",
         "setdress": "setdress",

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -82,6 +82,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             for map_family, map_value in self.family_mapping.items():
                 if map_family.lower() == family_low:
                     asset_type = map_value
+                    break
 
         if not asset_type:
             asset_type = "upload"

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -455,7 +455,7 @@
             "family_mapping": {
                 "camera": "cam",
                 "look": "look",
-                "mayaascii": "scene",
+                "mayaAscii": "scene",
                 "model": "geo",
                 "rig": "rig",
                 "setdress": "setdress",


### PR DESCRIPTION
## Brief description

Fix typo in legacy family name `mayaascii` -> `mayaAscii`.

## Description

Not sure how relevant this tweak is because I think this is the legacy family name for `mayaScene` family. Correct?

[Mentioned on discord](https://discord.com/channels/517362899170230292/517382145552154634/1017751095734452264)

## Testing notes:

1. Not sure where to test this best. Publish a Maya scene and check with Ftrack?