### PR TITLE
Publisher: Prepare publisher controller  for remote publishing

### DIFF
--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -3,7 +3,7 @@ import re
 import collections
 import uuid
 import json
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 
 import six
 import clique
@@ -115,6 +115,16 @@ class AbtractAttrDef:
             return False
         return self.key == other.key
 
+    @abstractproperty
+    def type(self):
+        """Attribute definition type also used as identifier of class.
+
+        Returns:
+            str: Type of attribute definition.
+        """
+
+        pass
+
     @abstractmethod
     def convert_value(self, value):
         """Convert value to a valid one.
@@ -141,10 +151,12 @@ class UIDef(AbtractAttrDef):
 
 
 class UISeparatorDef(UIDef):
-    pass
+    type = "separator"
 
 
 class UILabelDef(UIDef):
+    type = "label"
+
     def __init__(self, label):
         super(UILabelDef, self).__init__(label=label)
 
@@ -159,6 +171,8 @@ class UnknownDef(AbtractAttrDef):
     This attribute can be used to keep existing data unchanged but does not
     have known definition of type.
     """
+
+    type = "unknown"
 
     def __init__(self, key, default=None, **kwargs):
         kwargs["default"] = default
@@ -181,6 +195,7 @@ class NumberDef(AbtractAttrDef):
         default(int, float): Default value for conversion.
     """
 
+    type = "number"
     def __init__(
         self, key, minimum=None, maximum=None, decimals=None, default=None,
         **kwargs
@@ -301,6 +316,8 @@ class EnumDef(AbtractAttrDef):
         default: Default value. Must be one key(value) from passed items.
     """
 
+    type = "enum"
+
     def __init__(self, key, items, default=None, **kwargs):
         if not items:
             raise ValueError((
@@ -342,6 +359,8 @@ class BoolDef(AbtractAttrDef):
     Args:
         default(bool): Default value. Set to `False` if not defined.
     """
+
+    type = "bool"
 
     def __init__(self, key, default=None, **kwargs):
         if default is None:
@@ -585,6 +604,7 @@ class FileDef(AbtractAttrDef):
         default(str, List[str]): Default value.
     """
 
+    type = "path"
     def __init__(
         self, key, single_item=True, folders=None, extensions=None,
         allow_sequences=True, extensions_label=None, default=None, **kwargs

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -90,6 +90,8 @@ class AbtractAttrDef:
             next to value input or ahead.
     """
 
+    type_attributes = []
+
     is_value_def = True
 
     def __init__(
@@ -134,6 +136,35 @@ class AbtractAttrDef:
         """
 
         pass
+
+    def serialize(self):
+        """Serialize object to data so it's possible to recreate it.
+
+        Returns:
+            Dict[str, Any]: Serialized object that can be passed to
+                'deserialize' method.
+        """
+
+        data = {
+            "type": self.type,
+            "key": self.key,
+            "label": self.label,
+            "tooltip": self.tooltip,
+            "default": self.default,
+            "is_label_horizontal": self.is_label_horizontal
+        }
+        for attr in self.type_attributes:
+            data[attr] = getattr(self, attr)
+        return data
+
+    @classmethod
+    def deserialize(cls, data):
+        """Recreate object from data.
+
+        Data can be received using 'serialize' method.
+        """
+
+        return cls(**data)
 
 
 # -----------------------------------------
@@ -196,6 +227,12 @@ class NumberDef(AbtractAttrDef):
     """
 
     type = "number"
+    type_attributes = [
+        "minimum",
+        "maximum",
+        "decimals"
+    ]
+
     def __init__(
         self, key, minimum=None, maximum=None, decimals=None, default=None,
         **kwargs
@@ -267,6 +304,12 @@ class TextDef(AbtractAttrDef):
         default(str, None): Default value. Empty string used when not defined.
     """
 
+    type = "text"
+    type_attributes = [
+        "multiline",
+        "placeholder",
+    ]
+
     def __init__(
         self, key, multiline=None, regex=None, placeholder=None, default=None,
         **kwargs
@@ -304,6 +347,11 @@ class TextDef(AbtractAttrDef):
         if isinstance(value, six.string_types):
             return value
         return self.default
+
+    def serialize(self):
+        data = super(TextDef, self).serialize()
+        data["regex"] = self.regex.pattern
+        return data
 
 
 class EnumDef(AbtractAttrDef):
@@ -351,6 +399,11 @@ class EnumDef(AbtractAttrDef):
         if value in self.items:
             return value
         return self.default
+
+    def serialize(self):
+        data = super(TextDef, self).serialize()
+        data["items"] = list(self.items)
+        return data
 
 
 class BoolDef(AbtractAttrDef):
@@ -605,6 +658,14 @@ class FileDef(AbtractAttrDef):
     """
 
     type = "path"
+    type_attributes = [
+        "single_item",
+        "folders",
+        "extensions",
+        "allow_sequences",
+        "extensions_label",
+    ]
+
     def __init__(
         self, key, single_item=True, folders=None, extensions=None,
         allow_sequences=True, extensions_label=None, default=None, **kwargs

--- a/openpype/lib/events.py
+++ b/openpype/lib/events.py
@@ -1,6 +1,7 @@
 """Events holding data about specific event."""
 import os
 import re
+import copy
 import inspect
 import logging
 import weakref
@@ -207,6 +208,12 @@ class Event(object):
 
     @property
     def source(self):
+        """Event's source used for triggering callbacks.
+
+        Returns:
+            Union[str, None]: Source string or None. Source is optional.
+        """
+
         return self._source
 
     @property
@@ -215,6 +222,12 @@ class Event(object):
 
     @property
     def topic(self):
+        """Event's topic used for triggering callbacks.
+
+        Returns:
+            str: Topic string.
+        """
+
         return self._topic
 
     def emit(self):
@@ -226,6 +239,42 @@ class Event(object):
                 )
             )
         self._event_system.emit_event(self)
+
+    def to_data(self):
+        """Convert Event object to data.
+
+        Returns:
+            Dict[str, Any]: Event data.
+        """
+
+        return {
+            "id": self.id,
+            "topic": self.topic,
+            "source": self.source,
+            "data": copy.deepcopy(self.data)
+        }
+
+    @classmethod
+    def from_data(cls, event_data, event_system=None):
+        """Create event from data.
+
+        Args:
+            event_data (Dict[str, Any]): Event data with defined keys. Can be
+                created using 'to_data' method.
+            event_system (EventSystem): System to which the event belongs.
+
+        Returns:
+            Event: Event with attributes from passed data.
+        """
+
+        obj = cls(
+            event_data["topic"],
+            event_data["data"],
+            event_data["source"],
+            event_system
+        )
+        obj._id = event_data["id"]
+        return obj
 
 
 class EventSystem(object):

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -197,6 +197,16 @@ class AttributeValues:
     def changes(self):
         return self.calculate_changes(self._data, self._origin_data)
 
+    def apply_changes(self, changes):
+        for key, item in changes.items():
+            old_value, new_value = item
+            if new_value is None:
+                if key in self:
+                    self.pop(key)
+
+            elif self.get(key) != new_value:
+                self[key] = new_value
+
 
 class CreatorAttributeValues(AttributeValues):
     """Creator specific attribute values of an instance.
@@ -326,6 +336,21 @@ class PublishAttributes:
             if key not in self._data:
                 changes[key] = (value, None)
         return changes
+
+    def apply_changes(self, changes):
+        for key, item in changes.items():
+            if isinstance(item, dict):
+                self._data[key].apply_changes(item)
+                continue
+
+            old_value, new_value = item
+            if new_value is not None:
+                raise ValueError(
+                    "Unexpected type \"{}\" expected None".format(
+                        str(type(new_value))
+                    )
+                )
+            self.pop(key)
 
     def set_publish_plugins(self, attr_plugins):
         """Set publish plugins attribute definitions."""
@@ -692,6 +717,97 @@ class CreatedInstance:
         for member in members:
             if member not in self._members:
                 self._members.append(member)
+
+    def serialize_for_remote(self):
+        return {
+            "data": self.data_to_store(),
+            "orig_data": copy.deepcopy(self._orig_data)
+        }
+
+    @classmethod
+    def deserialize_on_remote(cls, serialized_data, creator_items):
+        """Convert instance data to CreatedInstance.
+
+        This is fake instance in remote process e.g. in UI process. The creator
+        is not a full creator and should not be used for calling methods when
+        instance is created from this method (matters on implementation).
+
+        Args:
+            serialized_data (Dict[str, Any]): Serialized data for remote
+                recreating. Should contain 'data' and 'orig_data'.
+            creator_items (Dict[str, Any]): Mapping of creator identifier and
+                objects that behave like a creator for most of attribute
+                access.
+        """
+
+        instance_data = copy.deepcopy(serialized_data["data"])
+        creator_identifier = instance_data["creator_identifier"]
+        creator_item = creator_items[creator_identifier]
+
+        family = instance_data.get("family", None)
+        if family is None:
+            family = creator_item.family
+        subset_name = instance_data.get("subset", None)
+
+        obj = cls(
+            family, subset_name, instance_data, creator_item, new=False
+        )
+        obj._orig_data = serialized_data["orig_data"]
+
+        return obj
+
+    def remote_changes(self):
+        """Prepare serializable changes on remote side.
+
+        Returns:
+            Dict[str, Any]: Prepared changes that can be send to client side.
+        """
+
+        return {
+            "changes": self.changes(),
+            "asset_is_valid": self._asset_is_valid,
+            "task_is_valid": self._task_is_valid,
+        }
+
+    def update_from_remote(self, remote_changes):
+        """Apply changes from remote side on client side.
+
+        Args:
+            remote_changes (Dict[str, Any]): Changes created on remote side.
+        """
+
+        self._asset_is_valid = remote_changes["asset_is_valid"]
+        self._task_is_valid = remote_changes["task_is_valid"]
+
+        changes = remote_changes["changes"]
+        creator_attributes = changes.pop("creator_attributes", None) or {}
+        publish_attributes = changes.pop("publish_attributes", None) or {}
+        if changes:
+            self.apply_changes(changes)
+
+        if creator_attributes:
+            self.creator_attributes.apply_changes(creator_attributes)
+
+        if publish_attributes:
+            self.publish_attributes.apply_changes(publish_attributes)
+
+    def apply_changes(self, changes):
+        """Apply changes created via 'changes'.
+
+        Args:
+            Dict[str, Tuple[Any, Any]]: Instance changes to apply. Same values
+                are kept untouched.
+        """
+
+        for key, item in changes.items():
+            old_value, new_value = item
+            if new_value is None:
+                if key in self:
+                    self.pop(key)
+            else:
+                current_value = self.get(key)
+                if current_value != new_value:
+                    self[key] = new_value
 
 
 class CreateContext:

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -781,6 +781,10 @@ class CreateContext:
         return self._instances_by_id.values()
 
     @property
+    def instances_by_id(self):
+        return self._instances_by_id
+
+    @property
     def publish_attributes(self):
         """Access to global publish attributes."""
         return self._publish_attributes

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -536,9 +536,6 @@ class PublisherController(AbstractPublisherController):
         self._host = registered_host()
         self._headless = headless
 
-        # Inner event system of controller
-        self._event_system = EventSystem()
-
         self._create_context = CreateContext(
             self._host, dbcon, headless=headless, reset=False
         )
@@ -645,29 +642,6 @@ class PublisherController(AbstractPublisherController):
     def _publish_plugins(self):
         """Publish plugins."""
         return self._create_context.publish_plugins
-
-    @property
-    def event_system(self):
-        """Inner event system for publisher controller.
-
-        Known topics:
-            "show.detailed.help" - Detailed help requested (UI related).
-            "show.card.message" - Show card message request (UI related).
-            "instances.refresh.finished" - Instances are refreshed.
-            "plugins.refresh.finished" - Plugins refreshed.
-            "publish.reset.finished" - Controller reset finished.
-            "publish.process.started" - Publishing started. Can be started from
-                paused state.
-            "publish.process.validated" - Publishing passed validation.
-            "publish.process.stopped" - Publishing stopped/paused process.
-            "publish.process.plugin.changed" - Plugin state has changed.
-            "publish.process.instance.changed" - Instance state has changed.
-
-        Returns:
-            EventSystem: Event system which can trigger callbacks for topics.
-        """
-
-        return self._event_system
 
     def _emit_event(self, topic, data=None):
         if data is None:

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -797,10 +797,12 @@ class AbstractPublisherController(object):
 
     @abstractmethod
     def reset(self):
-        pass
+        """Reset whole controller.
 
-    @abstractmethod
-    def emit_card_message(self, message):
+        This should reset create context, publish context and all variables
+        that are related to it.
+        """
+
         pass
 
     @abstractmethod
@@ -828,52 +830,113 @@ class AbstractPublisherController(object):
     def create(
         self, creator_identifier, subset_name, instance_data, options
     ):
-        pass
+        """Trigger creation by creator identifier.
+
+        Should also trigger refresh of instanes.
+
+        Args:
+            creator_identifier (str): Identifier of Creator plugin.
+            subset_name (str): Calculated subset name.
+            instance_data (Dict[str, Any]): Base instance data with variant,
+                asset name and task name.
+            options (Dict[str, Any]): Data from pre-create attributes.
+        """
 
     def save_changes(self):
-        """Save changes happened during creation."""
+        """Save changes in create context."""
 
         pass
 
     def remove_instances(self, instances):
-        """Remove list of instances."""
+        """Remove list of instances from create context."""
 
         pass
 
     @abstractproperty
     def publish_has_finished(self):
+        """Has publishing finished.
+
+        Returns:
+            bool: If publishing finished and all plugins were iterated.
+        """
+
         pass
 
     @abstractproperty
     def publish_is_running(self):
+        """Publishing is running right now.
+
+        Returns:
+            bool: If publishing is in progress.
+        """
+
         pass
 
     @abstractproperty
     def publish_has_validated(self):
+        """Publish validation passed.
+
+        Returns:
+            bool: If publishing passed last possible validation order.
+        """
+
         pass
 
     @abstractproperty
     def publish_has_crashed(self):
+        """Publishing crashed for any reason.
+
+        Returns:
+            bool: Publishing crashed.
+        """
+
         pass
 
     @abstractproperty
     def publish_has_validation_errors(self):
+        """During validation happened at least one validation error.
+
+        Returns:
+            bool: Validation error was raised during validation.
+        """
+
         pass
 
     @abstractproperty
     def publish_max_progress(self):
+        """Get maximum possible progress number.
+
+        Returns:
+            int: Number that can be used as 100% of publish progress bar.
+        """
+
         pass
 
     @abstractproperty
     def publish_progress(self):
+        """Current progress number.
+
+        Returns:
+            int: Current progress value which is between 0 and
+                'publish_max_progress'.
+        """
+
         pass
 
     @abstractproperty
     def publish_comment_is_set(self):
+        """Publish comment was at least once set.
+
+        Publish comment can be set only once when publish is started for a
+        first time. This helpt to idetify if 'set_comment' should be called or
+        not.
+        """
+
         pass
 
     @abstractmethod
     def get_publish_crash_error(self):
+
         pass
 
     @abstractmethod
@@ -885,27 +948,65 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def set_comment(self, comment):
-        pass
-
-    @abstractmethod
     def publish(self):
+        """Trigger publishing without any order limitations."""
+
         pass
 
     @abstractmethod
     def validate(self):
+        """Trigger publishing which will stop after validation order."""
+
         pass
 
     @abstractmethod
     def stop_publish(self):
+        """Stop publishing can be also used to pause publishing.
+
+        Pause of publishing is possible only if all plugins successfully
+        finished.
+        """
+
         pass
 
     @abstractmethod
-    def run_action(self, plugin, action):
+    def run_action(self, plugin_id, action_id):
+        """Trigger pyblish action on a plugin.
+
+        Args:
+            plugin_id (str): Id of publish plugin.
+            action_id (str): Id of publish action.
+        """
+
         pass
 
     @abstractmethod
     def reset_project_data_cache(self):
+        pass
+
+    @abstractmethod
+    def set_comment(self, comment):
+        """Set comment on pyblish context.
+
+        Set "comment" key on current pyblish.api.Context data.
+
+        Args:
+            comment (str): Artist's comment.
+        """
+
+        pass
+
+    @abstractmethod
+    def emit_card_message(self, message):
+        """Emit a card message which can have a lifetime.
+
+        This is for UI purposes. Method can be extended to more arguments
+        in future e.g. different message timeout or type (color).
+
+        Args:
+            message (str): Message that will be showed.
+        """
+
         pass
 
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1438,6 +1438,8 @@ class PublisherController(AbstractPublisherController):
         # Reset avalon context
         self._create_context.reset_avalon_context()
 
+        self._asset_docs_cache.reset()
+
         self._reset_plugins()
         # Publish part must be reset after plugins
         self._reset_publish()

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1995,11 +1995,11 @@ class PublisherController(BasePublishController):
 
         # Cleanup of publishing process
         self.publish_finished = True
-        self.publish_progress = self._publish_max_progress
+        self.publish_progress = self.publish_max_progress
         yield MainThreadItem(self.stop_publish)
 
     def _add_validation_error(self, result):
-        self.publish_has_validation_errors = False
+        self.publish_has_validation_errors = True
         self._publish_validation_errors.add_error(
             result["plugin"],
             result["error"],
@@ -2030,7 +2030,7 @@ class PublisherController(BasePublishController):
                         " to your supervisor or OpenPype."
                     )
                 self.publish_error_msg = msg
-                self.publish_has_crashed = False
+                self.publish_has_crashed = True
 
         self._publish_next_process()
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1025,6 +1025,7 @@ class PublisherController(AbstractPublisherController):
     @property
     def host_is_valid(self):
         """Host is valid for creation."""
+
         return self._create_context.host_is_valid
 
     @property
@@ -1035,7 +1036,7 @@ class PublisherController(AbstractPublisherController):
     def _emit_event(self, topic, data=None):
         if data is None:
             data = {}
-        self._event_system.emit(topic, data, "controller")
+        self.event_system.emit(topic, data, "controller")
 
     # --- Publish specific callbacks ---
     def get_asset_docs(self):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -784,6 +784,12 @@ class CreatorItem:
         self.instance_attributes_defs = instance_attributes_defs
         self.pre_create_attributes_defs = pre_create_attributes_defs
 
+    def get_instance_attr_defs(self):
+        return self.instance_attributes_defs
+
+    def get_group_label(self):
+        return self.group_label
+
     @classmethod
     def from_creator(cls, creator):
         if isinstance(creator, AutoCreator):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -874,6 +874,29 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
+    def get_subset_name(
+        self,
+        creator_identifier,
+        variant,
+        task_name,
+        asset_name,
+        instance_id=None
+    ):
+        """Get subset name based on passed data.
+
+        Args:
+            creator_identifier (str): Identifier of creator which should be
+                responsible for subset name creation.
+            variant (str): Variant value from user's input.
+            task_name (str): Name of task for which is instance created.
+            asset_name (str): Name of asset for which is instance created.
+            instance_id (Union[str, None]): Existing instance id when subset
+                name is updated.
+        """
+
+        pass
+
+    @abstractmethod
     def create(
         self, creator_identifier, subset_name, instance_data, options
     ):
@@ -1379,6 +1402,35 @@ class PublisherController(AbstractPublisherController):
         if creator is not None:
             return creator.get_icon()
         return None
+
+    def get_subset_name(
+        self,
+        creator_identifier,
+        variant,
+        task_name,
+        asset_name,
+        instance_id=None
+    ):
+        """Get subset name based on passed data.
+
+        Args:
+            creator_identifier (str): Identifier of creator which should be
+                responsible for subset name creation.
+            variant (str): Variant value from user's input.
+            task_name (str): Name of task for which is instance created.
+            asset_name (str): Name of asset for which is instance created.
+            instance_id (Union[str, None]): Existing instance id when subset
+                name is updated.
+        """
+
+        creator = self._creators[creator_identifier]
+        project_name = self.project_name
+        print(asset_name)
+        asset_doc = self._asset_docs_cache.get_full_asset_by_name(asset_name)
+
+        return creator.get_subset_name(
+            variant, task_name, asset_doc, project_name
+        )
 
     def create(
         self, creator_identifier, subset_name, instance_data, options

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1320,7 +1320,6 @@ class BasePublishController(AbstractPublisherController):
             "publish.has_validated.changed" - Attr 'publish_has_validated'
                 changed.
             "publish.is_running.changed" - Attr 'publish_is_running' changed.
-            "publish.has_validated.changed" - Attr 'has_validated' changed.
             "publish.has_crashed.changed" - Attr 'publish_has_crashed' changed.
             "publish.publish_error.changed" - Attr 'publish_error'
             "publish.has_validation_errors.changed" - Attr

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -920,6 +920,8 @@ class PublisherController(AbstractPublisherController):
             self._host, dbcon, headless=headless, reset=False
         )
 
+        self._publish_plugins_proxy = None
+
         # pyblish.api.Context
         self._publish_context = None
         # Pyblish report
@@ -1289,6 +1291,10 @@ class PublisherController(AbstractPublisherController):
         # QUESTION
         # - pop the key after first collector using it would be safest option?
         self._publish_context.data["create_context"] = self._create_context
+
+        self._publish_plugins_proxy = PublishPluginsProxy(
+            self._publish_plugins
+        )
 
         self._publish_report.reset(self._publish_context, self._create_context)
         self._publish_validation_errors = []

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -773,16 +773,6 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def get_manual_creators_base_info(self):
-        """Creators that can be selected and triggered by artist.
-
-        Returns:
-            List[CreatorBaseInfo]: Base information about creator plugin.
-        """
-
-        pass
-
-    @abstractmethod
     def get_context_title(self):
         """Get context title for artist shown at the top of main window.
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -11,6 +11,7 @@ import pyblish.api
 from openpype.client import (
     get_assets,
     get_asset_by_id,
+    get_subsets,
 )
 from openpype.lib.events import EventSystem
 from openpype.pipeline import (
@@ -838,6 +839,10 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
+    def get_existing_subset_names(self, asset_name):
+        pass
+
+    @abstractmethod
     def reset(self):
         """Reset whole controller.
 
@@ -1222,6 +1227,21 @@ class PublisherController(AbstractPublisherController):
                 task_names_by_asset_name.get(asset_name) or []
             )
         return result
+
+    def get_existing_subset_names(self, asset_name):
+        project_name = self.project_name
+        asset_doc = self._asset_docs_cache.get_asset_by_name(asset_name)
+        if not asset_doc:
+            return None
+
+        asset_id = asset_doc["_id"]
+        subset_docs = get_subsets(
+            project_name, asset_ids=[asset_id], fields=["name"]
+        )
+        return {
+            subset_doc["name"]
+            for subset_doc in subset_docs
+        }
 
     def reset(self):
         """Reset everything related to creation and publishing."""

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1214,10 +1214,6 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def reset_project_data_cache(self):
-        pass
-
-    @abstractmethod
     def set_comment(self, comment):
         """Set comment on pyblish context.
 
@@ -1904,9 +1900,6 @@ class PublisherController(AbstractPublisherController):
                 self._publish_error = exception
 
         self._publish_next_process()
-
-    def reset_project_data_cache(self):
-        self._asset_docs_cache.reset()
 
 
 def collect_families_from_instances(instances, only_active=False):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1656,6 +1656,7 @@ class PublisherController(AbstractPublisherController):
     def _set_publish_has_finished(self, value):
         if self._publish_finished != value:
             self._publish_finished = value
+            self._emit_event("publish.finished.changed", {"value": value})
 
     def _get_publish_is_running(self):
         return self._publish_is_running

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -626,8 +626,9 @@ class PublisherController(AbstractPublisherController):
         return self._create_context.instances
 
     @property
-    def creators(self):
+    def _creators(self):
         """All creators loaded in create context."""
+
         return self._create_context.creators
 
     @property
@@ -846,7 +847,7 @@ class PublisherController(AbstractPublisherController):
 
     def get_icon_for_family(self, family):
         """TODO rename to get creator icon."""
-        creator = self.creators.get(family)
+        creator = self._creators.get(family)
         if creator is not None:
             return creator.get_icon()
         return None
@@ -855,7 +856,7 @@ class PublisherController(AbstractPublisherController):
         self, creator_identifier, subset_name, instance_data, options
     ):
         """Trigger creation and refresh of instances in UI."""
-        creator = self.creators[creator_identifier]
+        creator = self._creators[creator_identifier]
         creator.create(subset_name, instance_data, options)
 
         self._emit_event("instances.refresh.finished")

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1407,9 +1407,6 @@ class PublisherController(AbstractPublisherController):
         for idx, plugin in enumerate(self._publish_plugins):
             self._publish_progress = idx
 
-            # Reset current plugin validations error
-            self._publish_current_plugin_validation_errors = None
-
             # Check if plugin is over validation order
             if not self._publish_validated:
                 self._publish_validated = (

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1251,7 +1251,7 @@ class AbstractPublisherController(object):
         pass
 
 
-class BasePublishController(AbstractPublisherController):
+class BasePublisherController(AbstractPublisherController):
     """Implement common logic for controllers.
 
     Implement event system, logger and common attributes. Attributes are
@@ -1491,7 +1491,7 @@ class BasePublishController(AbstractPublisherController):
         return None
 
 
-class PublisherController(BasePublishController):
+class PublisherController(BasePublisherController):
     """Middleware between UI, CreateContext and publish Context.
 
     Handle both creation and publishing parts.

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1098,7 +1098,7 @@ class AbstractPublisherController(object):
 
         pass
 
-    def remove_instances(self, instances):
+    def remove_instances(self, instance_ids):
         """Remove list of instances from create context."""
         # TODO expect instance ids
 
@@ -1632,18 +1632,23 @@ class PublisherController(AbstractPublisherController):
         if self._create_context.host_is_valid:
             self._create_context.save_changes()
 
-    def remove_instances(self, instances):
+    def remove_instances(self, instance_ids):
         """"""
         # TODO expect instance ids instead of instances
         # QUESTION Expect that instances are really removed? In that case save
         #   reset is not required and save changes too.
         self.save_changes()
 
-        self._remove_instances_from_context(instances)
+        self._remove_instances_from_context(instance_ids)
 
         self._on_create_instance_change()
 
-    def _remove_instances_from_context(self, instances):
+    def _remove_instances_from_context(self, instance_ids):
+        instances_by_id = self._create_context.instances_by_id
+        instances = [
+            instances_by_id[instance_id]
+            for instance_id in instance_ids
+        ]
         self._create_context.remove_instances(instances)
 
     def _on_create_instance_change(self):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1089,6 +1089,7 @@ class AbstractPublisherController(object):
 
     def remove_instances(self, instances):
         """Remove list of instances from create context."""
+        # TODO expect instance ids
 
         pass
 
@@ -1485,7 +1486,7 @@ class PublisherController(AbstractPublisherController):
 
         self._resetting_instances = False
 
-        self._emit_event("instances.refresh.finished")
+        self._on_create_instance_change()
 
     def emit_card_message(self, message):
         self._emit_event("show.card.message", {"message": message})
@@ -1494,9 +1495,10 @@ class PublisherController(AbstractPublisherController):
         """Collect creator attribute definitions for multuple instances.
 
         Args:
-            instances(list<CreatedInstance>): List of created instances for
+            instances(List[CreatedInstance]): List of created instances for
                 which should be attribute definitions returned.
         """
+
         output = []
         _attr_defs = {}
         for instance in instances:
@@ -1530,6 +1532,7 @@ class PublisherController(AbstractPublisherController):
                 which should be attribute definitions returned.
             include_context(bool): Add context specific attribute definitions.
         """
+
         _tmp_items = []
         if include_context:
             _tmp_items.append(self._create_context)
@@ -1614,7 +1617,7 @@ class PublisherController(AbstractPublisherController):
         creator = self._creators[creator_identifier]
         creator.create(subset_name, instance_data, options)
 
-        self._emit_event("instances.refresh.finished")
+        self._on_create_instance_change()
 
     def save_changes(self):
         """Save changes happened during creation."""
@@ -1623,12 +1626,19 @@ class PublisherController(AbstractPublisherController):
 
     def remove_instances(self, instances):
         """"""
+        # TODO expect instance ids instead of instances
         # QUESTION Expect that instances are really removed? In that case save
         #   reset is not required and save changes too.
         self.save_changes()
 
+        self._remove_instances_from_context(instances)
+
+        self._on_create_instance_change()
+
+    def _remove_instances_from_context(self, instances):
         self._create_context.remove_instances(instances)
 
+    def _on_create_instance_change(self):
         self._emit_event("instances.refresh.finished")
 
     # --- Publish specific implementations ---

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -642,7 +642,7 @@ class PublisherController(AbstractPublisherController):
         return self._create_context.host_is_valid
 
     @property
-    def publish_plugins(self):
+    def _publish_plugins(self):
         """Publish plugins."""
         return self._create_context.publish_plugins
 
@@ -681,6 +681,7 @@ class PublisherController(AbstractPublisherController):
 
     def get_context_title(self):
         """Get context title for artist shown at the top of main window."""
+
         context_title = None
         if hasattr(self._host, "get_context_title"):
             context_title = self._host.get_context_title()
@@ -913,7 +914,7 @@ class PublisherController(AbstractPublisherController):
         return self._publish_error
 
     def get_publish_report(self):
-        return self._publish_report.get_report(self.publish_plugins)
+        return self._publish_report.get_report(self._publish_plugins)
 
     def get_validation_errors(self):
         return self._publish_validation_errors
@@ -940,7 +941,7 @@ class PublisherController(AbstractPublisherController):
         self._publish_current_plugin_validation_errors = None
         self._publish_error = None
 
-        self._publish_max_progress = len(self.publish_plugins)
+        self._publish_max_progress = len(self._publish_plugins)
         self._publish_progress = 0
 
         self._emit_event("publish.reset.finished")
@@ -1034,7 +1035,7 @@ class PublisherController(AbstractPublisherController):
         QUESTION:
         Does validate button still make sense?
         """
-        for idx, plugin in enumerate(self.publish_plugins):
+        for idx, plugin in enumerate(self._publish_plugins):
             self._publish_progress = idx
 
             # Reset current plugin validations error

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1278,12 +1278,15 @@ class PublisherController(AbstractPublisherController):
         self._publish_validation_errors = PublishValidationErrors()
         # Any other exception that happened during publishing
         self._publish_error = None
+        self._publish_error_msg = None
         # Publishing is in progress
         self._publish_is_running = False
         # Publishing is over validation order
-        self._publish_validated = False
+        self._publish_has_validated = False
         # Publishing should stop at validation stage
         self._publish_up_validation = False
+        self._publish_has_validation_errors = False
+        self._publish_has_crashed = False
         # All publish plugins are processed
         self._publish_finished = False
         self._publish_max_progress = 0
@@ -1642,40 +1645,99 @@ class PublisherController(AbstractPublisherController):
         self._emit_event("instances.refresh.finished")
 
     # --- Publish specific implementations ---
-    @property
-    def publish_has_finished(self):
-        return self._publish_finished
-
-    @property
-    def publish_is_running(self):
-        return self._publish_is_running
-
-    @property
-    def publish_has_validated(self):
-        return self._publish_validated
-
-    @property
-    def publish_has_crashed(self):
-        return bool(self._publish_error)
-
-    @property
-    def publish_has_validation_errors(self):
-        return bool(self._publish_validation_errors)
-
-    @property
-    def publish_max_progress(self):
-        return self._publish_max_progress
-
-    @property
-    def publish_progress(self):
-        return self._publish_progress
-
-    @property
-    def publish_comment_is_set(self):
-        return self._publish_comment_is_set
-
     def get_publish_crash_error(self):
         return self._publish_error
+
+    def _get_publish_has_finished(self):
+        return self._publish_finished
+
+    def _set_publish_has_finished(self, value):
+        if self._publish_finished != value:
+            self._publish_finished = value
+
+    def _get_publish_is_running(self):
+        return self._publish_is_running
+
+    def _set_publish_is_running(self, value):
+        if self._publish_is_running != value:
+            self._publish_is_running = value
+            self._emit_event("publish.is_running.changed", {"value": value})
+
+    def _get_publish_has_validated(self):
+        return self._publish_has_validated
+
+    def _set_publish_has_validated(self, value):
+        if self._publish_has_validated != value:
+            self._publish_has_validated = value
+            self._emit_event("publish.has_validated.changed", {"value": value})
+
+    def _get_publish_has_crashed(self):
+        return self._publish_has_crashed
+
+    def _set_publish_has_crashed(self, value):
+        if self._publish_has_crashed != value:
+            self._publish_has_crashed = value
+            self._emit_event("publish.has_crashed.changed", {"value": value})
+
+    def _get_publish_has_validation_errors(self):
+        return self._publish_has_validation_errors
+
+    def _set_publish_has_validation_errors(self, value):
+        if self._publish_has_validation_errors != value:
+            self._publish_has_validation_errors = value
+            self._emit_event(
+                "publish.has_validation_errors.changed",
+                {"value": value}
+            )
+
+    def _get_publish_max_progress(self):
+        return self._publish_max_progress
+
+    def _set_publish_max_progress(self, value):
+        if self._publish_max_progress != value:
+            self._publish_max_progress = value
+            self._emit_event("publish.max_progress.changed", {"value": value})
+
+    def _get_publish_progress(self):
+        return self._publish_progress
+
+    def _set_publish_progress(self, value):
+        if self._publish_progress != value:
+            self._publish_progress = value
+            self._emit_event("publish.progress.changed", {"value": value})
+
+    def _get_publish_error_msg(self):
+        return self._publish_error_msg
+
+    def _set_publish_error_msg(self, value):
+        if self._publish_error_msg != value:
+            self._publish_error_msg = value
+            self._emit_event("publish.publish_error.changed", {"value": value})
+
+    publish_has_finished = property(
+        _get_publish_has_finished, _set_publish_has_finished
+    )
+    publish_is_running = property(
+        _get_publish_is_running, _set_publish_is_running
+    )
+    publish_has_validated = property(
+        _get_publish_has_validated, _set_publish_has_validated
+    )
+    publish_has_crashed = property(
+        _get_publish_has_crashed, _set_publish_has_crashed
+    )
+    publish_has_validation_errors = property(
+        _get_publish_has_validation_errors, _set_publish_has_validation_errors
+    )
+    publish_max_progress = property(
+        _get_publish_max_progress, _set_publish_max_progress
+    )
+    publish_progress = property(
+        _get_publish_progress, _set_publish_progress
+    )
+    publish_error_msg = property(
+        _get_publish_error_msg, _set_publish_error_msg
+    )
 
     def get_publish_report(self):
         return self._publish_report.get_report(self._publish_plugins)

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -8,7 +8,10 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import six
 import pyblish.api
 
-from openpype.client import get_assets
+from openpype.client import (
+    get_assets,
+    get_asset_by_id,
+)
 from openpype.lib.events import EventSystem
 from openpype.pipeline import (
     PublishValidationError,
@@ -48,6 +51,7 @@ class AssetDocsCache:
         # TODO use asset ids instead
         self._task_names_by_asset_name = {}
         self._asset_docs_by_name = {}
+        self._full_asset_docs_by_name = {}
 
     def reset(self):
         self._asset_docs = None
@@ -87,6 +91,15 @@ class AssetDocsCache:
         if asset_doc is None:
             return None
         return copy.deepcopy(asset_doc)
+
+    def get_full_asset_by_name(self, asset_name):
+        self._query()
+        if asset_name not in self._full_asset_docs_by_name:
+            asset_doc = self._asset_docs_by_name.get(asset_name)
+            project_name = self._controller.project_name
+            full_asset_doc = get_asset_by_id(project_name, asset_doc["_id"])
+            self._full_asset_docs_by_name[asset_name] = full_asset_doc
+        return copy.deepcopy(self._full_asset_docs_by_name[asset_name])
 
 
 class PublishReport:

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1500,7 +1500,9 @@ class PublisherController(AbstractPublisherController):
         output = []
         _attr_defs = {}
         for instance in instances:
-            for attr_def in instance.creator_attribute_defs:
+            creator_identifier = instance.creator_identifier
+            creator_item = self._creator_items[creator_identifier]
+            for attr_def in creator_item.instance_attributes_defs:
                 found_idx = None
                 for idx, _attr_def in _attr_defs.items():
                     if attr_def == _attr_def:

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -812,7 +812,16 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def get_icon_for_family(self, family):
+    def get_creator_icon(self, identifier):
+        """Receive creator's icon by identifier.
+
+        Args:
+            identifier (str): Creator's identifier.
+
+        Returns:
+            Union[str, None]: Creator's icon string.
+        """
+
         pass
 
     @abstractmethod
@@ -1200,9 +1209,9 @@ class PublisherController(AbstractPublisherController):
             ))
         return output
 
-    def get_icon_for_family(self, family):
+    def get_creator_icon(self, identifier):
         """TODO rename to get creator icon."""
-        creator = self._creators.get(family)
+        creator = self._creators.get(identifier)
         if creator is not None:
             return creator.get_icon()
         return None

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1107,7 +1107,6 @@ class AbstractPublisherController(object):
 
     @abstractmethod
     def get_publish_crash_error(self):
-
         pass
 
     @abstractmethod
@@ -1201,6 +1200,8 @@ class PublisherController(AbstractPublisherController):
             self._host, dbcon, headless=headless, reset=False
         )
 
+        self._creator_items = {}
+
         self._publish_plugins_proxy = None
 
         # pyblish.api.Context
@@ -1290,9 +1291,10 @@ class PublisherController(AbstractPublisherController):
         return self._create_context.creators
 
     @property
-    def manual_creators(self):
+    def creator_items(self):
         """Creators that can be shown in create dialog."""
-        return self._create_context.manual_creators
+
+        return self._creator_items
 
     @property
     def host_is_valid(self):
@@ -1392,6 +1394,12 @@ class PublisherController(AbstractPublisherController):
         self._resetting_plugins = True
 
         self._create_context.reset_plugins()
+
+        creator_items = {
+            identifier: CreatorItem.from_creator(creator)
+            for identifier, creator in self._create_context.creators.items()
+        }
+        self._creator_items = creator_items
 
         self._resetting_plugins = False
 
@@ -1498,10 +1506,9 @@ class PublisherController(AbstractPublisherController):
         return output
 
     def get_creator_icon(self, identifier):
-        """TODO rename to get creator icon."""
-        creator = self._creators.get(identifier)
-        if creator is not None:
-            return creator.get_icon()
+        creator_item = self._creator_items.get(identifier)
+        if creator_item is not None:
+            return creator_item.icon
         return None
 
     def get_subset_name(
@@ -1526,7 +1533,6 @@ class PublisherController(AbstractPublisherController):
 
         creator = self._creators[creator_identifier]
         project_name = self.project_name
-        print(asset_name)
         asset_doc = self._asset_docs_cache.get_full_asset_by_name(asset_name)
 
         return creator.get_subset_name(

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1345,7 +1345,7 @@ class PublisherController(AbstractPublisherController):
     @property
     def instances(self):
         """Current instances in create context."""
-        return self._create_context.instances
+        return self._create_context.instances_by_id
 
     @property
     def _creators(self):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -646,11 +646,6 @@ class PublisherController(AbstractPublisherController):
         return self._create_context.publish_plugins
 
     @property
-    def plugins_with_defs(self):
-        """Publish plugins with possible attribute definitions."""
-        return self._create_context.plugins_with_defs
-
-    @property
     def event_system(self):
         """Inner event system for publisher controller.
 
@@ -838,7 +833,7 @@ class PublisherController(AbstractPublisherController):
                     attr_values.append((item, value))
 
         output = []
-        for plugin in self.plugins_with_defs:
+        for plugin in self._create_context.plugins_with_defs:
             plugin_name = plugin.__name__
             if plugin_name not in all_defs_by_plugin_name:
                 continue

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1354,8 +1354,11 @@ class PublisherController(AbstractPublisherController):
         if self._publish_is_running:
             self._stop_publish()
 
-    def run_action(self, plugin, action):
+    def run_action(self, plugin_id, action_id):
         # TODO handle result in UI
+        plugin = self._publish_plugins_proxy.get_plugin(plugin_id)
+        action = self._publish_plugins_proxy.get_action(action_id)
+
         result = pyblish.plugin.process(
             plugin, self._publish_context, None, action.id
         )

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -687,7 +687,8 @@ class AbstractPublisherController(object):
     Define what must be implemented to be able use Publisher functionality.
 
     Goal is to have "data driven" controller that can be used to control UI
-    running in different process. That lead to some ""
+    running in different process. That lead to some disadvantages like UI can't
+    access objects directly but by using wrappers that can be serialized.
     """
 
     _log = None
@@ -758,6 +759,19 @@ class AbstractPublisherController(object):
 
         Returns:
             Union[str, None]: Name of task.
+        """
+
+        pass
+
+    @abstractproperty
+    def host_is_valid(self):
+        """Host is valid for creation part.
+
+        Host must have implemented certain functionality to be able create
+        in Publisher tool.
+
+        Returns:
+            bool: Host can handle creation of instances.
         """
 
         pass

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -167,6 +167,10 @@ class QtRemotePublishController(BasePublisherController):
             self.publish_finished = event["value"]
             return
 
+        if event.topic == "publish.host_is_valid.changed":
+            self.host_is_valid = event["value"]
+            return
+
         # Topics that can be just passed by because are not affecting
         #   controller itself
         # - "show.card.message"
@@ -174,6 +178,7 @@ class QtRemotePublishController(BasePublisherController):
         # - "publish.reset.finished"
         # - "instances.refresh.finished"
         # - "plugins.refresh.finished"
+        # - "controller.reset.finished"
         # - "publish.process.started"
         # - "publish.process.stopped"
         # - "publish.process.plugin.changed"

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -2,6 +2,8 @@ import collections
 
 from Qt import QtCore
 
+from openpype.pipeline.create import CreatedInstance
+
 from .control import MainThreadItem, PublisherController
 
 
@@ -86,3 +88,312 @@ class QtPublisherController(PublisherController):
 
     def _qt_on_publish_stop(self):
         self._main_thread_processor.stop()
+
+
+class QtRemotePublishController(QtPublisherController):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._created_instances = {}
+
+    def _on_create_instance_change(self):
+        # TODO somehow get serialized instances from client
+        serialized_instances = []
+
+        created_instances = {}
+        for serialized_data in serialized_instances:
+            item = CreatedInstance.deserialize_on_remote(
+                serialized_data,
+                self._creator_items
+            )
+            created_instances[item.id] = item
+
+        self._created_instances = created_instances
+        self._emit_event("instances.refresh.finished")
+
+    @property
+    def project_name(self):
+        """Current context project name.
+
+        Returns:
+            str: Name of project.
+        """
+
+        pass
+
+    @property
+    def current_asset_name(self):
+        """Current context asset name.
+
+        Returns:
+            Union[str, None]: Name of asset.
+        """
+
+        pass
+
+    @property
+    def current_task_name(self):
+        """Current context task name.
+
+        Returns:
+            Union[str, None]: Name of task.
+        """
+
+        pass
+
+    @property
+    def host_is_valid(self):
+        """Host is valid for creation part.
+
+        Host must have implemented certain functionality to be able create
+        in Publisher tool.
+
+        Returns:
+            bool: Host can handle creation of instances.
+        """
+
+        pass
+
+    @property
+    def instances(self):
+        """Collected/created instances.
+
+        Returns:
+            List[CreatedInstance]: List of created instances.
+        """
+
+        return self._created_instances
+
+    def get_context_title(self):
+        """Get context title for artist shown at the top of main window.
+
+        Returns:
+            Union[str, None]: Context title for window or None. In case of None
+                a warning is displayed (not nice for artists).
+        """
+
+        pass
+
+    def get_asset_docs(self):
+        pass
+
+    def get_asset_hierarchy(self):
+        pass
+
+    def get_task_names_by_asset_names(self, asset_names):
+        pass
+
+    def get_existing_subset_names(self, asset_name):
+        pass
+
+    def reset(self):
+        """Reset whole controller.
+
+        This should reset create context, publish context and all variables
+        that are related to it.
+        """
+
+        pass
+
+    def get_publish_attribute_definitions(self, instances, include_context):
+        pass
+
+    def get_subset_name(
+        self,
+        creator_identifier,
+        variant,
+        task_name,
+        asset_name,
+        instance_id=None
+    ):
+        """Get subset name based on passed data.
+
+        Args:
+            creator_identifier (str): Identifier of creator which should be
+                responsible for subset name creation.
+            variant (str): Variant value from user's input.
+            task_name (str): Name of task for which is instance created.
+            asset_name (str): Name of asset for which is instance created.
+            instance_id (Union[str, None]): Existing instance id when subset
+                name is updated.
+        """
+
+        pass
+
+    def create(
+        self, creator_identifier, subset_name, instance_data, options
+    ):
+        """Trigger creation by creator identifier.
+
+        Should also trigger refresh of instanes.
+
+        Args:
+            creator_identifier (str): Identifier of Creator plugin.
+            subset_name (str): Calculated subset name.
+            instance_data (Dict[str, Any]): Base instance data with variant,
+                asset name and task name.
+            options (Dict[str, Any]): Data from pre-create attributes.
+        """
+
+        pass
+
+    def save_changes(self):
+        """Save changes happened during creation."""
+
+        created_instance_changes = {}
+        for instance_id, instance in self._created_instances.items():
+            created_instance_changes[instance_id] = (
+                instance.remote_changes()
+            )
+
+        # TODO trigger save changes
+        self._trigger("save_changes", created_instance_changes)
+
+    def remove_instances(self, instances):
+        """Remove list of instances from create context."""
+        # TODO add Args:
+
+        pass
+
+    @property
+    def publish_has_finished(self):
+        """Has publishing finished.
+
+        Returns:
+            bool: If publishing finished and all plugins were iterated.
+        """
+
+        pass
+
+    @property
+    def publish_is_running(self):
+        """Publishing is running right now.
+
+        Returns:
+            bool: If publishing is in progress.
+        """
+
+        pass
+
+    @property
+    def publish_has_validated(self):
+        """Publish validation passed.
+
+        Returns:
+            bool: If publishing passed last possible validation order.
+        """
+
+        pass
+
+    @property
+    def publish_has_crashed(self):
+        """Publishing crashed for any reason.
+
+        Returns:
+            bool: Publishing crashed.
+        """
+
+        pass
+
+    @property
+    def publish_has_validation_errors(self):
+        """During validation happened at least one validation error.
+
+        Returns:
+            bool: Validation error was raised during validation.
+        """
+
+        pass
+
+    @property
+    def publish_max_progress(self):
+        """Get maximum possible progress number.
+
+        Returns:
+            int: Number that can be used as 100% of publish progress bar.
+        """
+
+        pass
+
+    @property
+    def publish_progress(self):
+        """Current progress number.
+
+        Returns:
+            int: Current progress value which is between 0 and
+                'publish_max_progress'.
+        """
+
+        pass
+
+    @property
+    def publish_comment_is_set(self):
+        """Publish comment was at least once set.
+
+        Publish comment can be set only once when publish is started for a
+        first time. This helpt to idetify if 'set_comment' should be called or
+        not.
+        """
+
+        pass
+
+    def get_publish_crash_error(self):
+        pass
+
+    def get_publish_report(self):
+        pass
+
+    def get_validation_errors(self):
+        pass
+
+    def publish(self):
+        """Trigger publishing without any order limitations."""
+
+        pass
+
+    def validate(self):
+        """Trigger publishing which will stop after validation order."""
+
+        pass
+
+    def stop_publish(self):
+        """Stop publishing can be also used to pause publishing.
+
+        Pause of publishing is possible only if all plugins successfully
+        finished.
+        """
+
+        pass
+
+    def run_action(self, plugin_id, action_id):
+        """Trigger pyblish action on a plugin.
+
+        Args:
+            plugin_id (str): Id of publish plugin.
+            action_id (str): Id of publish action.
+        """
+
+        pass
+
+    def set_comment(self, comment):
+        """Set comment on pyblish context.
+
+        Set "comment" key on current pyblish.api.Context data.
+
+        Args:
+            comment (str): Artist's comment.
+        """
+
+        pass
+
+    def emit_card_message(self, message):
+        """Emit a card message which can have a lifetime.
+
+        This is for UI purposes. Method can be extended to more arguments
+        in future e.g. different message timeout or type (color).
+
+        Args:
+            message (str): Message that will be showed.
+        """
+
+        pass

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -6,7 +6,11 @@ from Qt import QtCore
 from openpype.lib.events import Event
 from openpype.pipeline.create import CreatedInstance
 
-from .control import MainThreadItem, PublisherController
+from .control import (
+    MainThreadItem,
+    PublisherController,
+    BasePublisherController,
+)
 
 
 class MainThreadProcess(QtCore.QObject):
@@ -92,7 +96,7 @@ class QtPublisherController(PublisherController):
         self._main_thread_processor.stop()
 
 
-class QtRemotePublishController(PublisherController):
+class QtRemotePublishController(BasePublisherController):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -97,12 +97,24 @@ class QtPublisherController(PublisherController):
 
 
 class QtRemotePublishController(BasePublisherController):
+    """Abstract Remote controller for Qt UI.
+
+    This controller should be used in process where UI is running and should
+    listen and ask for data on a client side.
+
+    All objects that are used during UI processing should be able to convert
+    on client side to json serializable data and then recreated here. Keep in
+    mind that all changes made here should be send back to client controller
+    before critical actions.
+
+    ATM Was not tested and will require some changes. All code written here is
+    based on theoretical idea how it could work.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._created_instances = {}
-        self._main_thread_processor = MainThreadProcess()
-        self._main_thread_processor.start()
 
     @abstractmethod
     def _get_serialized_instances(self):
@@ -113,9 +125,6 @@ class QtRemotePublishController(BasePublisherController):
         """
 
         pass
-
-    def _process_main_thread_item(self, item):
-        self._main_thread_processor.add_item(item)
 
     def _on_create_instance_change(self):
         serialized_instances = self._get_serialized_instances()

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -111,7 +111,7 @@ class QtRemotePublishController(QtPublisherController):
         self._created_instances = created_instances
         self._emit_event("instances.refresh.finished")
 
-    @property
+    @abstractproperty
     def project_name(self):
         """Current context project name.
 
@@ -121,7 +121,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
-    @property
+    @abstractproperty
     def current_asset_name(self):
         """Current context asset name.
 
@@ -131,7 +131,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
-    @property
+    @abstractproperty
     def current_task_name(self):
         """Current context task name.
 
@@ -141,7 +141,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
-    @property
+    @abstractproperty
     def host_is_valid(self):
         """Host is valid for creation part.
 
@@ -186,6 +186,7 @@ class QtRemotePublishController(QtPublisherController):
     def get_existing_subset_names(self, asset_name):
         pass
 
+    @abstractmethod
     def reset(self):
         """Reset whole controller.
 
@@ -195,9 +196,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
-    def get_publish_attribute_definitions(self, instances, include_context):
-        pass
-
+    @abstractmethod
     def get_subset_name(
         self,
         creator_identifier,
@@ -220,6 +219,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
+    @abstractmethod
     def create(
         self, creator_identifier, subset_name, instance_data, options
     ):
@@ -237,6 +237,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
+    @abstractmethod
     def save_changes(self):
         """Save changes happened during creation."""
 
@@ -246,116 +247,36 @@ class QtRemotePublishController(QtPublisherController):
                 instance.remote_changes()
             )
 
-        # TODO trigger save changes
-        self._trigger("save_changes", created_instance_changes)
+        # Send 'created_instance_changes' value to client
 
+    @abstractmethod
     def remove_instances(self, instances):
         """Remove list of instances from create context."""
         # TODO add Args:
 
         pass
 
-    @property
-    def publish_has_finished(self):
-        """Has publishing finished.
-
-        Returns:
-            bool: If publishing finished and all plugins were iterated.
-        """
-
-        pass
-
-    @property
-    def publish_is_running(self):
-        """Publishing is running right now.
-
-        Returns:
-            bool: If publishing is in progress.
-        """
-
-        pass
-
-    @property
-    def publish_has_validated(self):
-        """Publish validation passed.
-
-        Returns:
-            bool: If publishing passed last possible validation order.
-        """
-
-        pass
-
-    @property
-    def publish_has_crashed(self):
-        """Publishing crashed for any reason.
-
-        Returns:
-            bool: Publishing crashed.
-        """
-
-        pass
-
-    @property
-    def publish_has_validation_errors(self):
-        """During validation happened at least one validation error.
-
-        Returns:
-            bool: Validation error was raised during validation.
-        """
-
-        pass
-
-    @property
-    def publish_max_progress(self):
-        """Get maximum possible progress number.
-
-        Returns:
-            int: Number that can be used as 100% of publish progress bar.
-        """
-
-        pass
-
-    @property
-    def publish_progress(self):
-        """Current progress number.
-
-        Returns:
-            int: Current progress value which is between 0 and
-                'publish_max_progress'.
-        """
-
-        pass
-
-    @property
-    def publish_comment_is_set(self):
-        """Publish comment was at least once set.
-
-        Publish comment can be set only once when publish is started for a
-        first time. This helpt to idetify if 'set_comment' should be called or
-        not.
-        """
-
-        pass
-
-    def get_publish_crash_error(self):
-        pass
-
+    @abstractmethod
     def get_publish_report(self):
         pass
 
+    @abstractmethod
     def get_validation_errors(self):
         pass
 
+    @abstractmethod
     def publish(self):
         """Trigger publishing without any order limitations."""
 
         pass
 
+    @abstractmethod
     def validate(self):
         """Trigger publishing which will stop after validation order."""
 
         pass
 
+    @abstractmethod
     def stop_publish(self):
         """Stop publishing can be also used to pause publishing.
 
@@ -365,6 +286,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
+    @abstractmethod
     def run_action(self, plugin_id, action_id):
         """Trigger pyblish action on a plugin.
 
@@ -375,6 +297,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
+    @abstractmethod
     def set_comment(self, comment):
         """Set comment on pyblish context.
 
@@ -386,6 +309,7 @@ class QtRemotePublishController(QtPublisherController):
 
         pass
 
+    @abstractmethod
     def emit_card_message(self, message):
         """Emit a card message which can have a lifetime.
 

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -187,7 +187,7 @@ class QtRemotePublishController(BasePublisherController):
 
     @abstractproperty
     def project_name(self):
-        """Current context project name.
+        """Current context project name from client.
 
         Returns:
             str: Name of project.
@@ -197,7 +197,7 @@ class QtRemotePublishController(BasePublisherController):
 
     @abstractproperty
     def current_asset_name(self):
-        """Current context asset name.
+        """Current context asset name from client.
 
         Returns:
             Union[str, None]: Name of asset.
@@ -207,23 +207,10 @@ class QtRemotePublishController(BasePublisherController):
 
     @abstractproperty
     def current_task_name(self):
-        """Current context task name.
+        """Current context task name from client.
 
         Returns:
             Union[str, None]: Name of task.
-        """
-
-        pass
-
-    @abstractproperty
-    def host_is_valid(self):
-        """Host is valid for creation part.
-
-        Host must have implemented certain functionality to be able create
-        in Publisher tool.
-
-        Returns:
-            bool: Host can handle creation of instances.
         """
 
         pass
@@ -258,16 +245,6 @@ class QtRemotePublishController(BasePublisherController):
         pass
 
     def get_existing_subset_names(self, asset_name):
-        pass
-
-    @abstractmethod
-    def reset(self):
-        """Reset whole controller.
-
-        This should reset create context, publish context and all variables
-        that are related to it.
-        """
-
         pass
 
     @abstractmethod
@@ -311,17 +288,26 @@ class QtRemotePublishController(BasePublisherController):
 
         pass
 
-    @abstractmethod
-    def save_changes(self):
-        """Save changes happened during creation."""
+    def _get_instance_changes_for_client(self):
+        """Preimplemented method to receive instance changes for client."""
 
         created_instance_changes = {}
         for instance_id, instance in self._created_instances.items():
             created_instance_changes[instance_id] = (
                 instance.remote_changes()
             )
+        return created_instance_changes
 
-        # Send 'created_instance_changes' value to client
+    @abstractmethod
+    def _send_instance_changes_to_client(self):
+        instance_changes = self._get_instance_changes_for_client()
+        # Implement to send 'instance_changes' value to client
+
+    @abstractmethod
+    def save_changes(self):
+        """Save changes happened during creation."""
+
+        self._send_instance_changes_to_client()
 
     @abstractmethod
     def remove_instances(self, instance_ids):
@@ -339,15 +325,28 @@ class QtRemotePublishController(BasePublisherController):
         pass
 
     @abstractmethod
+    def reset(self):
+        """Reset whole controller.
+
+        This should reset create context, publish context and all variables
+        that are related to it.
+        """
+
+        self._send_instance_changes_to_client()
+        pass
+
+    @abstractmethod
     def publish(self):
         """Trigger publishing without any order limitations."""
 
+        self._send_instance_changes_to_client()
         pass
 
     @abstractmethod
     def validate(self):
         """Trigger publishing which will stop after validation order."""
 
+        self._send_instance_changes_to_client()
         pass
 
     @abstractmethod

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -250,7 +250,7 @@ class QtRemotePublishController(QtPublisherController):
         # Send 'created_instance_changes' value to client
 
     @abstractmethod
-    def remove_instances(self, instances):
+    def remove_instances(self, instance_ids):
         """Remove list of instances from create context."""
         # TODO add Args:
 

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -1,5 +1,5 @@
 import collections
-from ABC import abstractmethod, abstractproperty
+from abc import abstractmethod, abstractproperty
 
 from Qt import QtCore
 

--- a/openpype/tools/publisher/control_qt.py
+++ b/openpype/tools/publisher/control_qt.py
@@ -67,10 +67,10 @@ class QtPublisherController(PublisherController):
 
         super(QtPublisherController, self).__init__(*args, **kwargs)
 
-        self._event_system.add_callback(
+        self.event_system.add_callback(
             "publish.process.started", self._qt_on_publish_start
         )
-        self._event_system.add_callback(
+        self.event_system.add_callback(
             "publish.process.stopped", self._qt_on_publish_stop
         )
 

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -351,10 +351,11 @@ class InstanceCardView(AbstractInstanceView):
 
     Wrapper of all widgets in card view.
     """
+
     def __init__(self, controller, parent):
         super(InstanceCardView, self).__init__(parent)
 
-        self.controller = controller
+        self._controller = controller
 
         scroll_area = QtWidgets.QScrollArea(self)
         scroll_area.setWidgetResizable(True)
@@ -440,7 +441,7 @@ class InstanceCardView(AbstractInstanceView):
         # Prepare instances by group and identifiers by group
         instances_by_group = collections.defaultdict(list)
         identifiers_by_group = collections.defaultdict(set)
-        for instance in self.controller.instances:
+        for instance in self._controller.instances:
             group_name = instance.group_label
             instances_by_group[group_name].append(instance)
             identifiers_by_group[group_name].add(
@@ -469,7 +470,7 @@ class InstanceCardView(AbstractInstanceView):
                 group_widget = self._widgets_by_group[group_name]
             else:
                 group_icons = {
-                    idenfier: self.controller.get_creator_icon(idenfier)
+                    idenfier: self._controller.get_creator_icon(idenfier)
                     for idenfier in identifiers_by_group[group_name]
                 }
 

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -469,7 +469,7 @@ class InstanceCardView(AbstractInstanceView):
                 group_widget = self._widgets_by_group[group_name]
             else:
                 group_icons = {
-                    idenfier: self.controller.get_icon_for_family(idenfier)
+                    idenfier: self.controller.get_creator_icon(idenfier)
                     for idenfier in identifiers_by_group[group_name]
                 }
 

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -441,7 +441,7 @@ class InstanceCardView(AbstractInstanceView):
         # Prepare instances by group and identifiers by group
         instances_by_group = collections.defaultdict(list)
         identifiers_by_group = collections.defaultdict(set)
-        for instance in self._controller.instances:
+        for instance in self._controller.instances.values():
             group_name = instance.group_label
             instances_by_group[group_name].append(instance)
             identifiers_by_group[group_name].add(

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -409,7 +409,7 @@ class InstanceListView(AbstractInstanceView):
     def __init__(self, controller, parent):
         super(InstanceListView, self).__init__(parent)
 
-        self.controller = controller
+        self._controller = controller
 
         instance_view = InstanceTreeView(self)
         instance_delegate = ListItemDelegate(instance_view)
@@ -520,7 +520,7 @@ class InstanceListView(AbstractInstanceView):
         # Prepare instances by their groups
         instances_by_group_name = collections.defaultdict(list)
         group_names = set()
-        for instance in self.controller.instances:
+        for instance in self._controller.instances:
             group_label = instance.group_label
             group_names.add(group_label)
             instances_by_group_name[group_label].append(instance)
@@ -771,7 +771,7 @@ class InstanceListView(AbstractInstanceView):
         context_selected = False
         instances_by_id = {
             instance.id: instance
-            for instance in self.controller.instances
+            for instance in self._controller.instances
         }
 
         for index in self._instance_view.selectionModel().selectedIndexes():

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -520,7 +520,7 @@ class InstanceListView(AbstractInstanceView):
         # Prepare instances by their groups
         instances_by_group_name = collections.defaultdict(list)
         group_names = set()
-        for instance in self._controller.instances:
+        for instance in self._controller.instances.values():
             group_label = instance.group_label
             group_names.add(group_label)
             instances_by_group_name[group_label].append(instance)
@@ -769,10 +769,7 @@ class InstanceListView(AbstractInstanceView):
         """
         instances = []
         context_selected = False
-        instances_by_id = {
-            instance.id: instance
-            for instance in self._controller.instances
-        }
+        instances_by_id = self._controller.instances
 
         for index in self._instance_view.selectionModel().selectedIndexes():
             instance_id = index.data(INSTANCE_ID_ROLE)

--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -224,7 +224,11 @@ class OverviewWidget(QtWidgets.QFrame):
         dialog.exec_()
         # Skip if OK was not clicked
         if dialog.result() == QtWidgets.QMessageBox.Ok:
-            self._controller.remove_instances(instances)
+            instance_ids = {
+                instance.id
+                for instance in instances
+            }
+            self._controller.remove_instances(instance_ids)
 
     def _on_change_view_clicked(self):
         self._change_view_type()

--- a/openpype/tools/publisher/widgets/precreate_widget.py
+++ b/openpype/tools/publisher/widgets/precreate_widget.py
@@ -58,12 +58,12 @@ class PreCreateWidget(QtWidgets.QWidget):
     def current_value(self):
         return self._attributes_widget.current_value()
 
-    def set_plugin(self, creator):
+    def set_creator_item(self, creator_item):
         attr_defs = []
         creator_selected = False
-        if creator is not None:
+        if creator_item is not None:
             creator_selected = True
-            attr_defs = creator.get_pre_create_attr_defs()
+            attr_defs = creator_item.pre_create_attributes_defs
 
         self._attributes_widget.set_attr_defs(attr_defs)
 

--- a/openpype/tools/publisher/widgets/publish_frame.py
+++ b/openpype/tools/publisher/widgets/publish_frame.py
@@ -185,7 +185,7 @@ class PublishFrame(QtWidgets.QWidget):
 
         self._shrunk_anim = shrunk_anim
 
-        self.controller = controller
+        self._controller = controller
 
         self._content_frame = content_frame
         self._content_layout = content_layout
@@ -309,8 +309,8 @@ class PublishFrame(QtWidgets.QWidget):
         self._validate_btn.setEnabled(True)
         self._publish_btn.setEnabled(True)
 
-        self._progress_bar.setValue(self.controller.publish_progress)
-        self._progress_bar.setMaximum(self.controller.publish_max_progress)
+        self._progress_bar.setValue(self._controller.publish_progress)
+        self._progress_bar.setMaximum(self._controller.publish_max_progress)
 
     def _on_publish_start(self):
         self._set_success_property(-1)
@@ -334,34 +334,34 @@ class PublishFrame(QtWidgets.QWidget):
     def _on_plugin_change(self, event):
         """Change plugin label when instance is going to be processed."""
 
-        self._progress_bar.setValue(self.controller.publish_progress)
+        self._progress_bar.setValue(self._controller.publish_progress)
         self._plugin_label.setText(event["plugin_label"])
         QtWidgets.QApplication.processEvents()
 
     def _on_publish_stop(self):
-        self._progress_bar.setValue(self.controller.publish_progress)
+        self._progress_bar.setValue(self._controller.publish_progress)
 
         self._reset_btn.setEnabled(True)
         self._stop_btn.setEnabled(False)
-        validate_enabled = not self.controller.publish_has_crashed
-        publish_enabled = not self.controller.publish_has_crashed
+        validate_enabled = not self._controller.publish_has_crashed
+        publish_enabled = not self._controller.publish_has_crashed
         if validate_enabled:
-            validate_enabled = not self.controller.publish_has_validated
+            validate_enabled = not self._controller.publish_has_validated
         if publish_enabled:
             if (
-                self.controller.publish_has_validated
-                and self.controller.publish_has_validation_errors
+                self._controller.publish_has_validated
+                and self._controller.publish_has_validation_errors
             ):
                 publish_enabled = False
 
             else:
-                publish_enabled = not self.controller.publish_has_finished
+                publish_enabled = not self._controller.publish_has_finished
 
         self._validate_btn.setEnabled(validate_enabled)
         self._publish_btn.setEnabled(publish_enabled)
 
-        error = self.controller.get_publish_crash_error()
-        validation_errors = self.controller.get_validation_errors()
+        error = self._controller.get_publish_crash_error()
+        validation_errors = self._controller.get_validation_errors()
         if error:
             self._set_error(error)
 
@@ -369,7 +369,7 @@ class PublishFrame(QtWidgets.QWidget):
             self._set_progress_visibility(False)
             self._set_validation_errors()
 
-        elif self.controller.publish_has_finished:
+        elif self._controller.publish_has_finished:
             self._set_finished()
 
         else:
@@ -377,7 +377,7 @@ class PublishFrame(QtWidgets.QWidget):
 
     def _set_stopped(self):
         main_label = "Publish paused"
-        if self.controller.publish_has_validated:
+        if self._controller.publish_has_validated:
             main_label += " - Validation passed"
 
         self._set_main_label(main_label)
@@ -440,7 +440,7 @@ class PublishFrame(QtWidgets.QWidget):
                 widget.style().polish(widget)
 
     def _copy_report(self):
-        logs = self.controller.get_publish_report()
+        logs = self._controller.get_publish_report()
         logs_string = json.dumps(logs, indent=4)
 
         mime_data = QtCore.QMimeData()
@@ -463,7 +463,7 @@ class PublishFrame(QtWidgets.QWidget):
         if not ext or not new_filepath:
             return
 
-        logs = self.controller.get_publish_report()
+        logs = self._controller.get_publish_report()
         full_path = new_filepath + ext
         dir_path = os.path.dirname(full_path)
         if not os.path.exists(dir_path):
@@ -483,13 +483,13 @@ class PublishFrame(QtWidgets.QWidget):
             self.details_page_requested.emit()
 
     def _on_reset_clicked(self):
-        self.controller.reset()
+        self._controller.reset()
 
     def _on_stop_clicked(self):
-        self.controller.stop_publish()
+        self._controller.stop_publish()
 
     def _on_validate_clicked(self):
-        self.controller.validate()
+        self._controller.validate()
 
     def _on_publish_clicked(self):
-        self.controller.publish()
+        self._controller.publish()

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -678,7 +678,7 @@ class ValidationsWidget(QtWidgets.QFrame):
             self._set_errors(validation_errors)
             return
 
-        if self._contoller.publish_has_finished:
+        if self._controller.publish_has_finished:
             self._set_current_widget(self._publish_stop_ok_widget)
             return
 

--- a/openpype/tools/publisher/widgets/validations_widget.py
+++ b/openpype/tools/publisher/widgets/validations_widget.py
@@ -50,6 +50,7 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
     Has toggle button to show/hide instances on which validation error happened
     if there is a list (Valdation error may happen on context).
     """
+
     selected = QtCore.Signal(int)
     instance_changed = QtCore.Signal(int)
 
@@ -75,33 +76,33 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
         title_frame_layout.addWidget(toggle_instance_btn, 0)
 
         instances_model = QtGui.QStandardItemModel()
-        error_info = error_info["error_info"]
 
         help_text_by_instance_id = {}
-        context_validation = False
-        if (
-            not error_info
-            or (len(error_info) == 1 and error_info[0][0] is None)
-        ):
-            context_validation = True
-            toggle_instance_btn.setArrowType(QtCore.Qt.NoArrow)
-            description = self._prepare_description(error_info[0][1])
-            help_text_by_instance_id[None] = description
-        else:
-            items = []
-            for instance, exception in error_info:
-                label = instance.data.get("label") or instance.data.get("name")
-                item = QtGui.QStandardItem(label)
-                item.setFlags(
-                    QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
-                )
-                item.setData(label, QtCore.Qt.ToolTipRole)
-                item.setData(instance.id, INSTANCE_ID_ROLE)
-                items.append(item)
-                description = self._prepare_description(exception)
-                help_text_by_instance_id[instance.id] = description
 
-            instances_model.invisibleRootItem().appendRows(items)
+        items = []
+        context_validation = False
+        for error_item in error_info["error_items"]:
+            context_validation = error_item.context_validation
+            if context_validation:
+                toggle_instance_btn.setArrowType(QtCore.Qt.NoArrow)
+                description = self._prepare_description(error_item)
+                help_text_by_instance_id[None] = description
+                continue
+
+            label = error_item.instance_label
+            item = QtGui.QStandardItem(label)
+            item.setFlags(
+                QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
+            )
+            item.setData(label, QtCore.Qt.ToolTipRole)
+            item.setData(error_item.instance_id, INSTANCE_ID_ROLE)
+            items.append(item)
+            description = self._prepare_description(error_item)
+            help_text_by_instance_id[error_item.instance_id] = description
+
+        if items:
+            root_item = instances_model.invisibleRootItem()
+            root_item.appendRows(items)
 
         instances_view = ValidationErrorInstanceList(self)
         instances_view.setModel(instances_model)
@@ -162,9 +163,19 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
     def minimumSizeHint(self):
         return self.sizeHint()
 
-    def _prepare_description(self, exception):
-        dsc = exception.description
-        detail = exception.detail
+    def _prepare_description(self, error_item):
+        """Prepare description text for detail intput.
+
+        Args:
+            error_item (ValidationErrorItem): Item which hold information about
+                validation error.
+
+        Returns:
+            str: Prepared detailed description.
+        """
+
+        dsc = error_item.description
+        detail = error_item.detail
         if detail:
             dsc += "<br/><br/>{}".format(detail)
 
@@ -192,32 +203,51 @@ class ValidationErrorTitleWidget(QtWidgets.QWidget):
 
     @property
     def is_selected(self):
-        """Is widget marked a selected"""
+        """Is widget marked a selected.
+
+        Returns:
+            bool: Item is selected or not.
+        """
+
         return self._selected
 
     @property
     def index(self):
-        """Widget's index set by parent."""
+        """Widget's index set by parent.
+
+        Returns:
+            int: Index of widget.
+        """
+
         return self._index
 
     def set_index(self, index):
-        """Set index of widget (called by parent)."""
+        """Set index of widget (called by parent).
+
+        Args:
+            int: New index of widget.
+        """
+
         self._index = index
 
     def _change_style_property(self, selected):
         """Change style of widget based on selection."""
+
         value = "1" if selected else ""
         self._title_frame.setProperty("selected", value)
         self._title_frame.style().polish(self._title_frame)
 
     def set_selected(self, selected=None):
         """Change selected state of widget."""
+
         if selected is None:
             selected = not self._selected
 
+        # Clear instance view selection on deselect
         if not selected:
             self._instances_view.clearSelection()
 
+        # Skip if has same value
         if selected == self._selected:
             return
 
@@ -255,18 +285,23 @@ class ActionButton(BaseClickableFrame):
     """Plugin's action callback button.
 
     Action may have label or icon or both.
-    """
-    action_clicked = QtCore.Signal(str)
 
-    def __init__(self, action, parent):
+    Args:
+        plugin_action_item (PublishPluginActionItem): Action item that can be
+            triggered by it's id.
+    """
+
+    action_clicked = QtCore.Signal(str, str)
+
+    def __init__(self, plugin_action_item, parent):
         super(ActionButton, self).__init__(parent)
 
         self.setObjectName("ValidationActionButton")
 
-        self.action = action
+        self.plugin_action_item = plugin_action_item
 
-        action_label = action.label or action.__name__
-        action_icon = getattr(action, "icon", None)
+        action_label = plugin_action_item.label
+        action_icon = plugin_action_item.icon
         label_widget = QtWidgets.QLabel(action_label, self)
         icon_label = None
         if action_icon:
@@ -284,7 +319,10 @@ class ActionButton(BaseClickableFrame):
         )
 
     def _mouse_release_callback(self):
-        self.action_clicked.emit(self.action.id)
+        self.action_clicked.emit(
+            self.plugin_action_item.plugin_id,
+            self.plugin_action_item.action_id
+        )
 
 
 class ValidateActionsWidget(QtWidgets.QFrame):
@@ -292,6 +330,7 @@ class ValidateActionsWidget(QtWidgets.QFrame):
 
     Change actions based on selected validation error.
     """
+
     def __init__(self, controller, parent):
         super(ValidateActionsWidget, self).__init__(parent)
 
@@ -304,10 +343,9 @@ class ValidateActionsWidget(QtWidgets.QFrame):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(content_widget)
 
-        self.controller = controller
+        self._controller = controller
         self._content_widget = content_widget
         self._content_layout = content_layout
-        self._plugin = None
         self._actions_mapping = {}
 
     def clear(self):
@@ -320,28 +358,34 @@ class ValidateActionsWidget(QtWidgets.QFrame):
                 widget.deleteLater()
         self._actions_mapping = {}
 
-    def set_plugin(self, plugin):
+    def set_error_item(self, error_item):
         """Set selected plugin and show it's actions.
 
         Clears current actions from widget and recreate them from the plugin.
+
+        Args:
+            Dict[str, Any]: Object holding error items, title and possible
+                actions to run.
         """
+
         self.clear()
-        self._plugin = plugin
-        if not plugin:
+
+        if not error_item:
             self.setVisible(False)
             return
 
-        actions = getattr(plugin, "actions", [])
-        for action in actions:
-            if not action.active:
+        plugin_action_items = error_item["plugin_action_items"]
+        for plugin_action_item in plugin_action_items:
+            if not plugin_action_item.active:
                 continue
 
-            if action.on not in ("failed", "all"):
+            if plugin_action_item.on_filter not in ("failed", "all"):
                 continue
 
-            self._actions_mapping[action.id] = action
+            action_id = plugin_action_item.action_id
+            self._actions_mapping[action_id] = plugin_action_item
 
-            action_btn = ActionButton(action, self._content_widget)
+            action_btn = ActionButton(plugin_action_item, self._content_widget)
             action_btn.action_clicked.connect(self._on_action_click)
             self._content_layout.addWidget(action_btn)
 
@@ -351,9 +395,8 @@ class ValidateActionsWidget(QtWidgets.QFrame):
         else:
             self.setVisible(False)
 
-    def _on_action_click(self, action_id):
-        action = self._actions_mapping[action_id]
-        self.controller.run_action(self._plugin, action)
+    def _on_action_click(self, plugin_id, action_id):
+        self._controller.run_action(plugin_id, action_id)
 
 
 class VerticallScrollArea(QtWidgets.QScrollArea):
@@ -365,6 +408,7 @@ class VerticallScrollArea(QtWidgets.QScrollArea):
     Resize if deferred by 100ms because at the moment of resize are not yet
     propagated sizes and visibility of scroll bars.
     """
+
     def __init__(self, *args, **kwargs):
         super(VerticallScrollArea, self).__init__(*args, **kwargs)
 
@@ -576,45 +620,31 @@ class ValidationsWidget(QtWidgets.QFrame):
         self._errors_widget.setVisible(False)
         self._actions_widget.setVisible(False)
 
-    def set_errors(self, errors):
-        """Set errors into context and created titles."""
+    def _set_errors(self, validation_error_report):
+        """Set errors into context and created titles.
+
+        Args:
+            validation_error_report (PublishValidationErrorsReport): Report
+                with information about validation errors and publish plugin
+                actions.
+        """
+
         self.clear()
-        if not errors:
+        if not validation_error_report:
             return
 
         self._top_label.setVisible(True)
         self._error_details_frame.setVisible(True)
         self._errors_widget.setVisible(True)
 
-        errors_by_title = []
-        for plugin_info in errors:
-            titles = []
-            error_info_by_title = {}
-
-            for error_info in plugin_info["errors"]:
-                exception = error_info["exception"]
-                title = exception.title
-                if title not in titles:
-                    titles.append(title)
-                    error_info_by_title[title] = []
-                error_info_by_title[title].append(
-                    (error_info["instance"], exception)
-                )
-
-            for title in titles:
-                errors_by_title.append({
-                    "plugin": plugin_info["plugin"],
-                    "error_info": error_info_by_title[title],
-                    "title": title
-                })
-
-        for idx, item in enumerate(errors_by_title):
-            widget = ValidationErrorTitleWidget(idx, item, self)
+        grouped_error_items = validation_error_report.group_items_by_title()
+        for idx, error_info in enumerate(grouped_error_items):
+            widget = ValidationErrorTitleWidget(idx, error_info, self)
             widget.selected.connect(self._on_select)
             widget.instance_changed.connect(self._on_instance_change)
             self._errors_layout.addWidget(widget)
             self._title_widgets[idx] = widget
-            self._error_info[idx] = item
+            self._error_info[idx] = error_info
 
         self._errors_layout.addStretch(1)
 
@@ -640,7 +670,7 @@ class ValidationsWidget(QtWidgets.QFrame):
         if self._controller.publish_has_validation_errors:
             validation_errors = self._controller.get_validation_errors()
             self._set_current_widget(self._validations_widget)
-            self.set_errors(validation_errors)
+            self._set_errors(validation_errors)
             return
 
         if self._contoller.publish_has_finished:
@@ -659,7 +689,7 @@ class ValidationsWidget(QtWidgets.QFrame):
 
         error_item = self._error_info[index]
 
-        self._actions_widget.set_plugin(error_item["plugin"])
+        self._actions_widget.set_error_item(error_item)
 
         self._update_description()
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -994,7 +994,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
     def __init__(self, controller, parent):
         super(GlobalAttrsWidget, self).__init__(parent)
 
-        self.controller = controller
+        self._controller = controller
         self._current_instances = []
 
         variant_input = VariantInputWidget(self)
@@ -1068,7 +1068,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         else:
             asset_names.add(asset_name)
 
-        for asset_doc in self.controller.get_asset_docs():
+        for asset_doc in self._controller.get_asset_docs():
             _asset_name = asset_doc["name"]
             if _asset_name in asset_names:
                 asset_names.remove(_asset_name)
@@ -1077,7 +1077,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
             if not asset_names:
                 break
 
-        project_name = self.controller.project_name
+        project_name = self._controller.project_name
         subset_names = set()
         invalid_tasks = False
         for instance in self._current_instances:
@@ -1245,7 +1245,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
 
         self._main_layout = main_layout
 
-        self.controller = controller
+        self._controller = controller
         self._scroll_area = scroll_area
 
         self._attr_def_id_to_instances = {}
@@ -1274,7 +1274,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
         self._attr_def_id_to_instances = {}
         self._attr_def_id_to_attr_def = {}
 
-        result = self.controller.get_creator_attribute_definitions(
+        result = self._controller.get_creator_attribute_definitions(
             instances
         )
 
@@ -1366,7 +1366,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
 
         self._main_layout = main_layout
 
-        self.controller = controller
+        self._controller = controller
         self._scroll_area = scroll_area
 
         self._attr_def_id_to_instances = {}
@@ -1398,7 +1398,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
         self._attr_def_id_to_attr_def = {}
         self._attr_def_id_to_plugin_name = {}
 
-        result = self.controller.get_publish_attribute_definitions(
+        result = self._controller.get_publish_attribute_definitions(
             instances, context_selected
         )
 
@@ -1513,7 +1513,7 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
             self._on_instance_context_changed
         )
 
-        self.controller = controller
+        self._controller = controller
 
         self.global_attrs_widget = global_attrs_widget
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1060,24 +1060,6 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         if self.task_value_widget.has_value_changed():
             task_name = self.task_value_widget.get_selected_items()[0]
 
-        asset_docs_by_name = {}
-        asset_names = set()
-        if asset_name is None:
-            for instance in self._current_instances:
-                asset_names.add(instance.get("asset"))
-        else:
-            asset_names.add(asset_name)
-
-        for asset_doc in self._controller.get_asset_docs():
-            _asset_name = asset_doc["name"]
-            if _asset_name in asset_names:
-                asset_names.remove(_asset_name)
-                asset_docs_by_name[_asset_name] = asset_doc
-
-            if not asset_names:
-                break
-
-        project_name = self._controller.project_name
         subset_names = set()
         invalid_tasks = False
         for instance in self._current_instances:
@@ -1093,11 +1075,13 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
             if task_name is not None:
                 new_task_name = task_name
 
-            asset_doc = asset_docs_by_name[new_asset_name]
-
             try:
-                new_subset_name = instance.creator.get_subset_name(
-                    new_variant_value, new_task_name, asset_doc, project_name
+                new_subset_name = self._controller.get_subset_name(
+                    instance.creator_identifier,
+                    new_variant_value,
+                    new_task_name,
+                    new_asset_name,
+                    instance.id
                 )
             except TaskNotSetError:
                 invalid_tasks = True

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -523,7 +523,7 @@ class PublisherWindow(QtWidgets.QDialog):
             return
 
         all_valid = None
-        for instance in self._controller.instances:
+        for instance in self._controller.instances.values():
             if not instance["active"]:
                 continue
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -496,8 +496,9 @@ class PublisherWindow(QtWidgets.QDialog):
         self._set_publish_overlay_visibility(False)
         self._reset_btn.setEnabled(True)
         self._stop_btn.setEnabled(False)
-        validate_enabled = not self._controller.publish_has_crashed
-        publish_enabled = not self._controller.publish_has_crashed
+        publish_has_crashed = self._controller.publish_has_crashed
+        validate_enabled = not publish_has_crashed
+        publish_enabled = not publish_has_crashed
         if validate_enabled:
             validate_enabled = not self._controller.publish_has_validated
         if publish_enabled:

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -248,7 +248,7 @@ class PublisherWindow(QtWidgets.QDialog):
             "publish.process.started", self._on_publish_start
         )
         controller.event_system.add_callback(
-            "publish.process.validated", self._on_publish_validated
+            "publish.has_validated.changed", self._on_publish_validated_change
         )
         controller.event_system.add_callback(
             "publish.process.stopped", self._on_publish_stop
@@ -439,11 +439,7 @@ class PublisherWindow(QtWidgets.QDialog):
         self._controller.stop_publish()
 
     def _set_publish_comment(self):
-        if self._controller.publish_comment_is_set:
-            return
-
-        comment = self._comment_input.text()
-        self._controller.set_comment(comment)
+        self._controller.set_comment(self._comment_input.text())
 
     def _on_validate_clicked(self):
         self._set_publish_comment()
@@ -489,8 +485,9 @@ class PublisherWindow(QtWidgets.QDialog):
         if self._tabs_widget.is_current_tab(self._create_tab):
             self._tabs_widget.set_current_tab("publish")
 
-    def _on_publish_validated(self):
-        self._validate_btn.setEnabled(False)
+    def _on_publish_validated_change(self, event):
+        if event["value"]:
+            self._validate_btn.setEnabled(False)
 
     def _on_publish_stop(self):
         self._set_publish_overlay_visibility(False)

--- a/openpype/tools/traypublisher/window.py
+++ b/openpype/tools/traypublisher/window.py
@@ -30,6 +30,9 @@ class TrayPublisherController(QtPublisherController):
     def host(self):
         return self._host
 
+    def reset_project_data_cache(self):
+        self._asset_docs_cache.reset()
+
 
 class TrayPublisherRegistry(JSONSettingRegistry):
     """Class handling OpenPype general settings registry.

--- a/openpype/tools/traypublisher/window.py
+++ b/openpype/tools/traypublisher/window.py
@@ -15,6 +15,7 @@ import appdirs
 from openpype.lib import JSONSettingRegistry
 from openpype.pipeline import install_host
 from openpype.hosts.traypublisher.api import TrayPublisherHost
+from openpype.tools.publisher.control_qt import QtPublisherController
 from openpype.tools.publisher.window import PublisherWindow
 from openpype.tools.utils import PlaceholderLineEdit
 from openpype.tools.utils.constants import PROJECT_NAME_ROLE
@@ -22,6 +23,12 @@ from openpype.tools.utils.models import (
     ProjectModel,
     ProjectSortFilterProxy
 )
+
+
+class TrayPublisherController(QtPublisherController):
+    @property
+    def host(self):
+        return self._host
 
 
 class TrayPublisherRegistry(JSONSettingRegistry):
@@ -179,7 +186,10 @@ class StandaloneOverlayWidget(QtWidgets.QFrame):
 
 class TrayPublishWindow(PublisherWindow):
     def __init__(self, *args, **kwargs):
-        super(TrayPublishWindow, self).__init__(reset_on_show=False)
+        controller = TrayPublisherController()
+        super(TrayPublishWindow, self).__init__(
+            controller=controller, reset_on_show=False
+        )
 
         flags = self.windowFlags()
         # Disable always on top hint

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -269,25 +269,25 @@ class HostToolsHelper:
             dialog.activateWindow()
             dialog.showNormal()
 
-    def get_publisher_tool(self, parent):
+    def get_publisher_tool(self, parent=None, controller=None):
         """Create, cache and return publisher window."""
 
         if self._publisher_tool is None:
-            from openpype.tools.publisher import PublisherWindow
+            from openpype.tools.publisher.window import PublisherWindow
 
             host = registered_host()
             ILoadHost.validate_load_methods(host)
 
             publisher_window = PublisherWindow(
-                parent=parent or self._parent
+                controller=controller, parent=parent or self._parent
             )
             self._publisher_tool = publisher_window
 
         return self._publisher_tool
 
-    def show_publisher_tool(self, parent=None):
+    def show_publisher_tool(self, parent=None, controller=None):
         with qt_app_context():
-            dialog = self.get_publisher_tool(parent)
+            dialog = self.get_publisher_tool(controller, parent)
 
             dialog.show()
             dialog.raise_()


### PR DESCRIPTION
## Brief description
Preparation for remote publisher UI. Controller was modified so it's not based Qt based. The import of controller does not require available Qt binding in python/sys path.

## Description
Main change is that UI does not have ability to work with logic related objects directly (e.g. with creators, publish plugin or their actions).  For that purposes were created warpper classes that hold just information and reference to real objects. They can be serialized and deserialized so they can be passed across processes. Attribute definitions have required attribute `type` and can be serialized/deserialized too. `CreatedInstance` has prepared few helper functions to recreate data and pass their changes to origin object. Creators are wrapped into `CreatorItem` which contain all information needed for UI and to trigger it's logic. All triggered events in controller must contain only json serializable data which simplified some logic. Attribute changes that were "dynamic" now have explicit setters which trigger event about the value change which helps to send that information from client controller to remote controller.

All of that is based on object idenfitiers as strings. For instances is used instance id for creators it's their identifier for actions on publish plugins it's their ids. Asset document ids are for UI purposes also converted to string.

Idea is that one controller is running in client (DCC) and second controller in different UI process. There must be 2-way communication between them so controller in client can send data to process where UI is running and UI can trigger callbacks on client side.

## Additional info
Remote controller is not tested and will probably require some tweaks and changes based on first feedback (probably in Unreal). This is preparation PR to make the feature available the default behavior should still work the same way as before.

## Testing notes:
1. Publisher functionality should not change at all in current implementations
- [ ] TrayPublisher
- [ ] Houdini ([PR](https://github.com/pypeclub/OpenPype/pull/3046))
- [ ] Fusion ([PR](https://github.com/pypeclub/OpenPype/pull/3892))