### PR TITLE
Fix - hardlink issue in integrate Hero

### DIFF
--- a/openpype/plugins/publish/integrate_hero_version.py
+++ b/openpype/plugins/publish/integrate_hero_version.py
@@ -577,8 +577,11 @@ class IntegrateHeroVersion(pyblish.api.InstancePlugin):
             return
 
         except OSError as exc:
-            # re-raise exception if different than cross drive path
-            if exc.errno != errno.EXDEV:
+            # re-raise exception if different than
+            # EXDEV - cross drive path
+            # EINVAL - wrong format, must be NTFS
+            self.log.debug("Hardlink failed with errno:'{}'".format(exc.errno))
+            if exc.errno not in [errno.EXDEV, errno.EINVAL]:
                 raise
 
         shutil.copy(src_path, dst_path)


### PR DESCRIPTION
## Brief description
Disk must be NTFS format or it will throw "[WinError 1", which matches to EINVAL. Still raise different errors.

## Description
Occured on disk formatted by `exFAT`.

## Testing notes:
1. publish Hero version