### PR TITLE
Photoshop: missed sync published version of workfile with workfile

### DIFF
--- a/openpype/hosts/photoshop/plugins/publish/collect_version.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_version.py
@@ -7,10 +7,15 @@ class CollectVersion(pyblish.api.InstancePlugin):
     Used to synchronize version from workfile to all publishable instances:
         - image (manually created or color coded)
         - review
+        - workfile
 
     Dev comment:
     Explicit collector created to control this from single place and not from
     3 different.
+
+    Workfile set here explicitly as version might to be forced from latest + 1
+    because of Webpublisher.
+    (This plugin must run after CollectPublishedVersion!)
     """
     order = pyblish.api.CollectorOrder + 0.200
     label = 'Collect Version'

--- a/openpype/hosts/photoshop/plugins/publish/collect_version.py
+++ b/openpype/hosts/photoshop/plugins/publish/collect_version.py
@@ -16,7 +16,7 @@ class CollectVersion(pyblish.api.InstancePlugin):
     label = 'Collect Version'
 
     hosts = ["photoshop"]
-    families = ["image", "review"]
+    families = ["image", "review", "workfile"]
 
     def process(self, instance):
         workfile_version = instance.context.data["version"]


### PR DESCRIPTION
## Brief description
If Collect Version is enabled, everything published (`image`, `review`, even `workfile`) from workfile should carry its version number.


## Testing notes:
1. check that you have `project_settings/photoshop/publish/CollectVersion` enabled
2. publish workfile from PS, check all published images, reviews and workfile version