### PR TITLE
General: import 'Logger' from 'openpype.lib'

### DIFF
--- a/openpype/hosts/aftereffects/api/launch_logic.py
+++ b/openpype/hosts/aftereffects/api/launch_logic.py
@@ -12,6 +12,7 @@ from wsrpc_aiohttp import (
 
 from Qt import QtCore
 
+from openpype.lib import Logger
 from openpype.pipeline import legacy_io
 from openpype.tools.utils import host_tools
 from openpype.tools.adobe_webserver.app import WebServerTool
@@ -84,8 +85,6 @@ class ProcessLauncher(QtCore.QObject):
     @property
     def log(self):
         if self._log is None:
-            from openpype.api import Logger
-
             self._log = Logger.get_logger("{}-launcher".format(
                 self.route_name))
         return self._log

--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -4,8 +4,7 @@ from Qt import QtWidgets
 
 import pyblish.api
 
-from openpype import lib
-from openpype.api import Logger
+from openpype.lib import Logger, register_event_callback
 from openpype.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,
@@ -16,9 +15,8 @@ from openpype.pipeline import (
 )
 from openpype.pipeline.load import any_outdated_containers
 import openpype.hosts.aftereffects
-from openpype.lib import register_event_callback
 
-from .launch_logic import get_stub
+from .launch_logic import get_stub, ConnectionNotEstablishedYet
 
 log = Logger.get_logger(__name__)
 
@@ -111,7 +109,7 @@ def ls():
     """
     try:
         stub = get_stub()  # only after AfterEffects is up
-    except lib.ConnectionNotEstablishedYet:
+    except ConnectionNotEstablishedYet:
         print("Not connected yet, ignoring")
         return
 
@@ -284,7 +282,7 @@ def _get_stub():
     """
     try:
         stub = get_stub()  # only after Photoshop is up
-    except lib.ConnectionNotEstablishedYet:
+    except ConnectionNotEstablishedYet:
         print("Not connected yet, ignoring")
         return
 

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Union
 
 import bpy
 import addon_utils
-from openpype.api import Logger
+from openpype.lib import Logger
 
 from . import pipeline
 

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -20,8 +20,8 @@ from openpype.pipeline import (
     deregister_creator_plugin_path,
     AVALON_CONTAINER_ID,
 )
-from openpype.api import Logger
 from openpype.lib import (
+    Logger,
     register_event_callback,
     emit_event
 )

--- a/openpype/hosts/celaction/api/cli.py
+++ b/openpype/hosts/celaction/api/cli.py
@@ -6,9 +6,8 @@ import argparse
 import pyblish.api
 import pyblish.util
 
-from openpype.api import Logger
-import openpype
 import openpype.hosts.celaction
+from openpype.lib import Logger
 from openpype.hosts.celaction import api as celaction
 from openpype.tools.utils import host_tools
 from openpype.pipeline import install_openpype_plugins

--- a/openpype/hosts/flame/api/lib.py
+++ b/openpype/hosts/flame/api/lib.py
@@ -12,6 +12,9 @@ import xml.etree.cElementTree as cET
 from copy import deepcopy, copy
 from xml.etree import ElementTree as ET
 from pprint import pformat
+
+from openpype.lib import Logger, run_subprocess
+
 from .constants import (
     MARKER_COLOR,
     MARKER_DURATION,
@@ -20,9 +23,7 @@ from .constants import (
     MARKER_PUBLISH_DEFAULT
 )
 
-import openpype.api as openpype
-
-log = openpype.Logger.get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 FRAME_PATTERN = re.compile(r"[\._](\d+)[\.]")
 
@@ -1016,7 +1017,7 @@ class MediaInfoFile(object):
 
         try:
             # execute creation of clip xml template data
-            openpype.run_subprocess(cmd_args)
+            run_subprocess(cmd_args)
         except TypeError as error:
             raise TypeError(
                 "Error creating `{}` due: {}".format(fpath, error))

--- a/openpype/hosts/flame/api/pipeline.py
+++ b/openpype/hosts/flame/api/pipeline.py
@@ -5,7 +5,7 @@ import os
 import contextlib
 from pyblish import api as pyblish
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,

--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -9,13 +9,14 @@ from Qt import QtCore, QtWidgets
 import openpype.api as openpype
 import qargparse
 from openpype import style
+from openpype.lib import Logger
 from openpype.pipeline import LegacyCreator, LoaderPlugin
 
 from . import constants
 from . import lib as flib
 from . import pipeline as fpipeline
 
-log = openpype.Logger.get_logger(__name__)
+log = Logger.get_logger(__name__)
 
 
 class CreatorWidget(QtWidgets.QDialog):

--- a/openpype/hosts/flame/api/render_utils.py
+++ b/openpype/hosts/flame/api/render_utils.py
@@ -1,6 +1,6 @@
 import os
 from xml.etree import ElementTree as ET
-from openpype.api import Logger
+from openpype.lib import Logger
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/hosts/flame/api/utils.py
+++ b/openpype/hosts/flame/api/utils.py
@@ -4,7 +4,7 @@ Flame utils for syncing scripts
 
 import os
 import shutil
-from openpype.api import Logger
+from openpype.lib import Logger
 log = Logger.get_logger(__name__)
 
 

--- a/openpype/hosts/hiero/api/menu.py
+++ b/openpype/hosts/hiero/api/menu.py
@@ -4,7 +4,7 @@ import sys
 import hiero.core
 from hiero.ui import findMenuAction
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import legacy_io
 from openpype.tools.utils import host_tools
 

--- a/openpype/hosts/hiero/api/tags.py
+++ b/openpype/hosts/hiero/api/tags.py
@@ -3,7 +3,7 @@ import os
 import hiero
 
 from openpype.client import get_project, get_assets
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import legacy_io
 
 log = Logger.get_logger(__name__)

--- a/openpype/hosts/hiero/api/workio.py
+++ b/openpype/hosts/hiero/api/workio.py
@@ -1,7 +1,7 @@
 import os
 import hiero
 
-from openpype.api import Logger
+from openpype.lib import Logger
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/hosts/nuke/api/gizmo_menu.py
+++ b/openpype/hosts/nuke/api/gizmo_menu.py
@@ -2,7 +2,7 @@ import os
 import re
 import nuke
 
-from openpype.api import Logger
+from openpype.lib import Logger
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -8,10 +8,9 @@ import pyblish.api
 
 import openpype
 from openpype.api import (
-    Logger,
     get_current_project_settings
 )
-from openpype.lib import register_event_callback
+from openpype.lib import register_event_callback, Logger
 from openpype.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,

--- a/openpype/hosts/nuke/plugins/inventory/repair_old_loaders.py
+++ b/openpype/hosts/nuke/plugins/inventory/repair_old_loaders.py
@@ -1,4 +1,4 @@
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import InventoryAction
 from openpype.hosts.nuke.api.lib import set_avalon_knob_data
 

--- a/openpype/hosts/nuke/startup/menu.py
+++ b/openpype/hosts/nuke/startup/menu.py
@@ -1,7 +1,7 @@
 import nuke
 import os
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import install_host
 from openpype.hosts.nuke import api
 from openpype.hosts.nuke.api.lib import (

--- a/openpype/hosts/photoshop/api/launch_logic.py
+++ b/openpype/hosts/photoshop/api/launch_logic.py
@@ -10,7 +10,7 @@ from wsrpc_aiohttp import (
 
 from Qt import QtCore
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import legacy_io
 from openpype.tools.utils import host_tools
 from openpype.tools.adobe_webserver.app import WebServerTool

--- a/openpype/hosts/photoshop/api/pipeline.py
+++ b/openpype/hosts/photoshop/api/pipeline.py
@@ -3,8 +3,7 @@ from Qt import QtWidgets
 
 import pyblish.api
 
-from openpype.api import Logger
-from openpype.lib import register_event_callback
+from openpype.lib import register_event_callback, Logger
 from openpype.pipeline import (
     legacy_io,
     register_loader_plugin_path,

--- a/openpype/hosts/resolve/api/workio.py
+++ b/openpype/hosts/resolve/api/workio.py
@@ -1,7 +1,7 @@
 """Host API required Work Files tool"""
 
 import os
-from openpype.api import Logger
+from openpype.lib import Logger
 from .lib import (
     get_project_manager,
     get_current_project,

--- a/openpype/hosts/traypublisher/plugins/create/create_from_settings.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_from_settings.py
@@ -1,5 +1,6 @@
 import os
-from openpype.api import get_project_settings, Logger
+from openpype.lib import Logger
+from openpype.api import get_project_settings
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/modules/ftrack/scripts/sub_event_status.py
+++ b/openpype/modules/ftrack/scripts/sub_event_status.py
@@ -15,8 +15,8 @@ from openpype_modules.ftrack.ftrack_server.lib import (
     TOPIC_STATUS_SERVER,
     TOPIC_STATUS_SERVER_RESULT
 )
-from openpype.api import Logger
 from openpype.lib import (
+    Logger,
     is_current_version_studio_latest,
     is_running_from_build,
     get_expected_version,

--- a/openpype/modules/ftrack/scripts/sub_event_storer.py
+++ b/openpype/modules/ftrack/scripts/sub_event_storer.py
@@ -17,10 +17,10 @@ from openpype_modules.ftrack.ftrack_server.lib import (
 )
 from openpype_modules.ftrack.lib import get_ftrack_event_mongo_info
 from openpype.lib import (
+    Logger,
     get_openpype_version,
     get_build_version
 )
-from openpype.api import Logger
 
 log = Logger.get_logger("Event storer")
 subprocess_started = datetime.datetime.now()

--- a/openpype/modules/log_viewer/log_view_module.py
+++ b/openpype/modules/log_viewer/log_view_module.py
@@ -1,4 +1,3 @@
-from openpype.api import Logger
 from openpype.modules import OpenPypeModule
 from openpype_interfaces import ITrayModule
 

--- a/openpype/modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/sync_server/providers/local_drive.py
@@ -4,7 +4,7 @@ import shutil
 import threading
 import time
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.pipeline import Anatomy
 from .abstract_provider import AbstractProvider
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -9,7 +9,7 @@ from abc import (
 import six
 
 from openpype.settings import get_system_settings, get_project_settings
-from .subset_name import get_subset_name
+from openpype.lib import Logger
 from openpype.pipeline.plugin_discover import (
     discover,
     register_plugin,
@@ -18,6 +18,7 @@ from openpype.pipeline.plugin_discover import (
     deregister_plugin_path
 )
 
+from .subset_name import get_subset_name
 from .legacy_create import LegacyCreator
 
 
@@ -143,8 +144,6 @@ class BaseCreator:
         """
 
         if self._log is None:
-            from openpype.api import Logger
-
             self._log = Logger.get_logger(self.__class__.__name__)
         return self._log
 

--- a/openpype/pipeline/plugin_discover.py
+++ b/openpype/pipeline/plugin_discover.py
@@ -2,7 +2,7 @@ import os
 import inspect
 import traceback
 
-from openpype.api import Logger
+from openpype.lib import Logger
 from openpype.lib.python_module_tools import (
     modules_from_path,
     classes_from_module,

--- a/openpype/tools/launcher/actions.py
+++ b/openpype/tools/launcher/actions.py
@@ -4,8 +4,9 @@ from Qt import QtWidgets, QtGui
 
 from openpype import PLUGINS_DIR
 from openpype import style
-from openpype.api import Logger, resources
+from openpype.api import resources
 from openpype.lib import (
+    Logger,
     ApplictionExecutableNotFound,
     ApplicationLaunchFailed
 )

--- a/openpype/tools/settings/local_settings/window.py
+++ b/openpype/tools/settings/local_settings/window.py
@@ -1,4 +1,3 @@
-import logging
 from Qt import QtWidgets, QtGui
 
 from openpype import style
@@ -7,10 +6,10 @@ from openpype.settings.lib import (
     get_local_settings,
     save_local_settings
 )
+from openpype.lib import Logger
 from openpype.tools.settings import CHILD_OFFSET
 from openpype.tools.utils import MessageOverlayObject
 from openpype.api import (
-    Logger,
     SystemSettings,
     ProjectSettings
 )

--- a/openpype/tools/standalonepublish/widgets/widget_components.py
+++ b/openpype/tools/standalonepublish/widgets/widget_components.py
@@ -6,9 +6,10 @@ import string
 
 from Qt import QtWidgets, QtCore
 
-from openpype.api import execute, Logger
 from openpype.pipeline import legacy_io
 from openpype.lib import (
+    execute,
+    Logger,
     get_openpype_execute_args,
     apply_project_environments_value
 )

--- a/openpype/tools/stdout_broker/app.py
+++ b/openpype/tools/stdout_broker/app.py
@@ -6,8 +6,8 @@ import websocket
 import json
 from datetime import datetime
 
+from openpype.lib import Logger
 from openpype_modules.webserver.host_console_listener import MsgAction
-from openpype.api import Logger
 
 log = Logger.get_logger(__name__)
 

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -7,6 +7,7 @@ import os
 
 import pyblish.api
 from openpype.host import IWorkfileHost, ILoadHost
+from openpype.lib import Logger
 from openpype.pipeline import (
     registered_host,
     legacy_io,
@@ -23,6 +24,7 @@ class HostToolsHelper:
 
     Class may also contain tools that are available only for one or few hosts.
     """
+
     def __init__(self, parent=None):
         self._log = None
         # Global parent for all tools (may and may not be set)
@@ -42,8 +44,6 @@ class HostToolsHelper:
     @property
     def log(self):
         if self._log is None:
-            from openpype.api import Logger
-
             self._log = Logger.get_logger(self.__class__.__name__)
         return self._log
 

--- a/openpype/tools/utils/lib.py
+++ b/openpype/tools/utils/lib.py
@@ -16,11 +16,8 @@ from openpype.style import (
     get_objected_colors,
 )
 from openpype.resources import get_image_path
-from openpype.lib import filter_profiles
-from openpype.api import (
-    get_project_settings,
-    Logger
-)
+from openpype.lib import filter_profiles, Logger
+from openpype.api import get_project_settings
 from openpype.pipeline import registered_host
 
 log = Logger.get_logger(__name__)


### PR DESCRIPTION
## Brief description
Changed imports of `Logger` to be imported from `openpype.lib` instead of `openpype.api`.


## Testing notes:
All should work as expected
- [x] Aftereffects launch and integration works
- [ ] Blender launch and integration works
- [ ] Flame launch and integration works
- [ ] Hiero launch and integration works
- [ ] Nuke launch and integration works
- [x] Photoshop launch and integration works
- [x] Traypublisher creators from settings
- [ ] Ftrack event server is working
- [x] Sync server has no issues with local provider
- [x] Plugin discovery works
- [x] Launcher UI is working
- [x] Local settings UI is working