### PR TITLE
General: Copy of workfile does not use 'copy' function but 'copyfile'

### DIFF
--- a/openpype/tools/workfiles/files_widget.py
+++ b/openpype/tools/workfiles/files_widget.py
@@ -578,7 +578,7 @@ class FilesWidget(QtWidgets.QWidget):
 
         src = self._get_selected_filepath()
         dst = os.path.join(self._workfiles_root, work_file)
-        shutil.copy(src, dst)
+        shutil.copyfile(src, dst)
 
         self.workfile_created.emit(dst)
 
@@ -675,7 +675,7 @@ class FilesWidget(QtWidgets.QWidget):
             else:
                 self.host.save_file(filepath)
         else:
-            shutil.copy(src_path, filepath)
+            shutil.copyfile(src_path, filepath)
             if isinstance(self.host, IWorkfileHost):
                 self.host.open_workfile(filepath)
             else:


### PR DESCRIPTION
## Brief description
Use function `copyfile` instead of `copy` in which cause some issues on linux distribution.

## Description
Function `copy` also tries to change permissions of file but most of artist users don't have the permissions to change permissions so whole operation crashes after the file is copied.

## Testing notes:
1. Open workfile in a host in linux dist
2. Run `Copy & Open` on some published file
3. File should be copied and opened as expected