### PR TITLE
Ftrack: Url validation does not require ftrackapp

### DIFF
--- a/openpype/modules/ftrack/__init__.py
+++ b/openpype/modules/ftrack/__init__.py
@@ -2,12 +2,12 @@ from .ftrack_module import (
     FtrackModule,
     FTRACK_MODULE_DIR,
 
-    check_ftrack_url,
+    resolve_ftrack_url,
 )
 
 __all__ = (
     "FtrackModule",
     "FTRACK_MODULE_DIR",
 
-    "check_ftrack_url",
+    "resolve_ftrack_url",
 )

--- a/openpype/modules/ftrack/__init__.py
+++ b/openpype/modules/ftrack/__init__.py
@@ -1,9 +1,13 @@
 from .ftrack_module import (
     FtrackModule,
-    FTRACK_MODULE_DIR
+    FTRACK_MODULE_DIR,
+
+    check_ftrack_url,
 )
 
 __all__ = (
     "FtrackModule",
-    "FTRACK_MODULE_DIR"
+    "FTRACK_MODULE_DIR",
+
+    "check_ftrack_url",
 )

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -6,7 +6,7 @@ import platform
 import click
 
 from openpype.modules import OpenPypeModule
-from openpype_interfaces import (
+from openpype.modules.interfaces import (
     ITrayModule,
     IPluginPaths,
     ISettingsChangeListener

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -520,8 +520,9 @@ def check_ftrack_url(url, log_errors=True, logger=None):
 
     if ftrack_url:
         logger.debug("Ftrack server \"{}\" is accessible.".format(ftrack_url))
+
     elif log_errors:
-        logger.error("Entered Ftrack URL \"{}\" is not accessible!".format(url))
+        logger.error("Ftrack server \"{}\" is not accessible!".format(url))
 
     return ftrack_url
 

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -521,7 +521,7 @@ def check_ftrack_url(url, log_errors=True, logger=None):
     if ftrack_url:
         logger.debug("Ftrack server \"{}\" is accessible.".format(ftrack_url))
     elif log_errors:
-        logger.error("Entered Ftrack URL \"{}\" is not accesible!".format(url))
+        logger.error("Entered Ftrack URL \"{}\" is not accessible!".format(url))
 
     return ftrack_url
 

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -15,7 +15,7 @@ from openpype.settings import SaveWarningExc
 from openpype.lib import Logger
 
 FTRACK_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-_PLACEHOLDER = object()
+_URL_NOT_SET = object()
 
 
 class FtrackModule(
@@ -31,7 +31,7 @@ class FtrackModule(
 
         self.enabled = ftrack_settings["enabled"]
         self._settings_ftrack_url = ftrack_settings["ftrack_server"]
-        self._ftrack_url = _PLACEHOLDER
+        self._ftrack_url = _URL_NOT_SET
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         low_platform = platform.system().lower()
@@ -64,7 +64,7 @@ class FtrackModule(
         self._timers_manager_module = None
 
     def get_ftrack_url(self):
-        if self._ftrack_url is _PLACEHOLDER:
+        if self._ftrack_url is _URL_NOT_SET:
             self._ftrack_url = resolve_ftrack_url(
                 self._settings_ftrack_url,
                 logger=self.log

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -65,7 +65,7 @@ class FtrackModule(
 
     def get_ftrack_url(self):
         if self._ftrack_url is _PLACEHOLDER:
-            self._ftrack_url = check_ftrack_url(
+            self._ftrack_url = resolve_ftrack_url(
                 self._settings_ftrack_url,
                 logger=self.log
             )
@@ -495,8 +495,8 @@ def _check_ftrack_url(url):
     return True
 
 
-def check_ftrack_url(url, log_errors=True, logger=None):
-    """Checks if Ftrack server is responding"""
+def resolve_ftrack_url(url, log_errors=True, logger=None):
+    """Checks if Ftrack server is responding."""
 
     if logger is None:
         logger = Logger.get_logger(__name__)

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -495,7 +495,7 @@ def _check_ftrack_url(url):
     return True
 
 
-def resolve_ftrack_url(url, log_errors=True, logger=None):
+def resolve_ftrack_url(url, logger=None):
     """Checks if Ftrack server is responding."""
 
     if logger is None:
@@ -521,7 +521,7 @@ def resolve_ftrack_url(url, log_errors=True, logger=None):
     if ftrack_url:
         logger.debug("Ftrack server \"{}\" is accessible.".format(ftrack_url))
 
-    elif log_errors:
+    else:
         logger.error("Ftrack server \"{}\" is not accessible!".format(url))
 
     return ftrack_url

--- a/openpype/modules/ftrack/ftrack_server/__init__.py
+++ b/openpype/modules/ftrack/ftrack_server/__init__.py
@@ -1,8 +1,6 @@
 from .ftrack_server import FtrackServer
-from .lib import check_ftrack_url
 
 
 __all__ = (
     "FtrackServer",
-    "check_ftrack_url"
 )

--- a/openpype/modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/ftrack/ftrack_server/event_server_cli.py
@@ -20,9 +20,11 @@ from openpype.lib import (
     get_openpype_version,
     get_build_version,
 )
-from openpype_modules.ftrack import FTRACK_MODULE_DIR
+from openpype_modules.ftrack import (
+    FTRACK_MODULE_DIR,
+    check_ftrack_url,
+)
 from openpype_modules.ftrack.lib import credentials
-from openpype_modules.ftrack.ftrack_server.lib import check_ftrack_url
 from openpype_modules.ftrack.ftrack_server import socket_thread
 
 

--- a/openpype/modules/ftrack/ftrack_server/event_server_cli.py
+++ b/openpype/modules/ftrack/ftrack_server/event_server_cli.py
@@ -22,7 +22,7 @@ from openpype.lib import (
 )
 from openpype_modules.ftrack import (
     FTRACK_MODULE_DIR,
-    check_ftrack_url,
+    resolve_ftrack_url,
 )
 from openpype_modules.ftrack.lib import credentials
 from openpype_modules.ftrack.ftrack_server import socket_thread
@@ -116,7 +116,7 @@ def legacy_server(ftrack_url):
 
     while True:
         if not ftrack_accessible:
-            ftrack_accessible = check_ftrack_url(ftrack_url)
+            ftrack_accessible = resolve_ftrack_url(ftrack_url)
 
         # Run threads only if Ftrack is accessible
         if not ftrack_accessible and not printed_ftrack_error:
@@ -259,7 +259,7 @@ def main_loop(ftrack_url):
     while True:
         # Check if accessible Ftrack and Mongo url
         if not ftrack_accessible:
-            ftrack_accessible = check_ftrack_url(ftrack_url)
+            ftrack_accessible = resolve_ftrack_url(ftrack_url)
 
         if not mongo_accessible:
             mongo_accessible = check_mongo_url(mongo_uri)
@@ -443,7 +443,7 @@ def run_event_server(
         os.environ["CLOCKIFY_API_KEY"] = clockify_api_key
 
     # Check url regex and accessibility
-    ftrack_url = check_ftrack_url(ftrack_url)
+    ftrack_url = resolve_ftrack_url(ftrack_url)
     if not ftrack_url:
         print('Exiting! < Please enter Ftrack server url >')
         return 1

--- a/openpype/modules/ftrack/ftrack_server/lib.py
+++ b/openpype/modules/ftrack/ftrack_server/lib.py
@@ -26,43 +26,10 @@ except ImportError:
 from openpype_modules.ftrack.lib import get_ftrack_event_mongo_info
 
 from openpype.client import OpenPypeMongoConnection
-from openpype.api import Logger
+from openpype.lib import Logger
 
 TOPIC_STATUS_SERVER = "openpype.event.server.status"
 TOPIC_STATUS_SERVER_RESULT = "openpype.event.server.status.result"
-
-
-def check_ftrack_url(url, log_errors=True, logger=None):
-    """Checks if Ftrack server is responding"""
-    if logger is None:
-        logger = Logger.get_logger(__name__)
-
-    if not url:
-        logger.error("Ftrack URL is not set!")
-        return None
-
-    url = url.strip('/ ')
-
-    if 'http' not in url:
-        if url.endswith('ftrackapp.com'):
-            url = 'https://' + url
-        else:
-            url = 'https://{0}.ftrackapp.com'.format(url)
-    try:
-        result = requests.get(url, allow_redirects=False)
-    except requests.exceptions.RequestException:
-        if log_errors:
-            logger.error("Entered Ftrack URL is not accesible!")
-        return False
-
-    if (result.status_code != 200 or 'FTRACK_VERSION' not in result.headers):
-        if log_errors:
-            logger.error("Entered Ftrack URL is not accesible!")
-        return False
-
-    logger.debug("Ftrack server {} is accessible.".format(url))
-
-    return url
 
 
 class SocketBaseEventHub(ftrack_api.event.hub.EventHub):

--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -19,11 +19,8 @@ from openpype.client.operations import (
     CURRENT_PROJECT_SCHEMA,
     CURRENT_PROJECT_CONFIG_SCHEMA,
 )
-from openpype.api import (
-    Logger,
-    get_anatomy_settings
-)
-from openpype.lib import ApplicationManager
+from openpype.settings import get_anatomy_settings
+from openpype.lib import ApplicationManager, Logger
 from openpype.pipeline import AvalonMongoDB, schema
 
 from .constants import CUST_ATTR_ID_KEY, FPS_KEYS

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -6,22 +6,18 @@ import threading
 from Qt import QtCore, QtWidgets, QtGui
 
 import ftrack_api
-from ..ftrack_server.lib import check_ftrack_url
-from ..ftrack_server import socket_thread
-from ..lib import credentials
-from ..ftrack_module import FTRACK_MODULE_DIR
-from . import login_dialog
-
 from openpype import resources
 from openpype.lib import Logger
-
-
-log = Logger.get_logger("FtrackModule")
+from openpype_modules.ftrack import check_ftrack_url, FTRACK_MODULE_DIR
+from openpype_modules.ftrack.ftrack_server import socket_thread
+from openpype_modules.ftrack.lib import credentials
+from . import login_dialog
 
 
 class FtrackTrayWrapper:
     def __init__(self, module):
         self.module = module
+        self.log = Logger.get_logger(self.__class__.__name__)
 
         self.thread_action_server = None
         self.thread_socket_server = None
@@ -62,19 +58,19 @@ class FtrackTrayWrapper:
         if validation:
             self.widget_login.set_credentials(ft_user, ft_api_key)
             self.module.set_credentials_to_env(ft_user, ft_api_key)
-            log.info("Connected to Ftrack successfully")
+            self.log.info("Connected to Ftrack successfully")
             self.on_login_change()
 
             return validation
 
         if not validation and ft_user and ft_api_key:
-            log.warning(
+            self.log.warning(
                 "Current Ftrack credentials are not valid. {}: {} - {}".format(
                     str(os.environ.get("FTRACK_SERVER")), ft_user, ft_api_key
                 )
             )
 
-        log.info("Please sign in to Ftrack")
+        self.log.info("Please sign in to Ftrack")
         self.bool_logged = False
         self.show_login_widget()
         self.set_menu_visibility()
@@ -104,7 +100,7 @@ class FtrackTrayWrapper:
             self.action_credentials.setIcon(self.icon_not_logged)
             self.action_credentials.setToolTip("Logged out")
 
-        log.info("Logged out of Ftrack")
+        self.log.info("Logged out of Ftrack")
         self.bool_logged = False
         self.set_menu_visibility()
 
@@ -125,10 +121,6 @@ class FtrackTrayWrapper:
 
         ftrack_url = self.module.ftrack_url
         os.environ["FTRACK_SERVER"] = ftrack_url
-
-        parent_file_path = os.path.dirname(
-            os.path.dirname(os.path.realpath(__file__))
-        )
 
         min_fail_seconds = 5
         max_fail_count = 3
@@ -154,7 +146,7 @@ class FtrackTrayWrapper:
         # Main loop
         while True:
             if not self.bool_action_server_running:
-                log.debug("Action server was pushed to stop.")
+                self.log.debug("Action server was pushed to stop.")
                 break
 
             # Check if accessible Ftrack and Mongo url
@@ -164,7 +156,9 @@ class FtrackTrayWrapper:
             # Run threads only if Ftrack is accessible
             if not ftrack_accessible:
                 if not printed_ftrack_error:
-                    log.warning("Can't access Ftrack {}".format(ftrack_url))
+                    self.log.warning(
+                        "Can't access Ftrack {}".format(ftrack_url)
+                    )
 
                 if self.thread_socket_server is not None:
                     self.thread_socket_server.stop()
@@ -191,7 +185,7 @@ class FtrackTrayWrapper:
                     self.set_menu_visibility()
 
                 elif failed_count == max_fail_count:
-                    log.warning((
+                    self.log.warning((
                         "Action server failed {} times."
                         " I'll try to run again {}s later"
                     ).format(
@@ -243,10 +237,10 @@ class FtrackTrayWrapper:
                 self.thread_action_server.join()
                 self.thread_action_server = None
 
-            log.info("Ftrack action server was forced to stop")
+            self.log.info("Ftrack action server was forced to stop")
 
         except Exception:
-            log.warning(
+            self.log.warning(
                 "Error has happened during Killing action server",
                 exc_info=True
             )
@@ -343,7 +337,7 @@ class FtrackTrayWrapper:
                 self.thread_timer = None
 
         except Exception as e:
-            log.error("During Killing Timer event server: {0}".format(e))
+            self.log.error("During Killing Timer event server: {0}".format(e))
 
     def changed_user(self):
         self.stop_action_server()

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -8,7 +8,7 @@ from Qt import QtCore, QtWidgets, QtGui
 import ftrack_api
 from openpype import resources
 from openpype.lib import Logger
-from openpype_modules.ftrack import check_ftrack_url, FTRACK_MODULE_DIR
+from openpype_modules.ftrack import resolve_ftrack_url, FTRACK_MODULE_DIR
 from openpype_modules.ftrack.ftrack_server import socket_thread
 from openpype_modules.ftrack.lib import credentials
 from . import login_dialog
@@ -151,7 +151,7 @@ class FtrackTrayWrapper:
 
             # Check if accessible Ftrack and Mongo url
             if not ftrack_accessible:
-                ftrack_accessible = check_ftrack_url(ftrack_url)
+                ftrack_accessible = resolve_ftrack_url(ftrack_url)
 
             # Run threads only if Ftrack is accessible
             if not ftrack_accessible:


### PR DESCRIPTION
## Brief description
Self deployed ftrack server does not have to end with `.ftrackapp.com` which is now possible to handle in OpenPype.

## Description
The validation does 2 validations of server connection, one with `ftrackapp.com` and one without. This way it is backwards compatible but works when url does not end with `.ftrackapp.com`. Function `check_ftrack_url` was moved to module level.

## Additional info
To get ftrack url it is required to connect to ftrack server which can slow down tray launch. That is because environment variable `FTRACK_SERVER` is set on launch. We should maybe not set the environment variable on start but get it from module when needed - has high potential to break ftrack code (created [issue](https://github.com/pypeclub/OpenPype/issues/3835)).

## Testing notes:
1. Set ftrack url to self deployed server without `ftrackapp.com` at the end
2. Start OpenPype
3. Ftrack login should work
4. Publishing to ftrack should work