### PR TITLE
TrayPublisher: Original Basename cause crash too early

### DIFF
--- a/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_simple_instances.py
@@ -70,11 +70,17 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             repre_names,
             representation_files_mapping
         )
-
+        source_filepaths = list(set(source_filepaths))
         instance.data["source"] = source
-        instance.data["sourceFilepaths"] = list(set(source_filepaths))
-        instance.data["originalBasename"] = Path(
-            instance.data["sourceFilepaths"][0]).stem
+        instance.data["sourceFilepaths"] = source_filepaths
+
+        # NOTE: Missing filepaths should not cause crashes (at least not here)
+        # - if filepaths are required they should crash on validation
+        if source_filepaths:
+            # NOTE: Original basename is not handling sequences
+            # - we should maybe not fill the key when sequence is used?
+            origin_basename = Path(source_filepaths[0]).stem
+            instance.data["originalBasename"] = origin_basename
 
         self.log.debug(
             (


### PR DESCRIPTION
## Brief description
Don't crash in collection when files are not filled with `IndexError`.

## Description
This is "UX" change to not crash in collector of simple instances when files are not filled but let it on validator. If files are not filled `originalBasename` key is not filled.

## Additional information
Crashed is happening after [this PR](https://github.com/pypeclub/OpenPype/pull/3988). I thought it could maybe cause known publish error but that would not show a nice UI error with list of crashed instances...

## Testing notes:
1. Open TrayPublisher
2. Create an instance without filled filepaths
3. Publishing should crash with validation error instance of IndexError