### PR TITLE
Houdini: Tweak Shelves set manager to ignore invalids

### DIFF
--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import platform
-import six
 
 from openpype.settings import get_project_settings
 
@@ -9,16 +8,10 @@ import hou
 
 log = logging.getLogger("openpype.hosts.houdini.shelves")
 
-if six.PY2:
-    FileNotFoundError = IOError
-
 
 def generate_shelves():
     """This function generates complete shelves from shelf set to tools
     in Houdini from openpype project settings houdini shelf definition.
-
-    Raises:
-        FileNotFoundError: Raised when the shelf set filepath does not exist
     """
     current_os = platform.system().lower()
 

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -41,7 +41,7 @@ def generate_shelves():
                           "{}".format(shelf_set_os_filepath))
                 continue
 
-            hou.shelves.newShelfSet(file_path=shelf_set_filepath[current_os])
+            hou.shelves.newShelfSet(file_path=shelf_set_os_filepath)
             continue
 
         shelf_set_name = shelf_set_config.get('shelf_set_name')

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -34,14 +34,12 @@ def generate_shelves():
 
     for shelf_set_config in shelves_set_config:
         shelf_set_filepath = shelf_set_config.get('shelf_set_source_path')
-
-        if shelf_set_filepath[current_os]:
-            if not os.path.isfile(shelf_set_filepath[current_os]):
-                raise FileNotFoundError(
-                    "This path doesn't exist - {}".format(
-                        shelf_set_filepath[current_os]
-                    )
-                )
+        shelf_set_os_filepath = shelf_set_filepath[current_os]
+        if shelf_set_os_filepath:
+            if not os.path.isfile(shelf_set_os_filepath):
+                log.error("Shelf path doesn't exist - "
+                          "{}".format(shelf_set_os_filepath))
+                continue
 
             hou.shelves.newShelfSet(file_path=shelf_set_filepath[current_os])
             continue

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -122,7 +122,7 @@ def get_or_create_shelf_set(shelf_set_label):
     shelf_set = next((shelf for shelf in all_shelves_sets if
                       shelf.label() == shelf_set_label), None)
     if shelf_set:
-        return shelf_set[0]
+        return shelf_set
 
     shelf_set_name = shelf_set_label.replace(' ', '_').lower()
     new_shelf_set = hou.shelves.newShelfSet(

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -144,10 +144,9 @@ def get_or_create_shelf(shelf_label):
     """
     all_shelves = hou.shelves.shelves().values()
 
-    shelf = [s for s in all_shelves if s.label() == shelf_label]
-
+    shelf = next((s for s in all_shelves if s.label() == shelf_label), None)
     if shelf:
-        return shelf[0]
+        return shelf
 
     shelf_name = shelf_label.replace(' ', '_').lower()
     new_shelf = hou.shelves.newShelf(

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -170,15 +170,15 @@ def get_or_create_tool(tool_definition, shelf):
     existing_tools = shelf.tools()
     tool_label = tool_definition.get('label')
 
-    existing_tool = [
-        tool for tool in existing_tools if tool.label() == tool_label
-    ]
-
+    existing_tool = next(
+        (tool for tool in existing_tools if tool.label() == tool_label),
+        None
+    )
     if existing_tool:
         tool_definition.pop('name', None)
         tool_definition.pop('label', None)
-        existing_tool[0].setData(**tool_definition)
-        return existing_tool[0]
+        existing_tool.setData(**tool_definition)
+        return existing_tool
 
     tool_name = tool_label.replace(' ', '_').lower()
 

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -80,8 +80,8 @@ def generate_shelves():
                     tool_definition[key] for key in mandatory_attributes
                 ):
                     log.warning(
-                        "You need to specify at least the name and \
-the script path of the tool.")
+                        "You need to specify at least the name and the "
+                        "script path of the tool.")
                     continue
 
                 tool = get_or_create_tool(tool_definition, shelf)

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -119,12 +119,10 @@ def get_or_create_shelf_set(shelf_set_label):
     """
     all_shelves_sets = hou.shelves.shelfSets().values()
 
-    shelf_sets = [
-        shelf for shelf in all_shelves_sets if shelf.label() == shelf_set_label
-    ]
-
-    if shelf_sets:
-        return shelf_sets[0]
+    shelf_set = next((shelf for shelf in all_shelves_sets if
+                      shelf.label() == shelf_set_label), None)
+    if shelf_set:
+        return shelf_set[0]
 
     shelf_set_name = shelf_set_label.replace(' ', '_').lower()
     new_shelf_set = hou.shelves.newShelfSet(

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -53,10 +53,7 @@ def generate_shelves():
             )
             continue
 
-        shelf_set = get_or_create_shelf_set(shelf_set_name)
-
         shelves_definition = shelf_set_config.get('shelf_definition')
-
         if not shelves_definition:
             log.debug(
                 "No shelf definition found for shelf set named '{}'".format(
@@ -65,6 +62,7 @@ def generate_shelves():
             )
             continue
 
+        shelf_set = get_or_create_shelf_set(shelf_set_name)
         for shelf_definition in shelves_definition:
             shelf_name = shelf_definition.get('shelf_name')
             if not shelf_name:

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -51,7 +51,7 @@ def generate_shelves():
             log.warning(
                 "No name found in shelf set definition."
             )
-            return
+            continue
 
         shelf_set = get_or_create_shelf_set(shelf_set_name)
 
@@ -63,7 +63,7 @@ def generate_shelves():
                     shelf_set_name
                 )
             )
-            return
+            continue
 
         for shelf_definition in shelves_definition:
             shelf_name = shelf_definition.get('shelf_name')
@@ -71,7 +71,7 @@ def generate_shelves():
                 log.warning(
                     "No name found in shelf definition."
                 )
-                return
+                continue
 
             shelf = get_or_create_shelf(shelf_name)
 
@@ -81,7 +81,7 @@ def generate_shelves():
                         shelf_name
                     )
                 )
-                return
+                continue
 
             mandatory_attributes = {'name', 'script'}
             for tool_definition in shelf_definition.get('tools_list'):
@@ -98,7 +98,7 @@ the script path of the tool.")
                 tool = get_or_create_tool(tool_definition, shelf)
 
                 if not tool:
-                    return
+                    continue
 
                 # Add the tool to the shelf if not already in it
                 if tool not in shelf.tools():

--- a/openpype/hosts/houdini/api/shelves.py
+++ b/openpype/hosts/houdini/api/shelves.py
@@ -20,9 +20,7 @@ def generate_shelves():
     shelves_set_config = project_settings["houdini"]["shelves"]
 
     if not shelves_set_config:
-        log.debug(
-            "No custom shelves found in project settings."
-        )
+        log.debug("No custom shelves found in project settings.")
         return
 
     for shelf_set_config in shelves_set_config:
@@ -39,9 +37,7 @@ def generate_shelves():
 
         shelf_set_name = shelf_set_config.get('shelf_set_name')
         if not shelf_set_name:
-            log.warning(
-                "No name found in shelf set definition."
-            )
+            log.warning("No name found in shelf set definition.")
             continue
 
         shelves_definition = shelf_set_config.get('shelf_definition')
@@ -57,9 +53,7 @@ def generate_shelves():
         for shelf_definition in shelves_definition:
             shelf_name = shelf_definition.get('shelf_name')
             if not shelf_name:
-                log.warning(
-                    "No name found in shelf definition."
-                )
+                log.warning("No name found in shelf definition.")
                 continue
 
             shelf = get_or_create_shelf(shelf_name)
@@ -175,9 +169,7 @@ def get_or_create_tool(tool_definition, shelf):
 
     if not os.path.exists(tool_definition['script']):
         log.warning(
-            "This path doesn't exist - {}".format(
-                tool_definition['script']
-            )
+            "This path doesn't exist - {}".format(tool_definition['script'])
         )
         return
 

--- a/openpype/settings/defaults/project_settings/houdini.json
+++ b/openpype/settings/defaults/project_settings/houdini.json
@@ -1,15 +1,5 @@
 {
-    "shelves": [
-        {
-            "shelf_set_name": "OpenPype Shelves",
-            "shelf_set_source_path": {
-                "windows": "",
-                "darwin": "",
-                "linux": ""
-            },
-            "shelf_definition": []
-        }
-    ],
+    "shelves": [],
     "create": {
         "CreateArnoldAss": {
             "enabled": true,


### PR DESCRIPTION
## Brief description

I was unable to start **Houdini Core 19.5.303 Py 3.7** on Windows due to the Shelf Set Manager implemented with #3652 

It would just hang on Houdini splash screen without continuing. What causes it exactly I'm not sure - but I had no shelves set or defined but the shelves still tried to create and or set shelves which apparently broken my Houdini start.

With the changes implemented here the default is now correctly fully empty to avoid warnings, it'll now also not try `get_or_create_shelf_set` if the shelf definition for that shelf is empty (like previous default value in settings).

Also instead of returning it'll now continue on entries that are invalid in settings.

### Additional Info

I'd still like to figure out what exactly stops my Houdini from continuing past the splash screen - still investigating now.

[Originally mentioned in comments of this other PR](https://github.com/pypeclub/OpenPype/pull/3046#discussion_r979923594)

## Testing notes:
1. Start Houdini
2. Set up shelves in OpenPype settings for Houdini - ensure they work as intended.