### PR TITLE
Maya: add object to attr.s declaration

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -48,7 +48,7 @@ def _validate_deadline_bool_value(instance, attribute, value):
 
 
 @attr.s
-class MayaPluginInfo:
+class MayaPluginInfo(object):
     SceneFile = attr.ib(default=None)   # Input
     OutputFilePath = attr.ib(default=None)  # Output directory and filename
     OutputFilePrefix = attr.ib(default=None)
@@ -63,7 +63,7 @@ class MayaPluginInfo:
 
 
 @attr.s
-class PythonPluginInfo:
+class PythonPluginInfo(object):
     ScriptFile = attr.ib()
     Version = attr.ib(default="3.6")
     Arguments = attr.ib(default=None)
@@ -71,7 +71,7 @@ class PythonPluginInfo:
 
 
 @attr.s
-class VRayPluginInfo:
+class VRayPluginInfo(object):
     InputFilename = attr.ib(default=None)   # Input
     SeparateFilesPerFrame = attr.ib(default=None)
     VRayEngine = attr.ib(default="V-Ray")
@@ -82,7 +82,7 @@ class VRayPluginInfo:
 
 
 @attr.s
-class ArnoldPluginInfo:
+class ArnoldPluginInfo(object):
     ArnoldFile = attr.ib(default=None)
 
 


### PR DESCRIPTION
## Brief description
Older Maya (Python2) doesn't like declaration of attr.s without (object)


## Description
This handles issue when `Submit Render to Deadline` doesn't show up in Publish and when manually imported in Maya console it throws 
```
# Error: TypeError: file C:\Users\petrk\PycharmProjects\Pype3.0\pype\openpype\vendor\python\python_2\attr\_make.py line 1514: attrs only works with new-style classes. # 
```

## Additional info
Maybe this is not needed as new Maya's (with Python3) might not have an issue with it, but it just happened to me on Maya 2019 and on same day someone from community on Discord reported it too.
https://discord.com/channels/517362899170230292/517382145552154634/1029628902701805609

I don't see it to be too offensive to have object as an argument there for now.

## Testing notes:
1. Publish from Maya to DL
2. `Submit Render to Deadline` should be visible during 