### PR TITLE
Maya: Set default value for RenderSetupIncludeLights option

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -57,8 +57,9 @@ class MayaPluginInfo:
     RenderLayer = attr.ib(default=None)  # Render only this layer
     Renderer = attr.ib(default=None)
     ProjectPath = attr.ib(default=None)  # Resolve relative references
+    # Include all lights flag
     RenderSetupIncludeLights = attr.ib(
-        default="1", validator=_validate_deadline_bool_value)  # Include all lights flag
+        default="1", validator=_validate_deadline_bool_value)
 
 
 @attr.s

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -201,11 +201,12 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
         # Set it to default Maya behaviour if it cannot be determined
         # from instance (but it should be, by the Collector).
 
-        default_rs_include_lights = instance.context.data\
-            .get('project_settings')\
-            .get('maya')\
-            .get('RenderSettings')\
-            .get('enable_all_lights')
+        default_rs_include_lights = (
+            instance.context.data['project_settings']
+                                 ['maya']
+                                 ['RenderSettings']
+                                 ['enable_all_lights']
+        )
 
         rs_include_lights = instance.data.get(
             "renderSetupIncludeLights", default_rs_include_lights)

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -199,10 +199,18 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
         context = instance.context
 
         # Set it to default Maya behaviour if it cannot be determined
-        # from instance (but it should be, by the Collector). Also
-        rs_include_lights = instance.data.get("renderSetupIncludeLights", "1")
+        # from instance (but it should be, by the Collector).
+
+        default_rs_include_lights = instance.context.data\
+            .get('project_settings')\
+            .get('maya')\
+            .get('RenderSettings')\
+            .get('enable_all_lights')
+
+        rs_include_lights = instance.data.get(
+            "renderSetupIncludeLights", default_rs_include_lights)
         if rs_include_lights not in {"1", "0", True, False}:
-            rs_include_lights = "1"
+            rs_include_lights = default_rs_include_lights
         plugin_info = MayaPluginInfo(
             SceneFile=self.scene_path,
             Version=cmds.about(version=True),

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -190,7 +190,9 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
             Version=cmds.about(version=True),
             RenderLayer=instance.data['setMembers'],
             Renderer=instance.data["renderer"],
-            RenderSetupIncludeLights=instance.data.get("renderSetupIncludeLights"),  # noqa
+            # Set it to default Maya behaviour if it cannot be determined
+            # from instance (but it should be, by the Collector).
+            RenderSetupIncludeLights=instance.data.get("renderSetupIncludeLights", 1),  # noqa
             ProjectPath=context.data["workspaceDir"],
             UsingRenderLayers=True,
         )

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -35,7 +35,7 @@
     "RenderSettings": {
         "apply_render_settings": true,
         "default_render_image_folder": "renders",
-        "enable_all_lights": false,
+        "enable_all_lights": true,
         "aov_separator": "underscore",
         "reset_current_frame": false,
         "arnold_renderer": {


### PR DESCRIPTION
## Fix

`RenderSetupIncludeLights` must be either set to 1 or 0 or not at all. This PR is adding default value for edge cases where this is not handled. Without it, DL is crashing.