### PR TITLE
workflows: adding milestone creator and assigner

### DIFF
--- a/.github/workflows/milestone_assign.yml
+++ b/.github/workflows/milestone_assign.yml
@@ -1,0 +1,28 @@
+name: Milestone - assign to PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+jobs:
+  run_if_release:
+    if:  startsWith(github.base_ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Assign Milestone [next-minor]'
+        if: github.event.pull_request.milestone == null
+        uses: zoispag/action-assign-milestone@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          milestone: 'next-minor'
+
+  run_if_develop:
+    if:  ${{ github.base_ref == 'develop' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Assign Milestone [next-patch]'
+        if: github.event.pull_request.milestone == null
+        uses: zoispag/action-assign-milestone@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          milestone: 'next-patch'

--- a/.github/workflows/milestone_create.yml
+++ b/.github/workflows/milestone_create.yml
@@ -1,0 +1,62 @@
+name: Milestone - create default
+
+on:
+  milestone:
+    types: [closed, edited]
+
+jobs:
+  generate-next-patch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Get Milestones'
+        uses: "WyriHaximus/github-action-get-milestones@master"
+        id: milestones
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - run: printf "name=number::%s" $(printenv MILESTONES | jq --arg MILESTONE $(printenv MILESTONE) '.[]  | select(.title == $MILESTONE) | .number')
+        id: querymilestone
+        env:
+          MILESTONES: ${{ steps.milestones.outputs.milestones }}
+          MILESTONE: "next-patch"
+
+      - name: Read output
+        run: |
+          echo "${{ steps.querymilestone.outputs.number }}"
+
+      - name: 'Create `next-patch` milestone'
+        if: steps.querymilestone.outputs.number == ''
+        id: createmilestone
+        uses: "WyriHaximus/github-action-create-milestone@v1"
+        with:
+          title: 'next-patch'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  generate-next-minor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Get Milestones'
+        uses: "WyriHaximus/github-action-get-milestones@master"
+        id: milestones
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - run: printf "name=number::%s" $(printenv MILESTONES | jq --arg MILESTONE $(printenv MILESTONE) '.[]  | select(.title == $MILESTONE) | .number')
+        id: querymilestone
+        env:
+          MILESTONES: ${{ steps.milestones.outputs.milestones }}
+          MILESTONE: "next-minor"
+
+      - name: Read output
+        run: |
+          echo "${{ steps.querymilestone.outputs.number }}"
+
+      - name: 'Create `next-minor` milestone'
+        if: steps.querymilestone.outputs.number == ''
+        id: createmilestone
+        uses: "WyriHaximus/github-action-create-milestone@v1"
+        with:
+          title: 'next-minor'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Brief description
Milestones on Github used in workflows

## Description
All PR will be now labelled by milestone according to its target:
- target to `develop` will be milestone `next-patch`
- target to `release/**` will be milestone `next-minor`

In case of later renaming of milestone to release number, new set of  default milestones will be created, so they will be always available.


## Additional info
- for this to work properly, we will need to merge this PR to `main`, latest `release/` and `develop` branches.
