### PR TITLE
Houdini: fix wrong path in ASS loader

### DIFF
--- a/openpype/hosts/houdini/plugins/load/load_ass.py
+++ b/openpype/hosts/houdini/plugins/load/load_ass.py
@@ -1,11 +1,10 @@
 import os
-
 import re
+
 from openpype.pipeline import (
     load,
     get_representation_path,
 )
-
 from openpype.hosts.houdini.api import pipeline
 
 
@@ -20,7 +19,6 @@ class AssLoader(load.LoaderPlugin):
     color = "orange"
 
     def load(self, context, name=None, namespace=None, data=None):
-
         import hou
 
         # Get the root node
@@ -35,8 +33,7 @@ class AssLoader(load.LoaderPlugin):
 
         procedural.setParms(
             {
-                "ar_filename": self.format_path(
-                    self.fname, context["representation"])
+                "ar_filename": self.format_path(context["representation"])
             })
 
         nodes = [procedural]
@@ -52,10 +49,8 @@ class AssLoader(load.LoaderPlugin):
         )
 
     def update(self, container, representation):
-
         # Update the file path
-        file_path = get_representation_path(representation)
-        file_path = self.format_path(file_path, representation)
+        file_path = self.format_path(representation)
 
         procedural = container["node"]
         procedural.setParms({"ar_filename": file_path})
@@ -64,26 +59,31 @@ class AssLoader(load.LoaderPlugin):
         procedural.setParms({"representation": str(representation["_id"])})
 
     def remove(self, container):
-
         node = container["node"]
         node.destroy()
 
     @staticmethod
-    def format_path(path, representation):
-        """Format file path correctly for single bgeo or bgeo sequence."""
+    def format_path(representation):
+        """Format file path correctly for single ass.* or ass.* sequence.
+
+        Args:
+            representation (dict): representation to be loaded.
+
+        Returns:
+             str: Formatted path to be used by the input node.
+
+        """
+        path = get_representation_path(representation)
         if not os.path.exists(path):
-            raise RuntimeError("Path does not exist: %s" % path)
+            raise RuntimeError("Path does not exist: {}".format(path))
 
         is_sequence = bool(representation["context"].get("frame"))
         # The path is either a single file or sequence in a folder.
-        if not is_sequence:
-            filename = path
-        else:
-            filename = re.sub(r"(.*)\.(\d+)\.(ass.*)", "\\1.$F4.\\3", path)
+        if is_sequence:
+            dir_path, file_name = os.path.split(path)
+            path = os.path.join(
+                dir_path,
+                re.sub(r"(.*)\.(\d+)\.(ass.*)", "\\1.$F4.\\3", file_name)
+            )
 
-            filename = os.path.join(path, filename)
-
-        filename = os.path.normpath(filename)
-        filename = filename.replace("\\", "/")
-
-        return filename
+        return os.path.normpath(path).replace("\\", "/")

--- a/openpype/hosts/houdini/plugins/load/load_ass.py
+++ b/openpype/hosts/houdini/plugins/load/load_ass.py
@@ -1,6 +1,6 @@
 import os
 
-import clique
+import re
 from openpype.pipeline import (
     load,
     get_representation_path,

--- a/openpype/hosts/houdini/plugins/load/load_ass.py
+++ b/openpype/hosts/houdini/plugins/load/load_ass.py
@@ -50,10 +50,8 @@ class AssLoader(load.LoaderPlugin):
 
     def update(self, container, representation):
         # Update the file path
-        file_path = self.format_path(representation)
-
         procedural = container["node"]
-        procedural.setParms({"ar_filename": file_path})
+        procedural.setParms({"ar_filename": self.format_path(representation)})
 
         # Update attribute
         procedural.setParms({"representation": str(representation["_id"])})

--- a/openpype/hosts/houdini/plugins/load/load_ass.py
+++ b/openpype/hosts/houdini/plugins/load/load_ass.py
@@ -85,3 +85,6 @@ class AssLoader(load.LoaderPlugin):
             )
 
         return os.path.normpath(path).replace("\\", "/")
+
+    def switch(self, container, representation):
+        self.update(container, representation)


### PR DESCRIPTION
## Fix

ASS loader was filling in only file name, not the whole path. This is fixing the problem.

### Testing

Load ASS file with OpenPype in Houdini, everything should work as expected.