### PR TITLE
Photoshop: review can be turned off

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_review.py
@@ -25,6 +25,8 @@ class CollectReview(pyblish.api.ContextPlugin):
     hosts = ["photoshop"]
     order = pyblish.api.CollectorOrder + 0.1
 
+    publish = True
+
     def process(self, context):
         family = "review"
         subset = get_subset_name(
@@ -45,5 +47,6 @@ class CollectReview(pyblish.api.ContextPlugin):
             "family": family,
             "families": [],
             "representations": [],
-            "asset": os.environ["AVALON_ASSET"]
+            "asset": os.environ["AVALON_ASSET"],
+            "publish": self.publish
         })

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -15,6 +15,9 @@
         "CollectInstances": {
             "flatten_subset_template": ""
         },
+        "CollectReview": {
+            "publish": true
+        },
         "ValidateContainers": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -132,6 +132,19 @@
                     ]
                 },
                 {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "CollectReview",
+                    "label": "Collect Review",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "publish",
+                            "label": "Publish review"
+                        }
+                    ]
+                },
+                {
                     "type": "schema_template",
                     "name": "template_publish_plugin",
                     "template_data": [

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -140,7 +140,7 @@
                         {
                             "type": "boolean",
                             "key": "publish",
-                            "label": "Publish review"
+                            "label": "Active"
                         }
                     ]
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_photoshop.json
@@ -145,6 +145,7 @@
                      ]
                  },
                  {
+                    "type": "dict",
                     "key": "CollectVersion",
                     "label": "Collect Version",
                     "children": [


### PR DESCRIPTION
## Brief description
Creating review in Photoshop is configurable by settings

## Description
Some studio might want to skip creating and publishing review by default. Now it could be configured in 
`project_settings/photoshop/publish/CollectReview/publish`.

Artist might always override by clicking on a square icon next to review.

![image](https://user-images.githubusercontent.com/4457962/191027388-d4a574b6-835f-4522-88ef-fe4fd35eb662.png)


## Testing notes:
1. Disable publishing of review in `project_settings/photoshop/publish/CollectReview/publish`
2. Publish in PS - Extract REview, Extract Burnins should be skipped
3. 
![collect_review](https://user-images.githubusercontent.com/4457962/191029051-a98c6ab7-88c2-42ad-9a8c-cd81eec0b78c.png)
