### PR TITLE
Maya: fix regression of Renderman Deadline hack

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -475,6 +475,13 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
         layer_metadata = render_products.layer_data
         layer_prefix = layer_metadata.filePrefix
 
+        plugin_info = copy.deepcopy(self.plugin_info)
+        plugin_info.update({
+            # Output directory and filename
+            "OutputFilePath": data["dirname"].replace("\\", "/"),
+            "OutputFilePrefix": layer_prefix,
+        })
+
         # This hack is here because of how Deadline handles Renderman version.
         # it considers everything with `renderman` set as version older than
         # Renderman 22, and so if we are using renderman > 21 we need to set
@@ -491,12 +498,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
             if int(rman_version.split(".")[0]) > 22:
                 renderer = "renderman22"
 
-        plugin_info = copy.deepcopy(self.plugin_info)
-        plugin_info.update({
-            # Output directory and filename
-            "OutputFilePath": data["dirname"].replace("\\", "/"),
-            "OutputFilePrefix": layer_prefix,
-        })
+            plugin_info["Renderer"] = renderer
 
         return job_info, plugin_info
 


### PR DESCRIPTION
## Fix

Fix regression of missing Renderman hack for Deadline.

For newer versions of Renderman, DL needs renderer to be set as `renderman22`. Refactoring of submission plugins removed this hack and this PR is putting it back.