### PR TITLE
General: Set root environments before DCC launch

### DIFF
--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -1403,6 +1403,7 @@ def get_app_environments_for_context(
 
         "env": env
     })
+    data["env"].update(anatomy.root_environments())
 
     prepare_app_environments(data, env_group, modules_manager)
     prepare_context_environments(data, env_group, modules_manager)


### PR DESCRIPTION
## Brief description
Root environments can be used in enviornments of applications now.

## Description
We set them after host launch so they were not available at the moment when system settings environment variables were resolved.

## Testing notes:
1. Use `OPENPYPE_ROOT_WORK` in DCC environments
    - e.g. `{"MY_ENV": "{OPENPYPE_ROOT_WORK}"}`
2. Launch the DCC
3. Check if the env is filled