### PR TITLE
Tray Publisher: add `originalBasename` data to simple creators

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from pathlib import Path
 
 import clique
 import pyblish.api
@@ -72,6 +73,8 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
 
         instance.data["source"] = source
         instance.data["sourceFilepaths"] = list(set(source_filepaths))
+        instance.data["originalBasename"] = Path(
+            instance.data["sourceFilepaths"][0]).stem
 
         self.log.debug(
             (


### PR DESCRIPTION
## Enhancement

Collect `originalBasename` data to be used in templates in Tray Publisher. 

This is useful for retaining original file name and it's use in publishing templates.