### PR TITLE
General: Fix deprecated warning in legacy creator

### DIFF
--- a/openpype/pipeline/create/legacy_create.py
+++ b/openpype/pipeline/create/legacy_create.py
@@ -9,7 +9,9 @@ import os
 import logging
 import collections
 
-from openpype.lib import get_subset_name
+from openpype.client import get_asset_by_id
+
+from .subset_name import get_subset_name
 
 
 class LegacyCreator(object):
@@ -147,11 +149,15 @@ class LegacyCreator(object):
             variant, task_name, asset_id, project_name, host_name
         )
 
+        asset_doc = get_asset_by_id(
+            project_name, asset_id, fields=["data.tasks"]
+        )
+
         return get_subset_name(
             cls.family,
             variant,
             task_name,
-            asset_id,
+            asset_doc,
             project_name,
             host_name,
             dynamic_data=dynamic_data


### PR DESCRIPTION
## Brief description
Fixed import of 'get_subset_name' function in `LegacyCreator`.

## Description
Function `get_subset_name` was moved from `openpype.lib` to `openpype.pipeline.create` and modified arguments. This PR is using new function location and is handling different arguments.

## Warning message
```
PluginToolsDeprecatedWarning: Call to deprecated function 'get_subset_name'
Function was moved or removed. Please check content of deprecated function to figure out possible replacement.
```

## Testing notes:
1. Deprecation warning should not be printed when `LegacyCreator` is used to create instance in scene