### PR TITLE
Bug: Create missing version dir

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -804,6 +804,8 @@ class BootstrapRepos:
         """
         version = OpenPypeVersion.version_in_str(zip_file.name)
         destination_dir = self.data_dir / f"{version.major}.{version.minor}"
+        if not destination_dir.exists():
+            destination_dir.mkdir(parents=True)
         destination = destination_dir / zip_file.name
 
         if destination.exists():


### PR DESCRIPTION
## Bug

In case of clean installation where there are not update zips available, OP tries to create the zip from the build and fails moving it to local app data folder if directory of the version doesn't exists. This PR is fixing it.

### How to test

Delete all versions from local app data. Be sure you have no newer version in update repository. Run Igniter and "install" OP. Everything should work.