### PR TITLE
Publisher: Add instance to context only if is not added yet

### DIFF
--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -153,7 +153,8 @@ class BaseCreator:
             instance (CreatedInstance): New created instance.
         """
 
-        self.create_context.creator_adds_instance(instance)
+        if instance.id not in self._instances_by_id:
+            self.create_context.creator_adds_instance(instance)
 
     def _remove_instance_from_context(self, instance):
         """Helper method to remove instance from create context.


### PR DESCRIPTION
## Brief description
Add instance to context only if is not added yet so there are no warnings on helper functions.