### PR TITLE
Publisher: Catch creator errors

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -62,19 +62,19 @@ class HostMissRequiredMethod(Exception):
         super(HostMissRequiredMethod, self).__init__(msg)
 
 
-class CreatorOperationFailed(Exception):
+class CreatorsOperationFailed(Exception):
     pass
 
 
-class CreatorsCollectionFailed(CreatorOperationFailed):
+class CreatorsCollectionFailed(CreatorsOperationFailed):
     pass
 
 
-class CreatorsSaveFailed(CreatorOperationFailed):
+class CreatorsSaveFailed(CreatorsOperationFailed):
     pass
 
 
-class CreatorsRemoveFailed(CreatorOperationFailed):
+class CreatorsRemoveFailed(CreatorsOperationFailed):
     pass
 
 

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -302,8 +302,11 @@ class PublishReport:
         }
 
     def _extract_context_data(self, context):
+        context_label = "Context"
+        if context is not None:
+            context_label = context.data.get("label")
         return {
-            "label": context.data.get("label")
+            "label": context_label
         }
 
     def _extract_instance_data(self, instance, exists):

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1662,10 +1662,7 @@ class PublisherController(BasePublisherController):
 
     def reset(self):
         """Reset everything related to creation and publishing."""
-        # Stop publishing
         self.stop_publish()
-
-        self.save_changes()
 
         self.host_is_valid = self._create_context.host_is_valid
 

--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -93,8 +93,8 @@ class OverviewWidget(QtWidgets.QFrame):
         main_layout.addWidget(subset_content_widget, 1)
 
         change_anim = QtCore.QVariantAnimation()
-        change_anim.setStartValue(0)
-        change_anim.setEndValue(self.anim_end_value)
+        change_anim.setStartValue(float(0))
+        change_anim.setEndValue(float(self.anim_end_value))
         change_anim.setDuration(self.anim_duration)
         change_anim.setEasingCurve(QtCore.QEasingCurve.InOutQuad)
 
@@ -264,9 +264,10 @@ class OverviewWidget(QtWidgets.QFrame):
                 + (self._subset_content_layout.spacing() * 2)
             )
         )
-        subset_attrs_width = int(float(width) / self.anim_end_value) * value
+        subset_attrs_width = int((float(width) / self.anim_end_value) * value)
         if subset_attrs_width > width:
             subset_attrs_width = width
+
         create_width = width - subset_attrs_width
 
         self._create_widget.setMinimumWidth(create_width)

--- a/openpype/tools/publisher/widgets/publish_frame.py
+++ b/openpype/tools/publisher/widgets/publish_frame.py
@@ -248,13 +248,13 @@ class PublishFrame(QtWidgets.QWidget):
             hint = self._top_content_widget.minimumSizeHint()
             end = hint.height()
 
-        self._shrunk_anim.setStartValue(start)
-        self._shrunk_anim.setEndValue(end)
+        self._shrunk_anim.setStartValue(float(start))
+        self._shrunk_anim.setEndValue(float(end))
         if not anim_is_running:
             self._shrunk_anim.start()
 
     def _on_shrunk_anim(self, value):
-        diff = self._top_content_widget.height() - value
+        diff = self._top_content_widget.height() - int(value)
         if not self._top_content_widget.isVisible():
             diff -= self._content_layout.spacing()
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -498,7 +498,7 @@ class PublisherWindow(QtWidgets.QDialog):
         self._update_publish_details_widget()
         if (
             not self._tabs_widget.is_current_tab("create")
-            or not self._tabs_widget.is_current_tab("publish")
+            and not self._tabs_widget.is_current_tab("publish")
         ):
             self._tabs_widget.set_current_tab("publish")
 

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -609,8 +609,9 @@ class PublisherWindow(QtWidgets.QDialog):
 
         item = self._dialog_messages_to_show.popleft()
         message, title = item
-        dialog = MessageDialog(message, title)
+        dialog = MessageDialog(message, title, self)
         dialog.exec_()
+        dialog.deleteLater()
 
     def _instance_collection_failed(self, event):
         self.add_message_dialog(event["message"], event["title"])
@@ -629,6 +630,7 @@ class MessageDialog(QtWidgets.QDialog):
         self.setWindowTitle(title or "Something happend")
 
         message_widget = QtWidgets.QLabel(message, self)
+        message_widget.setWordWrap(True)
 
         btns_widget = QtWidgets.QWidget(self)
         submit_btn = QtWidgets.QPushButton("OK", btns_widget)
@@ -639,9 +641,15 @@ class MessageDialog(QtWidgets.QDialog):
         btns_layout.addWidget(submit_btn)
 
         layout = QtWidgets.QVBoxLayout(self)
-        layout.addWidget(message_widget, 1)
+        layout.addWidget(message_widget, 0)
+        layout.addStretch(1)
         layout.addWidget(btns_widget, 0)
+
+        submit_btn.clicked.connect(self._on_submit_click)
+
+    def _on_submit_click(self):
+        self.close()
 
     def showEvent(self, event):
         super(MessageDialog, self).showEvent(event)
-        self.resize(400, 300)
+        self.resize(400, 200)

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -37,7 +37,7 @@ class PublisherWindow(QtWidgets.QDialog):
     footer_border = 8
     publish_footer_spacer = 2
 
-    def __init__(self, parent=None, controller=None, reset_on_first_show=None):
+    def __init__(self, parent=None, controller=None, reset_on_show=None):
         super(PublisherWindow, self).__init__(parent)
 
         self.setWindowTitle("OpenPype publisher")
@@ -45,8 +45,8 @@ class PublisherWindow(QtWidgets.QDialog):
         icon = QtGui.QIcon(resources.get_openpype_icon_filepath())
         self.setWindowIcon(icon)
 
-        if reset_on_first_show is None:
-            reset_on_first_show = True
+        if reset_on_show is None:
+            reset_on_show = True
 
         if parent is None:
             on_top_flag = QtCore.Qt.WindowStaysOnTopHint
@@ -312,7 +312,9 @@ class PublisherWindow(QtWidgets.QDialog):
         self._controller = controller
 
         self._first_show = True
-        self._reset_on_first_show = reset_on_first_show
+        # This is a little bit confusing but 'reset_on_first_show' is too long
+        #   forin init
+        self._reset_on_first_show = reset_on_show
         self._reset_on_show = True
         self._restart_timer = None
         self._publish_frame_visible = None

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -636,7 +636,8 @@ class CreatorsErrorMessageBox(ErrorMessageBox):
     def __init__(self, error_title, failed_info, parent):
         self._failed_info = failed_info
         self._info_with_id = [
-            {"id": idx, "info": info}
+            # Id must be string when used in tab widget
+            {"id": str(idx), "info": info}
             for idx, info in enumerate(failed_info)
         ]
         self._widgets_by_id = {}
@@ -725,6 +726,6 @@ class CreatorsErrorMessageBox(ErrorMessageBox):
         self._tabs_widget = tabs_widget
         self._stack_layout = stack_layout
 
-    def _on_tab_change(self, identifier):
+    def _on_tab_change(self, old_identifier, identifier):
         widget = self._widgets_by_id[identifier]
         self._stack_layout.setCurrentWidget(widget)

--- a/openpype/tools/utils/__init__.py
+++ b/openpype/tools/utils/__init__.py
@@ -7,6 +7,7 @@ from .widgets import (
     ExpandBtn,
     PixmapLabel,
     IconButton,
+    SeparatorWidget,
 )
 from .views import DeselectableTreeView
 from .error_dialog import ErrorMessageBox
@@ -37,6 +38,7 @@ __all__ = (
     "ExpandBtn",
     "PixmapLabel",
     "IconButton",
+    "SeparatorWidget",
 
     "DeselectableTreeView",
 

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -1,6 +1,6 @@
 from Qt import QtWidgets, QtCore
 
-from .widgets import ClickableFrame, ExpandBtn
+from .widgets import ClickableFrame, ExpandBtn, SeparatorWidget
 
 
 def convert_text_for_html(text):
@@ -139,12 +139,10 @@ class ErrorMessageBox(QtWidgets.QDialog):
             mime_data
         )
 
-    def _create_line(self):
-        line = QtWidgets.QFrame(self)
-        line.setObjectName("Separator")
-        line.setMinimumHeight(2)
-        line.setMaximumHeight(2)
-        return line
+    def _create_line(self, parent=None):
+        if parent is None:
+            parent = self
+        return SeparatorWidget(2, parent=parent)
 
     def _create_traceback_widget(self, traceback_text, parent=None):
         if parent is None:

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -3,7 +3,7 @@ from Qt import QtWidgets, QtCore
 from .widgets import ClickableFrame, ExpandBtn, SeparatorWidget
 
 
-def convert_text_for_html(text):
+def escape_text_for_html(text):
     return (
         text
         .replace("<", "&#60;")
@@ -19,7 +19,7 @@ class TracebackWidget(QtWidgets.QWidget):
 
         # Modify text to match html
         # - add more replacements when needed
-        tb_text = convert_text_for_html(tb_text)
+        tb_text = escape_text_for_html(tb_text)
         expand_btn = ExpandBtn(self)
 
         clickable_frame = ClickableFrame(self)
@@ -110,7 +110,7 @@ class ErrorMessageBox(QtWidgets.QDialog):
 
     @staticmethod
     def convert_text_for_html(text):
-        return convert_text_for_html(text)
+        return escape_text_for_html(text)
 
     def _create_top_widget(self, parent_widget):
         label_widget = QtWidgets.QLabel(parent_widget)

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -85,7 +85,9 @@ class ErrorMessageBox(QtWidgets.QDialog):
         copy_report_btn = QtWidgets.QPushButton("Copy report", self)
         ok_btn = QtWidgets.QPushButton("OK", self)
 
-        footer_layout = QtWidgets.QHBoxLayout()
+        footer_widget = QtWidgets.QWidget(self)
+        footer_layout = QtWidgets.QHBoxLayout(footer_widget)
+        footer_layout.setContentsMargins(0, 0, 0, 0)
         footer_layout.addWidget(copy_report_btn, 0)
         footer_layout.addStretch(1)
         footer_layout.addWidget(ok_btn, 0)
@@ -107,6 +109,8 @@ class ErrorMessageBox(QtWidgets.QDialog):
         if not report_data:
             copy_report_btn.setVisible(False)
 
+        self._content_scroll = content_scroll
+        self._footer_widget = footer_widget
         self._report_data = report_data
 
     @staticmethod

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -132,7 +132,8 @@ class ErrorMessageBox(QtWidgets.QDialog):
         self.close()
 
     def _on_copy_report(self):
-        report_text = (10 * "*").join(self._report_data)
+        sep = "\n{}\n".format(10 * "*")
+        report_text = sep.join(self._report_data)
 
         mime_data = QtCore.QMimeData()
         mime_data.setText(report_text)

--- a/openpype/tools/utils/error_dialog.py
+++ b/openpype/tools/utils/error_dialog.py
@@ -91,11 +91,12 @@ class ErrorMessageBox(QtWidgets.QDialog):
         footer_layout.addWidget(ok_btn, 0)
 
         bottom_line = self._create_line()
-        body_layout = QtWidgets.QVBoxLayout(self)
-        body_layout.addWidget(top_widget, 0)
-        body_layout.addWidget(content_scroll, 1)
-        body_layout.addWidget(bottom_line, 0)
-        body_layout.addLayout(footer_layout, 0)
+        main_layout = QtWidgets.QVBoxLayout(self)
+        if top_widget is not None:
+            main_layout.addWidget(top_widget, 0)
+        main_layout.addWidget(content_scroll, 1)
+        main_layout.addWidget(bottom_line, 0)
+        main_layout.addWidget(footer_widget, 0)
 
         copy_report_btn.clicked.connect(self._on_copy_report)
         ok_btn.clicked.connect(self._on_ok_clicked)

--- a/openpype/tools/utils/widgets.py
+++ b/openpype/tools/utils/widgets.py
@@ -448,3 +448,57 @@ class OptionDialog(QtWidgets.QDialog):
 
     def parse(self):
         return self._options.copy()
+
+
+class SeparatorWidget(QtWidgets.QFrame):
+    """Prepared widget that can be used as separator with predefined color.
+
+    Args:
+        size (int): Size of separator (width or height).
+        orientation (Qt.Horizontal|Qt.Vertical): Orintation of widget.
+        parent (QtWidgets.QWidget): Parent widget.
+    """
+
+    def __init__(self, size=2, orientation=QtCore.Qt.Horizontal, parent=None):
+        super(SeparatorWidget, self).__init__(parent)
+
+        self.setObjectName("Separator")
+
+        maximum_width = self.maximumWidth()
+        maximum_height = self.maximumHeight()
+
+        self._size = None
+        self._orientation = orientation
+        self._maximum_width = maximum_width
+        self._maximum_height = maximum_height
+        self.set_size(size)
+
+    def set_size(self, size):
+        if size == self._size:
+            return
+        if self._orientation == QtCore.Qt.Vertical:
+            self.setMinimumWidth(size)
+            self.setMaximumWidth(size)
+        else:
+            self.setMinimumHeight(size)
+            self.setMaximumHeight(size)
+
+        self._size = size
+
+    def set_orientation(self, orientation):
+        if self._orientation == orientation:
+            return
+
+        # Reset min/max sizes in opossite direction
+        if self._orientation == QtCore.Qt.Vertical:
+            self.setMinimumHeight(0)
+            self.setMaximumHeight(self._maximum_height)
+        else:
+            self.setMinimumWidth(0)
+            self.setMaximumWidth(self._maximum_width)
+
+        self._orientation = orientation
+
+        size = self._size
+        self._size = None
+        self.set_size(size)


### PR DESCRIPTION
## Brief description
Handle failed operations of creator plugins in Publihser UI to safe-guard failed state.

## Description
If creator failed during one of their operations the UI could stuck without any way how to rollback and user have no idea that something went wrong. For this purposes all oprations on create context raise special exceptions. Exception hold information about each failed creator with error message and optionally traceback. This can be showed in UI as a dialog. The dialog shows a tabs per each creator which failed. Exceptions are handled on collect, update, remove and create. Create widget does not handle exceptions on it's own because it would not be possible in remotelly controllerd UI instead a controller trigger events when dialog should be shown.

Reset of controller does not trigger save automatically. That is to prevent unwanted trigger e.g. when window is reopened, the previous state should not be saved because was already saved and the context could change meanwhile.

Fixed few smaller bugs. Tab `Details` crashed if was selected before publishing started. Animations were not working in older Qt bindings.

## Additional info
There is one remaining issue. We don't handle change of context/workfile in hosts. We should add that option in future.

The messages are really simple right now we could change them to something understandable by both users and developers. The raised error message should maybe contain information about all creators. Also the error dialog does not have title because it looked wierd above the tabs, could be added by changing the background of the title widget to same color as tabs have in empty space.

## Screenshots
![image](https://user-images.githubusercontent.com/43494761/197166920-8c222529-ae4c-4a72-8ba8-94c104e13376.png)
![image](https://user-images.githubusercontent.com/43494761/197166955-eb650f15-365b-4f89-a2a0-8eed8b18c2d3.png)
![image](https://user-images.githubusercontent.com/43494761/197166983-23b43960-5767-4c95-86d5-f3d668db3e2c.png)

## Testing notes:
1. Crashed created, collect, update, remove should show error dialog with information
2. Animations should work in Nuke