### PR TITLE
Houdini: Refactor container `schema` value

### DIFF
--- a/openpype/hosts/houdini/plugins/load/load_image.py
+++ b/openpype/hosts/houdini/plugins/load/load_image.py
@@ -73,7 +73,7 @@ class ImageLoader(load.LoaderPlugin):
 
         # Imprint it manually
         data = {
-            "schema": "avalon-core:container-2.0",
+            "schema": "openpype:container-2.0",
             "id": AVALON_CONTAINER_ID,
             "name": node_name,
             "namespace": namespace,

--- a/openpype/hosts/houdini/plugins/load/load_usd_layer.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_layer.py
@@ -43,7 +43,7 @@ class USDSublayerLoader(load.LoaderPlugin):
 
         # Imprint it manually
         data = {
-            "schema": "avalon-core:container-2.0",
+            "schema": "openpype:container-2.0",
             "id": AVALON_CONTAINER_ID,
             "name": node_name,
             "namespace": namespace,

--- a/openpype/hosts/houdini/plugins/load/load_usd_reference.py
+++ b/openpype/hosts/houdini/plugins/load/load_usd_reference.py
@@ -43,7 +43,7 @@ class USDReferenceLoader(load.LoaderPlugin):
 
         # Imprint it manually
         data = {
-            "schema": "avalon-core:container-2.0",
+            "schema": "openpype:container-2.0",
             "id": AVALON_CONTAINER_ID,
             "name": node_name,
             "namespace": namespace,


### PR DESCRIPTION
## Brief description

Refactor container schema key value `avalon-core:container-2.0` -> `openpype:container-2.0`

These were the only remainders using the old schema value

## Additional info

Not sure how relevant still with #3046 in progress. But just noticed this was the only usage of the old schema value.

## Testing notes:

1. Load + update Houdini containers for image and USD.