### PR TITLE
OP-1233/ Import Reference during Publish

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_look.py
+++ b/openpype/hosts/maya/plugins/create/create_look.py
@@ -21,6 +21,9 @@ class CreateLook(plugin.Creator):
         # Whether to automatically convert the textures to .tx upon publish.
         self.data["maketx"] = self.make_tx
 
+        # Enable users to import reference
+        self.data["importReference"] = False
+
         # Enable users to force a copy.
         # - on Windows is "forceCopy" always changed to `True` because of
         #   windows implementation of hardlinks

--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -255,6 +255,14 @@ class ExtractLook(publish.Extractor):
         hashes = results["fileHashes"]
         remap = results["attrRemap"]
 
+        # Import Reference if the option is enabled
+        ref_import = instance.data.get("importReference", True)
+        if ref_import:
+            reference_node = cmds.ls(type="reference")
+            for r in reference_node:
+                rFile = cmds.referenceQuery(r, f=True)
+                cmds.file(rFile, importReference=True)
+
         # Extract in correct render layer
         layer = instance.data.get("renderlayer", "defaultRenderLayer")
         with lib.renderlayer(layer):


### PR DESCRIPTION
## Brief description
The references are imported during publish if you set the attribute of "import reference" in look instance to True. So if the users want to import references, they can enable the function. While they dont want, they can just leave it by default(which doesn't import any reference). 
![image](https://user-images.githubusercontent.com/64118225/190650565-1bbb2c16-08e7-4367-a050-f0491fa5ea98.png)

