### PR TITLE
Publisher: Increase size of main window

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -30,8 +30,8 @@ from .widgets import (
 
 class PublisherWindow(QtWidgets.QDialog):
     """Main window of publisher."""
-    default_width = 1000
-    default_height = 600
+    default_width = 1200
+    default_height = 700
 
     def __init__(self, parent=None, reset_on_show=None):
         super(PublisherWindow, self).__init__(parent)


### PR DESCRIPTION
## Brief description
Main window of publisher is slighly bigger.

## Description
The publisher window can be bigger then is now to add more space for attributes and create dialog is smaller then the window and is clearly visible it is not the same window - it blended before.

## Testing notes:
1. Open Publisher in a host which has creators (e.g. tray publisher)