### PR TITLE
Style: Cache `get_objected_colors` function

### DIFF
--- a/openpype/style/__init__.py
+++ b/openpype/style/__init__.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import json
 import collections
 import six
@@ -49,13 +50,11 @@ def _get_colors_raw_data():
 
 def get_colors_data():
     """Only color data from stylesheet data."""
-    if _Cache.colors_data is not None:
-        return _Cache.colors_data
-
-    data = _get_colors_raw_data()
-    color_data = data.get("color") or {}
-    _Cache.colors_data = color_data
-    return color_data
+    if _Cache.colors_data is None:
+        data = _get_colors_raw_data()
+        color_data = data.get("color") or {}
+        _Cache.colors_data = color_data
+    return copy.deepcopy(_Cache.colors_data)
 
 
 def _convert_color_values_to_objects(value):
@@ -89,16 +88,15 @@ def get_objected_colors():
     Returns:
         dict: Parsed color objects by keys in data.
     """
-    if _Cache.objected_colors is not None:
-        return _Cache.objected_colors
+    if _Cache.objected_colors is None:
+        colors_data = get_colors_data()
+        output = {}
+        for key, value in colors_data.items():
+            output[key] = _convert_color_values_to_objects(value)
 
-    colors_data = get_colors_data()
-    output = {}
-    for key, value in colors_data.items():
-        output[key] = _convert_color_values_to_objects(value)
+        _Cache.objected_colors = output
 
-    _Cache.objected_colors = output
-    return output
+    return copy.deepcopy(_Cache.objected_colors)
 
 
 def _load_stylesheet():

--- a/openpype/style/__init__.py
+++ b/openpype/style/__init__.py
@@ -19,6 +19,7 @@ class _Cache:
     disabled_entity_icon_color = None
     deprecated_entity_font_color = None
 
+    colors_data = None
     objected_colors = None
 
 
@@ -48,8 +49,13 @@ def _get_colors_raw_data():
 
 def get_colors_data():
     """Only color data from stylesheet data."""
+    if _Cache.colors_data is not None:
+        return _Cache.colors_data
+
     data = _get_colors_raw_data()
-    return data.get("color") or {}
+    color_data = data.get("color") or {}
+    _Cache.colors_data = color_data
+    return color_data
 
 
 def _convert_color_values_to_objects(value):

--- a/openpype/style/__init__.py
+++ b/openpype/style/__init__.py
@@ -19,6 +19,8 @@ class _Cache:
     disabled_entity_icon_color = None
     deprecated_entity_font_color = None
 
+    objected_colors = None
+
 
 def get_style_image_path(image_name):
     # All filenames are lowered
@@ -81,10 +83,15 @@ def get_objected_colors():
     Returns:
         dict: Parsed color objects by keys in data.
     """
+    if _Cache.objected_colors is not None:
+        return _Cache.objected_colors
+
     colors_data = get_colors_data()
     output = {}
     for key, value in colors_data.items():
         output[key] = _convert_color_values_to_objects(value)
+
+    _Cache.objected_colors = output
     return output
 
 

--- a/openpype/style/__init__.py
+++ b/openpype/style/__init__.py
@@ -82,11 +82,25 @@ def _convert_color_values_to_objects(value):
     return parse_color(value)
 
 
-def get_objected_colors():
+def get_objected_colors(*keys):
     """Colors parsed from stylesheet data into color definitions.
 
+    You can pass multiple arguments to get a key from the data dict's colors.
+    Because this functions returns a deep copy of the cached data this allows
+    a much smaller dataset to be copied and thus result in a faster function.
+    It is however a micro-optimization in the area of 0.001s and smaller.
+
+    For example:
+        >>> get_colors_data()           # copy of full colors dict
+        >>> get_colors_data("font")
+        >>> get_colors_data("loader", "asset-view")
+
+    Args:
+        *keys: Each key argument will return a key nested deeper in the
+            objected colors data.
+
     Returns:
-        dict: Parsed color objects by keys in data.
+        Any: Parsed color objects by keys in data.
     """
     if _Cache.objected_colors is None:
         colors_data = get_colors_data()
@@ -96,7 +110,10 @@ def get_objected_colors():
 
         _Cache.objected_colors = output
 
-    return copy.deepcopy(_Cache.objected_colors)
+    output = _Cache.objected_colors
+    for key in keys:
+        output = output[key]
+    return copy.deepcopy(output)
 
 
 def _load_stylesheet():

--- a/openpype/tools/publisher/widgets/border_label_widget.py
+++ b/openpype/tools/publisher/widgets/border_label_widget.py
@@ -158,8 +158,7 @@ class BorderedLabelWidget(QtWidgets.QFrame):
     """
     def __init__(self, label, parent):
         super(BorderedLabelWidget, self).__init__(parent)
-        colors_data = get_objected_colors()
-        color_value = colors_data.get("border")
+        color_value = get_objected_colors("border")
         color = None
         if color_value:
             color = color_value.get_qcolor()

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -54,8 +54,7 @@ class ListItemDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(self, parent):
         super(ListItemDelegate, self).__init__(parent)
 
-        colors_data = get_objected_colors()
-        group_color_info = colors_data["publisher"]["list-view-group"]
+        colors_data = get_objected_colors("publisher", "list-view-group")
 
         self._group_colors = {
             key: value.get_qcolor()

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -54,7 +54,7 @@ class ListItemDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(self, parent):
         super(ListItemDelegate, self).__init__(parent)
 
-        colors_data = get_objected_colors("publisher", "list-view-group")
+        group_color_info = get_objected_colors("publisher", "list-view-group")
 
         self._group_colors = {
             key: value.get_qcolor()

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -323,7 +323,7 @@ class SettingsToolBtn(ImageButton):
     @classmethod
     def _get_icon_type(cls, btn_type):
         if btn_type not in cls._cached_icons:
-            settings_colors = get_objected_colors()["settings"]
+            settings_colors = get_objected_colors("settings")
             normal_color = settings_colors["image-btn"].get_qcolor()
             hover_color = settings_colors["image-btn-hover"].get_qcolor()
             disabled_color = settings_colors["image-btn-disabled"].get_qcolor()
@@ -789,8 +789,7 @@ class ProjectModel(QtGui.QStandardItemModel):
         self._items_by_name = {}
         self._versions_by_project = {}
 
-        colors = get_objected_colors()
-        font_color = colors["font"].get_qcolor()
+        font_color = get_objected_colors("font").get_qcolor()
         font_color.setAlpha(67)
         self._version_font_color = font_color
         self._current_version = get_openpype_version()

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -144,8 +144,7 @@ class VersionUpdateDialog(QtWidgets.QDialog):
             "gifts.png"
         )
         src_image = QtGui.QImage(image_path)
-        colors = style.get_objected_colors()
-        color_value = colors["font"]
+        color_value = style.get_objected_colors("font")
 
         return paint_image_with_color(
             src_image,

--- a/openpype/tools/utils/assets_widget.py
+++ b/openpype/tools/utils/assets_widget.py
@@ -114,7 +114,7 @@ class UnderlinesAssetDelegate(QtWidgets.QItemDelegate):
 
     def __init__(self, *args, **kwargs):
         super(UnderlinesAssetDelegate, self).__init__(*args, **kwargs)
-        asset_view_colors = get_objected_colors()["loader"]["asset-view"]
+        asset_view_colors = get_objected_colors("loader", "asset-view")
         self._selected_color = (
             asset_view_colors["selected"].get_qcolor()
         )

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -822,8 +822,6 @@ def get_warning_pixmap(color=None):
     src_image_path = get_image_path("warning.png")
     src_image = QtGui.QImage(src_image_path)
     if color is None:
-        colors = get_objected_colors()
-        color_value = colors["delete-btn-bg"]
-        color = color_value.get_qcolor()
+        color = get_objected_colors("delete-btn-bg").get_qcolor()
 
     return paint_image_with_color(src_image, color)

--- a/openpype/tools/utils/overlay_messages.py
+++ b/openpype/tools/utils/overlay_messages.py
@@ -14,8 +14,7 @@ class CloseButton(QtWidgets.QFrame):
 
     def __init__(self, parent):
         super(CloseButton, self).__init__(parent)
-        colors = get_objected_colors()
-        close_btn_color = colors["overlay-messages"]["close-btn"]
+        close_btn_color = get_objected_colors("overlay-messages", "close-btn")
         self._color = close_btn_color.get_qcolor()
         self._mouse_pressed = False
         policy = QtWidgets.QSizePolicy(

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -40,7 +40,7 @@ class PlaceholderLineEdit(QtWidgets.QLineEdit):
         # Change placeholder palette color
         if hasattr(QtGui.QPalette, "PlaceholderText"):
             filter_palette = self.palette()
-            color_obj = get_objected_colors()["font"]
+            color_obj = get_objected_colors("font")
             color = color_obj.get_qcolor()
             color.setAlpha(67)
             filter_palette.setColor(

--- a/openpype/widgets/nice_checkbox.py
+++ b/openpype/widgets/nice_checkbox.py
@@ -66,8 +66,7 @@ class NiceCheckbox(QtWidgets.QFrame):
         if cls._checked_bg_color is not None:
             return
 
-        colors_data = get_objected_colors()
-        colors_info = colors_data["nice-checkbox"]
+        colors_info = get_objected_colors("nice-checkbox")
 
         cls._checked_bg_color = colors_info["bg-checked"].get_qcolor()
         cls._unchecked_bg_color = colors_info["bg-unchecked"].get_qcolor()


### PR DESCRIPTION
## Brief description

The `get_objected_colors` function is called very often - e.g. over 1500 times when opening the Settings UI - and did a full read of the style's color `data.json` and converted it to the color objects with an average of 0.0009s per call on my machine.

## Description

See original discussion in the comments [here](https://github.com/pypeclub/OpenPype/pull/3910#issuecomment-1257727856) where I've elaborated on the usage of the function in the Settings UI.

## Additional info

Do we want to return a deep copy to ensure any usage of the data doesn't influence the cache? - It does seem that with a deep copy the time taken for the function returns almost to the same as without the caching. (However that is only if the data.json is read from my local SSD of course)

## Testing notes:

1. Test whether colors are still correct in the UIs.