### PR TITLE
Remove lockfile during publish

### DIFF
--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -1,5 +1,9 @@
 import pyblish.api
-
+from openpype.pipeline.workfile.lock_workfile import(
+    is_workfile_lock_enabled,
+    remove_workfile_lock
+)
+from openpype.pipeline import legacy_io
 
 class SaveCurrentScene(pyblish.api.ContextPlugin):
     """Save current scene
@@ -23,5 +27,8 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
                            "are no modifications..")
             return
 
+        active_project = legacy_io.active_project()
+        if is_workfile_lock_enabled("maya", active_project):
+            remove_workfile_lock(current)
         self.log.info("Saving current file..")
         cmds.file(save=True, force=True)

--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -3,7 +3,7 @@ from openpype.pipeline.workfile.lock_workfile import (
     is_workfile_lock_enabled,
     remove_workfile_lock
 )
-from openpype.pipeline import legacy_io
+
 
 class SaveCurrentScene(pyblish.api.ContextPlugin):
     """Save current scene

--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -26,10 +26,10 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
             self.log.debug("Skipping file save as there "
                            "are no modifications..")
             return
-
-        active_project = legacy_io.active_project()
+        project_name = context.data["projectName"]
+        project_settings = context.data["project_settings"]
         # remove lockfile before saving
-        if is_workfile_lock_enabled("maya", active_project):
+        if is_workfile_lock_enabled("maya", project_name, project_settings):
             remove_workfile_lock(current)
         self.log.info("Saving current file..")
         cmds.file(save=True, force=True)

--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -1,4 +1,5 @@
 import pyblish.api
+
 from openpype.pipeline.workfile.lock_workfile import(
     is_workfile_lock_enabled,
     remove_workfile_lock
@@ -28,6 +29,7 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
             return
 
         active_project = legacy_io.active_project()
+        # remove lockfile before saving
         if is_workfile_lock_enabled("maya", active_project):
             remove_workfile_lock(current)
         self.log.info("Saving current file..")

--- a/openpype/hosts/maya/plugins/publish/save_scene.py
+++ b/openpype/hosts/maya/plugins/publish/save_scene.py
@@ -1,6 +1,5 @@
 import pyblish.api
-
-from openpype.pipeline.workfile.lock_workfile import(
+from openpype.pipeline.workfile.lock_workfile import (
     is_workfile_lock_enabled,
     remove_workfile_lock
 )


### PR DESCRIPTION
## Brief description
During publish, the lockfile isn't removed currently for the maya scene when incrementing and saving the scene.\

### Solution
Adding the remove_lockfile function in `save_scene.py`
