### PR TITLE
Publisher: Fix PublishIconButton drawing disabled icon with the color specified

### DIFF
--- a/openpype/style/data.json
+++ b/openpype/style/data.json
@@ -20,7 +20,7 @@
     "color": {
         "font": "#D3D8DE",
         "font-hover": "#F0F2F5",
-        "font-disabled": "#99A3B2",
+        "font-disabled": "#5b6779",
         "font-view-selection": "#ffffff",
         "font-view-hover": "#F0F2F5",
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -125,28 +125,19 @@ class PublishIconBtn(IconButton):
     def __init__(self, pixmap_path, *args, **kwargs):
         super(PublishIconBtn, self).__init__(*args, **kwargs)
 
-        loaded_image = QtGui.QImage(pixmap_path)
+        icon = self.generate_icon(pixmap_path,
+                                  enabled_color=QtCore.Qt.white,
+                                  disabled_color=QtGui.QColor("#5b6779"))
+        self.setIcon(icon)
 
-        pixmap = self.paint_image_with_color(loaded_image, QtCore.Qt.white)
-
-        self._base_image = loaded_image
-        self._enabled_icon = QtGui.QIcon(pixmap)
-        self._disabled_icon = None
-
-        self.setIcon(self._enabled_icon)
-
-    def get_enabled_icon(self):
-        """Enabled icon."""
-        return self._enabled_icon
-
-    def get_disabled_icon(self):
-        """Disabled icon."""
-        if self._disabled_icon is None:
-            pixmap = self.paint_image_with_color(
-                self._base_image, QtCore.Qt.gray
-            )
-            self._disabled_icon = QtGui.QIcon(pixmap)
-        return self._disabled_icon
+    def generate_icon(self, pixmap_path, enabled_color, disabled_color):
+        icon = QtGui.QIcon()
+        image = QtGui.QImage(pixmap_path)
+        enabled_pixmap = self.paint_image_with_color(image, enabled_color)
+        icon.addPixmap(enabled_pixmap, icon.Normal)
+        disabled_pixmap = self.paint_image_with_color(image, disabled_color)
+        icon.addPixmap(disabled_pixmap, icon.Disabled)
+        return icon
 
     @staticmethod
     def paint_image_with_color(image, color):
@@ -186,13 +177,6 @@ class PublishIconBtn(IconButton):
         painter.end()
 
         return pixmap
-
-    def setEnabled(self, enabled):
-        super(PublishIconBtn, self).setEnabled(enabled)
-        if self.isEnabled():
-            self.setIcon(self.get_enabled_icon())
-        else:
-            self.setIcon(self.get_disabled_icon())
 
 
 class ResetBtn(PublishIconBtn):

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -16,6 +16,7 @@ from openpype.tools.utils import (
     BaseClickableFrame,
     set_style_property,
 )
+from openpype.style import get_objected_colors
 from openpype.pipeline.create import (
     SUBSET_NAME_ALLOWED_SYMBOLS,
     TaskNotSetError,
@@ -125,9 +126,11 @@ class PublishIconBtn(IconButton):
     def __init__(self, pixmap_path, *args, **kwargs):
         super(PublishIconBtn, self).__init__(*args, **kwargs)
 
-        icon = self.generate_icon(pixmap_path,
-                                  enabled_color=QtCore.Qt.white,
-                                  disabled_color=QtGui.QColor("#5b6779"))
+        colors = get_objected_colors()
+        icon = self.generate_icon(
+            pixmap_path,
+            enabled_color=colors["font"].get_qcolor(),
+            disabled_color=colors["font-disabled"].get_qcolor())
         self.setIcon(icon)
 
     def generate_icon(self, pixmap_path, enabled_color, disabled_color):


### PR DESCRIPTION
## Brief description

Fix PublishIconButton drawing disabled icon with the color specified.

## Description

Previously the color to draw in the `paint_image` logic was ignored when button was disabled because default color was applied to the disabled state. As such the disabled image always had a default "gray" state which QPushButtons generate.

Before:
![afbeelding](https://user-images.githubusercontent.com/2439881/192091065-6599d67f-932d-4039-b37b-870c03b77b9b.png)
(Only "reset" button is actually enabled here!)

After:
![afbeelding](https://user-images.githubusercontent.com/2439881/192091019-49065860-ae82-430f-9c14-74db42d35610.png)

## Additional info

Note that the disabled color is a bit hardcoded like this and randomly chosen. I picked the direct color from `openpype/style/data.json` for `font-disabled` which was `#99A3B2` but that just didn't show well enough.

## Testing notes:

1. Check in different platforms, Python and Qt versions