### PR TITLE
Maya + Yeti: Fix yeti cache load using wrong name in edge case

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_cache.py
@@ -73,8 +73,8 @@ class YetiCacheLoader(load.LoaderPlugin):
 
         c = colors.get(family)
         if c is not None:
-            cmds.setAttr(group_name + ".useOutlinerColor", 1)
-            cmds.setAttr(group_name + ".outlinerColor",
+            cmds.setAttr(group_node + ".useOutlinerColor", 1)
+            cmds.setAttr(group_node + ".outlinerColor",
                 (float(c[0])/255),
                 (float(c[1])/255),
                 (float(c[2])/255)


### PR DESCRIPTION
## Brief description

We hit this issue when the code was trying to create a group node that by pure luck had a node name that matched exactly with a name that was also in the namespace - thus maya would auto-rename the created group node.

As such `group_name != group_node` and the `.setOutlinerColor` failed to do its job correctly.

## Description

This fixes it by actually using the node name returned by maya.

## Testing notes:

Might be hard to test the specific edge case since I'm not entirely sure how we got the exact name match. But just testing a Yeti publish + load to begin with should be a good test.

1. Load a Yeti Cache.