### PR TITLE
Settings: Added configuration of ValidateVersion

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -31,7 +31,16 @@
         "ValidateVersion": {
             "enabled": true,
             "optional": false,
-            "active": true
+            "active": true,
+            "hosts": [
+                "aftereffects",
+                "blender",
+                "houdini",
+                "maya",
+                "nuke",
+                "photoshop",
+                "standalonepublisher"
+            ]
         },
         "ValidateIntent": {
             "enabled": false,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -81,12 +81,36 @@
             ]
         },
         {
-            "type": "schema_template",
-            "name": "template_publish_plugin",
-            "template_data": [
+            "type": "dict",
+            "key": "ValidateVersion",
+            "label": "Validate Version",
+            "collapsible": true,
+            "checkbox_key": "enabled",
+            "children": [
                 {
-                    "key": "ValidateVersion",
-                    "label": "Validate Version"
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "type": "boolean",
+                    "key": "optional",
+                    "label": "Optional"
+                },
+                {
+                    "type": "boolean",
+                    "key": "active",
+                    "label": "Active"
+                },
+                {
+                    "type": "label",
+                    "label": "Check if currently published version wasn't published before."
+                },
+                {
+                    "key": "hosts",
+                    "label": "Host names",
+                    "type": "hosts-enum",
+                    "multiselection": true
                 }
             ]
         },


### PR DESCRIPTION
## Brief description
ValidateVersion controls if publishing version wasn't published before, eg. we are not trying to overwrite existing files. It should be configurable in which hosts plugin gets triggered now.

## Description
Added as defaults existing values `maya`, `nuke`, `blender`, `houdini`, `standalone`.

Added also `photoshop`, `aftereffects` as they should be there (AE was as a default in 2.x)

## Testing notes:
1. publish with any of the configured hosts and check that "Validate Version" is present