### PR TITLE
Maya: RenderSettings set default image format for V-Ray+Redshift to exr

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -49,7 +49,7 @@
         "vray_renderer": {
             "image_prefix": "maya/<scene>/<Layer>/<Layer>",
             "engine": "1",
-            "image_format": "png",
+            "image_format": "exr",
             "aov_list": [],
             "additional_options": []
         },
@@ -57,7 +57,7 @@
             "image_prefix": "maya/<Scene>/<RenderLayer>/<RenderLayer>",
             "primary_gi_engine": "0",
             "secondary_gi_engine": "0",
-            "image_format": "iff",
+            "image_format": "exr",
             "multilayer_exr": true,
             "force_combine": true,
             "aov_list": [],


### PR DESCRIPTION
## Brief description

 Set default image format for V-Ray+Redshift to `exr` instead of `png` and `iff` in OP settings.

## Testing notes:

1. Test setting default rendersettings with V-Ray and Redshfit.