### PR TITLE
Publisher: Instances can be marked as stored

### DIFF
--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -104,6 +104,8 @@ class TrayPublishCreator(Creator):
 
         # Host implementation of storing metadata about instance
         HostContext.add_instance(new_instance.data_to_store())
+        new_instance.mark_stored()
+
         # Add instance to current context
         self._add_instance_to_context(new_instance)
 

--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -104,7 +104,7 @@ class TrayPublishCreator(Creator):
 
         # Host implementation of storing metadata about instance
         HostContext.add_instance(new_instance.data_to_store())
-        new_instance.mark_stored()
+        new_instance.mark_as_stored()
 
         # Add instance to current context
         self._add_instance_to_context(new_instance)

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -169,7 +169,7 @@ class AttributeValues:
     def reset_values(self):
         self._data = {}
 
-    def mark_stored(self):
+    def mark_as_stored(self):
         self._origin_data = copy.deepcopy(self._data)
 
     @property
@@ -307,7 +307,7 @@ class PublishAttributes:
         for name in self._plugin_names_order:
             yield name
 
-    def mark_stored(self):
+    def mark_as_stored(self):
         self._origin_data = copy.deepcopy(self._data)
 
     def data_to_store(self):
@@ -629,7 +629,7 @@ class CreatedInstance:
                 changes[key] = (old_value, None)
         return changes
 
-    def mark_stored(self):
+    def mark_as_stored(self):
         """Should be called when instance data are stored.
 
         Origin data are replaced by current data so changes are cleared.
@@ -645,8 +645,8 @@ class CreatedInstance:
         for key in orig_keys:
             self._orig_data.pop(key)
 
-        self.creator_attributes.mark_stored()
-        self.publish_attributes.mark_stored()
+        self.creator_attributes.mark_as_stored()
+        self.publish_attributes.mark_as_stored()
 
     @property
     def creator_attributes(self):

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -167,7 +167,7 @@ class AttributeValues:
         return self._data.pop(key, default)
 
     def reset_values(self):
-        self._data = []
+        self._data = {}
 
     def mark_stored(self):
         self._origin_data = copy.deepcopy(self._data)


### PR DESCRIPTION
## Brief description
Give ability to mark instance object as stored to clear changes.

## Description
New created instance have all attributes marked as changed (because there were none data before) but in most of cases are also stored to scene during creation so they should be marked as stored. Implemented method `mark_stored` to "clear changes" and from that moment instance object behave like has no changes.

Method `mark_as_stored` must be called explicitly in creator. I didn't find a good place how to automate it with being sure that the instance was actually stored. Traypublisher does it.

## Testing notes:
Testing requires some code changes. Easiest is probably using prints in tray publisher:
1. In `~/openpype/hosts/traypublisher/api/pipeline.py` add print of `update_list` variable in `update_instances`
2. Open TrayPublisher
3. Create an instance
4. Hit refresh at the bottom
5. Check console if there is printed output from the print
    - in this branch there should be no print
    - in develop there should be some print with a list of changes

Resolves https://github.com/pypeclub/OpenPype/issues/3772