### PR TITLE
Nuke/Hiero: Refactor openpype.api imports

### DIFF
--- a/openpype/hosts/hiero/api/pipeline.py
+++ b/openpype/hosts/hiero/api/pipeline.py
@@ -251,7 +251,6 @@ def reload_config():
     import importlib
 
     for module in (
-        "openpype.api",
         "openpype.hosts.hiero.lib",
         "openpype.hosts.hiero.menu",
         "openpype.hosts.hiero.tags"

--- a/openpype/hosts/hiero/plugins/publish/integrate_version_up_workfile.py
+++ b/openpype/hosts/hiero/plugins/publish/integrate_version_up_workfile.py
@@ -1,5 +1,6 @@
 from pyblish import api
-import openpype.api as pype
+
+from openpype.lib import version_up
 
 
 class IntegrateVersionUpWorkfile(api.ContextPlugin):
@@ -15,7 +16,7 @@ class IntegrateVersionUpWorkfile(api.ContextPlugin):
     def process(self, context):
         project = context.data["activeProject"]
         path = context.data.get("currentFile")
-        new_path = pype.version_up(path)
+        new_path = version_up(path)
 
         if project:
             project.saveAs(new_path)

--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -66,7 +66,6 @@ def reload_config():
     """
 
     for module in (
-        "openpype.api",
         "openpype.hosts.nuke.api.actions",
         "openpype.hosts.nuke.api.menu",
         "openpype.hosts.nuke.api.plugin",

--- a/openpype/hosts/nuke/plugins/publish/precollect_workfile.py
+++ b/openpype/hosts/nuke/plugins/publish/precollect_workfile.py
@@ -3,7 +3,8 @@ import os
 import nuke
 
 import pyblish.api
-import openpype.api as pype
+
+from openpype.lib import get_version_from_path
 from openpype.hosts.nuke.api.lib import (
     add_publish_knob,
     get_avalon_knob_data
@@ -74,7 +75,7 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
             "fps": root['fps'].value(),
 
             "currentFile": current_file,
-            "version": int(pype.get_version_from_path(current_file)),
+            "version": int(get_version_from_path(current_file)),
 
             "host": pyblish.api.current_host(),
             "hostVersion": nuke.NUKE_VERSION_STRING


### PR DESCRIPTION
## Brief description
Replaced `openpype.api` imports with explicit imports in foundry hosts.

## Testing notes:
- [ ] Nuke's precollect workfile is working
- [ ] Hiero version up workfile is working