### PR TITLE
General: Added Photoshop and Aftereffects into ValidateVersion

### DIFF
--- a/openpype/plugins/publish/validate_version.py
+++ b/openpype/plugins/publish/validate_version.py
@@ -10,7 +10,8 @@ class ValidateVersion(pyblish.api.InstancePlugin):
     order = pyblish.api.ValidatorOrder
 
     label = "Validate Version"
-    hosts = ["nuke", "maya", "houdini", "blender", "standalonepublisher"]
+    hosts = ["nuke", "maya", "houdini", "blender", "standalonepublisher",
+             "photoshop", "aftereffects"]
 
     optional = False
     active = True


### PR DESCRIPTION
## Brief description
PS and AE allow synchronization of workfile version (version number from work workfile) as a version of all published items.
This could result in unwanted overwrites of existing version, this Validator protects from this.

## Testing notes:
1. enbale sync workfile version in photohop
2. try in PS publish workfile with a version number that is already published