### PR TITLE
Maya: Hotfix for Deadline + Redshift renders without merge AOVs

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -32,6 +32,9 @@ from maya import cmds
 
 from openpype.pipeline import legacy_io
 
+from openpype.hosts.maya.api.lib_rendersettings import RenderSettings
+from openpype.hosts.maya.api.lib import get_attr_in_layer
+
 from openpype_modules.deadline import abstract_submit_deadline
 from openpype_modules.deadline.abstract_submit_deadline import DeadlineJobInfo
 
@@ -471,9 +474,10 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
             job_info.AssetDependency += self.scene_path
 
         # Get layer prefix
-        render_products = self._instance.data["renderProducts"]
-        layer_metadata = render_products.layer_data
-        layer_prefix = layer_metadata.filePrefix
+        renderlayer = self._instance.data["setMembers"]
+        renderer = self._instance.data["renderer"]
+        layer_prefix_attr = RenderSettings.get_image_prefix_attr(renderer)
+        layer_prefix = get_attr_in_layer(layer_prefix_attr, layer=renderlayer)
 
         plugin_info = copy.deepcopy(self.plugin_info)
         plugin_info.update({


### PR DESCRIPTION
Fixes #3953

## Brief description

Instead of taking the resolved output from Render Products which is the "image prefix" that matches the written output files for the renderer with the current layer's setting submit to Deadline with the actual "image prefix" value of that layer.

## Description

See #3953 for more details on why the error happened originally.

### Additional info

Would've preferred the code to be even cleaner than this by e.g. just having something like `imageFilePrefix` or `rawImageFilePrefix` stored in the `instance.data` so we could retrieve it directly instead of having to access the scene again.

## Testing notes:

1. Render with Redshift from Maya without merge AOVs / multilayer through Deadline.
2. Publish of rendered images fails.
