### PR TITLE
Maya: Fix very slow `get_container_members` calls for instances

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -1532,7 +1532,7 @@ def get_container_members(container):
         if ref.rsplit(":", 1)[-1].startswith("_UNKNOWN_REF_NODE_"):
             continue
 
-        reference_members = cmds.referenceQuery(ref, nodes=True)
+        reference_members = cmds.referenceQuery(ref, nodes=True, dagPath=True)
         reference_members = cmds.ls(reference_members,
                                     long=True,
                                     objectsOnly=True)


### PR DESCRIPTION
## Brief description

If you load content with many instances inside of it - you'll want this fix for `get_container_members`.

Previously the short (non-unique) names would be returned per instance from `cmds.referenceQuery` and then the call to `cmds.ls` afterwards would take each of these instances and for those return all instances.

It would turn 7000 instances into 7000*7000 = 49.000.000 long paths to be returned - and that's slow and basically just duplicates. Now it just returns the 7000 long paths.

For our scene this was a difference between 16 seconds for the call to 0.17 seconds.

I noticed this was slightly faster:
```python
reference_members = cmds.referenceQuery(ref, nodes=True)
reference_members = list(set(reference_members))
reference_members = cmds.ls(reference_members,
                            long=True,
                            objectsOnly=True)
```
But I was a bit wary about the implications that might actually have with it returning non-unique names to begin with. It would bring it down to even 0.08 seconds for our test case instead of 0.17 seconds - so close to twice as fast still. (These were consistent results). So if anyone knows whether it's just as safe we might as well change it to that instead? Could have been it was just faster due to it being _just_ 7000 nodes of which many were 'the same'? Might need more speed testing then.

## Testing notes:

1. Test areas that use `get_container_members` like Look assignments, ReferenceLoader, SelectInScene actions, etc.
2. Feel free to check speed difference with an alembic file that has many instanced/non-unique shape node names.