### PR TITLE
changed default image prefix to comply with multilayer exr Maya Arnold render settings

### DIFF
--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -39,7 +39,7 @@
         "aov_separator": "underscore",
         "reset_current_frame": false,
         "arnold_renderer": {
-            "image_prefix": "maya/<Scene>/<RenderLayer>/<RenderLayer>",
+            "image_prefix": "maya/<Scene>/<RenderLayer>/<RenderLayer>{aov_separator}<RenderPass>",
             "image_format": "exr",
             "multilayer_exr": true,
             "tiled": true,

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -39,7 +39,7 @@
         "aov_separator": "underscore",
         "reset_current_frame": false,
         "arnold_renderer": {
-            "image_prefix": "maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>",
+            "image_prefix": "maya/<Scene>/<RenderLayer>/<RenderLayer>",
             "image_format": "exr",
             "multilayer_exr": true,
             "tiled": true,


### PR DESCRIPTION
our defaults for Arnold renderer have conflict of Multilayer exr and `<RenderPass>` image token

![image](https://user-images.githubusercontent.com/352795/191027121-dbc8f143-0fec-49da-b073-830c6253e5d9.png)
 

![image](https://user-images.githubusercontent.com/352795/191027353-300c231a-909e-4368-bda4-f31f50b25318.png)
