### PR TITLE
Webpublisher: use max next published version number  for all items in batch

### DIFF
--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -37,6 +37,15 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
 
     This is not applicable for 'studio' processing where host application is
     called to process uploaded workfile and render frames itself.
+
+    For each task configure what properties should resulting instance have
+    based on uploaded files:
+    - uploading sequence of 'png' >> create instance of 'render' family,
+    by adding 'review' to 'Families' and 'Create review' to Tags it will
+    produce review.
+
+    There might be difference between single(>>image) and sequence(>>render)
+    uploaded files.
     """
     # must be really early, context values are only in json file
     order = pyblish.api.CollectorOrder - 0.490

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -147,13 +147,14 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
             instances.append(instance)
             self.log.info("instance.data:: {}".format(instance.data))
 
-        if not self.sync_version:
+        if not self.sync_next_version:
             return
 
         # overwrite specific version with same version for all
         max_next_version = max(next_versions)
         for inst in instances:
             inst.data["version"] = max_next_version
+            self.log.debug("overwritten version:: {}".format(max_next_version))
 
     def _get_subset_name(self, family, subset_template, task_name, variant):
         fill_pairs = {

--- a/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
+++ b/openpype/hosts/webpublisher/plugins/publish/collect_published_files.py
@@ -91,15 +91,19 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
                 host_name="webpublisher",
                 project_settings=context.data["project_settings"]
             )
-            next_versions.append(self._get_next_version(
+            version = self._get_next_version(
                 project_name, asset_doc, subset_name
-            ))
+            )
+            next_versions.append(version)
 
             instance = context.create_instance(subset_name)
             instance.data["asset"] = asset_name
             instance.data["subset"] = subset_name
+            # set configurable result family
             instance.data["family"] = family
+            # set configurable additional families
             instance.data["families"] = families
+            instance.data["version"] = version
             instance.data["stagingDir"] = tempfile.mkdtemp()
             instance.data["source"] = "webpublisher"
 
@@ -146,6 +150,7 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
         if not self.sync_version:
             return
 
+        # overwrite specific version with same version for all
         max_next_version = max(next_versions)
         for inst in instances:
             inst.data["version"] = max_next_version
@@ -187,7 +192,7 @@ class CollectPublishedFiles(pyblish.api.ContextPlugin):
             "ext": ext[1:],
             "files": files,
             "stagingDir": task_dir,
-            "tags": tags
+            "tags": tags  # configurable tags from Settings
         }
         self.log.info("sequences repre_data.data:: {}".format(repre_data))
         return [repre_data]

--- a/openpype/settings/defaults/project_settings/webpublisher.json
+++ b/openpype/settings/defaults/project_settings/webpublisher.json
@@ -10,6 +10,7 @@
     ],
     "publish": {
         "CollectPublishedFiles": {
+            "sync_next_version": false,
             "task_type_to_family": {
                 "Animation": [
                     {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
@@ -50,6 +50,19 @@
                     "label": "Collect Published Files",
                     "children": [
                         {
+                            "type": "label",
+                            "label": "Select if all versions of published items should be kept same. (As max(published) + 1.)"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "sync_next_version",
+                            "label": "Sync next publish version"
+                        },
+                        {
+                            "type": "label",
+                            "label": "Configure resulting family and tags on representation based on uploaded file and task. <br>Eg. '.png' is uploaded >> create instance of 'render' family<br>'Create review' in Tags >> mark representation to create review from."
+                        },
+                        {
                             "type": "dict-modifiable",
                             "collapsible": true,
                             "key": "task_type_to_family",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_webpublisher.json
@@ -88,6 +88,9 @@
                                             "object_type": "text"
                                         },
                                         {
+                                            "type": "separator"
+                                        },
+                                        {
                                             "type": "list",
                                             "key": "families",
                                             "label": "Families",
@@ -96,9 +99,6 @@
                                         {
                                             "type": "schema",
                                             "name": "schema_representation_tags"
-                                        },
-                                        {
-                                            "type": "separator"
                                         },
                                         {
                                             "type": "text",


### PR DESCRIPTION
## Brief description
With this PR it is possible to keep same version for all published items via WP (without studio processing).

## Description
Artist is uploading `.psd` and `.png`, it should look for highest published of `workfile (.psd)` or `image (.png)`, increase this by 1 and use this version number for BOTH workfile and image instances.

It looks for max version number, from both subsets, eg. if more `image` than `workfile` is published , workfile version number will follow image one.

## Testing notes:
1. set `Sync next publish version `project_settings/webpublisher/publish/CollectPublishedFiles`
![Screenshot 2022-10-11 152401](https://user-images.githubusercontent.com/4457962/195114288-99841f92-935f-4b09-9e31-ba7483a80535.png)
3. publish only .psd (maybe couple of times)
4. publish both .psd and .png >> resulting version for .png should match to .psd (eg. there will be gaps in images versions)