### PR TITLE
Tray Publisher: skip plugin if otioTimeline is missing

### DIFF
--- a/openpype/plugins/publish/extract_otio_file.py
+++ b/openpype/plugins/publish/extract_otio_file.py
@@ -16,6 +16,8 @@ class ExtractOTIOFile(publish.Extractor):
     hosts = ["resolve", "hiero", "traypublisher"]
 
     def process(self, instance):
+        if not instance.context.data.get("otioTimeline"):
+            return
         # create representation data
         if "representations" not in instance.data:
             instance.data["representations"] = []


### PR DESCRIPTION
## Fix

This is quick fix for publishing workfile with tray publisher, skipping **Extract OTIO File** if data is missing on instance.

It should be fixed more thoroughly but I hadn't time to dig deeper as how this OTIO stuff works with workfilles and this is needed by client.