### PR TITLE
Publisher: Enhancement proposals

### DIFF
--- a/openpype/host/__init__.py
+++ b/openpype/host/__init__.py
@@ -5,6 +5,7 @@ from .host import (
 from .interfaces import (
     IWorkfileHost,
     ILoadHost,
+    IPublishHost,
     INewPublisher,
 )
 
@@ -16,6 +17,7 @@ __all__ = (
 
     "IWorkfileHost",
     "ILoadHost",
+    "IPublishHost",
     "INewPublisher",
 
     "HostDirmap",

--- a/openpype/host/interfaces.py
+++ b/openpype/host/interfaces.py
@@ -282,7 +282,7 @@ class IWorkfileHost:
         return self.workfile_has_unsaved_changes()
 
 
-class INewPublisher:
+class IPublishHost:
     """Functions related to new creation system in new publisher.
 
     New publisher is not storing information only about each created instance
@@ -306,7 +306,7 @@ class INewPublisher:
                 workflow.
         """
 
-        if isinstance(host, INewPublisher):
+        if isinstance(host, IPublishHost):
             return []
 
         required = [
@@ -330,7 +330,7 @@ class INewPublisher:
             MissingMethodsError: If there are missing methods on host
                 implementation.
         """
-        missing = INewPublisher.get_missing_publish_methods(host)
+        missing = IPublishHost.get_missing_publish_methods(host)
         if missing:
             raise MissingMethodsError(host, missing)
 
@@ -368,3 +368,7 @@ class INewPublisher:
         """
 
         pass
+
+
+class INewPublisher(IPublishHost):
+    pass

--- a/openpype/host/interfaces.py
+++ b/openpype/host/interfaces.py
@@ -371,4 +371,14 @@ class IPublishHost:
 
 
 class INewPublisher(IPublishHost):
+    """Legacy interface replaced by 'IPublishHost'.
+
+    Deprecated:
+        'INewPublisher' is replaced by 'IPublishHost' please change your
+        imports.
+        There is no "reasonable" way hot mark these classes as deprecated
+        to show warning of wrong import. Deprecated since 3.14.* will be
+        removed in 3.15.*
+    """
+
     pass

--- a/openpype/hosts/traypublisher/api/pipeline.py
+++ b/openpype/hosts/traypublisher/api/pipeline.py
@@ -9,7 +9,7 @@ from openpype.pipeline import (
     register_creator_plugin_path,
     legacy_io,
 )
-from openpype.host import HostBase, INewPublisher
+from openpype.host import HostBase, IPublishHost
 
 
 ROOT_DIR = os.path.dirname(os.path.dirname(
@@ -19,7 +19,7 @@ PUBLISH_PATH = os.path.join(ROOT_DIR, "plugins", "publish")
 CREATE_PATH = os.path.join(ROOT_DIR, "plugins", "create")
 
 
-class TrayPublisherHost(HostBase, INewPublisher):
+class TrayPublisherHost(HostBase, IPublishHost):
     name = "traypublisher"
 
     def install(self):

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -7,6 +7,10 @@ from uuid import uuid4
 from contextlib import contextmanager
 
 from openpype.client import get_assets
+from openpype.settings import (
+    get_system_settings,
+    get_project_settings
+)
 from openpype.host import INewPublisher
 from openpype.pipeline import legacy_io
 from openpype.pipeline.mongodb import (
@@ -18,11 +22,6 @@ from .creator_plugins import (
     Creator,
     AutoCreator,
     discover_creator_plugins,
-)
-
-from openpype.api import (
-    get_system_settings,
-    get_project_settings
 )
 
 UpdateData = collections.namedtuple("UpdateData", ["instance", "changes"])
@@ -402,6 +401,7 @@ class CreatedInstance:
         self.creator = creator
 
         # Instance members may have actions on them
+        # TODO implement members logic
         self._members = []
 
         # Data that can be used for lifetime of object

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -404,6 +404,9 @@ class CreatedInstance:
         # Instance members may have actions on them
         self._members = []
 
+        # Data that can be used for lifetime of object
+        self._lifetime_data = {}
+
         # Create a copy of passed data to avoid changing them on the fly
         data = copy.deepcopy(data or {})
         # Store original value of passed data
@@ -595,6 +598,26 @@ class CreatedInstance:
         """
 
         return self
+
+    @property
+    def lifetime_data(self):
+        """Data stored for lifetime of instance object.
+
+        These data are not stored to scene and will be lost on object
+        deletion.
+
+        Can be used to store objects. In some host implementations is not
+        possible to reference to object in scene with some unique identifier
+        (e.g. node in Fusion.). In that case it is handy to store the object
+        here. Should be used that way only if instance data are stored on the
+        node itself.
+
+        Returns:
+            Dict[str, Any]: Dictionary object where you can store data related
+                to instance for lifetime of instance object.
+        """
+
+        return self._lifetime_data
 
     def changes(self):
         """Calculate and return changes."""

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -11,7 +11,7 @@ from openpype.settings import (
     get_system_settings,
     get_project_settings
 )
-from openpype.host import INewPublisher
+from openpype.host import IPublishHost
 from openpype.pipeline import legacy_io
 from openpype.pipeline.mongodb import (
     AvalonMongoDB,
@@ -794,7 +794,7 @@ class CreateContext:
         """
 
         missing = set(
-            INewPublisher.get_missing_publish_methods(host)
+            IPublishHost.get_missing_publish_methods(host)
         )
         return missing
 

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -405,7 +405,7 @@ class CreatedInstance:
         self._members = []
 
         # Data that can be used for lifetime of object
-        self._lifetime_data = {}
+        self._transient_data = {}
 
         # Create a copy of passed data to avoid changing them on the fly
         data = copy.deepcopy(data or {})
@@ -600,7 +600,7 @@ class CreatedInstance:
         return self
 
     @property
-    def lifetime_data(self):
+    def transient_data(self):
         """Data stored for lifetime of instance object.
 
         These data are not stored to scene and will be lost on object
@@ -617,7 +617,7 @@ class CreatedInstance:
                 to instance for lifetime of instance object.
         """
 
-        return self._lifetime_data
+        return self._transient_data
 
     def changes(self):
         """Calculate and return changes."""

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -81,6 +81,13 @@ class BaseCreator:
         # - we may use UI inside processing this attribute should be checked
         self.headless = headless
 
+        self.apply_settings(project_settings, system_settings)
+
+    def apply_settings(self, project_settings, system_settings):
+        """Method called on initialization of plugin to apply settings."""
+
+        pass
+
     @property
     def identifier(self):
         """Identifier of creator (must be unique).

--- a/openpype/plugins/publish/collect_from_create_context.py
+++ b/openpype/plugins/publish/collect_from_create_context.py
@@ -26,7 +26,7 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
             instance_data = created_instance.data_to_store()
             if instance_data["active"]:
                 self.create_instance(
-                    context, instance_data, created_instance.lifetime_data
+                    context, instance_data, created_instance.transient_data
                 )
 
         # Update global data to context
@@ -39,7 +39,7 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
                 legacy_io.Session[key] = value
                 os.environ[key] = value
 
-    def create_instance(self, context, in_data, lifetime_data):
+    def create_instance(self, context, in_data, transient_data):
         subset = in_data["subset"]
         # If instance data already contain families then use it
         instance_families = in_data.get("families") or []
@@ -59,7 +59,7 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
             if key not in instance.data:
                 instance.data[key] = value
 
-        instance.data["lifetimeData"] = lifetime_data
+        instance.data["transientData"] = transient_data
 
         self.log.info("collected instance: {}".format(instance.data))
         self.log.info("parsing data: {}".format(in_data))

--- a/openpype/plugins/publish/collect_from_create_context.py
+++ b/openpype/plugins/publish/collect_from_create_context.py
@@ -25,7 +25,9 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
         for created_instance in create_context.instances:
             instance_data = created_instance.data_to_store()
             if instance_data["active"]:
-                self.create_instance(context, instance_data)
+                self.create_instance(
+                    context, instance_data, created_instance.lifetime_data
+                )
 
         # Update global data to context
         context.data.update(create_context.context_data_to_store())
@@ -37,7 +39,7 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
                 legacy_io.Session[key] = value
                 os.environ[key] = value
 
-    def create_instance(self, context, in_data):
+    def create_instance(self, context, in_data, lifetime_data):
         subset = in_data["subset"]
         # If instance data already contain families then use it
         instance_families = in_data.get("families") or []
@@ -56,5 +58,8 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
         for key, value in in_data.items():
             if key not in instance.data:
                 instance.data[key] = value
+
+        instance.data["lifetimeData"] = lifetime_data
+
         self.log.info("collected instance: {}".format(instance.data))
         self.log.info("parsing data: {}".format(in_data))


### PR DESCRIPTION
## Brief description
Proposing possible enhancements related to new publisher.

## Description
Instance object has `lifetime_data` where can creator add objects from scene or other objects not related to instance data, during publishing can be accessed using `lifetimeData` on instance. Renamed `INewPublisher` to `IHostPublish` -> match other interfaces and get rid of "new publisher" (`INewPublisher` kept for backwards compatibility, but we could remove it now?). Creators have method `apply_settings` to simplify initialization.

## Additional information
The `lifetime_data` were requested from Fusion implementation where node name is not enough to be able identify the node. I would say it's reasonable enough to provide this option too.