### PR TITLE
Maya: Extract Playblast fix textures + labelize viewport show settings

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2483,7 +2483,7 @@ def load_capture_preset(data=None):
     # DISPLAY OPTIONS
     id = 'Display Options'
     disp_options = {}
-    for key in preset['Display Options']:
+    for key in preset[id]:
         if key.startswith('background'):
             disp_options[key] = preset['Display Options'][key]
             if len(disp_options[key]) == 4:

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -678,9 +678,6 @@
                     "isolate_view": true,
                     "off_screen": true
                 },
-                "PanZoom": {
-                    "pan_zoom": true
-                },
                 "Renderer": {
                     "rendererName": "vp2Renderer"
                 },

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -686,9 +686,7 @@
                 },
                 "Resolution": {
                     "width": 1920,
-                    "height": 1080,
-                    "percent": 1.0,
-                    "mode": "Custom"
+                    "height": 1080
                 },
                 "Viewport Options": {
                     "override_viewport_options": true,

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -693,10 +693,10 @@
                 "Viewport Options": {
                     "override_viewport_options": true,
                     "displayLights": "default",
+                    "displayTextures": true,
                     "textureMaxResolution": 1024,
                     "renderDepthOfField": true,
                     "shadows": true,
-                    "textures": true,
                     "twoSidedLighting": true,
                     "lineAAEnable": true,
                     "multiSample": 8,
@@ -719,7 +719,6 @@
                     "motionBlurShutterOpenFraction": 0.2,
                     "cameras": false,
                     "clipGhosts": false,
-                    "controlVertices": false,
                     "deformers": false,
                     "dimensions": false,
                     "dynamicConstraints": false,
@@ -732,7 +731,6 @@
                     "hairSystems": true,
                     "handles": false,
                     "hud": false,
-                    "hulls": false,
                     "ikHandles": false,
                     "imagePlane": true,
                     "joints": false,
@@ -743,7 +741,9 @@
                     "nCloths": false,
                     "nParticles": false,
                     "nRigids": false,
+                    "controlVertices": false,
                     "nurbsCurves": false,
+                    "hulls": false,
                     "nurbsSurfaces": false,
                     "particleInstancers": false,
                     "pivots": false,
@@ -751,7 +751,8 @@
                     "pluginShapes": false,
                     "polymeshes": true,
                     "strokes": false,
-                    "subdivSurfaces": false
+                    "subdivSurfaces": false,
+                    "textures": false
                 },
                 "Camera Options": {
                     "displayGateMask": false,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -153,19 +153,6 @@
                             "decimal": 0,
                             "minimum": 0,
                             "maximum": 99999
-                        },
-                        {
-                            "type": "number",
-                            "key": "percent",
-                            "label": "Percent",
-                            "decimal": 1,
-                            "minimum": 0,
-                            "maximum": 200
-                        },
-                        {
-                            "type": "text",
-                            "key": "mode",
-                            "label": "Mode"
                         }
                     ]
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -141,7 +141,7 @@
                         {
                             "type": "number",
                             "key": "width",
-                            "label": "Width",
+                            "label": "                  Width",
                             "decimal": 0,
                             "minimum": 0,
                             "maximum": 99999

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -94,18 +94,6 @@
                         }
                     ]
                 },
-
-                {
-                    "type": "dict",
-                    "key": "PanZoom",
-                    "children": [
-                        {
-                            "type": "boolean",
-                            "key": "pan_zoom",
-                            "label": "              Pan Zoom"
-                        }
-                    ]
-                },
                 {
                     "type": "splitter"
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -381,11 +381,6 @@
                         },
                         {
                             "type": "boolean",
-                            "key": "controlVertices",
-                            "label": "NURBS CVs"
-                        },
-                        {
-                            "type": "boolean",
                             "key": "deformers",
                             "label": "Deformers"
                         },
@@ -437,17 +432,12 @@
                         {
                             "type": "boolean",
                             "key": "handles",
-                            "label": "handles"
+                            "label": "Handles"
                         },
                         {
                             "type": "boolean",
                             "key": "hud",
                             "label": "HUD"
-                        },
-                        {
-                            "type": "boolean",
-                            "key": "hulls",
-                            "label": "NURBS Hulls"
                         },
                         {
                             "type": "boolean",
@@ -501,8 +491,18 @@
                         },
                         {
                             "type": "boolean",
+                            "key": "controlVertices",
+                            "label": "NURBS CVs"
+                        },
+                        {
+                            "type": "boolean",
                             "key": "nurbsCurves",
                             "label": "NURBS Curves"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "hulls",
+                            "label": "NURBS Hulls"
                         },
                         {
                             "type": "boolean",

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -564,47 +564,47 @@
                         {
                             "type": "boolean",
                             "key": "displayGateMask",
-                            "label": "displayGateMask"
+                            "label": "Display Gate Mask"
                         },
                         {
                             "type": "boolean",
                             "key": "displayResolution",
-                            "label": "displayResolution"
+                            "label": "Display Resolution"
                         },
                         {
                             "type": "boolean",
                             "key": "displayFilmGate",
-                            "label": "displayFilmGate"
+                            "label": "Display Film Gate"
                         },
                         {
                             "type": "boolean",
                             "key": "displayFieldChart",
-                            "label": "displayFieldChart"
+                            "label": "Display Field Chart"
                         },
                         {
                             "type": "boolean",
                             "key": "displaySafeAction",
-                            "label": "displaySafeAction"
+                            "label": "Display Safe Action"
                         },
                         {
                             "type": "boolean",
                             "key": "displaySafeTitle",
-                            "label": "displaySafeTitle"
+                            "label": "Display Safe Title"
                         },
                         {
                             "type": "boolean",
                             "key": "displayFilmPivot",
-                            "label": "displayFilmPivot"
+                            "label": "Display Film Pivot"
                         },
                         {
                             "type": "boolean",
                             "key": "displayFilmOrigin",
-                            "label": "displayFilmOrigin"
+                            "label": "Display Film Origin"
                         },
                         {
                             "type": "number",
                             "key": "overscan",
-                            "label": "overscan",
+                            "label": "Overscan",
                             "decimal": 1,
                             "minimum": 0,
                             "maximum": 10

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -141,7 +141,7 @@
                         {
                             "type": "number",
                             "key": "width",
-                            "label": "                  Width",
+                            "label": "Width",
                             "decimal": 0,
                             "minimum": 0,
                             "maximum": 99999

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -432,11 +432,6 @@
                         },
                         {
                             "type": "boolean",
-                            "key": "hulls",
-                            "label": "hulls"
-                        },
-                        {
-                            "type": "boolean",
                             "key": "ikHandles",
                             "label": "IK Handles"
                         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -157,7 +157,7 @@
                         {
                             "type": "number",
                             "key": "percent",
-                            "label": "percent",
+                            "label": "Percent",
                             "decimal": 1,
                             "minimum": 0,
                             "maximum": 200

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -370,6 +370,10 @@
                             "type": "splitter"
                         },
                         {
+                            "type": "label",
+                            "label": "<b>Show</b>"
+                        },
+                        {
                             "type": "boolean",
                             "key": "cameras",
                             "label": "Cameras"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_capture.json
@@ -196,6 +196,11 @@
                             ]
                         },
                         {
+                            "type": "boolean",
+                            "key": "displayTextures",
+                            "label": "Display Textures"
+                        },
+                        {
                             "type": "number",
                             "key": "textureMaxResolution",
                             "label": "Texture Clamp Resolution",
@@ -216,11 +221,6 @@
                             "type": "boolean",
                             "key": "shadows",
                             "label": "Display Shadows"
-                        },
-                        {
-                            "type": "boolean",
-                            "key": "textures",
-                            "label": "Display Textures"
                         },
                         {
                             "type": "boolean",
@@ -372,67 +372,67 @@
                         {
                             "type": "boolean",
                             "key": "cameras",
-                            "label": "cameras"
+                            "label": "Cameras"
                         },
                         {
                             "type": "boolean",
                             "key": "clipGhosts",
-                            "label": "clipGhosts"
+                            "label": "Clip Ghosts"
                         },
                         {
                             "type": "boolean",
                             "key": "controlVertices",
-                            "label": "controlVertices"
+                            "label": "NURBS CVs"
                         },
                         {
                             "type": "boolean",
                             "key": "deformers",
-                            "label": "deformers"
+                            "label": "Deformers"
                         },
                         {
                             "type": "boolean",
                             "key": "dimensions",
-                            "label": "dimensions"
+                            "label": "Dimensions"
                         },
                         {
                             "type": "boolean",
                             "key": "dynamicConstraints",
-                            "label": "dynamicConstraints"
+                            "label": "Dynamic Constraints"
                         },
                         {
                             "type": "boolean",
                             "key": "dynamics",
-                            "label": "dynamics"
+                            "label": "Dynamics"
                         },
                         {
                             "type": "boolean",
                             "key": "fluids",
-                            "label": "fluids"
+                            "label": "Fluids"
                         },
                         {
                             "type": "boolean",
                             "key": "follicles",
-                            "label": "follicles"
+                            "label": "Follicles"
                         },
                         {
                             "type": "boolean",
                             "key": "gpuCacheDisplayFilter",
-                            "label": "gpuCacheDisplayFilter"
+                            "label": "GPU Cache"
                         },
                         {
                             "type": "boolean",
                             "key": "greasePencils",
-                            "label": "greasePencils"
+                            "label": "Grease Pencil"
                         },
                         {
                             "type": "boolean",
                             "key": "grid",
-                            "label": "grid"
+                            "label": "Grid"
                         },
                         {
                             "type": "boolean",
                             "key": "hairSystems",
-                            "label": "hairSystems"
+                            "label": "Hair Systems"
                         },
                         {
                             "type": "boolean",
@@ -442,47 +442,47 @@
                         {
                             "type": "boolean",
                             "key": "hud",
-                            "label": "hud"
+                            "label": "HUD"
                         },
                         {
                             "type": "boolean",
                             "key": "hulls",
-                            "label": "hulls"
+                            "label": "NURBS Hulls"
                         },
                         {
                             "type": "boolean",
                             "key": "ikHandles",
-                            "label": "ikHandles"
+                            "label": "IK Handles"
                         },
                         {
                             "type": "boolean",
                             "key": "imagePlane",
-                            "label": "imagePlane"
+                            "label": "Image Planes"
                         },
                         {
                             "type": "boolean",
                             "key": "joints",
-                            "label": "joints"
+                            "label": "Joints"
                         },
                         {
                             "type": "boolean",
                             "key": "lights",
-                            "label": "lights"
+                            "label": "Lights"
                         },
                         {
                             "type": "boolean",
                             "key": "locators",
-                            "label": "locators"
+                            "label": "Locators"
                         },
                         {
                             "type": "boolean",
                             "key": "manipulators",
-                            "label": "manipulators"
+                            "label": "Manipulators"
                         },
                         {
                             "type": "boolean",
                             "key": "motionTrails",
-                            "label": "motionTrails"
+                            "label": "Motion Trails"
                         },
                         {
                             "type": "boolean",
@@ -502,47 +502,52 @@
                         {
                             "type": "boolean",
                             "key": "nurbsCurves",
-                            "label": "nurbsCurves"
+                            "label": "NURBS Curves"
                         },
                         {
                             "type": "boolean",
                             "key": "nurbsSurfaces",
-                            "label": "nurbsSurfaces"
+                            "label": "NURBS Surfaces"
                         },
                         {
                             "type": "boolean",
                             "key": "particleInstancers",
-                            "label": "particleInstancers"
+                            "label": "Particle Instancers"
                         },
                         {
                             "type": "boolean",
                             "key": "pivots",
-                            "label": "pivots"
+                            "label": "Pivots"
                         },
                         {
                             "type": "boolean",
                             "key": "planes",
-                            "label": "planes"
+                            "label": "Planes"
                         },
                         {
                             "type": "boolean",
                             "key": "pluginShapes",
-                            "label": "pluginShapes"
+                            "label": "Plugin Shapes"
                         },
                         {
                             "type": "boolean",
                             "key": "polymeshes",
-                            "label": "polymeshes"
+                            "label": "Polygons"
                         },
                         {
                             "type": "boolean",
                             "key": "strokes",
-                            "label": "strokes"
+                            "label": "Strokes"
                         },
                         {
                             "type": "boolean",
                             "key": "subdivSurfaces",
-                            "label": "subdivSurfaces"
+                            "label": "Subdiv Surfaces"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "textures",
+                            "label": "Texture Placements"
                         }
                     ]
                 },


### PR DESCRIPTION
## Brief description

Adds a `displayTextures` setting that actually does what you expect it to do - toggle display of textures.
The old `textures` setting is preserved, but now labelized that it is actually about Texture Placements.

I've also labelized all settings to match the Show menu in Maya to avoid confusion.


### FIXES

- This **fixes** "textures" by adding the new but correct `displayTextures` key-value for settings to toggle Display Textures.
- This **fixes** the toggle for HUD / Heads Up Display from #3850 
- This **labelizes** all Viewport Show Options and Camera Options to match more with Maya

## Description

<details>
  <summary>Click to expand and see screenshots</summary>

New settings in OpenPype:
![afbeelding](https://user-images.githubusercontent.com/2439881/190170422-f8da5b9f-2986-4588-9c45-644a0df31e08.png)

Display Textures is added higher:
![afbeelding](https://user-images.githubusercontent.com/2439881/190170537-d877bf98-d877-46c2-9c47-5baf67ca0fcd.png)

Reference: Maya **Show** menu in viewport:
![afbeelding](https://user-images.githubusercontent.com/2439881/190170377-0b768984-50f3-40d5-9d6c-9cb5889cd0dd.png)

</details>

## Testing notes:

1. Playblast away with nice settings
    - Tweak settings for Extract Review > Viewport Options > Show
    - Publish playblasts with reviews in Maya
2. Test the "displayTextures" option: `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/displayTextures`
3. Test the "HUD" option: `project_settings/maya/publish/ExtractPlayblast/capture_preset/Viewport Options/headsUpDisplay`
