### PR TITLE
Maya: Render Settings remove double setting of additional attributes for Arnold

### DIFF
--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -133,20 +133,7 @@ class RenderSettings(object):
 
         cmds.setAttr(
             "defaultArnoldDriver.mergeAOVs", multi_exr)
-        # Passes additional options in from the schema as a list
-        # but converts it to a dictionary because ftrack doesn't
-        # allow fullstops in custom attributes. Then checks for
-        # type of MtoA attribute passed to adjust the `setAttr`
-        # command accordingly.
         self._additional_attribs_setter(additional_options)
-        for item in additional_options:
-            attribute, value = item
-            if (cmds.getAttr(str(attribute), type=True)) == "long":
-                cmds.setAttr(str(attribute), int(value))
-            elif (cmds.getAttr(str(attribute), type=True)) == "bool":
-                cmds.setAttr(str(attribute), int(value), type = "Boolean") # noqa
-            elif (cmds.getAttr(str(attribute), type=True)) == "string":
-                cmds.setAttr(str(attribute), str(value), type = "string") # noqa
         reset_frame_range()
 
     def _set_redshift_settings(self, width, height):

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -217,7 +217,6 @@ class RenderSettings(object):
         cmds.setAttr("defaultRenderGlobals.extensionPadding", 4)
 
     def _additional_attribs_setter(self, additional_attribs):
-        print(additional_attribs)
         for item in additional_attribs:
             attribute, value = item
             if (cmds.getAttr(str(attribute), type=True)) == "long":

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -228,6 +228,8 @@ class RenderSettings(object):
                 cmds.setAttr(attribute, int(value))
             elif attribute_type == "string":
                 cmds.setAttr(attribute, str(value), type="string")
+            elif attribute_type in {"double", "doubleAngle", "doubleLinear"}:
+                cmds.setAttr(attribute, float(value))
             else:
                 self.log.error(
                     "Attribute {attribute} can not be set due to unsupported "


### PR DESCRIPTION
## Brief description

I'm noticing a lot of "duplicated" code and logic that contradicts itself in separate areas regarding Maya + Render Settings. Specifically:
- Sometimes checking the project settings and sometimes using a hardcoded default
- `lib_rendersettings` is totally decoupled from the validating of the rendersettings. This should be unified where possible.

The issue is relatively widespread so I'm not sure how to best clean this without going into a big refactor of logic. As such, I'll try to make tiny PRs for each individual problem where I can first.

## Description

Remove double setting of additional attributes for Arnold renderer.

## Testing notes:

1. Create render settings for arnold (with the "set render settings" enabled in settings)