### PR TITLE
Transcoding: Fix typo in logic for matrix type

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -154,7 +154,7 @@ def convert_value_by_type_name(value_type, value, logger=None):
         elif parts_len == 4:
             divisor = 2
         elif parts_len == 9:
-            divisor == 3
+            divisor = 3
         elif parts_len == 16:
             divisor = 4
         else:

--- a/openpype/modules/deadline/repository/custom/plugins/OpenPypeTileAssembler/OpenPypeTileAssembler.py
+++ b/openpype/modules/deadline/repository/custom/plugins/OpenPypeTileAssembler/OpenPypeTileAssembler.py
@@ -71,7 +71,7 @@ def convert_value_by_type_name(value_type, value):
         elif parts_len == 4:
             divisor = 2
         elif parts_len == 9:
-            divisor == 3
+            divisor = 3
         elif parts_len == 16:
             divisor = 4
         else:


### PR DESCRIPTION
## Brief description

Logic did `divisor == 3` instead of `divisor = 3`. 
Variable `divisor` wasn't defined.

## Description

This felt like a bug - not entirely sure it was a typo. Was it?

## Testing notes:

1. Try transcoding with matrix3 type (3x3 = 9 values)?