### PR TITLE
Settings: Add missing default settings

### DIFF
--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -36,22 +36,7 @@
                 "layout"
             ]
         },
-        "ExtractBlendAnimation": {
-            "enabled": true,
-            "optional": true,
-            "active": true
-        },
-        "ExtractCamera": {
-            "enabled": true,
-            "optional": true,
-            "active": true
-        },
         "ExtractFBX": {
-            "enabled": true,
-            "optional": true,
-            "active": false
-        },
-        "ExtractAnimationFBX": {
             "enabled": true,
             "optional": true,
             "active": false
@@ -60,6 +45,21 @@
             "enabled": true,
             "optional": true,
             "active": false
+        },
+        "ExtractBlendAnimation": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        },
+        "ExtractAnimationFBX": {
+            "enabled": true,
+            "optional": true,
+            "active": false
+        },
+        "ExtractCamera": {
+            "enabled": true,
+            "optional": true,
+            "active": true
         },
         "ExtractLayout": {
             "enabled": true,

--- a/openpype/settings/defaults/project_settings/houdini.json
+++ b/openpype/settings/defaults/project_settings/houdini.json
@@ -6,7 +6,8 @@
                 "windows": "",
                 "darwin": "",
                 "linux": ""
-            }
+            },
+            "shelf_definition": []
         }
     ],
     "create": {


### PR DESCRIPTION
## Brief description
Added missing default settings for houdini shelf. Blender settings are saved in different order.

## Testing notes:
1. Houdini settings should not be blue on settings open