### PR TITLE
Nuke | Global: adding custom tags representation filtering

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2930,3 +2930,47 @@ def get_nodes_by_names(names):
         nuke.toNode(name)
         for name in names
     ]
+
+
+def get_viewer_config_from_string(input_string):
+    """Convert string to display and viewer string
+
+    Args:
+        input_string (str): string with viewer
+
+    Raises:
+        IndexError: if more then one slash in input string
+        IndexError: if missing closing bracket
+
+    Returns:
+        tuple[str]: display, viewer
+    """
+    display = None
+    viewer = input_string
+    # check if () or / or \ in name
+    if "/" in viewer:
+        split = viewer.split("/")
+
+        # rise if more then one column
+        if len(split) > 2:
+            raise IndexError((
+                "Viewer Input string is not correct. "
+                "more then two `/` slashes! {}"
+            ).format(input_string))
+
+        viewer = split[1]
+        display = split[0]
+    elif "(" in viewer:
+        pattern = r"([\w\d\s]+).*[(](.*)[)]"
+        result = re.findall(pattern, viewer)
+        try:
+            result = result.pop()
+            display = str(result[1]).rstrip()
+            viewer = str(result[0]).rstrip()
+        except IndexError:
+            raise IndexError((
+                "Viewer Input string is not correct. "
+                "Missing bracket! {}"
+            ).format(input_string))
+
+    return (display, viewer)

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -19,7 +19,8 @@ from .lib import (
     add_publish_knob,
     get_nuke_imageio_settings,
     set_node_knobs_from_settings,
-    get_view_process_node
+    get_view_process_node,
+    get_viewer_config_from_string
 )
 
 
@@ -312,7 +313,8 @@ class ExporterReviewLut(ExporterReview):
                 dag_node.setInput(0, self.previous_node)
                 self._temp_nodes.append(dag_node)
                 self.previous_node = dag_node
-                self.log.debug("OCIODisplay...   `{}`".format(self._temp_nodes))
+                self.log.debug(
+                    "OCIODisplay...   `{}`".format(self._temp_nodes))
 
         # GenerateLUT
         gen_lut_node = nuke.createNode("GenerateLUT")
@@ -491,7 +493,15 @@ class ExporterReviewMov(ExporterReview):
             if not self.viewer_lut_raw:
                 # OCIODisplay
                 dag_node = nuke.createNode("OCIODisplay")
-                dag_node["view"].setValue(str(baking_view_profile))
+
+                display, viewer = get_viewer_config_from_string(
+                    str(baking_view_profile)
+                )
+                if display:
+                    dag_node["display"].setValue(display)
+
+                # assign viewer
+                dag_node["view"].setValue(viewer)
 
                 # connect
                 dag_node.setInput(0, self.previous_node)

--- a/openpype/hosts/nuke/api/plugin.py
+++ b/openpype/hosts/nuke/api/plugin.py
@@ -191,7 +191,20 @@ class ExporterReview(object):
         if "#" in self.fhead:
             self.fhead = self.fhead.replace("#", "")[:-1]
 
-    def get_representation_data(self, tags=None, range=False):
+    def get_representation_data(
+        self, tags=None, range=False,
+        custom_tags=None
+    ):
+        """ Add representation data to self.data
+
+        Args:
+            tags (list[str], optional): list of defined tags.
+                                        Defaults to None.
+            range (bool, optional): flag for adding ranges.
+                                    Defaults to False.
+            custom_tags (list[str], optional): user inputed custom tags.
+                                               Defaults to None.
+        """
         add_tags = tags or []
         repre = {
             "name": self.name,
@@ -200,6 +213,9 @@ class ExporterReview(object):
             "stagingDir": self.staging_dir,
             "tags": [self.name.replace("_", "-")] + add_tags
         }
+
+        if custom_tags:
+            repre["custom_tags"] = custom_tags
 
         if range:
             repre.update({
@@ -417,6 +433,7 @@ class ExporterReviewMov(ExporterReview):
         return path
 
     def generate_mov(self, farm=False, **kwargs):
+        add_tags = []
         self.publish_on_farm = farm
         read_raw = kwargs["read_raw"]
         reformat_node_add = kwargs["reformat_node_add"]
@@ -435,10 +452,10 @@ class ExporterReviewMov(ExporterReview):
         self.log.debug(">> baking_view_profile   `{}`".format(
             baking_view_profile))
 
-        add_tags = kwargs.get("add_tags", [])
+        add_custom_tags = kwargs.get("add_custom_tags", [])
 
         self.log.info(
-            "__ add_tags: `{0}`".format(add_tags))
+            "__ add_custom_tags: `{0}`".format(add_custom_tags))
 
         subset = self.instance.data["subset"]
         self._temp_nodes[subset] = []
@@ -552,6 +569,7 @@ class ExporterReviewMov(ExporterReview):
         # ---------- generate representation data
         self.get_representation_data(
             tags=["review", "delete"] + add_tags,
+            custom_tags=add_custom_tags,
             range=True
         )
 

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -128,6 +128,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         for repre in instance.data["representations"]:
             repre_name = str(repre.get("name"))
             tags = repre.get("tags") or []
+            custom_tags = repre.get("custom_tags")
             if "review" not in tags:
                 self.log.debug((
                     "Repre: {} - Didn't found \"review\" in tags. Skipping"
@@ -158,15 +159,18 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 )
                 continue
 
-            # Filter output definition by representation tags (optional)
-            outputs = self.filter_outputs_by_tags(profile_outputs, tags)
+            # Filter output definition by representation's
+            # custom tags (optional)
+            outputs = self.filter_outputs_by_custom_tags(
+                profile_outputs, custom_tags)
             if not outputs:
                 self.log.info((
                     "Skipped representation. All output definitions from"
                     " selected profile does not match to representation's"
-                    " tags. \"{}\""
+                    " custom tags. \"{}\""
                 ).format(str(tags)))
                 continue
+
             outputs_per_representations.append((repre, outputs))
         return outputs_per_representations
 
@@ -1619,24 +1623,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         return self.profile_exclusion(matching_profiles)
 
-    def custom_tags_filter_validation(
-        self, repr_custom_tags, output_custom_tags_filter
-    ):
-        """Determines if entered custom tags intersect with custom tags filters.
-
-        All cutsom tags values are lowered to avoid unexpected results.
-        """
-        repr_custom_tags = repr_custom_tags or []
-        valid = False
-        for tag in output_custom_tags_filter:
-            if tag in repr_custom_tags:
-                valid = True
-                break
-
-        if valid:
-            return True
-        return False
-
     def families_filter_validation(self, families, output_families_filter):
         """Determines if entered families intersect with families filters.
 
@@ -1675,7 +1661,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         return False
 
     def filter_output_defs(
-        self, profile, subset_name, families, custom_tags=None
+        self, profile, subset_name, families
     ):
         """Return outputs matching input instance families.
 
@@ -1684,6 +1670,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         Args:
             profile (dict): Profile from presets matching current context.
             families (list): All families of current instance.
+            subset_name (str): name of subset
 
         Returns:
             list: Containg all output definitions matching entered families.
@@ -1709,12 +1696,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
             if not self.families_filter_validation(families, families_filters):
                 continue
 
-            custom_tags_filters = output_filters.get("custom_tags")
-            if custom_tags and not self.custom_tags_filter_validation(
-                custom_tags, custom_tags_filters
-            ):
-                continue
-
             # Subsets name filters
             subset_filters = [
                 subset_filter
@@ -1737,39 +1718,55 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         return filtered_outputs
 
-    def filter_outputs_by_tags(self, outputs, tags):
-        """Filter output definitions by entered representation tags.
+    def filter_outputs_by_custom_tags(self, outputs, custom_tags):
+        """Filter output definitions by entered representation custom_tags.
 
-        Output definitions without tags filter are marked as valid.
+        Output definitions without custom_tags filter are marked as invalid,
+        only in case representation is having any custom_tags defined.
 
         Args:
             outputs (list): Contain list of output definitions from presets.
-            tags (list): Tags of processed representation.
+            custom_tags (list): Custom Tags of processed representation.
 
         Returns:
             list: Containg all output definitions matching entered tags.
         """
         filtered_outputs = []
-        repre_tags_low = [tag.lower() for tag in tags]
+        repre_c_tags_low = [tag.lower() for tag in (custom_tags or [])]
         for output_def in outputs:
-            valid = True
-            output_filters = output_def.get("filter")
-            if output_filters:
-                # Check tag filters
-                tag_filters = output_filters.get("tags")
-                if tag_filters:
-                    tag_filters_low = [tag.lower() for tag in tag_filters]
-                    valid = False
-                    for tag in repre_tags_low:
-                        if tag in tag_filters_low:
-                            valid = True
-                            break
+            valid = False
+            tag_filters = output_def.get("filter", {}).get("custom_tags")
 
-                    if not valid:
-                        continue
+            if (
+                # if any of tag filter is empty, skip
+                custom_tags and not tag_filters
+                or not custom_tags and tag_filters
+            ):
+                continue
+            elif not custom_tags and not tag_filters:
+                valid = True
 
-            if valid:
-                filtered_outputs.append(output_def)
+            # lower all filter tags
+            tag_filters_low = [tag.lower() for tag in tag_filters]
+
+            self.log.debug("__ tag_filters: {}".format(tag_filters))
+            self.log.debug("__ repre_c_tags_low: {}".format(
+                repre_c_tags_low))
+
+            # check if any repre tag is not in filter tags
+            for tag in repre_c_tags_low:
+                if tag in tag_filters_low:
+                    valid = True
+                    break
+
+            if not valid:
+                continue
+
+            filtered_outputs.append(output_def)
+
+        self.log.debug("__ filtered_outputs: {}".format(
+            [_o["filename_suffix"] for _o in filtered_outputs]
+        ))
 
         return filtered_outputs
 

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1619,6 +1619,24 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         return self.profile_exclusion(matching_profiles)
 
+    def custom_tags_filter_validation(
+        self, repr_custom_tags, output_custom_tags_filter
+    ):
+        """Determines if entered custom tags intersect with custom tags filters.
+
+        All cutsom tags values are lowered to avoid unexpected results.
+        """
+        repr_custom_tags = repr_custom_tags or []
+        valid = False
+        for tag in output_custom_tags_filter:
+            if tag in repr_custom_tags:
+                valid = True
+                break
+
+        if valid:
+            return True
+        return False
+
     def families_filter_validation(self, families, output_families_filter):
         """Determines if entered families intersect with families filters.
 
@@ -1656,7 +1674,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 return True
         return False
 
-    def filter_output_defs(self, profile, subset_name, families):
+    def filter_output_defs(
+        self, profile, subset_name, families, custom_tags=None
+    ):
         """Return outputs matching input instance families.
 
         Output definitions without families filter are marked as valid.
@@ -1687,6 +1707,12 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
             families_filters = output_filters.get("families")
             if not self.families_filter_validation(families, families_filters):
+                continue
+
+            custom_tags_filters = output_filters.get("custom_tags")
+            if custom_tags and not self.custom_tags_filter_validation(
+                custom_tags, custom_tags_filters
+            ):
                 continue
 
             # Subsets name filters

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -78,7 +78,8 @@
                                     "review",
                                     "ftrack"
                                 ],
-                                "subsets": []
+                                "subsets": [],
+                                "custom_tags": []
                             },
                             "overscan_crop": "",
                             "overscan_color": [

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -434,7 +434,7 @@
                         }
                     ],
                     "extension": "mov",
-                    "add_tags": []
+                    "add_custom_tags": []
                 }
             }
         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -295,6 +295,15 @@
                                                     "label": "Subsets",
                                                     "type": "list",
                                                     "object_type": "text"
+                                                },
+                                                {
+                                                    "type": "separator"
+                                                },
+                                                {
+                                                    "key": "custom_tags",
+                                                    "label": "Custom Tags",
+                                                    "type": "list",
+                                                    "object_type": "text"
                                                 }
                                             ]
                                         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_nuke_publish.json
@@ -296,8 +296,8 @@
                                 "label": "Write node file type"
                             },
                             {
-                                "key": "add_tags",
-                                "label": "Add additional tags to representations",
+                                "key": "add_custom_tags",
+                                "label": "Add custom tags",
                                 "type": "list",
                                 "object_type": "text"
                             }


### PR DESCRIPTION
## Brief description
Representation can be filtered by custom tagging in extract review

## Description
Extract review was filtering only on the publishing instance level and not able to aim directly at particular representation. We have to implement filtering method to be able to activate output preset only to particular representation.

## Additional info
- adding `custom_tag` as optional key to representation
- adding `custom_tags` to nuke extract review data movie plugin
- improving nuke's way of handling viewerProcess to include also display selector which is now pars-able from a string. The syntax is as follows:
	- add string input to `project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/viewer_process_override` in case you want to add bake stream overide of `project_settings/nuke/imageio/baking/viewerProcess` (notice we hade moved imagio from Anatomy settings to project settings)
	- syntax is either: `viewer_name (display_name)` or `display_name/viewer_name`
	- examples are: `sRGB (ACES)` or `ACES/sRGB`

## Matching mechanics:
![image](https://user-images.githubusercontent.com/40640033/197043594-2d244895-7f08-4019-a7bb-3a7424bf01f8.png)

## Testing notes:
1. Open Studio settings and go to your project settings
2. go to `project_settings/nuke/publish/ExtractReviewDataMov/outputs`
3. Add one more baking stream and set its Add custom tag to some value
4. Go to `project_settings/global/publish/ExtractReview/profiles`
5. Create a new profile, add it at first, set the host input to `nuke`
6. Add two output profiles > it could be h264 ffmpeg args copied form default preset. Set names to `h264first` and `h264first` two the same profiles, except one of them is having set Additional filtering to `custom tags` with the same input from step 3.
7. In the same project open Nuke and Create render write node.
8. Publish and notice that preset  defined filter on custom tag was run only once.