### PR TITLE
Fusion: Implement Alembic and FBX mesh loader

### DIFF
--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -182,7 +182,7 @@ def ls():
     """
 
     comp = get_current_comp()
-    tools = comp.GetToolList(False, "Loader").values()
+    tools = comp.GetToolList(False).values()
 
     for tool in tools:
         container = parse_container(tool)

--- a/openpype/hosts/fusion/plugins/load/load_alembic.py
+++ b/openpype/hosts/fusion/plugins/load/load_alembic.py
@@ -1,0 +1,70 @@
+from openpype.pipeline import (
+    load,
+    get_representation_path,
+)
+from openpype.hosts.fusion.api import (
+    imprint_container,
+    get_current_comp,
+    comp_lock_and_undo_chunk
+)
+
+
+class FusionLoadAlembicMesh(load.LoaderPlugin):
+    """Load Alembic mesh into Fusion"""
+
+    families = ["pointcache", "model"]
+    representations = ["abc"]
+
+    label = "Load alembic mesh"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    tool_type = "SurfaceAlembicMesh"
+
+    def load(self, context, name, namespace, data):
+        # Fallback to asset name when namespace is None
+        if namespace is None:
+            namespace = context['asset']['name']
+
+        # Create the Loader with the filename path set
+        comp = get_current_comp()
+        with comp_lock_and_undo_chunk(comp, "Create tool"):
+
+            path = self.fname
+
+            args = (-32768, -32768)
+            tool = comp.AddTool(self.tool_type, *args)
+            tool["Filename"] = path
+
+            imprint_container(tool,
+                              name=name,
+                              namespace=namespace,
+                              context=context,
+                              loader=self.__class__.__name__)
+
+    def switch(self, container, representation):
+        self.update(container, representation)
+
+    def update(self, container, representation):
+        """Update Alembic path"""
+
+        tool = container["_tool"]
+        assert tool.ID == self.tool_type, f"Must be {self.tool_type}"
+        comp = tool.Comp()
+
+        path = get_representation_path(representation)
+
+        with comp_lock_and_undo_chunk(comp, "Update tool"):
+            tool["Filename"] = path
+
+            # Update the imprinted representation
+            tool.SetData("avalon.representation", str(representation["_id"]))
+
+    def remove(self, container):
+        tool = container["_tool"]
+        assert tool.ID == self.tool_type, f"Must be {self.tool_type}"
+        comp = tool.Comp()
+
+        with comp_lock_and_undo_chunk(comp, "Remove tool"):
+            tool.Delete()

--- a/openpype/hosts/fusion/plugins/load/load_fbx.py
+++ b/openpype/hosts/fusion/plugins/load/load_fbx.py
@@ -1,0 +1,71 @@
+
+from openpype.pipeline import (
+    load,
+    get_representation_path,
+)
+from openpype.hosts.fusion.api import (
+    imprint_container,
+    get_current_comp,
+    comp_lock_and_undo_chunk
+)
+
+
+class FusionLoadFBXMesh(load.LoaderPlugin):
+    """Load FBX mesh into Fusion"""
+
+    families = ["*"]
+    representations = ["fbx"]
+
+    label = "Load FBX mesh"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    tool_type = "SurfaceFBXMesh"
+
+    def load(self, context, name, namespace, data):
+        # Fallback to asset name when namespace is None
+        if namespace is None:
+            namespace = context['asset']['name']
+
+        # Create the Loader with the filename path set
+        comp = get_current_comp()
+        with comp_lock_and_undo_chunk(comp, "Create tool"):
+
+            path = self.fname
+
+            args = (-32768, -32768)
+            tool = comp.AddTool(self.tool_type, *args)
+            tool["ImportFile"] = path
+
+            imprint_container(tool,
+                              name=name,
+                              namespace=namespace,
+                              context=context,
+                              loader=self.__class__.__name__)
+
+    def switch(self, container, representation):
+        self.update(container, representation)
+
+    def update(self, container, representation):
+        """Update path"""
+
+        tool = container["_tool"]
+        assert tool.ID == self.tool_type, f"Must be {self.tool_type}"
+        comp = tool.Comp()
+
+        path = get_representation_path(representation)
+
+        with comp_lock_and_undo_chunk(comp, "Update tool"):
+            tool["ImportFile"] = path
+
+            # Update the imprinted representation
+            tool.SetData("avalon.representation", str(representation["_id"]))
+
+    def remove(self, container):
+        tool = container["_tool"]
+        assert tool.ID == self.tool_type, f"Must be {self.tool_type}"
+        comp = tool.Comp()
+
+        with comp_lock_and_undo_chunk(comp, "Remove tool"):
+            tool.Delete()


### PR DESCRIPTION
## Brief description

Implement Alembic and FBX mesh loader

## Description

This only works for Alembic and FBX geometry - not for e.g. cameras due to the nature of how these nodes/tools work in Fusion.

## Testing notes:

1. Launch Fusion
2. Import and manage FBX / Alembic meshes