### PR TITLE
General: Fix links query on hero version

### DIFF
--- a/openpype/client/entity_links.py
+++ b/openpype/client/entity_links.py
@@ -132,7 +132,9 @@ def get_linked_representation_id(
 
     match = {
         "_id": version_id,
-        "type": {"$in": ["version", "hero_version"]}
+        # Links are not stored to hero versions at this moment so filter
+        #   is limited to just versions
+        "type": "version"
     }
 
     graph_lookup = {

--- a/openpype/client/entity_links.py
+++ b/openpype/client/entity_links.py
@@ -189,7 +189,7 @@ def _process_referenced_pipeline_result(result, link_type):
     referenced_version_ids = set()
     correctly_linked_ids = set()
     for item in result:
-        input_links = item["data"].get("inputLinks")
+        input_links = item.get("data", {}).get("inputLinks")
         if not input_links:
             continue
 
@@ -205,7 +205,7 @@ def _process_referenced_pipeline_result(result, link_type):
             continue
 
         for output in sorted(outputs_recursive, key=lambda o: o["depth"]):
-            output_links = output["data"].get("inputLinks")
+            output_links = output.get("data", {}).get("inputLinks")
             if not output_links:
                 continue
 


### PR DESCRIPTION
## Brief description
Fixed function to find links which crashed on hero versions.

## Description
Don't lookup for hero versions in `get_linked_representation_id` because they don't have links. Made safer access to `"data"` key on found items to avoid possible crashes on items without links.

## Testing notes:
1. Run Add to Site action on hero version
2. It should not crash on finding linked representations