### PR TITLE
Tray: Change order of attribute changes

### DIFF
--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -775,12 +775,26 @@ class PypeTrayStarter(QtCore.QObject):
 def main():
     log = Logger.get_logger(__name__)
     app = QtWidgets.QApplication.instance()
+
+    high_dpi_scale_attr = None
     if not app:
+        # 'AA_EnableHighDpiScaling' must be set before app instance creation
+        high_dpi_scale_attr = getattr(
+            QtCore.Qt, "AA_EnableHighDpiScaling", None
+        )
+        if high_dpi_scale_attr is not None:
+            QtWidgets.QApplication.setAttribute(high_dpi_scale_attr)
+
         app = QtWidgets.QApplication([])
 
+    if high_dpi_scale_attr is None:
+        log.debug((
+            "Attribute 'AA_EnableHighDpiScaling' was not set."
+            " UI quality may be affected."
+        ))
+
     for attr_name in (
-        "AA_EnableHighDpiScaling",
-        "AA_UseHighDpiPixmaps"
+        "AA_UseHighDpiPixmaps",
     ):
         attr = getattr(QtCore.Qt, attr_name, None)
         if attr is None:


### PR DESCRIPTION
## Brief description
Set `AA_EnableHighDpiScaling` before QApplication is initialized.

## Testing notes:
1. Launch of tray should not cause warning `"Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created."`