### PR TITLE
Fix kitsu openpype sync without project resolution

### DIFF
--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -18,7 +18,7 @@ from openpype.client import (
     create_project,
 )
 from openpype.pipeline import AvalonMongoDB
-from openpype.settings import get_project_settings, get_anatomy_settings
+from openpype.settings import get_project_settings
 from openpype.modules.kitsu.utils.credentials import validate_credentials
 
 
@@ -262,24 +262,19 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
         # Update Zou
         gazu.project.update_project(project)
 
-    project_attributes = get_anatomy_settings(project_name)['attributes']
-    if "x" in project["resolution"]:
-        resolutionWidth = int(project["resolution"].split("x")[0])
-        resolutionHeight = int(project["resolution"].split("x")[1])
-    else:
-        resolutionWidth = project_attributes['resolutionWidth']
-        resolutionHeight = project_attributes['resolutionHeight']
-
     # Update data
     project_data.update(
         {
             "code": project_code,
             "fps": float(project["fps"]),
-            "resolutionWidth": resolutionWidth,
-            "resolutionHeight": resolutionHeight,
             "zou_id": project["id"],
         }
     )
+
+    proj_res = project["resolution"]
+    if "x" in proj_res:
+        project_data['resolutionWidth'] = int(proj_res.split("x")[0])
+        project_data['resolutionHeight'] = int(proj_res.split("x")[1])
 
     return UpdateOne(
         {"_id": project_doc["_id"]},

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -279,8 +279,8 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
         project_data['resolutionWidth'] = match_res.group(1)
         project_data['resolutionHeight'] = match_res.group(2)
     else:
-        log.warning(f"\'{project['resolution']}\' does not match the expected "\
-            "format for the resolution, for example: 1920x1080")
+        log.warning(f"\'{project['resolution']}\' does not match the "
+            "expected format for the resolution, for example: 1920x1080")
 
     return UpdateOne(
         {"_id": project_doc["_id"]},

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -276,8 +276,8 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
 
     match_res = re.match(r"(\d+)x(\d+)", project["resolution"])
     if match_res:
-        project_data['resolutionWidth'] = match_res.group(1)
-        project_data['resolutionHeight'] = match_res.group(2)
+        project_data['resolutionWidth'] = int(match_res.group(1))
+        project_data['resolutionHeight'] = int(match_res.group(2))
     else:
         log.warning(f"\'{project['resolution']}\' does not match the expected"
                     " format for the resolution, for example: 1920x1080")

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -279,8 +279,8 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
         project_data['resolutionWidth'] = match_res.group(1)
         project_data['resolutionHeight'] = match_res.group(2)
     else:
-        log.warning(f"\'{project['resolution']}\' does not match the "
-            "expected format for the resolution, for example: 1920x1080")
+        log.warning(f"\'{project['resolution']}\' does not match the expected"
+                    " format for the resolution, for example: 1920x1080")
 
     return UpdateOne(
         {"_id": project_doc["_id"]},

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -82,7 +82,7 @@ def update_op_assets(
         List[Dict[str, dict]]: List of (doc_id, update_dict) tuples
     """
     project_name = project_doc["name"]
-    # project_module_settings = get_project_settings(project_name)["kitsu"]
+    project_module_settings = get_project_settings(project_name)["kitsu"]
 
     assets_with_update = []
     for item in entities_list:

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -18,7 +18,7 @@ from openpype.client import (
     create_project,
 )
 from openpype.pipeline import AvalonMongoDB
-from openpype.settings import get_project_settings
+from openpype.settings import get_project_settings, get_anatomy_settings
 from openpype.modules.kitsu.utils.credentials import validate_credentials
 
 
@@ -82,7 +82,7 @@ def update_op_assets(
         List[Dict[str, dict]]: List of (doc_id, update_dict) tuples
     """
     project_name = project_doc["name"]
-    project_module_settings = get_project_settings(project_name)["kitsu"]
+    # project_module_settings = get_project_settings(project_name)["kitsu"]
 
     assets_with_update = []
     for item in entities_list:
@@ -230,7 +230,6 @@ def update_op_assets(
                     },
                 )
             )
-
     return assets_with_update
 
 
@@ -263,13 +262,21 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
         # Update Zou
         gazu.project.update_project(project)
 
+    project_attributes = get_anatomy_settings(project_name)['attributes']
+    if "x" in project["resolution"]:
+        resolutionWidth = int(project["resolution"].split("x")[0])
+        resolutionHeight = int(project["resolution"].split("x")[1])
+    else:
+        resolutionWidth = project_attributes['resolutionWidth']
+        resolutionHeight = project_attributes['resolutionHeight']
+
     # Update data
     project_data.update(
         {
             "code": project_code,
             "fps": float(project["fps"]),
-            "resolutionWidth": int(project["resolution"].split("x")[0]),
-            "resolutionHeight": int(project["resolution"].split("x")[1]),
+            "resolutionWidth": resolutionWidth,
+            "resolutionHeight": resolutionHeight,
             "zou_id": project["id"],
         }
     )


### PR DESCRIPTION
## Brief description
In the case where the resolution of the project has been removed by a soft user that the resolution does not contain x, the update of openpype by zou crashes.

## Description
In case the character 'x' is not in the resolution of kitsu, this information is not updated.
