### PR TITLE
Publisher: Nice checkbox visible in Python 2

### DIFF
--- a/openpype/widgets/nice_checkbox.py
+++ b/openpype/widgets/nice_checkbox.py
@@ -111,14 +111,14 @@ class NiceCheckbox(QtWidgets.QFrame):
         return QtCore.QSize(width, height)
 
     def get_width_hint_by_height(self, height):
-        return (
-            height / self._base_size.height()
-        ) * self._base_size.width()
+        return int((
+            float(height) / self._base_size.height()
+        ) * self._base_size.width())
 
     def get_height_hint_by_width(self, width):
-        return (
-            width / self._base_size.width()
-        ) * self._base_size.height()
+        return int((
+            float(width) / self._base_size.width()
+        ) * self._base_size.height())
 
     def setFixedHeight(self, *args, **kwargs):
         self._fixed_height_set = True
@@ -321,7 +321,7 @@ class NiceCheckbox(QtWidgets.QFrame):
             bg_color = self.unchecked_bg_color
 
         else:
-            offset_ratio = self._current_step / self._steps
+            offset_ratio = float(self._current_step) / self._steps
             # Animation bg
             bg_color = self.steped_color(
                 self.checked_bg_color,
@@ -332,7 +332,8 @@ class NiceCheckbox(QtWidgets.QFrame):
         margins_ratio = self._checker_margins_divider
         if margins_ratio > 0:
             size_without_margins = int(
-                (frame_rect.height() / margins_ratio) * (margins_ratio - 2)
+                (float(frame_rect.height()) / margins_ratio)
+                * (margins_ratio - 2)
             )
             size_without_margins -= size_without_margins % 2
             margin_size_c = ceil(
@@ -434,21 +435,21 @@ class NiceCheckbox(QtWidgets.QFrame):
     def _get_enabled_icon_path(
         self, painter, checker_rect, step=None, half_steps=None
     ):
-        fifteenth = checker_rect.height() / 15
+        fifteenth = float(checker_rect.height()) / 15
         # Left point
         p1 = QtCore.QPoint(
-            checker_rect.x() + (5 * fifteenth),
-            checker_rect.y() + (9 * fifteenth)
+            int(checker_rect.x() + (5 * fifteenth)),
+            int(checker_rect.y() + (9 * fifteenth))
         )
         # Middle bottom point
         p2 = QtCore.QPoint(
             checker_rect.center().x(),
-            checker_rect.y() + (11 * fifteenth)
+            int(checker_rect.y() + (11 * fifteenth))
         )
         # Top right point
         p3 = QtCore.QPoint(
-            checker_rect.x() + (10 * fifteenth),
-            checker_rect.y() + (5 * fifteenth)
+            int(checker_rect.x() + (10 * fifteenth)),
+            int(checker_rect.y() + (5 * fifteenth))
         )
         if step is not None:
             multiplier = (half_steps - step)
@@ -458,16 +459,16 @@ class NiceCheckbox(QtWidgets.QFrame):
             p3c = p3 - checker_rect.center()
 
             p1o = QtCore.QPoint(
-                (p1c.x() / half_steps) * multiplier,
-                (p1c.y() / half_steps) * multiplier
+                int((float(p1c.x()) / half_steps) * multiplier),
+                int((float(p1c.y()) / half_steps) * multiplier)
             )
             p2o = QtCore.QPoint(
-                (p2c.x() / half_steps) * multiplier,
-                (p2c.y() / half_steps) * multiplier
+                int((float(p2c.x()) / half_steps) * multiplier),
+                int((float(p2c.y()) / half_steps) * multiplier)
             )
             p3o = QtCore.QPoint(
-                (p3c.x() / half_steps) * multiplier,
-                (p3c.y() / half_steps) * multiplier
+                int((float(p3c.x()) / half_steps) * multiplier),
+                int((float(p3c.y()) / half_steps) * multiplier)
             )
 
             p1 -= p1o
@@ -484,11 +485,12 @@ class NiceCheckbox(QtWidgets.QFrame):
         self, painter, checker_rect, step=None, half_steps=None
     ):
         center_point = QtCore.QPointF(
-            checker_rect.width() / 2, checker_rect.height() / 2
+            float(checker_rect.width()) / 2,
+            float(checker_rect.height()) / 2
         )
-        offset = (
+        offset = float((
             (center_point + QtCore.QPointF(0, 0)) / 2
-        ).x() / 4 * 5
+        ).x()) / 4 * 5
         if step is not None:
             diff = center_point.x() - offset
             diff_offset = (diff / half_steps) * (half_steps - step)


### PR DESCRIPTION
## Brief description
NiceCheckbox widget should work in Python 2 environment.

## Description
NiceCheckbox is expecting auto-conversions to float which does not happen in Python 2 so it's width is `0` and the checker does not move. By converting numbers to float at all places where it's expected should be the issue resolved.

## Additional information
I don't have any Python 2 application available so let me know if something does not work.

## Testing notes:
1. Open Publisher in DCC with Python 2 (e.g. Houdini 18.5)
2. Checkboxes should be visible and should behave right way on changing check state

Resolves https://github.com/pypeclub/OpenPype/issues/3782