### PR TITLE
TrayPublisher: Disable sequences in batch mov creator

### DIFF
--- a/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_movie_batch.py
@@ -188,6 +188,7 @@ class BatchMovieCreator(TrayPublishCreator):
                 folders=False,
                 single_item=False,
                 extensions=self.extensions,
+                allow_sequences=False,
                 label="Filepath"
             ),
             BoolDef(


### PR DESCRIPTION
## Brief description
Batch mov creator does not support sequences anymore as it's redundant for mov files.

## Description
It is confusing to be able pass sequences of mov files into the input when movie files just can't support sequences.

## Testing notes:
1. Open TrayPublisher
2. Go to create page
3. Select `Batch Movies` creator
4. If multiple files are dropped to file input, they should never be grouped as sequence
    - e.g. `asset_sh0010.mov` and `asset_sh0020.mov` should not be grouped as one item