### PR TITLE
Maya: Render settings validation attribute check tweak logging

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -269,7 +269,8 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             nodes = cmds.ls(type=node_type)
 
             if not nodes:
-                cls.log.info("No nodes of type '{}' found.".format(node_type))
+                cls.log.warning(
+                    "No nodes of type '{}' found.".format(node_type))
                 continue
 
             for node in nodes:

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -257,14 +257,18 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
         # go through definitions and test if such node.attribute exists.
         # if so, compare its value from the one required.
         for attr, value in OrderedDict(validation_settings).items():
-            # first get node of that type
             cls.log.debug("{}: {}".format(attr, value))
-            node_type = attr.split(".")[0]
-            attribute_name = ".".join(attr.split(".")[1:])
+            if "." not in attr:
+                cls.log.warning("Skipping invalid attribute defined in "
+                                "validation settings: '{}'".format(attr))
+
+            node_type, attribute_name = attr.split(".", 1)
+
+            # first get node of that type
             nodes = cmds.ls(type=node_type)
 
-            if not isinstance(nodes, list):
-                cls.log.warning("No nodes of '{}' found.".format(node_type))
+            if not nodes:
+                cls.log.info("No nodes of type '{}' found.".format(node_type))
                 continue
 
             for node in nodes:

--- a/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rendersettings.py
@@ -261,6 +261,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
             if "." not in attr:
                 cls.log.warning("Skipping invalid attribute defined in "
                                 "validation settings: '{}'".format(attr))
+                continue
 
             node_type, attribute_name = attr.split(".", 1)
 


### PR DESCRIPTION
## Brief description

If settings was previously set up with an attribute name that was NOT `{node_type}.{attr}` like e.g. `foobar` without a dot the logic would've made it into `foobar` as node_name and would have tried to getAttr `node.` which seems odd. Now the logic will warn the user about the invalid settings.

I also believe the previous `isinstance` list check would have never proceeded to detect no nodes found since `cmds.ls()` always returns a list, even when no matching nodes detected.

It's mostly logging related cosmetics.

## Testing notes:

1. Submit renders for different renderers with different attribute value check implemented in settings.
2. Test with invalid attr names - you should be warned.. but publish should not error hard.