### PR TITLE
Maya: Deadline OutputFilePath hack regression for Renderman

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -502,8 +502,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
 
             # this is needed because renderman plugin in Deadline
             # handles directory and file prefixes separately
-            plugin_info["OutputFilePath"] = os.path.dirname(
-                job_info.OutputDirectory[0]).replace("\\", "/")
+            plugin_info["OutputFilePath"] = job_info.OutputDirectory[0]
 
         return job_info, plugin_info
 

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -500,6 +500,11 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
 
             plugin_info["Renderer"] = renderer
 
+            # this is needed because renderman plugin in Deadline
+            # handles directory and file prefixes separately
+            plugin_info["OutputFilePath"] = os.path.dirname(
+                job_info.OutputDirectory[0]).replace("\\", "/")
+
         return job_info, plugin_info
 
     def _get_vray_export_payload(self, data):


### PR DESCRIPTION
## Fix

During refactoring of Maya Deadline submitter, we've accidentaly dropped Renderman specific hacks. This is returning back one of them. 

Renderman integration in Deadline relies on plugin info `OutputFilePath` to be set differently than in other renderes. I has to point directly to the file output, unlike with other renderers where this can be further expanded by `OutputFilePrefix`

### Testing

Renderman renders should render and publish correctly