### PR TITLE
Publisher: Add new publisher to host tools

### DIFF
--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -32,6 +32,7 @@ class HostToolsHelper:
         self._workfiles_tool = None
         self._loader_tool = None
         self._creator_tool = None
+        self._publisher_tool = None
         self._subset_manager_tool = None
         self._scene_inventory_tool = None
         self._library_loader_tool = None
@@ -205,6 +206,7 @@ class HostToolsHelper:
         pyblish_show = self._discover_pyblish_gui()
         return pyblish_show(parent)
 
+
     def _discover_pyblish_gui(self):
         """Return the most desirable of the currently registered GUIs"""
         # Prefer last registered
@@ -269,6 +271,30 @@ class HostToolsHelper:
             dialog.activateWindow()
             dialog.showNormal()
 
+    def get_publisher_tool(self, parent):
+        """Create, cache and return scene inventory tool window."""
+        if self._scene_inventory_tool is None:
+            from openpype.tools.publisher import PublisherWindow
+
+            host = registered_host()
+            ILoadHost.validate_load_methods(host)
+
+            publisher_window = PublisherWindow(
+                parent=parent or self._parent
+            )
+            self._publisher_tool = publisher_window
+
+        return self._publisher_tool
+
+    def show_publisher_tool(self, parent=None):
+        with qt_app_context():
+            dialog = self.get_publisher_tool(parent)
+
+            dialog.show()
+            dialog.raise_()
+            dialog.activateWindow()
+            dialog.showNormal()
+
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.
 
@@ -297,6 +323,10 @@ class HostToolsHelper:
 
         elif tool_name == "publish":
             self.log.info("Can't return publish tool window.")
+
+        # "new" publisher
+        elif tool_name == "publisher":
+            return self.get_publisher_tool(parent, *args, **kwargs)
 
         elif tool_name == "experimental_tools":
             return self.get_experimental_tools_dialog(parent, *args, **kwargs)
@@ -334,6 +364,9 @@ class HostToolsHelper:
 
         elif tool_name == "publish":
             self.show_publish(parent, *args, **kwargs)
+
+        elif tool_name == "publisher":
+            self.show_publisher_tool(parent, *args, **kwargs)
 
         elif tool_name == "experimental_tools":
             self.show_experimental_tools_dialog(parent, *args, **kwargs)
@@ -412,6 +445,10 @@ def show_look_assigner(parent=None):
 
 def show_publish(parent=None):
     _SingletonPoint.show_tool_by_name("publish", parent)
+
+
+def show_publisher(parent=None):
+    _SingletonPoint.show_tool_by_name("publisher", parent)
 
 
 def show_experimental_tools_dialog(parent=None):

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -273,7 +273,8 @@ class HostToolsHelper:
 
     def get_publisher_tool(self, parent):
         """Create, cache and return scene inventory tool window."""
-        if self._scene_inventory_tool is None:
+
+        if self._publisher_tool is None:
             from openpype.tools.publisher import PublisherWindow
 
             host = registered_host()

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -272,7 +272,7 @@ class HostToolsHelper:
             dialog.showNormal()
 
     def get_publisher_tool(self, parent):
-        """Create, cache and return scene inventory tool window."""
+        """Create, cache and return publisher window."""
 
         if self._publisher_tool is None:
             from openpype.tools.publisher import PublisherWindow

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -194,7 +194,6 @@ class HostToolsHelper:
             library_loader_tool.showNormal()
             library_loader_tool.refresh()
 
-
     def show_publish(self, parent=None):
         """Try showing the most desirable publish GUI
 
@@ -205,7 +204,6 @@ class HostToolsHelper:
 
         pyblish_show = self._discover_pyblish_gui()
         return pyblish_show(parent)
-
 
     def _discover_pyblish_gui(self):
         """Return the most desirable of the currently registered GUIs"""


### PR DESCRIPTION
## Brief description
Added new publisher to host tools. Code copied from https://github.com/pypeclub/OpenPype/pull/3046 which is in draft and the code is already needed for other PRs.

## Description
Added new publisher to host tools to be able easily open the tool from hosts.

## Testing notes:
1. Calling `show_publisher` in host tools should work

```
from openpype.tools.utils.host_tools import show_publisher

show_publisher()
```