### PR TITLE
Flame: make migratable projects after creation

### DIFF
--- a/openpype/hosts/flame/hooks/pre_flame_setup.py
+++ b/openpype/hosts/flame/hooks/pre_flame_setup.py
@@ -129,7 +129,7 @@ class FlamePrelaunch(PreLaunchHook):
                     for name in set(dirs) | set(files):
                         path = os.path.join(root, name)
                         st = os.stat(path)
-                        if oct(st.st_mode) != self.permissions:
+                        if oct(st.st_mode) != self.permisisons:
                             os.chmod(path, self.permisisons)
 
                 except OSError as exc:

--- a/openpype/hosts/flame/hooks/pre_flame_setup.py
+++ b/openpype/hosts/flame/hooks/pre_flame_setup.py
@@ -126,12 +126,14 @@ class FlamePrelaunch(PreLaunchHook):
         for dirtm in dirs_to_modify:
             for root, dirs, files in os.walk(dirtm):
                 try:
-                    for d in dirs:
-                        os.chmod(os.path.join(root, d), self.permisisons)
-                    for f in files:
-                        os.chmod(os.path.join(root, f), self.permisisons)
-                except OSError as _E:
-                    self.log.warning("Not able to open files: {}".format(_E))
+                    for name in set(dirs) | set(files):
+                        path = os.path.join(root, name)
+                        st = os.stat(path)
+                        if oct(st.st_mode) != self.permissions:
+                            os.chmod(path, self.permisisons)
+
+                except OSError as exc:
+                    self.log.warning("Not able to open files: {}".format(exc))
 
 
     def _get_flame_fps(self, fps_num):

--- a/openpype/hosts/flame/hooks/pre_flame_setup.py
+++ b/openpype/hosts/flame/hooks/pre_flame_setup.py
@@ -22,6 +22,7 @@ class FlamePrelaunch(PreLaunchHook):
     in environment var FLAME_SCRIPT_DIR.
     """
     app_groups = ["flame"]
+    permisisons = 0o777
 
     wtc_script_path = os.path.join(
         opflame.HOST_DIR, "api", "scripts", "wiretap_com.py")
@@ -38,6 +39,7 @@ class FlamePrelaunch(PreLaunchHook):
         """Hook entry method."""
         project_doc = self.data["project_doc"]
         project_name = project_doc["name"]
+        volume_name = _env.get("FLAME_WIRETAP_VOLUME")
 
         # get image io
         project_anatomy = self.data["anatomy"]
@@ -81,7 +83,7 @@ class FlamePrelaunch(PreLaunchHook):
         data_to_script = {
             # from settings
             "host_name": _env.get("FLAME_WIRETAP_HOSTNAME") or hostname,
-            "volume_name": _env.get("FLAME_WIRETAP_VOLUME"),
+            "volume_name": volume_name,
             "group_name": _env.get("FLAME_WIRETAP_GROUP"),
             "color_policy": str(imageio_flame["project"]["colourPolicy"]),
 
@@ -99,7 +101,38 @@ class FlamePrelaunch(PreLaunchHook):
 
         app_arguments = self._get_launch_arguments(data_to_script)
 
+        # fix project data permission issue
+        self._fix_permissions(project_name, volume_name)
+
         self.launch_context.launch_args.extend(app_arguments)
+
+    def _fix_permissions(self, project_name, volume_name):
+        """Work around for project data permissions
+
+        Reported issue: when project is created locally on one machine,
+        it is impossible to migrate it to other machine. Autodesk Flame
+        is crating some unmanagable files which needs to be opened to 0o777.
+
+        Args:
+            project_name (str): project name
+            volume_name (str): studio volume
+        """
+        dirs_to_modify = [
+            "/usr/discreet/project/{}".format(project_name),
+            "/opt/Autodesk/clip/{}/{}.prj".format(volume_name, project_name),
+            "/usr/discreet/clip/{}/{}.prj".format(volume_name, project_name)
+        ]
+
+        for dirtm in dirs_to_modify:
+            for root, dirs, files in os.walk(dirtm):
+                try:
+                    for d in dirs:
+                        os.chmod(os.path.join(root, d), self.permisisons)
+                    for f in files:
+                        os.chmod(os.path.join(root, f), self.permisisons)
+                except OSError as _E:
+                    self.log.warning("Not able to open files: {}".format(_E))
+
 
     def _get_flame_fps(self, fps_num):
         fps_table = {

--- a/openpype/hosts/flame/hooks/pre_flame_setup.py
+++ b/openpype/hosts/flame/hooks/pre_flame_setup.py
@@ -22,7 +22,7 @@ class FlamePrelaunch(PreLaunchHook):
     in environment var FLAME_SCRIPT_DIR.
     """
     app_groups = ["flame"]
-    permisisons = 0o777
+    permissions = 0o777
 
     wtc_script_path = os.path.join(
         opflame.HOST_DIR, "api", "scripts", "wiretap_com.py")
@@ -129,8 +129,8 @@ class FlamePrelaunch(PreLaunchHook):
                     for name in set(dirs) | set(files):
                         path = os.path.join(root, name)
                         st = os.stat(path)
-                        if oct(st.st_mode) != self.permisisons:
-                            os.chmod(path, self.permisisons)
+                        if oct(st.st_mode) != self.permissions:
+                            os.chmod(path, self.permissions)
 
                 except OSError as exc:
                     self.log.warning("Not able to open files: {}".format(exc))


### PR DESCRIPTION
## Brief description
Flame projects are migratable after they are created.

## Description
It was reported that when project is created by `user01` at `machine01`, Flame is creating its own unmanaged project data which are locked to 722 and therefore they are not migratable to other machines. This is workaround. The process will open immediately all those files after the project is crated. 
