### PR TITLE
Unreal: add `uproject` extension to Unreal project template

### DIFF
--- a/openpype/settings/defaults/project_anatomy/templates.json
+++ b/openpype/settings/defaults/project_anatomy/templates.json
@@ -29,7 +29,7 @@
     "delivery": {},
     "unreal": {
         "folder": "{root[work]}/{project[name]}/unreal/{task[name]}",
-        "file": "{project[code]}_{asset}",
+        "file": "{project[code]}_{asset}.uproject",
         "path": "{@folder}/{@file}"
     },
     "others": {


### PR DESCRIPTION
## Problem

Without `.uproject` extension in template Unreal cannot open newly created project. This PR is fixing it.