### PR TITLE
General: Use direct import of resources

### DIFF
--- a/openpype/hosts/maya/api/customize.py
+++ b/openpype/hosts/maya/api/customize.py
@@ -8,7 +8,7 @@ from functools import partial
 import maya.cmds as cmds
 import maya.mel as mel
 
-from openpype.api import resources
+from openpype import resources
 from openpype.tools.utils import host_tools
 from .lib import get_main_window
 

--- a/openpype/hosts/nuke/api/utils.py
+++ b/openpype/hosts/nuke/api/utils.py
@@ -1,7 +1,7 @@
 import os
 import nuke
 
-from openpype.api import resources
+from openpype import resources
 from .lib import maintained_selection
 
 

--- a/openpype/tools/launcher/actions.py
+++ b/openpype/tools/launcher/actions.py
@@ -4,7 +4,7 @@ from Qt import QtWidgets, QtGui
 
 from openpype import PLUGINS_DIR
 from openpype import style
-from openpype.api import resources
+from openpype import resources
 from openpype.lib import (
     Logger,
     ApplictionExecutableNotFound,

--- a/openpype/tools/launcher/lib.py
+++ b/openpype/tools/launcher/lib.py
@@ -1,7 +1,7 @@
 import os
 from Qt import QtGui
 import qtawesome
-from openpype.api import resources
+from openpype import resources
 
 ICON_CACHE = {}
 NOT_FOUND = type("NotFound", (object, ), {})

--- a/openpype/tools/launcher/window.py
+++ b/openpype/tools/launcher/window.py
@@ -4,7 +4,7 @@ import logging
 from Qt import QtWidgets, QtCore, QtGui
 
 from openpype import style
-from openpype.api import resources
+from openpype import resources
 from openpype.pipeline import AvalonMongoDB
 
 import qtawesome

--- a/openpype/tools/standalonepublish/app.py
+++ b/openpype/tools/standalonepublish/app.py
@@ -13,7 +13,7 @@ from .widgets import (
 )
 from .widgets.constants import HOST_NAME
 from openpype import style
-from openpype.api import resources
+from openpype import resources
 from openpype.pipeline import AvalonMongoDB
 from openpype.modules import ModulesManager
 

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -5,7 +5,7 @@ import collections
 from Qt import QtCore, QtGui, QtWidgets
 
 from openpype import style
-from openpype.api import resources
+from openpype import resources
 from openpype.settings.lib import get_local_settings
 from openpype.lib.pype_info import (
     get_all_current_info,


### PR DESCRIPTION
## Brief description
Import `resources` directly instead of through api.

## Testing notes:
- [x] Launcher tool should work propely
- [x] OpenPype info widget should work propely (click on version in Tray)
- [x] StandalonePublisher should work propely
- [x] Maya should integrate properly
- [ ] Nuke should integrate properly