### PR TITLE
Settings + Houdini: Fix missing default settings value for houdini shelf definition

### DIFF
--- a/openpype/settings/defaults/project_settings/houdini.json
+++ b/openpype/settings/defaults/project_settings/houdini.json
@@ -6,7 +6,8 @@
                 "windows": "",
                 "darwin": "",
                 "linux": ""
-            }
+            },
+            "shelf_definition": []
         }
     ],
     "create": {


### PR DESCRIPTION
## Brief description

This #3652 PR introduced a Houdini Shelf Manager - however the `shelf_definition` was missing in default values for the settings and thus OP would complain about it.

## Description

Saved default settings for Houdini.

## Testing notes:

1. Houdini Shelf manager?