### PR TITLE
Flame: OpenPype submenu to batch and media manager

### DIFF
--- a/openpype/hosts/flame/api/__init__.py
+++ b/openpype/hosts/flame/api/__init__.py
@@ -51,7 +51,8 @@ from .pipeline import (
 )
 from .menu import (
     FlameMenuProjectConnect,
-    FlameMenuTimeline
+    FlameMenuTimeline,
+    FlameMenuBatch
 )
 from .plugin import (
     Creator,
@@ -131,6 +132,7 @@ __all__ = [
     # menu
     "FlameMenuProjectConnect",
     "FlameMenuTimeline",
+    "FlameMenuBatch",
 
     # plugin
     "Creator",

--- a/openpype/hosts/flame/api/__init__.py
+++ b/openpype/hosts/flame/api/__init__.py
@@ -52,7 +52,7 @@ from .pipeline import (
 from .menu import (
     FlameMenuProjectConnect,
     FlameMenuTimeline,
-    FlameMenuBatch
+    FlameMenuUniversal
 )
 from .plugin import (
     Creator,
@@ -132,7 +132,7 @@ __all__ = [
     # menu
     "FlameMenuProjectConnect",
     "FlameMenuTimeline",
-    "FlameMenuBatch",
+    "FlameMenuUniversal",
 
     # plugin
     "Creator",

--- a/openpype/hosts/flame/api/menu.py
+++ b/openpype/hosts/flame/api/menu.py
@@ -201,3 +201,53 @@ class FlameMenuTimeline(_FlameMenuApp):
         if self.flame:
             self.flame.execute_shortcut('Rescan Python Hooks')
             self.log.info('Rescan Python Hooks')
+
+
+class FlameMenuBatch(_FlameMenuApp):
+
+    # flameMenuProjectconnect app takes care of the preferences dialog as well
+
+    def __init__(self, framework):
+        _FlameMenuApp.__init__(self, framework)
+
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            project = self.dynamic_menu_data.get(name)
+            if project:
+                self.link_project(project)
+        return method
+
+    def build_menu(self):
+        if not self.flame:
+            return []
+
+        menu = deepcopy(self.menu)
+
+        menu['actions'].append({
+            "name": "Load...",
+            "execute": lambda x: self.tools_helper.show_loader()
+        })
+        menu['actions'].append({
+            "name": "Manage...",
+            "execute": lambda x: self.tools_helper.show_scene_inventory()
+        })
+        menu['actions'].append({
+            "name": "Library...",
+            "execute": lambda x: self.tools_helper.show_library_loader()
+        })
+        return menu
+
+    def refresh(self, *args, **kwargs):
+        self.rescan()
+
+    def rescan(self, *args, **kwargs):
+        if not self.flame:
+            try:
+                import flame
+                self.flame = flame
+            except ImportError:
+                self.flame = None
+
+        if self.flame:
+            self.flame.execute_shortcut('Rescan Python Hooks')
+            self.log.info('Rescan Python Hooks')

--- a/openpype/hosts/flame/api/menu.py
+++ b/openpype/hosts/flame/api/menu.py
@@ -203,7 +203,7 @@ class FlameMenuTimeline(_FlameMenuApp):
             self.log.info('Rescan Python Hooks')
 
 
-class FlameMenuBatch(_FlameMenuApp):
+class FlameMenuUniversal(_FlameMenuApp):
 
     # flameMenuProjectconnect app takes care of the preferences dialog as well
 

--- a/openpype/hosts/flame/startup/openpype_in_flame.py
+++ b/openpype/hosts/flame/startup/openpype_in_flame.py
@@ -73,6 +73,8 @@ def load_apps():
         opfapi.FlameMenuProjectConnect(opfapi.CTX.app_framework))
     opfapi.CTX.flame_apps.append(
         opfapi.FlameMenuTimeline(opfapi.CTX.app_framework))
+    opfapi.CTX.flame_apps.append(
+        opfapi.FlameMenuBatch(opfapi.CTX.app_framework))
     opfapi.CTX.app_framework.log.info("Apps are loaded")
 
 
@@ -191,3 +193,14 @@ def get_timeline_custom_ui_actions():
     openpype_install()
 
     return _build_app_menu("FlameMenuTimeline")
+
+def get_batch_custom_ui_actions():
+    """Hook to create submenu in batch
+
+    Returns:
+        list: menu object
+    """
+    # install openpype and the host
+    openpype_install()
+
+    return _build_app_menu("FlameMenuBatch")

--- a/openpype/hosts/flame/startup/openpype_in_flame.py
+++ b/openpype/hosts/flame/startup/openpype_in_flame.py
@@ -194,6 +194,7 @@ def get_timeline_custom_ui_actions():
 
     return _build_app_menu("FlameMenuTimeline")
 
+
 def get_batch_custom_ui_actions():
     """Hook to create submenu in batch
 
@@ -203,4 +204,16 @@ def get_batch_custom_ui_actions():
     # install openpype and the host
     openpype_install()
 
-    return _build_app_menu("FlameMenuBatch")
+    return _build_app_menu("FlameMenuUniversal")
+
+
+def get_media_panel_custom_ui_actions():
+    """Hook to create submenu in desktop
+
+    Returns:
+        list: menu object
+    """
+    # install openpype and the host
+    openpype_install()
+
+    return _build_app_menu("FlameMenuUniversal")

--- a/openpype/hosts/flame/startup/openpype_in_flame.py
+++ b/openpype/hosts/flame/startup/openpype_in_flame.py
@@ -74,7 +74,7 @@ def load_apps():
     opfapi.CTX.flame_apps.append(
         opfapi.FlameMenuTimeline(opfapi.CTX.app_framework))
     opfapi.CTX.flame_apps.append(
-        opfapi.FlameMenuBatch(opfapi.CTX.app_framework))
+        opfapi.FlameMenuUniversal(opfapi.CTX.app_framework))
     opfapi.CTX.app_framework.log.info("Apps are loaded")
 
 


### PR DESCRIPTION
## Brief description
Invoking OpenPype submenu from more UI contexts

## Description
We can invoke OpenPype submenu with other actions not only from timeline editor but also from Batch and Media manager panels.

## Testing notes:
1. start Flame from Openpype
2. Go to Batch tab and RMB click to node graph > you should see OpenPype menu at bottom
3. Go to Media manager panel and RMB click any item in panel > you should see OpenPype menu at bottom