### PR TITLE
Maya: remove invalid prefix token for non-multipart outputs

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -260,20 +260,20 @@ class ARenderProducts:
 
         """
         try:
-            file_prefix_attr = IMAGE_PREFIXES[self.renderer]
+            prefix_attr = IMAGE_PREFIXES[self.renderer]
         except KeyError:
             raise UnsupportedRendererException(
                 "Unsupported renderer {}".format(self.renderer)
             )
 
-        file_prefix = self._get_attr(file_prefix_attr)
+        prefix = self._get_attr(prefix_attr)
 
-        if not file_prefix:
+        if not prefix:
             # Fall back to scene name by default
             log.debug("Image prefix not set, using <Scene>")
             file_prefix = "<Scene>"
 
-        return file_prefix
+        return prefix
 
     def get_render_attribute(self, attribute):
         """Get attribute from render options.
@@ -730,13 +730,16 @@ class RenderProductsVray(ARenderProducts):
         """Get image prefix for V-Ray.
 
         This overrides :func:`ARenderProducts.get_renderer_prefix()` as
-        we must add `<aov>` token manually.
+        we must add `<aov>` token manually. This is done only for
+        non-multipart outputs, where `<aov>` token doesn't make sense.
 
         See also:
             :func:`ARenderProducts.get_renderer_prefix()`
 
         """
         prefix = super(RenderProductsVray, self).get_renderer_prefix()
+        if self.multipart:
+            return prefix
         aov_separator = self._get_aov_separator()
         prefix = "{}{}<aov>".format(prefix, aov_separator)
         return prefix
@@ -974,15 +977,18 @@ class RenderProductsRedshift(ARenderProducts):
         """Get image prefix for Redshift.
 
         This overrides :func:`ARenderProducts.get_renderer_prefix()` as
-        we must add `<aov>` token manually.
+        we must add `<aov>` token manually. This is done only for
+        non-multipart outputs, where `<aov>` token doesn't make sense.
 
         See also:
             :func:`ARenderProducts.get_renderer_prefix()`
 
         """
-        file_prefix = super(RenderProductsRedshift, self).get_renderer_prefix()
-        separator = self.extract_separator(file_prefix)
-        prefix = "{}{}<aov>".format(file_prefix, separator or "_")
+        prefix = super(RenderProductsRedshift, self).get_renderer_prefix()
+        if self.multipart:
+            return prefix
+        separator = self.extract_separator(prefix)
+        prefix = "{}{}<aov>".format(prefix, separator or "_")
         return prefix
 
     def get_render_products(self):

--- a/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -32,6 +32,9 @@ from maya import cmds
 
 from openpype.pipeline import legacy_io
 
+from openpype.hosts.maya.api.lib_rendersettings import RenderSettings
+from openpype.hosts.maya.api.lib import get_attr_in_layer
+
 from openpype_modules.deadline import abstract_submit_deadline
 from openpype_modules.deadline.abstract_submit_deadline import DeadlineJobInfo
 
@@ -498,9 +501,10 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
             job_info.AssetDependency += self.scene_path
 
         # Get layer prefix
-        render_products = self._instance.data["renderProducts"]
-        layer_metadata = render_products.layer_data
-        layer_prefix = layer_metadata.filePrefix
+        renderlayer = self._instance.data["setMembers"]
+        renderer = self._instance.data["renderer"]
+        layer_prefix_attr = RenderSettings.get_image_prefix_attr(renderer)
+        layer_prefix = get_attr_in_layer(layer_prefix_attr, layer=renderlayer)
 
         plugin_info = copy.deepcopy(self.plugin_info)
         plugin_info.update({


### PR DESCRIPTION
## Fix

This is fixing image prefixes for Vray and Redshift to not add `<aov>` token for outputs that are multipart (merged aovs).

### Testing

Submit render to Deadline with merged AOVs from vray or redshift.

Close #3956