### PR TITLE
Fix typo in ContainersFilterResult namedtuple `not_foud` -> `not_found`

### DIFF
--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 
 ContainersFilterResult = collections.namedtuple(
     "ContainersFilterResult",
-    ["latest", "outdated", "not_foud", "invalid"]
+    ["latest", "outdated", "not_found", "invalid"]
 )
 
 
@@ -808,7 +808,7 @@ def filter_containers(containers, project_name):
 
     Categories are 'latest', 'outdated', 'invalid' and 'not_found'.
     The 'lastest' containers are from last version, 'outdated' are not,
-    'invalid' are invalid containers (invalid content) and 'not_foud' has
+    'invalid' are invalid containers (invalid content) and 'not_found' has
     some missing entity in database.
 
     Args:


### PR DESCRIPTION
## Brief description

Fixes typo. Good to refactor now since it's pretty much unused.

## Testing notes:

1. Run some `filter_containers` and make sure there is one that's not found.