### PR TITLE
Publisher: Files Drag n Drop cleanup

### DIFF
--- a/openpype/widgets/attribute_defs/files_widget.py
+++ b/openpype/widgets/attribute_defs/files_widget.py
@@ -138,11 +138,13 @@ class DropEmpty(QtWidgets.QWidget):
             allowed_items = [item + "s" for item in allowed_items]
 
         if not allowed_items:
+            self._drop_label_widget.setVisible(False)
             self._items_label_widget.setText(
                 "It is not allowed to add anything here!"
             )
             return
 
+        self._drop_label_widget.setVisible(True)
         items_label = "Multiple "
         if self._single_item:
             items_label = "Single "

--- a/openpype/widgets/attribute_defs/files_widget.py
+++ b/openpype/widgets/attribute_defs/files_widget.py
@@ -245,7 +245,13 @@ class FilesModel(QtGui.QStandardItemModel):
         return self._id
 
     def _on_about_to_be_removed(self, parent_index, start, end):
-        # Make sure items are removed from cache
+        """Make sure that removed items are removed from items mapping.
+
+        Connected with '_on_insert'. When user drag item and drop it to same
+        view the item is actually removed and creted again but it happens in
+        inner calls of Qt.
+        """
+
         for row in range(start, end + 1):
             index = self.index(row, 0, parent_index)
             item_id = index.data(ITEM_ID_ROLE)
@@ -253,6 +259,13 @@ class FilesModel(QtGui.QStandardItemModel):
                 self._items_by_id.pop(item_id, None)
 
     def _on_insert(self, parent_index, start, end):
+        """Make sure new added items are stored in items mapping.
+
+        Connected to '_on_about_to_be_removed'. Some items are not created
+        using '_create_item' but are recreated using Qt. So the item is not in
+        mapping and if it would it would not lead to same item pointer.
+        """
+
         for row in range(start, end + 1):
             index = self.index(start, end, parent_index)
             item_id = index.data(ITEM_ID_ROLE)

--- a/openpype/widgets/attribute_defs/files_widget.py
+++ b/openpype/widgets/attribute_defs/files_widget.py
@@ -594,6 +594,13 @@ class FilesView(QtWidgets.QListView):
 
         self._remove_btn.setVisible(not multivalue)
 
+    def update_remove_btn_visibility(self):
+        model = self.model()
+        visible = False
+        if model:
+            visible = model.rowCount() > 0
+        self._remove_btn.setVisible(visible)
+
     def has_selected_item_ids(self):
         """Is any index selected."""
         for index in self.selectionModel().selectedIndexes():
@@ -657,6 +664,7 @@ class FilesView(QtWidgets.QListView):
     def showEvent(self, event):
         super(FilesView, self).showEvent(event)
         self._update_remove_btn()
+        self.update_remove_btn_visibility()
 
 
 class FilesWidget(QtWidgets.QFrame):
@@ -968,3 +976,4 @@ class FilesWidget(QtWidgets.QFrame):
         files_exists = self._files_proxy_model.rowCount() > 0
         self._files_view.setVisible(files_exists)
         self._empty_widget.setVisible(not files_exists)
+        self._files_view.update_remove_btn_visibility()

--- a/openpype/widgets/attribute_defs/files_widget.py
+++ b/openpype/widgets/attribute_defs/files_widget.py
@@ -784,6 +784,8 @@ class FilesWidget(QtWidgets.QFrame):
         if not self._in_set_value:
             self.value_changed.emit()
 
+        self._update_visibility()
+
     def _on_rows_removed(self, parent_index, start_row, end_row):
         available_item_ids = set()
         for row in range(self._files_proxy_model.rowCount()):
@@ -803,6 +805,7 @@ class FilesWidget(QtWidgets.QFrame):
 
         if not self._in_set_value:
             self.value_changed.emit()
+        self._update_visibility()
 
     def _on_split_request(self):
         if self._multivalue:
@@ -966,11 +969,9 @@ class FilesWidget(QtWidgets.QFrame):
 
     def _add_filepaths(self, filepaths):
         self._files_model.add_filepaths(filepaths)
-        self._update_visibility()
 
     def _remove_item_by_ids(self, item_ids):
         self._files_model.remove_item_by_ids(item_ids)
-        self._update_visibility()
 
     def _update_visibility(self):
         files_exists = self._files_proxy_model.rowCount() > 0


### PR DESCRIPTION
## Brief description
Cleanup code of files widgets used in publisher.

## Description
Handle moving around of items in files widget. Stack widgets in files widget to handle their size hints. Proper showing of empty widget on moving items around. Hide Drag'n'Drop label if user can't drop any.

## Additional info
Files widget changed a look when have no items in. The view is painted underneath so the beackground is dark grey.

### Screenshot
![image](https://user-images.githubusercontent.com/43494761/191208246-7cd0bb2d-9f1d-43bf-ac76-bee822383ca0.png)

## Testing notes:
1. Open TrayPublisher where files widget is available
2. Try to play with it to validate if reported issues that should be resolved do not happen.

Resolves https://github.com/pypeclub/OpenPype/issues/3837
Resolves https://github.com/pypeclub/OpenPype/issues/3836