### PR TITLE
Maya: ExtractPlayblast viewport heads up display setting is ignored

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -731,7 +731,7 @@
                     "grid": false,
                     "hairSystems": true,
                     "handles": false,
-                    "hud": false,
+                    "headsUpDisplay": false,
                     "hulls": false,
                     "ikHandles": false,
                     "imagePlane": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -441,8 +441,8 @@
                         },
                         {
                             "type": "boolean",
-                            "key": "hud",
-                            "label": "hud"
+                            "key": "headsUpDisplay",
+                            "label": "headsUpDisplay"
                         },
                         {
                             "type": "boolean",


### PR DESCRIPTION
## Brief description

Rename Heads Up Display setting key `hud` to `headsUpDisplay` to fix the setting to correctly propagate into playblasts.

## Description

Capture has a default setting named `headsUpDisplay` which is the long name for the setting `hud`. Thus when supplying `hud` as viewport option then `capture` will merge the key-values and thus will try to set both `headsUpDisplay` and `hud` value for the modelEditor which ends up ignoring `hud` and instead applying the `headsUpDisplay`.

Thus, `hud` didn't do anything.

## Testing notes:

Before this PR disable setting: `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/hud`
HUD will still be playblasted in reviews.

After this PR disable setting: `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/headsUpDisplay`
HUD will now correctly be disabled in playblasts for reviews.