### PR TITLE
Maya: Remove unused 'openpype.api' imports in plugins

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_animation_content.py
+++ b/openpype/hosts/maya/plugins/publish/validate_animation_content.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
@@ -1,7 +1,6 @@
 import maya.cmds as cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_namespaces.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_namespaces.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 
 

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 
 from maya import cmds
 

--- a/openpype/hosts/maya/plugins/publish/validate_camera_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_attributes.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_camera_contents.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_color_sets.py
+++ b/openpype/hosts/maya/plugins/publish/validate_color_sets.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_cycle_error.py
+++ b/openpype/hosts/maya/plugins/publish/validate_cycle_error.py
@@ -2,7 +2,6 @@ from maya import cmds
 
 import pyblish.api
 
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib import maintained_selection
 from openpype.pipeline.publish import ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_has_members.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_look_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_contents.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_look_id_reference_edits.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_id_reference_edits.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_look_members_unique.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_members_unique.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidatePipelineOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_look_no_default_shaders.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_no_default_shaders.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_look_sets.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_sets.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_look_shading_group.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_shading_group.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_look_single_shader.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_single_shader.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_arnold_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_arnold_attributes.py
@@ -1,7 +1,6 @@
 import pymel.core as pc
 from maya import cmds
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.lib import maintained_selection
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_has_uv.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_has_uv.py
@@ -3,7 +3,6 @@ import re
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateMeshOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_lamina_faces.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateMeshOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_ngons.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_ngons.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_no_negative_scale.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_no_negative_scale.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateMeshOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_non_manifold.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_non_manifold.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateMeshOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_non_zero_edge.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import ValidateMeshOrder

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
@@ -2,7 +2,6 @@ from maya import cmds
 import maya.api.OpenMaya as om2
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_overlapping_uvs.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 import math
 import maya.api.OpenMaya as om

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_shader_connections.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_shader_connections.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_single_uv_set.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_uv_set_map1.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_uv_set_map1.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mesh_vertices_have_edges.py
@@ -3,7 +3,6 @@ import re
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_model_content.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_content.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_model_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_model_name.py
@@ -5,7 +5,6 @@ import re
 from maya import cmds
 import pyblish.api
 
-import openpype.api
 from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import ValidateContentsOrder
 import openpype.hosts.maya.api.action

--- a/openpype/hosts/maya/plugins/publish/validate_mvlook_contents.py
+++ b/openpype/hosts/maya/plugins/publish/validate_mvlook_contents.py
@@ -1,6 +1,5 @@
 import os
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_no_animation.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_animation.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_no_default_camera.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_default_camera.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_namespace.py
@@ -2,7 +2,6 @@ import pymel.core as pm
 import maya.cmds as cmds
 
 import pyblish.api
-import openpype.api
 from openpype.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,

--- a/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_null_transforms.py
@@ -1,7 +1,6 @@
 import maya.cmds as cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_no_unknown_nodes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_no_unknown_nodes.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids.py
@@ -1,5 +1,5 @@
 import pyblish.api
-import openpype.api
+
 from openpype.pipeline.publish import ValidatePipelineOrder
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_deformed_shapes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_deformed_shapes.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -1,6 +1,5 @@
 import pyblish.api
 
-import openpype.api
 from openpype.client import get_assets
 from openpype.pipeline import legacy_io
 from openpype.pipeline.publish import ValidatePipelineOrder

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_related.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_related.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 
 from openpype.pipeline.publish import ValidatePipelineOrder
 import openpype.hosts.maya.api.action

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_unique.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_unique.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 import pyblish.api
-import openpype.api
 from openpype.pipeline.publish import ValidatePipelineOrder
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib

--- a/openpype/hosts/maya/plugins/publish/validate_node_no_ghosting.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_no_ghosting.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_render_no_default_cameras.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_no_default_cameras.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_render_single_camera.py
+++ b/openpype/hosts/maya/plugins/publish/validate_render_single_camera.py
@@ -3,7 +3,6 @@ import re
 import pyblish.api
 from maya import cmds
 
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api.render_settings import RenderSettings
 from openpype.pipeline.publish import ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_rig_controllers_arnold_attributes.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_controllers_arnold_attributes.py
@@ -1,7 +1,6 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
 
 from openpype.pipeline.publish import (
     ValidateContentsOrder,

--- a/openpype/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
@@ -1,7 +1,7 @@
 import maya.cmds as cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
+++ b/openpype/hosts/maya/plugins/publish/validate_rig_output_ids.py
@@ -2,7 +2,6 @@ import pymel.core as pc
 
 import pyblish.api
 
-import openpype.api
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     RepairAction,

--- a/openpype/hosts/maya/plugins/publish/validate_shader_name.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shader_name.py
@@ -2,7 +2,7 @@ import re
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_default_names.py
@@ -3,7 +3,7 @@ import re
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import (
     ValidateContentsOrder,

--- a/openpype/hosts/maya/plugins/publish/validate_shape_render_stats.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_render_stats.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 
 from maya import cmds
 

--- a/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.hosts.maya.api import lib
 from openpype.pipeline.publish import (

--- a/openpype/hosts/maya/plugins/publish/validate_skinCluster_deformer_set.py
+++ b/openpype/hosts/maya/plugins/publish/validate_skinCluster_deformer_set.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_step_size.py
+++ b/openpype/hosts/maya/plugins/publish/validate_step_size.py
@@ -1,5 +1,5 @@
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_naming_suffix.py
@@ -3,7 +3,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/openpype/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_mesh_triangulated.py
@@ -2,8 +2,9 @@
 
 from maya import cmds
 import pyblish.api
-import openpype.api
+
 from openpype.pipeline.publish import ValidateMeshOrder
+import openpype.hosts.maya.api.action
 
 
 class ValidateUnrealMeshTriangulated(pyblish.api.InstancePlugin):

--- a/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
+++ b/openpype/hosts/maya/plugins/publish/validate_unreal_staticmesh_naming.py
@@ -3,7 +3,7 @@
 import re
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline import legacy_io
 from openpype.settings import get_project_settings

--- a/openpype/hosts/maya/plugins/publish/validate_visible_only.py
+++ b/openpype/hosts/maya/plugins/publish/validate_visible_only.py
@@ -1,6 +1,5 @@
 import pyblish.api
 
-import openpype.api
 from openpype.hosts.maya.api.lib import iter_visible_nodes_in_range
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder

--- a/openpype/hosts/maya/plugins/publish/validate_vrayproxy_members.py
+++ b/openpype/hosts/maya/plugins/publish/validate_vrayproxy_members.py
@@ -1,5 +1,4 @@
 import pyblish.api
-import openpype.api
 
 from maya import cmds
 

--- a/openpype/hosts/maya/plugins/publish/validate_yeti_rig_input_in_instance.py
+++ b/openpype/hosts/maya/plugins/publish/validate_yeti_rig_input_in_instance.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 import pyblish.api
-import openpype.api
+
 import openpype.hosts.maya.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 


### PR DESCRIPTION
## Brief description
Almost every Maya validator plugin has import of `openpype.api` which is not used.

## Description
Removed `openpype.api` imports from Maya validarors. They could be there because of hidden imports (found out 1 where I had to add different import).

## Testing notes:
1. All changed plugins should be discovered
2. All changed plugins should work