### PR TITLE
General: Control Thumbnail integration via explicit configuration profiles

### DIFF
--- a/openpype/plugins/publish/integrate_thumbnail.py
+++ b/openpype/plugins/publish/integrate_thumbnail.py
@@ -1,3 +1,13 @@
+""" Integrate Thumbnails for Openpype use in Loaders.
+
+    This thumbnail is different from 'thumbnail' representation which could
+    be uploaded to Ftrack, or used as any other representation in Loaders to
+    pull into a scene.
+
+    This one is used only as image describing content of published item and
+    shows up only in Loader in right column section.
+"""
+
 import os
 import sys
 import errno
@@ -12,7 +22,7 @@ from openpype.client.operations import OperationsSession, new_thumbnail_doc
 
 
 class IntegrateThumbnails(pyblish.api.InstancePlugin):
-    """Integrate Thumbnails."""
+    """Integrate Thumbnails for Openpype use in Loaders."""
 
     label = "Integrate Thumbnails"
     order = pyblish.api.IntegratorOrder + 0.01

--- a/openpype/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/openpype/plugins/publish/preintegrate_thumbnail_representation.py
@@ -62,7 +62,7 @@ class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
                 thumbnail_repre["tags"].append("delete")
         else:
             if "delete" in thumbnail_repre["tags"]:
-                thumbnail_repre["tags"].pop("delete")
+                thumbnail_repre["tags"].remove("delete")
 
         self.log.debug(
             "Thumbnail repre tags {}".format(thumbnail_repre["tags"]))

--- a/openpype/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/openpype/plugins/publish/preintegrate_thumbnail_representation.py
@@ -19,7 +19,7 @@ from openpype.lib.profiles_filtering import filter_profiles
 class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
     """Marks thumbnail representation for integrate to DB or not."""
 
-    label = "Override Integrate Thumbnails"
+    label = "Override Integrate Thumbnail Representations"
     order = pyblish.api.IntegratorOrder - 0.1
     families = ["review"]
 

--- a/openpype/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/openpype/plugins/publish/preintegrate_thumbnail_representation.py
@@ -20,7 +20,7 @@ class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
     """Marks thumbnail representation for integrate to DB or not."""
 
     label = "Should Integrate Thumbnails"
-    order = pyblish.api.IntegratorOrder
+    order = pyblish.api.IntegratorOrder - 0.1
     families = ["review"]
 
     integrate_profiles = {}

--- a/openpype/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/openpype/plugins/publish/preintegrate_thumbnail_representation.py
@@ -1,0 +1,68 @@
+""" Marks thumbnail representation for integrate to DB or not.
+
+    Some hosts produce thumbnail representation, most of them do not create
+    them explicitly, but they created during extract phase.
+
+    In some cases it might be useful to override implicit setting for host/task
+
+    This plugin needs to run after extract phase, but before integrate.py as
+    thumbnail is part of review family and integrated there.
+
+    It should be better to control integration of thumbnail in one place than
+    configure it in multiple places on host implementations.
+"""
+import pyblish.api
+
+from openpype.lib.profiles_filtering import filter_profiles
+
+
+class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
+    """Marks thumbnail representation for integrate to DB or not."""
+
+    label = "Should Integrate Thumbnails"
+    order = pyblish.api.IntegratorOrder
+    families = ["review"]
+
+    integrate_profiles = {}
+
+    def process(self, instance):
+        thumbnail_repre = None
+        for repre in instance.data["representations"]:
+            if repre["name"] == "thumbnail":
+                thumbnail_repre = repre
+                break
+
+        if not thumbnail_repre:
+            return
+
+        family = instance.data["family"]
+        subset_name = instance.data["subset"]
+        host_name = instance.context.data["hostName"]
+
+        anatomy_data = instance.data["anatomyData"]
+        task = anatomy_data.get("task", {})
+
+        found_profile = filter_profiles(
+            self.integrate_profiles,
+            {
+                "hosts": host_name,
+                "tasks": task.get("name"),
+                "task_types": task.get("type"),
+                "families": family,
+                "subsets": subset_name,
+            },
+            logger=self.log
+        )
+
+        if not found_profile:
+            return
+
+        if not found_profile["integrate_thumbnail"]:
+            if "delete" not in thumbnail_repre["tags"]:
+                thumbnail_repre["tags"].append("delete")
+        else:
+            if "delete" in thumbnail_repre["tags"]:
+                thumbnail_repre["tags"].pop("delete")
+
+        self.log.debug(
+            "Thumbnail repre tags {}".format(thumbnail_repre["tags"]))

--- a/openpype/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/openpype/plugins/publish/preintegrate_thumbnail_representation.py
@@ -46,7 +46,7 @@ class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
             self.integrate_profiles,
             {
                 "hosts": host_name,
-                "tasks": task.get("name"),
+                "task_names": task.get("name"),
                 "task_types": task.get("type"),
                 "families": family,
                 "subsets": subset_name,

--- a/openpype/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/openpype/plugins/publish/preintegrate_thumbnail_representation.py
@@ -19,7 +19,7 @@ from openpype.lib.profiles_filtering import filter_profiles
 class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
     """Marks thumbnail representation for integrate to DB or not."""
 
-    label = "Should Integrate Thumbnails"
+    label = "Override Integrate Thumbnails"
     order = pyblish.api.IntegratorOrder - 0.1
     families = ["review"]
 

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -164,6 +164,10 @@
                 }
             ]
         },
+        "PreIntegrateThumbnails": {
+            "enabled": true,
+            "integrate_profiles": []
+        },
         "IntegrateSubsetGroup": {
             "subset_grouping_profiles": [
                 {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -558,6 +558,73 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "PreIntegrateThumbnails",
+            "label": "Integrate Thumbnail Representations",
+            "is_group": true,
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "label",
+                    "label": "Explicitly set if Thumbnail representation should be integrated into DB.<br> If no matching profile set, existing state from Host implementation is kept."
+                },
+                {
+                    "type": "list",
+                    "key": "integrate_profiles",
+                    "label": "Integrate profiles",
+                    "use_label_wrap": true,
+                    "object_type": {
+                        "type": "dict",
+                        "children": [
+                            {
+                                "key": "families",
+                                "label": "Families",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "type": "hosts-enum",
+                                "key": "hosts",
+                                "label": "Hosts",
+                                "multiselection": true
+                            },
+                            {
+                                "key": "task_types",
+                                "label": "Task types",
+                                "type": "task-types-enum"
+                            },
+                            {
+                                "key": "tasks",
+                                "label": "Task names",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "key": "subsets",
+                                "label": "Subset names",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "type": "separator"
+                            },
+                            {
+                                "type": "boolean",
+                                "key": "integrate_thumbnail",
+                                "label": "Integrate thumbnail"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "key": "IntegrateSubsetGroup",
             "label": "Integrate Subset Group",
             "is_group": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -598,7 +598,7 @@
                                 "type": "task-types-enum"
                             },
                             {
-                                "key": "tasks",
+                                "key": "task_names",
                                 "label": "Task names",
                                 "type": "list",
                                 "object_type": "text"

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -559,7 +559,7 @@
             "type": "dict",
             "collapsible": true,
             "key": "PreIntegrateThumbnails",
-            "label": "Integrate Thumbnail Representations",
+            "label": "Override Integrate Thumbnail Representations",
             "is_group": true,
             "checkbox_key": "enabled",
             "children": [


### PR DESCRIPTION
## Brief description
Thumbnail representations are needed for Ftrack integration to show something in Versions. This provides more explicit configuration if they should be integrated, eg. stored in DB.

## Description
This PR provides setting up explicit profiles (host, task name, task type, subset, family) to enable/disable integration (eg storing in DB AND storing thumbnail in 'publish' folder)

Storing in publish folder might be sometimes confusing for artists.

This adds explicit step, if no profile gets added, state as is still remains.

## Additional info
In most cases thumbnail representations shouldn't be integrated. There is no standardization right now if the thumbnail repre gets  stored or not. 
After customer issue it was decided that more control could be beneficial, It could be approached that configuration gets added to each host, but better solution would to have single point of configuration (in similar fashion as ftrack family is being added right now).

In the future it might be good to clean up all host implementations (which will require wider testing), this mostly solves important issue for a customer.


## Testing notes:
1. configure `project_settings/global/publish/PreIntegrateThumbnails/integrate_profiles/0/integrate_thumbnail`
2. publish some simple image through Webpublisher, without studio processing