### PR TITLE
Unreal: Remove redundant Creator stub

### DIFF
--- a/openpype/hosts/unreal/api/__init__.py
+++ b/openpype/hosts/unreal/api/__init__.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 """Unreal Editor OpenPype host API."""
 
-from .plugin import (
-    Loader,
-    Creator
-)
+from .plugin import Loader
+
 from .pipeline import (
     install,
     uninstall,
@@ -25,7 +23,6 @@ from .pipeline import (
 __all__ = [
     "install",
     "uninstall",
-    "Creator",
     "Loader",
     "ls",
     "publish",

--- a/openpype/hosts/unreal/api/plugin.py
+++ b/openpype/hosts/unreal/api/plugin.py
@@ -1,16 +1,7 @@
 # -*- coding: utf-8 -*-
 from abc import ABC
 
-from openpype.pipeline import (
-    LegacyCreator,
-    LoaderPlugin,
-)
-
-
-class Creator(LegacyCreator):
-    """This serves as skeleton for future OpenPype specific functionality"""
-    defaults = ['Main']
-    maintain_selection = False
+from openpype.pipeline import LoaderPlugin
 
 
 class Loader(LoaderPlugin, ABC):

--- a/openpype/hosts/unreal/plugins/create/create_camera.py
+++ b/openpype/hosts/unreal/plugins/create/create_camera.py
@@ -2,11 +2,11 @@ import unreal
 from unreal import EditorAssetLibrary as eal
 from unreal import EditorLevelLibrary as ell
 
-from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import instantiate
+from openpype.pipeline import LegacyCreator
 
 
-class CreateCamera(plugin.Creator):
+class CreateCamera(LegacyCreator):
     """Layout output for character rigs"""
 
     name = "layoutMain"

--- a/openpype/hosts/unreal/plugins/create/create_layout.py
+++ b/openpype/hosts/unreal/plugins/create/create_layout.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from unreal import EditorLevelLibrary
 
-from openpype.hosts.unreal.api import plugin
+from openpype.pipeline import LegacyCreator
 from openpype.hosts.unreal.api.pipeline import instantiate
 
 
-class CreateLayout(plugin.Creator):
+class CreateLayout(LegacyCreator):
     """Layout output for character rigs."""
 
     name = "layoutMain"

--- a/openpype/hosts/unreal/plugins/create/create_look.py
+++ b/openpype/hosts/unreal/plugins/create/create_look.py
@@ -2,9 +2,10 @@
 """Create look in Unreal."""
 import unreal  # noqa
 from openpype.hosts.unreal.api import pipeline, plugin
+from openpype.pipeline import LegacyCreator
 
 
-class CreateLook(plugin.Creator):
+class CreateLook(LegacyCreator):
     """Shader connections defining shape look."""
 
     name = "unrealLook"

--- a/openpype/hosts/unreal/plugins/create/create_render.py
+++ b/openpype/hosts/unreal/plugins/create/create_render.py
@@ -1,10 +1,10 @@
 import unreal
 
 from openpype.hosts.unreal.api import pipeline
-from openpype.hosts.unreal.api.plugin import Creator
+from openpype.pipeline import LegacyCreator
 
 
-class CreateRender(Creator):
+class CreateRender(LegacyCreator):
     """Create instance for sequence for rendering"""
 
     name = "unrealRender"

--- a/openpype/hosts/unreal/plugins/create/create_staticmeshfbx.py
+++ b/openpype/hosts/unreal/plugins/create/create_staticmeshfbx.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Create Static Meshes as FBX geometry."""
 import unreal  # noqa
-from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api.pipeline import (
     instantiate,
 )
+from openpype.pipeline import LegacyCreator
 
 
-class CreateStaticMeshFBX(plugin.Creator):
+class CreateStaticMeshFBX(LegacyCreator):
     """Static FBX geometry."""
 
     name = "unrealStaticMeshMain"


### PR DESCRIPTION
## Refactor

This is simplifying code for Creator plugins in Unreal and dealing with issue that Creator stub was for some reason shown in Creator dialog as empty item.