### PR TITLE
Photoshop: create single frame image in Ftrack as review

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -195,22 +195,6 @@ class ExtractReview(publish.Extractor):
 
         return source_files_pattern
 
-    def _get_image_path_from_instances(self, instance):
-        img_list = []
-
-        for instance in sorted(instance.context):
-            if instance.data["family"] != "image":
-                continue
-
-            for rep in instance.data["representations"]:
-                img_path = os.path.join(
-                    rep["stagingDir"],
-                    rep["files"]
-                )
-                img_list.append(img_path)
-
-        return img_list
-
     def _copy_image_to_staging_dir(self, staging_dir, img_list):
         copy_files = []
         for i, img_src in enumerate(img_list):

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -164,7 +164,7 @@ class ExtractReview(publish.Extractor):
             "ext": "jpg",
             "files": os.path.basename(thumbnail_path),
             "stagingDir": staging_dir,
-            "tags": ["thumbnail"]
+            "tags": ["thumbnail", "delete"]
         })
 
     def _check_and_resize(self, processed_img_names, source_files_pattern,

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -195,20 +195,6 @@ class ExtractReview(publish.Extractor):
 
         return source_files_pattern
 
-    def _copy_image_to_staging_dir(self, staging_dir, img_list):
-        copy_files = []
-        for i, img_src in enumerate(img_list):
-            img_filename = self.output_seq_filename % i
-            img_dst = os.path.join(staging_dir, img_filename)
-
-            self.log.debug(
-                "Copying file .. {} -> {}".format(img_src, img_dst)
-            )
-            shutil.copy(img_src, img_dst)
-            copy_files.append(img_filename)
-
-        return copy_files
-
     def _get_layers_from_image_instances(self, instance):
         layers = []
         for image_instance in instance.context:

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -87,9 +87,10 @@ class ExtractReview(publish.Extractor):
         self._generate_thumbnail(ffmpeg_path, instance, source_files_pattern,
                                  staging_dir)
 
-        no_of_frames = len(img_list)
-        self._generate_mov(ffmpeg_path, instance, fps, no_of_frames,
-                           source_files_pattern, staging_dir)
+        no_of_frames = len(processed_img_names)
+        if no_of_frames > 1:
+            self._generate_mov(ffmpeg_path, instance, fps, no_of_frames,
+                               source_files_pattern, staging_dir)
 
         self.log.info(f"Extracted {instance} to {staging_dir}")
 

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -120,8 +120,7 @@ class ExtractReview(publish.Extractor):
             mov_path
         ]
         self.log.debug("mov args:: {}".format(args))
-        output = run_subprocess(args)
-        self.log.debug(output)
+        _output = run_subprocess(args)
         instance.data["representations"].append({
             "name": "mov",
             "ext": "mov",
@@ -158,7 +157,7 @@ class ExtractReview(publish.Extractor):
             thumbnail_path
         ]
         self.log.debug("thumbnail args:: {}".format(args))
-        output = run_subprocess(args)
+        _output = run_subprocess(args)
         instance.data["representations"].append({
             "name": "thumbnail",
             "ext": "jpg",

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -162,6 +162,7 @@ class ExtractReview(publish.Extractor):
         instance.data["representations"].append({
             "name": "thumbnail",
             "ext": "jpg",
+            "outputName": "thumb",
             "files": os.path.basename(thumbnail_path),
             "stagingDir": staging_dir,
             "tags": ["thumbnail", "delete"]

--- a/openpype/hosts/photoshop/plugins/publish/extract_review.py
+++ b/openpype/hosts/photoshop/plugins/publish/extract_review.py
@@ -49,7 +49,7 @@ class ExtractReview(publish.Extractor):
 
         if self.make_image_sequence and len(layers) > 1:
             self.log.info("Extract layers to image sequence.")
-            img_list = self._saves_sequences_layers(staging_dir, layers)
+            img_list = self._save_sequence_images(staging_dir, layers)
 
             instance.data["representations"].append({
                 "name": "jpg",
@@ -64,7 +64,7 @@ class ExtractReview(publish.Extractor):
             processed_img_names = img_list
         else:
             self.log.info("Extract layers to flatten image.")
-            img_list = self._saves_flattened_layers(staging_dir, layers)
+            img_list = self._save_flatten_image(staging_dir, layers)
 
             instance.data["representations"].append({
                 "name": "jpg",
@@ -196,6 +196,11 @@ class ExtractReview(publish.Extractor):
         return source_files_pattern
 
     def _get_layers_from_image_instances(self, instance):
+        """Collect all layers from 'instance'.
+
+        Returns:
+            (list) of PSItem
+        """
         layers = []
         for image_instance in instance.context:
             if image_instance.data["family"] != "image":
@@ -207,7 +212,12 @@ class ExtractReview(publish.Extractor):
 
         return sorted(layers)
 
-    def _saves_flattened_layers(self, staging_dir, layers):
+    def _save_flatten_image(self, staging_dir, layers):
+        """Creates flat image from 'layers' into 'staging_dir'.
+
+        Returns:
+            (str): path to new image
+        """
         img_filename = self.output_seq_filename % 0
         output_image_path = os.path.join(staging_dir, img_filename)
         stub = photoshop.stub()
@@ -221,7 +231,13 @@ class ExtractReview(publish.Extractor):
 
         return img_filename
 
-    def _saves_sequences_layers(self, staging_dir, layers):
+    def _save_sequence_images(self, staging_dir, layers):
+        """Creates separate flat images from 'layers' into 'staging_dir'.
+
+        Used as source for multi frames .mov to review at once.
+        Returns:
+            (list): paths to new images
+        """
         stub = photoshop.stub()
 
         list_img_filename = []

--- a/openpype/hosts/traypublisher/api/plugin.py
+++ b/openpype/hosts/traypublisher/api/plugin.py
@@ -11,27 +11,9 @@ from .pipeline import (
     remove_instances,
     HostContext,
 )
+from openpype.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 
-IMAGE_EXTENSIONS = [
-    ".ani", ".anim", ".apng", ".art", ".bmp", ".bpg", ".bsave", ".cal",
-    ".cin", ".cpc", ".cpt", ".dds", ".dpx", ".ecw", ".exr", ".fits",
-    ".flic", ".flif", ".fpx", ".gif", ".hdri", ".hevc", ".icer",
-    ".icns", ".ico", ".cur", ".ics", ".ilbm", ".jbig", ".jbig2",
-    ".jng", ".jpeg", ".jpeg-ls", ".jpeg", ".2000", ".jpg", ".xr",
-    ".jpeg", ".xt", ".jpeg-hdr", ".kra", ".mng", ".miff", ".nrrd",
-    ".ora", ".pam", ".pbm", ".pgm", ".ppm", ".pnm", ".pcx", ".pgf",
-    ".pictor", ".png", ".psb", ".psp", ".qtvr", ".ras",
-    ".rgbe", ".logluv", ".tiff", ".sgi", ".tga", ".tiff", ".tiff/ep",
-    ".tiff/it", ".ufo", ".ufp", ".wbmp", ".webp", ".xbm", ".xcf",
-    ".xpm", ".xwd"
-]
-VIDEO_EXTENSIONS = [
-    ".3g2", ".3gp", ".amv", ".asf", ".avi", ".drc", ".f4a", ".f4b",
-    ".f4p", ".f4v", ".flv", ".gif", ".gifv", ".m2v", ".m4p", ".m4v",
-    ".mkv", ".mng", ".mov", ".mp2", ".mp4", ".mpe", ".mpeg", ".mpg",
-    ".mpv", ".mxf", ".nsv", ".ogg", ".ogv", ".qt", ".rm", ".rmvb",
-    ".roq", ".svi", ".vob", ".webm", ".wmv", ".yuv"
-]
+
 REVIEW_EXTENSIONS = IMAGE_EXTENSIONS + VIDEO_EXTENSIONS
 
 

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -42,6 +42,28 @@ XML_CHAR_REF_REGEX_HEX = re.compile(r"&#x?[0-9a-fA-F]+;")
 # Regex to parse array attributes
 ARRAY_TYPE_REGEX = re.compile(r"^(int|float|string)\[\d+\]$")
 
+IMAGE_EXTENSIONS = [
+    ".ani", ".anim", ".apng", ".art", ".bmp", ".bpg", ".bsave", ".cal",
+    ".cin", ".cpc", ".cpt", ".dds", ".dpx", ".ecw", ".exr", ".fits",
+    ".flic", ".flif", ".fpx", ".gif", ".hdri", ".hevc", ".icer",
+    ".icns", ".ico", ".cur", ".ics", ".ilbm", ".jbig", ".jbig2",
+    ".jng", ".jpeg", ".jpeg-ls", ".jpeg", ".2000", ".jpg", ".xr",
+    ".jpeg", ".xt", ".jpeg-hdr", ".kra", ".mng", ".miff", ".nrrd",
+    ".ora", ".pam", ".pbm", ".pgm", ".ppm", ".pnm", ".pcx", ".pgf",
+    ".pictor", ".png", ".psb", ".psp", ".qtvr", ".ras",
+    ".rgbe", ".logluv", ".tiff", ".sgi", ".tga", ".tiff", ".tiff/ep",
+    ".tiff/it", ".ufo", ".ufp", ".wbmp", ".webp", ".xbm", ".xcf",
+    ".xpm", ".xwd"
+]
+
+VIDEO_EXTENSIONS = [
+    ".3g2", ".3gp", ".amv", ".asf", ".avi", ".drc", ".f4a", ".f4b",
+    ".f4p", ".f4v", ".flv", ".gif", ".gifv", ".m2v", ".m4p", ".m4v",
+    ".mkv", ".mng", ".mov", ".mp2", ".mp4", ".mpe", ".mpeg", ".mpg",
+    ".mpv", ".mxf", ".nsv", ".ogg", ".ogv", ".qt", ".rm", ".rmvb",
+    ".roq", ".svi", ".vob", ".webm", ".wmv", ".yuv"
+]
+
 
 def get_transcode_temp_directory():
     """Creates temporary folder for transcoding.

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -150,38 +150,38 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         # TODO what if there is multiple thumbnails?
         first_thumbnail_component = None
         first_thumbnail_component_repre = None
-        for repre in thumbnail_representations:
-            if review_representations and not has_movie_review:
-                break
-            repre_path = self._get_repre_path(instance, repre, False)
-            if not repre_path:
-                self.log.warning(
-                    "Published path is not set and source was removed."
+
+        if has_movie_review:
+            for repre in thumbnail_representations:
+                repre_path = self._get_repre_path(instance, repre, False)
+                if not repre_path:
+                    self.log.warning(
+                        "Published path is not set and source was removed."
+                    )
+                    continue
+
+                # Create copy of base comp item and append it
+                thumbnail_item = copy.deepcopy(base_component_item)
+                thumbnail_item["component_path"] = repre_path
+                thumbnail_item["component_data"] = {
+                    "name": "thumbnail"
+                }
+                thumbnail_item["thumbnail"] = True
+
+                # Create copy of item before setting location
+                if "delete" not in repre["tags"]:
+                    src_components_to_add.append(copy.deepcopy(thumbnail_item))
+                # Create copy of first thumbnail
+                if first_thumbnail_component is None:
+                    first_thumbnail_component_repre = repre
+                    first_thumbnail_component = thumbnail_item
+                # Set location
+                thumbnail_item["component_location_name"] = (
+                    ftrack_server_location_name
                 )
-                continue
 
-            # Create copy of base comp item and append it
-            thumbnail_item = copy.deepcopy(base_component_item)
-            thumbnail_item["component_path"] = repre_path
-            thumbnail_item["component_data"] = {
-                "name": "thumbnail"
-            }
-            thumbnail_item["thumbnail"] = True
-
-            # Create copy of item before setting location
-            if "delete" not in repre["tags"]:
-                src_components_to_add.append(copy.deepcopy(thumbnail_item))
-            # Create copy of first thumbnail
-            if first_thumbnail_component is None:
-                first_thumbnail_component_repre = repre
-                first_thumbnail_component = thumbnail_item
-            # Set location
-            thumbnail_item["component_location_name"] = (
-                ftrack_server_location_name
-            )
-
-            # Add item to component list
-            component_list.append(thumbnail_item)
+                # Add item to component list
+                component_list.append(thumbnail_item)
 
         if first_thumbnail_component is not None:
             metadata = self._prepare_image_component_metadata(
@@ -455,7 +455,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             streams = get_ffprobe_streams(component_path)
         except Exception:
             self.log.debug(
-                "Failed to retrieve information about " 
+                "Failed to retrieve information about "
                 "input {}".format(component_path))
 
         # Find video streams

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -9,7 +9,7 @@ from openpype.lib.transcoding import (
     convert_ffprobe_fps_to_float,
 )
 from openpype.lib.profiles_filtering import filter_profiles
-from openpype.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
+from openpype.lib.transcoding import VIDEO_EXTENSIONS
 
 
 class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
@@ -454,9 +454,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         try:
             streams = get_ffprobe_streams(component_path)
         except Exception:
-            self.log.debug((
-                               "Failed to retrieve information about input {}"
-                           ).format(component_path))
+            self.log.debug(
+                "Failed to retrieve information about " 
+                "input {}".format(component_path))
 
         # Find video streams
         video_streams = [
@@ -500,9 +500,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                     input_framerate
                 )
             except ValueError:
-                self.log.warning((
-                    "Could not convert ffprobe fps to float \"{}\""
-                                 ).format(input_framerate))
+                self.log.warning(
+                    "Could not convert ffprobe "
+                    "fps to float \"{}\"".format(input_framerate))
                 continue
 
             stream_width = tmp_width
@@ -583,9 +583,9 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             try:
                 streams = get_ffprobe_streams(component_path)
             except Exception:
-                self.log.debug((
-                    "Failed to retrieve information about intput {}"
-                               ).format(component_path))
+                self.log.debug(
+                    "Failed to retrieve information "
+                    "about input {}".format(component_path))
 
             for stream in streams:
                 if "width" in stream and "height" in stream:

--- a/openpype/settings/defaults/project_settings/photoshop.json
+++ b/openpype/settings/defaults/project_settings/photoshop.json
@@ -34,7 +34,10 @@
             "make_image_sequence": false,
             "max_downscale_size": 8192,
             "jpg_options": {
-                "tags": []
+                "tags": [
+                    "review",
+                    "ftrackreview"
+                ]
             },
             "mov_options": {
                 "tags": [


### PR DESCRIPTION
## Brief description
Previously PS was creating .mov even for single frame review. This PR allows to create and upload single image instead.

## Description
Next paragraf is more elaborate text with more info. This will be displayed for example in collapsed form under the first sentence in a changelog.

## Additional info
Still in progress as Play button under Versions metadata is finicky, Play button on thumbnail in version list seems to work fine.


## Testing notes:
![Screenshot 2022-09-20 165806](https://user-images.githubusercontent.com/4457962/192029060-b0b561cf-1e51-4661-b098-4d9cb61ceb0a.png)

1. Double check jpg options for Photoshop ExtractReview in Setting
2. Publish workfile that has single or no `image` instance.
3. Check that `publish/review` folder contains high res review
4. Check in Ftrack by clicking on Thumbnail in Versions list that high res image pops up