### PR TITLE
Maya + Yeti: Load Yeti Cache fix frame number recognition

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/load/load_yeti_cache.py
@@ -250,7 +250,7 @@ class YetiCacheLoader(load.LoaderPlugin):
         """
 
         name = node_name.replace(":", "_")
-        pattern = r"^({name})(\.[0-4]+)?(\.fur)$".format(name=re.escape(name))
+        pattern = r"^({name})(\.[0-9]+)?(\.fur)$".format(name=re.escape(name))
 
         files = [fname for fname in os.listdir(root) if re.match(pattern,
                                                                  fname)]


### PR DESCRIPTION
## Brief description

Previously a cache starting at frame 1005 would fail due to a "5" being present. This would only be noticable if the start frame used for detection included a digit that was not 0, 1, 2, 3 or 4. I guess we've had the luck to always have been starting with a frame number like 1001, 1000, etc. because if any number in 56789 would have been present then this would previously fail.

## Description

It's funny how long this must have been missed. We've been so lucky!

## Testing notes:

1. Publish a yeti cache with 5, 6, 7, 8 or 9 in the frame number (e.g. single frame at frame 1005)
2. Load yeti cache should work. 