### PR TITLE
Maya: Fix Scene Inventory possibly starting off-screen due to maya preferences

### DIFF
--- a/openpype/tools/sceneinventory/window.py
+++ b/openpype/tools/sceneinventory/window.py
@@ -40,8 +40,6 @@ class SceneInventoryWindow(QtWidgets.QDialog):
         project_name = os.getenv("AVALON_PROJECT") or "<Project not set>"
         self.setWindowTitle("Scene Inventory 1.0 - {}".format(project_name))
         self.setObjectName("SceneInventory")
-        # Maya only property
-        self.setProperty("saveWindowPref", True)
 
         self.resize(1100, 480)
 


### PR DESCRIPTION
## Brief description

Remove "saveWindowPref" property.

This should fix #3921 

## Description

Now Maya will not restore/remember the previous Scene Inventory position.
The UI will now behave similar to other hosts.

## Testing notes:
1. Start Scene Inventory - move it off-screen off to the side.
2. Close it down, close maya, save maya preferences, etc.
3. Restart Maya. 
 
Previously before this PR Maya would have reopened Scene Inventory in position where it was last time, now it doesn't.