### PR TITLE
Integrate: Preserve existing subset group if instance does not set it for new version

### DIFF
--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -418,6 +418,11 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         subset_group = instance.data.get("subsetGroup")
         if subset_group:
             data["subsetGroup"] = subset_group
+        elif existing_subset_doc:
+            # Preserve previous subset group if new version does not set it
+            if "subsetGroup" in existing_subset_doc.get("data", {}):
+                subset_group = existing_subset_doc["data"]["subsetGroup"]
+                data["subsetGroup"] = subset_group
 
         subset_id = None
         if existing_subset_doc:


### PR DESCRIPTION
## Brief description

Preserve existing subset group if instance does not set it for new version

## Additional info

[Came up on discord](https://discord.com/channels/517362899170230292/517382145552154634/1029755458069729412)

## Testing notes:
1. Publish e.g. a new `pointcacheMain` version that was previously manually added in Loader to a subsetGroup. 
2. Group should now be preserved after publish.