### PR TITLE
Launcher: Skip opening last work file works for groups

### DIFF
--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -312,11 +312,12 @@ class ActionBar(QtWidgets.QWidget):
 
         is_group = index.data(GROUP_ROLE)
         is_variant_group = index.data(VARIANT_GROUP_ROLE)
+        force_not_open_workfile = index.data(FORCE_NOT_OPEN_WORKFILE_ROLE)
         if not is_group and not is_variant_group:
             action = index.data(ACTION_ROLE)
             # Change data of application action
             if issubclass(action, ApplicationAction):
-                if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
+                if force_not_open_workfile:
                     action.data["start_last_workfile"] = False
                 else:
                     action.data.pop("start_last_workfile", None)
@@ -385,10 +386,18 @@ class ActionBar(QtWidgets.QWidget):
                 menu.addMenu(sub_menu)
 
         result = menu.exec_(QtGui.QCursor.pos())
-        if result:
-            action = actions_mapping[result]
-            self._start_animation(index)
-            self.action_clicked.emit(action)
+        if not result:
+            return
+
+        action = actions_mapping[result]
+        if issubclass(action, ApplicationAction):
+            if force_not_open_workfile:
+                action.data["start_last_workfile"] = False
+            else:
+                action.data.pop("start_last_workfile", None)
+
+        self._start_animation(index)
+        self.action_clicked.emit(action)
 
 
 class ActionHistory(QtWidgets.QPushButton):


### PR DESCRIPTION
## Brief description
Fixed "Skip opening last workfile" for grouped applications.

## Description
The option to skip last workfile was not working if there was more then one variant of application group. In that case `"start_last_workfile"` was not set on action data and the cache of applications stored the cache only for first application.

## Testing notes:
1. Make sure you have at least 2 variants of application enabled on project
2. Open launcher on some task
3. Change state "Skip opening last workfile" with right click on the application
4. Launch the application
5. Last workfile should not be opened

Resolves https://github.com/pypeclub/OpenPype/issues/3533 and https://github.com/pypeclub/OpenPype/issues/2788