### PR TITLE
General - Color definitions - Fix variable name `sat` -> `sat_str`

### DIFF
--- a/openpype/style/color_defs.py
+++ b/openpype/style/color_defs.py
@@ -337,8 +337,8 @@ class HSLAColor:
     as float (0-1 range).
 
     Examples:
-        "hsl(27, 0.7, 0.3)"
-        "hsl(27, 70%, 30%)"
+        "hsla(27, 0.7, 0.3, 0.5)"
+        "hsla(27, 70%, 30%, 0.5)"
     """
     def __init__(self, value):
         modified_color = value.lower().strip()

--- a/openpype/style/color_defs.py
+++ b/openpype/style/color_defs.py
@@ -296,7 +296,7 @@ class HSLColor:
         if "%" in sat_str:
             sat = float(sat_str.rstrip("%")) / 100
         else:
-            sat = float(sat)
+            sat = float(sat_str)
 
         if "%" in light_str:
             light = float(light_str.rstrip("%")) / 100
@@ -350,7 +350,7 @@ class HSLAColor:
         if "%" in sat_str:
             sat = float(sat_str.rstrip("%")) / 100
         else:
-            sat = float(sat)
+            sat = float(sat_str)
 
         if "%" in light_str:
             light = float(light_str.rstrip("%")) / 100


### PR DESCRIPTION
## Brief description

Fix variable name `sat` -> `sat_str`
`sat` is actually undefined in the else statemen

This actually not being found earlier is due to the fact that saturation for `hsl` and `hsla` was never used without a percentage sign in the saturation value in the style `data.json`

## Testing notes:

1. Usage of these color definitions (e.g. run different UIs)