### PR TITLE
Fusion: Implement backwards compatibility (+/- Fusion 17.2)

### DIFF
--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -44,11 +44,26 @@ INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 class FusionLogHandler(logging.Handler):
     # Keep a reference to fusion's Print function (Remote Object)
-    _print = getattr(sys.modules["__main__"], "fusion").Print
+    _print = None
+
+    @property
+    def print(self):
+        if self._print is not None:
+            # Use cached
+            return self._print
+
+        _print = getattr(sys.modules["__main__"], "fusion").Print
+        if _print is None:
+            # Backwards compatibility: Print method on Fusion instance was
+            # added around Fusion 17.4 and wasn't available on PyRemote Object
+            # before
+            _print = get_current_comp().Print
+        self._print = _print
+        return _print
 
     def emit(self, record):
         entry = self.format(record)
-        self._print(entry)
+        self.print(entry)
 
 
 def install():


### PR DESCRIPTION
## Brief description

As mentioned [here](https://github.com/pypeclub/OpenPype/pull/3928#discussion_r991384981) the [recent PR](https://github.com/pypeclub/OpenPype/pull/3928) affected backwards compatibility for Fusion before around Fusion 17.4. I'm pretty sure Fusion 17.2 would not work without this PR. This should resolve that.

## Testing notes:

1. Test OpenPype in Fusion 17.2 or lower