### PR TITLE
Houdini: Fix validate workfile paths for non-parm file references

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/validate_workfile_paths.py
+++ b/openpype/hosts/houdini/plugins/publish/validate_workfile_paths.py
@@ -35,6 +35,9 @@ class ValidateWorkfilePaths(pyblish.api.InstancePlugin):
     def get_invalid(cls):
         invalid = []
         for param, _ in hou.fileReferences():
+            if param is None:
+                continue
+
             # skip nodes we are not interested in
             if param.node().type().name() not in cls.node_types:
                 continue


### PR DESCRIPTION
## Brief description

Fix error on `param=None` for HDA file references

## Additional info

Previous error:
![afbeelding](https://user-images.githubusercontent.com/2439881/194345184-bdd62d4c-7c99-417f-8c3a-004ed46c5d4c.png)

## Testing notes:

1. Publish workfile from Houdini with HDAs loaded