### PR TITLE
Publisher: Convertors for legacy instances

### DIFF
--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1195,9 +1195,7 @@ class CreateContext:
                 ))
                 continue
 
-            legacy_convertors[convertor_identifier] = (
-                convertor_identifier(self)
-            )
+            legacy_convertors[convertor_identifier] = convertor_class(self)
 
         self.legacy_convertors = legacy_convertors
 

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1823,7 +1823,8 @@ class CreateContext:
     def run_convertors(self, convertor_identifiers):
         """Run convertor plugins by idenfitifiers.
 
-        Conversion is skipped if convertor is not available.
+        Conversion is skipped if convertor is not available. It is recommended
+        to trigger reset after conversion to reload instances.
 
         Args:
             convertor_identifiers (Iterator[str]): Identifiers of convertors

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1500,3 +1500,8 @@ class CreateContext:
                 "Accessed Collection shared data out of collection phase"
             )
         return self._collection_shared_data
+
+    def run_convertor(self, convertor_identifier):
+        convertor = self.legacy_convertors.get(convertor_identifier)
+        if convertor is not None:
+            convertor.convert()

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -862,18 +862,26 @@ class LegacyInstancesItem(object):
     """
 
     def __init__(self, identifier, label):
+        self._id = str(uuid4())
         self.identifier = identifier
         self.label = label
 
+    @property
+    def id(self):
+        return self._id
+
     def to_data(self):
         return {
+            "id": self.id,
             "identifier": self.identifier,
             "label": self.label
         }
 
     @classmethod
     def from_data(cls, data):
-        return cls(data["identifier"], data["label"])
+        obj = cls(data["identifier"], data["label"])
+        obj._id = data["id"]
+        return obj
 
 
 class CreateContext:

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -1074,6 +1074,11 @@ class CreateContext:
         Reloads creators from preregistered paths and can load publish plugins
         if it's enabled on context.
         """
+
+        self._reset_publish_plugins(discover_publish_plugins)
+        self._reset_creator_plugins()
+
+    def _reset_publish_plugins(self, discover_publish_plugins):
         import pyblish.logic
 
         from openpype.pipeline import OpenPypePyblishPluginMixin
@@ -1115,6 +1120,7 @@ class CreateContext:
         self.publish_plugins = plugins_by_targets
         self.plugins_with_defs = plugins_with_defs
 
+    def _reset_creator_plugins(self):
         # Prepare settings
         system_settings = get_system_settings()
         project_settings = get_project_settings(self.project_name)

--- a/openpype/pipeline/create/context.py
+++ b/openpype/pipeline/create/context.py
@@ -852,6 +852,29 @@ class CreatedInstance:
                     self[key] = new_value
 
 
+class LegacyInstancesItem(object):
+    """Item representing convertor for legacy instances.
+
+    Args:
+        identifier (str): Identifier of convertor.
+        label (str): Label which will be shown in UI.
+    """
+
+    def __init__(self, identifier, label):
+        self.identifier = identifier
+        self.label = label
+
+    def to_data(self):
+        return {
+            "identifier": self.identifier,
+            "label": self.label
+        }
+
+    @classmethod
+    def from_data(cls, data):
+        return cls(data["identifier"], data["label"])
+
+
 class CreateContext:
     """Context of instance creation.
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -34,6 +34,96 @@ class CreatorError(Exception):
 
 
 @six.add_metaclass(ABCMeta)
+class LegacyInstanceConvertor(object):
+    """Helper for conversion of instances created using legacy creators.
+
+    Conversion from legacy creators would mean to loose legacy instances,
+    convert them automatically or write a script which must user run. All of
+    these solutions are workign but will happen without asking or user must
+    know about them. This plugin can be used to show legacy instances in
+    Publisher and give user ability to run conversion script.
+
+    Convertor logic should be very simple. Method 'find_instances' is to
+    look for legacy instances in scene a possibly call
+    pre-implemented 'add_legacy_item'.
+
+    User will have ability to trigger conversion which is executed by calling
+    'convert' which should call 'remove_legacy_item' when is done.
+
+    It does make sense to add only one or none legacy item to create context
+    for convertor as it's not possible to choose which instace are converted
+    and which are not.
+
+    Convertor can use 'collection_shared_data' property like creators. Also
+    can store any information to it's object for conversion purposes.
+
+    Args:
+        create_context
+    """
+
+    def __init__(self, create_context):
+        self._create_context = create_context
+
+    @abstractproperty
+    def identifier(self):
+        """Converted identifier.
+
+        Returns:
+            str: Converted identifier unique for all converters in host.
+        """
+
+        pass
+
+    @abstractmethod
+    def find_instances(self):
+        """Look for legacy instances in the scene.
+
+        Should call 'add_legacy_item' if there is at least one item.
+        """
+
+        pass
+
+    @abstractmethod
+    def convert(self):
+        """Conversion code."""
+
+        pass
+
+    @property
+    def create_context(self):
+        """Quick access to create context."""
+
+        return self._create_context
+
+    @property
+    def collection_shared_data(self):
+        """Access to shared data that can be used during 'find_instances'.
+
+        Retruns:
+            Dict[str, Any]: Shared data.
+
+        Raises:
+            UnavailableSharedData: When called out of collection phase.
+        """
+
+        return self._create_context.collection_shared_data
+
+    def add_legacy_item(self, label):
+        """Add item to CreateContext.
+
+        Args:
+            label (str): Label of item which will show in UI.
+        """
+
+        self._create_context.add_legacy_item(self.identifier, label)
+
+    def remove_legacy_item(self):
+        """Remove legacy item from create context when conversion finished."""
+
+        self._create_context.remove_legacy_item(self.identifier)
+
+
+@six.add_metaclass(ABCMeta)
 class BaseCreator:
     """Plugin that create and modify instance data before publishing process.
 

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -61,8 +61,22 @@ class SubsetConvertorPlugin(object):
         create_context
     """
 
+    _log = None
+
     def __init__(self, create_context):
         self._create_context = create_context
+
+    @property
+    def log(self):
+        """Logger of the plugin.
+
+        Returns:
+            logging.Logger: Logger with name of the plugin.
+        """
+
+        if self._log is None:
+            self._log = Logger.get_logger(self.__class__.__name__)
+        return self._log
 
     @abstractproperty
     def identifier(self):

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -34,7 +34,7 @@ class CreatorError(Exception):
 
 
 @six.add_metaclass(ABCMeta)
-class LegacySubsetConvertor(object):
+class SubsetConvertorPlugin(object):
     """Helper for conversion of instances created using legacy creators.
 
     Conversion from legacy creators would mean to loose legacy instances,
@@ -561,7 +561,7 @@ def discover_creator_plugins():
 
 
 def discover_convertor_plugins():
-    return discover(LegacySubsetConvertor)
+    return discover(SubsetConvertorPlugin)
 
 
 def discover_legacy_creator_plugins():
@@ -621,8 +621,8 @@ def register_creator_plugin(plugin):
     elif issubclass(plugin, LegacyCreator):
         register_plugin(LegacyCreator, plugin)
 
-    elif issubclass(plugin, LegacySubsetConvertor):
-        register_plugin(LegacySubsetConvertor, plugin)
+    elif issubclass(plugin, SubsetConvertorPlugin):
+        register_plugin(SubsetConvertorPlugin, plugin)
 
 
 def deregister_creator_plugin(plugin):
@@ -632,17 +632,17 @@ def deregister_creator_plugin(plugin):
     elif issubclass(plugin, LegacyCreator):
         deregister_plugin(LegacyCreator, plugin)
 
-    elif issubclass(plugin, LegacySubsetConvertor):
-        deregister_plugin(LegacySubsetConvertor, plugin)
+    elif issubclass(plugin, SubsetConvertorPlugin):
+        deregister_plugin(SubsetConvertorPlugin, plugin)
 
 
 def register_creator_plugin_path(path):
     register_plugin_path(BaseCreator, path)
     register_plugin_path(LegacyCreator, path)
-    register_plugin_path(LegacySubsetConvertor, path)
+    register_plugin_path(SubsetConvertorPlugin, path)
 
 
 def deregister_creator_plugin_path(path):
     deregister_plugin_path(BaseCreator, path)
     deregister_plugin_path(LegacyCreator, path)
-    deregister_plugin_path(LegacySubsetConvertor, path)
+    deregister_plugin_path(SubsetConvertorPlugin, path)

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -34,7 +34,7 @@ class CreatorError(Exception):
 
 
 @six.add_metaclass(ABCMeta)
-class LegacyInstanceConvertor(object):
+class LegacySubsetConvertor(object):
     """Helper for conversion of instances created using legacy creators.
 
     Conversion from legacy creators would mean to loose legacy instances,
@@ -45,10 +45,10 @@ class LegacyInstanceConvertor(object):
 
     Convertor logic should be very simple. Method 'find_instances' is to
     look for legacy instances in scene a possibly call
-    pre-implemented 'add_legacy_item'.
+    pre-implemented 'add_convertor_item'.
 
     User will have ability to trigger conversion which is executed by calling
-    'convert' which should call 'remove_legacy_item' when is done.
+    'convert' which should call 'remove_convertor_item' when is done.
 
     It does make sense to add only one or none legacy item to create context
     for convertor as it's not possible to choose which instace are converted
@@ -78,7 +78,8 @@ class LegacyInstanceConvertor(object):
     def find_instances(self):
         """Look for legacy instances in the scene.
 
-        Should call 'add_legacy_item' if there is at least one item.
+        Should call 'add_convertor_item' if there is at least one instance to
+        convert.
         """
 
         pass
@@ -108,19 +109,19 @@ class LegacyInstanceConvertor(object):
 
         return self._create_context.collection_shared_data
 
-    def add_legacy_item(self, label):
+    def add_convertor_item(self, label):
         """Add item to CreateContext.
 
         Args:
             label (str): Label of item which will show in UI.
         """
 
-        self._create_context.add_legacy_item(self.identifier, label)
+        self._create_context.add_convertor_item(self.identifier, label)
 
-    def remove_legacy_item(self):
+    def remove_convertor_item(self):
         """Remove legacy item from create context when conversion finished."""
 
-        self._create_context.remove_legacy_item(self.identifier)
+        self._create_context.remove_convertor_item(self.identifier)
 
 
 @six.add_metaclass(ABCMeta)
@@ -559,8 +560,8 @@ def discover_creator_plugins():
     return discover(BaseCreator)
 
 
-def discover_legacy_convertor_plugins():
-    return discover(LegacyInstanceConvertor)
+def discover_convertor_plugins():
+    return discover(LegacySubsetConvertor)
 
 
 def discover_legacy_creator_plugins():
@@ -620,8 +621,8 @@ def register_creator_plugin(plugin):
     elif issubclass(plugin, LegacyCreator):
         register_plugin(LegacyCreator, plugin)
 
-    elif issubclass(plugin, LegacyInstanceConvertor):
-        register_plugin(LegacyInstanceConvertor, plugin)
+    elif issubclass(plugin, LegacySubsetConvertor):
+        register_plugin(LegacySubsetConvertor, plugin)
 
 
 def deregister_creator_plugin(plugin):
@@ -631,17 +632,17 @@ def deregister_creator_plugin(plugin):
     elif issubclass(plugin, LegacyCreator):
         deregister_plugin(LegacyCreator, plugin)
 
-    elif issubclass(plugin, LegacyInstanceConvertor):
-        deregister_plugin(LegacyInstanceConvertor, plugin)
+    elif issubclass(plugin, LegacySubsetConvertor):
+        deregister_plugin(LegacySubsetConvertor, plugin)
 
 
 def register_creator_plugin_path(path):
     register_plugin_path(BaseCreator, path)
     register_plugin_path(LegacyCreator, path)
-    register_plugin_path(LegacyInstanceConvertor, path)
+    register_plugin_path(LegacySubsetConvertor, path)
 
 
 def deregister_creator_plugin_path(path):
     deregister_plugin_path(BaseCreator, path)
     deregister_plugin_path(LegacyCreator, path)
-    deregister_plugin_path(LegacyInstanceConvertor, path)
+    deregister_plugin_path(LegacySubsetConvertor, path)

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -559,6 +559,10 @@ def discover_creator_plugins():
     return discover(BaseCreator)
 
 
+def discover_legacy_convertor_plugins():
+    return discover(LegacyInstanceConvertor)
+
+
 def discover_legacy_creator_plugins():
     from openpype.lib import Logger
 
@@ -616,6 +620,9 @@ def register_creator_plugin(plugin):
     elif issubclass(plugin, LegacyCreator):
         register_plugin(LegacyCreator, plugin)
 
+    elif issubclass(plugin, LegacyInstanceConvertor):
+        register_plugin(LegacyInstanceConvertor, plugin)
+
 
 def deregister_creator_plugin(plugin):
     if issubclass(plugin, BaseCreator):
@@ -624,12 +631,17 @@ def deregister_creator_plugin(plugin):
     elif issubclass(plugin, LegacyCreator):
         deregister_plugin(LegacyCreator, plugin)
 
+    elif issubclass(plugin, LegacyInstanceConvertor):
+        deregister_plugin(LegacyInstanceConvertor, plugin)
+
 
 def register_creator_plugin_path(path):
     register_plugin_path(BaseCreator, path)
     register_plugin_path(LegacyCreator, path)
+    register_plugin_path(LegacyInstanceConvertor, path)
 
 
 def deregister_creator_plugin_path(path):
     deregister_plugin_path(BaseCreator, path)
     deregister_plugin_path(LegacyCreator, path)
+    deregister_plugin_path(LegacyInstanceConvertor, path)

--- a/openpype/style/data.json
+++ b/openpype/style/data.json
@@ -100,10 +100,7 @@
                 "bg-expander": "#2C313A",
                 "bg-expander-hover": "#2d6c9f",
                 "bg-expander-selected-hover": "#3784c5"
-            },
-            "bg-legacy": "rgb(17, 17, 17)",
-            "bg-legacy-hover": "rgb(41, 41, 41)",
-            "bg-legacy-selected": "rgba(42, 123, 174, .4)"
+            }
         },
         "settings": {
             "invalid-light": "#C93636",

--- a/openpype/style/data.json
+++ b/openpype/style/data.json
@@ -100,7 +100,10 @@
                 "bg-expander": "#2C313A",
                 "bg-expander-hover": "#2d6c9f",
                 "bg-expander-selected-hover": "#3784c5"
-            }
+            },
+            "bg-legacy": "rgb(17, 17, 17)",
+            "bg-legacy-hover": "rgb(41, 41, 41)",
+            "bg-legacy-selected": "rgba(42, 123, 174, .4)"
         },
         "settings": {
             "invalid-light": "#C93636",

--- a/openpype/style/data.json
+++ b/openpype/style/data.json
@@ -64,7 +64,9 @@
         "overlay-messages": {
             "close-btn": "#D3D8DE",
             "bg-success": "#458056",
-            "bg-success-hover": "#55a066"
+            "bg-success-hover": "#55a066",
+            "bg-error": "#AD2E2E",
+            "bg-error-hover": "#C93636"
         },
         "tab-widget": {
             "bg": "#21252B",

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -965,6 +965,18 @@ VariantInputsWidget QToolButton {
     background: {color:bg-view-selection};
 }
 
+#CardViewLegacyItemWidget {
+    background: {color:publisher:bg-legacy};
+    border-radius: 0.2em;
+
+}
+#CardViewLegacyItemWidget:hover {
+    background: {color:publisher:bg-legacy-hover};
+}
+#CardViewLegacyItemWidget[state="selected"] {
+    background: {color:publisher:bg-legacy-selected};
+}
+
 #ListViewSubsetName[state="invalid"] {
     color: {color:publisher:error};
 }

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -965,18 +965,6 @@ VariantInputsWidget QToolButton {
     background: {color:bg-view-selection};
 }
 
-#CardViewLegacyItemWidget {
-    background: {color:publisher:bg-legacy};
-    border-radius: 0.2em;
-
-}
-#CardViewLegacyItemWidget:hover {
-    background: {color:publisher:bg-legacy-hover};
-}
-#CardViewLegacyItemWidget[state="selected"] {
-    background: {color:publisher:bg-legacy-selected};
-}
-
 #ListViewSubsetName[state="invalid"] {
     color: {color:publisher:error};
 }

--- a/openpype/style/style.css
+++ b/openpype/style/style.css
@@ -688,22 +688,23 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 }
 
 /* Messages overlay */
-#OverlayMessageWidget {
+OverlayMessageWidget {
     border-radius: 0.2em;
-    background: {color:bg-buttons};
-}
-
-#OverlayMessageWidget:hover {
-    background: {color:bg-button-hover};
-}
-#OverlayMessageWidget {
     background: {color:overlay-messages:bg-success};
 }
-#OverlayMessageWidget:hover {
+
+OverlayMessageWidget:hover {
     background: {color:overlay-messages:bg-success-hover};
 }
 
-#OverlayMessageWidget QWidget {
+OverlayMessageWidget[type="error"] {
+    background: {color:overlay-messages:bg-error};
+}
+OverlayMessageWidget[type="error"]:hover {
+    background: {color:overlay-messages:bg-error-hover};
+}
+
+OverlayMessageWidget QWidget {
     background: transparent;
 }
 

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -6,6 +6,7 @@ CONTEXT_LABEL = "Options"
 # Not showed anywhere - used as identifier
 CONTEXT_GROUP = "__ContextGroup__"
 
+LEGACY_ITEM_GROUP = "Legacy instances"
 
 # Allowed symbols for subset name (and variant)
 # - characters, numbers, unsercore and dash
@@ -20,6 +21,8 @@ SORT_VALUE_ROLE = QtCore.Qt.UserRole + 2
 IS_GROUP_ROLE = QtCore.Qt.UserRole + 3
 CREATOR_IDENTIFIER_ROLE = QtCore.Qt.UserRole + 4
 FAMILY_ROLE = QtCore.Qt.UserRole + 5
+GROUP_ROLE = QtCore.Qt.UserRole + 6
+LEGACY_CONVERTER_IDENTIFIER = QtCore.Qt.UserRole + 7
 
 
 __all__ = (

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -6,7 +6,7 @@ CONTEXT_LABEL = "Options"
 # Not showed anywhere - used as identifier
 CONTEXT_GROUP = "__ContextGroup__"
 
-LEGACY_ITEM_GROUP = "Legacy instances"
+LEGACY_ITEM_GROUP = "Incompatible subsets"
 
 # Allowed symbols for subset name (and variant)
 # - characters, numbers, unsercore and dash

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -6,7 +6,7 @@ CONTEXT_LABEL = "Options"
 # Not showed anywhere - used as identifier
 CONTEXT_GROUP = "__ContextGroup__"
 
-LEGACY_ITEM_GROUP = "Incompatible subsets"
+CONVERTOR_ITEM_GROUP = "Incompatible subsets"
 
 # Allowed symbols for subset name (and variant)
 # - characters, numbers, unsercore and dash
@@ -22,7 +22,7 @@ IS_GROUP_ROLE = QtCore.Qt.UserRole + 3
 CREATOR_IDENTIFIER_ROLE = QtCore.Qt.UserRole + 4
 FAMILY_ROLE = QtCore.Qt.UserRole + 5
 GROUP_ROLE = QtCore.Qt.UserRole + 6
-LEGACY_CONVERTER_IDENTIFIER = QtCore.Qt.UserRole + 7
+CONVERTER_IDENTIFIER_ROLE = QtCore.Qt.UserRole + 7
 
 
 __all__ = (

--- a/openpype/tools/publisher/constants.py
+++ b/openpype/tools/publisher/constants.py
@@ -3,6 +3,9 @@ from Qt import QtCore
 # ID of context item in instance view
 CONTEXT_ID = "context"
 CONTEXT_LABEL = "Options"
+# Not showed anywhere - used as identifier
+CONTEXT_GROUP = "__ContextGroup__"
+
 
 # Allowed symbols for subset name (and variant)
 # - characters, numbers, unsercore and dash

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -40,6 +40,11 @@ from openpype.pipeline.create.context import (
 PLUGIN_ORDER_OFFSET = 0.5
 
 
+class CardMessageTypes:
+    standard = None
+    error = "error"
+
+
 class MainThreadItem:
     """Callback with args and kwargs."""
 
@@ -1264,7 +1269,9 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def emit_card_message(self, message, message_type=None):
+    def emit_card_message(
+        self, message, message_type=CardMessageTypes.standard
+    ):
         """Emit a card message which can have a lifetime.
 
         This is for UI purposes. Method can be extended to more arguments
@@ -1771,7 +1778,9 @@ class PublisherController(BasePublisherController):
 
         self._on_create_instance_change()
 
-    def emit_card_message(self, message, message_type=None):
+    def emit_card_message(
+        self, message, message_type=CardMessageTypes.standard
+    ):
         self._emit_event(
             "show.card.message",
             {
@@ -1910,8 +1919,12 @@ class PublisherController(BasePublisherController):
                     "failed_info": exc.failed_info
                 }
             )
+
+        if success:
+            self.emit_card_message("Conversion finished")
+        else:
+            self.emit_card_message("Conversion failed", CardMessageTypes.error)
         self._on_create_instance_change()
-        self.emit_card_message("Conversion finished")
 
     def create(
         self, creator_identifier, subset_name, instance_data, options

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1235,7 +1235,7 @@ class AbstractPublisherController(object):
         pass
 
     @abstractproperty
-    def legacy_items(self):
+    def convertor_items(self):
         pass
 
     @abstractmethod
@@ -1607,7 +1607,7 @@ class PublisherController(BasePublisherController):
         return self._create_context.instances_by_id
 
     @property
-    def legacy_items(self):
+    def convertor_items(self):
         return self._create_context.legacy_items_by_id
 
     @property

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1906,6 +1906,8 @@ class PublisherController(BasePublisherController):
         )
 
     def trigger_convertor_items(self, convertor_identifiers):
+        self.save_changes()
+
         success = True
         try:
             self._create_context.run_convertors(convertor_identifiers)
@@ -1924,7 +1926,8 @@ class PublisherController(BasePublisherController):
             self.emit_card_message("Conversion finished")
         else:
             self.emit_card_message("Conversion failed", CardMessageTypes.error)
-        self._on_create_instance_change()
+
+        self.reset()
 
     def create(
         self, creator_identifier, subset_name, instance_data, options
@@ -1972,7 +1975,6 @@ class PublisherController(BasePublisherController):
         Args:
             instance_ids (List[str]): List of instance ids to remove.
         """
-        # TODO expect instance ids instead of instances
         # QUESTION Expect that instances are really removed? In that case save
         #   reset is not required and save changes too.
         self.save_changes()

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1608,7 +1608,7 @@ class PublisherController(BasePublisherController):
 
     @property
     def convertor_items(self):
-        return self._create_context.legacy_items_by_id
+        return self._create_context.convertor_items_by_id
 
     @property
     def _creators(self):
@@ -1728,7 +1728,7 @@ class PublisherController(BasePublisherController):
         self._create_context.reset_context_data()
         with self._create_context.bulk_instances_collection():
             self._create_context.reset_instances()
-            self._create_context.find_legacy_items()
+            self._create_context.find_convertor_items()
             self._create_context.execute_autocreators()
 
         self._resetting_instances = False

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1239,7 +1239,7 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def convert_legacy_items(self, convertor_identifiers):
+    def trigger_convertor_items(self, convertor_identifiers):
         pass
 
     @abstractmethod
@@ -1854,7 +1854,7 @@ class PublisherController(BasePublisherController):
             variant, task_name, asset_doc, project_name, instance=instance
         )
 
-    def convert_legacy_items(self, convertor_identifiers):
+    def trigger_convertor_items(self, convertor_identifiers):
         for convertor_identifier in convertor_identifiers:
             self._create_context.run_convertor(convertor_identifier)
         self._on_create_instance_change()

--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -1264,7 +1264,7 @@ class AbstractPublisherController(object):
         pass
 
     @abstractmethod
-    def emit_card_message(self, message):
+    def emit_card_message(self, message, message_type=None):
         """Emit a card message which can have a lifetime.
 
         This is for UI purposes. Method can be extended to more arguments
@@ -1771,8 +1771,14 @@ class PublisherController(BasePublisherController):
 
         self._on_create_instance_change()
 
-    def emit_card_message(self, message):
-        self._emit_event("show.card.message", {"message": message})
+    def emit_card_message(self, message, message_type=None):
+        self._emit_event(
+            "show.card.message",
+            {
+                "message": message,
+                "message_type": message_type
+            }
+        )
 
     def get_creator_attribute_definitions(self, instances):
         """Collect creator attribute definitions for multuple instances.

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -39,7 +39,7 @@ from ..constants import (
     CONTEXT_ID,
     CONTEXT_LABEL,
     CONTEXT_GROUP,
-    LEGACY_ITEM_GROUP,
+    CONVERTOR_ITEM_GROUP,
 )
 
 
@@ -175,7 +175,7 @@ class BaseGroupWidget(QtWidgets.QWidget):
         self.selected.emit(instance_id, group_id, selection_type)
 
 
-class LegacyItemsGroupWidget(BaseGroupWidget):
+class ConvertorItemsGroupWidget(BaseGroupWidget):
     def update_items(self, items_by_id):
         items_by_label = collections.defaultdict(list)
         for item in items_by_id.values():
@@ -195,7 +195,7 @@ class LegacyItemsGroupWidget(BaseGroupWidget):
                     widget = self._widgets_by_id[item.id]
                     widget.update_item(item)
                 else:
-                    widget = LegacyItemCardWidget(item, self)
+                    widget = ConvertorItemCardWidget(item, self)
                     widget.selected.connect(self._on_widget_selection)
                     self._widgets_by_id[item.id] = widget
                     self._content_layout.insertWidget(widget_idx, widget)
@@ -345,18 +345,18 @@ class ContextCardWidget(CardWidget):
         self._label_widget = label_widget
 
 
-class LegacyItemCardWidget(CardWidget):
+class ConvertorItemCardWidget(CardWidget):
     """Card for global context.
 
     Is not visually under group widget and is always at the top of card view.
     """
 
     def __init__(self, item, parent):
-        super(LegacyItemCardWidget, self).__init__(parent)
+        super(ConvertorItemCardWidget, self).__init__(parent)
 
         self._id = item.id
         self.identifier = item.identifier
-        self._group_identifier = LEGACY_ITEM_GROUP
+        self._group_identifier = CONVERTOR_ITEM_GROUP
 
         icon_widget = IconValuePixmapLabel("fa.magic", self)
         icon_widget.setObjectName("FamilyIconLabel")
@@ -556,7 +556,7 @@ class InstanceCardView(AbstractInstanceView):
         self._content_widget = content_widget
 
         self._context_widget = None
-        self._legacy_items_group = None
+        self._convertor_items_group = None
         self._widgets_by_group = {}
         self._ordered_groups = []
 
@@ -589,8 +589,8 @@ class InstanceCardView(AbstractInstanceView):
         ):
             output.append(self._context_widget)
 
-        if self._legacy_items_group is not None:
-            output.extend(self._legacy_items_group.get_selected_widgets())
+        if self._convertor_items_group is not None:
+            output.extend(self._convertor_items_group.get_selected_widgets())
 
         for group_widget in self._widgets_by_group.values():
             for widget in group_widget.get_selected_widgets():
@@ -605,8 +605,8 @@ class InstanceCardView(AbstractInstanceView):
         ):
             output.append(CONTEXT_ID)
 
-        if self._legacy_items_group is not None:
-            output.extend(self._legacy_items_group.get_selected_item_ids())
+        if self._convertor_items_group is not None:
+            output.extend(self._convertor_items_group.get_selected_item_ids())
 
         for group_widget in self._widgets_by_group.values():
             output.extend(group_widget.get_selected_item_ids())
@@ -617,7 +617,7 @@ class InstanceCardView(AbstractInstanceView):
 
         self._make_sure_context_widget_exists()
 
-        self._update_legacy_items_group()
+        self._update_convertor_items_group()
 
         # Prepare instances by group and identifiers by group
         instances_by_group = collections.defaultdict(list)
@@ -648,7 +648,7 @@ class InstanceCardView(AbstractInstanceView):
         # Keep track of widget indexes
         # - we start with 1 because Context item as at the top
         widget_idx = 1
-        if self._legacy_items_group is not None:
+        if self._convertor_items_group is not None:
             widget_idx += 1
 
         for group_name in sorted_group_names:
@@ -702,27 +702,27 @@ class InstanceCardView(AbstractInstanceView):
         self.selection_changed.emit()
         self._content_layout.insertWidget(0, widget)
 
-    def _update_legacy_items_group(self):
-        legacy_items = self._controller.legacy_items
-        if not legacy_items and self._legacy_items_group is None:
+    def _update_convertor_items_group(self):
+        convertor_items = self._controller.convertor_items
+        if not convertor_items and self._convertor_items_group is None:
             return
 
-        if not legacy_items:
-            self._legacy_items_group.setVisible(False)
-            self._content_layout.removeWidget(self._legacy_items_group)
-            self._legacy_items_group.deleteLater()
-            self._legacy_items_group = None
+        if not convertor_items:
+            self._convertor_items_group.setVisible(False)
+            self._content_layout.removeWidget(self._convertor_items_group)
+            self._convertor_items_group.deleteLater()
+            self._convertor_items_group = None
             return
 
-        if self._legacy_items_group is None:
-            group_widget = LegacyItemsGroupWidget(
-                LEGACY_ITEM_GROUP, self._content_widget
+        if self._convertor_items_group is None:
+            group_widget = ConvertorItemsGroupWidget(
+                CONVERTOR_ITEM_GROUP, self._content_widget
             )
             group_widget.selected.connect(self._on_widget_selection)
             self._content_layout.insertWidget(1, group_widget)
-            self._legacy_items_group = group_widget
+            self._convertor_items_group = group_widget
 
-        self._legacy_items_group.update_items(legacy_items)
+        self._convertor_items_group.update_items(convertor_items)
 
     def refresh_instance_states(self):
         """Trigger update of instances on group widgets."""
@@ -742,8 +742,8 @@ class InstanceCardView(AbstractInstanceView):
             new_widget = self._context_widget
 
         else:
-            if group_name == LEGACY_ITEM_GROUP:
-                group_widget = self._legacy_items_group
+            if group_name == CONVERTOR_ITEM_GROUP:
+                group_widget = self._convertor_items_group
             else:
                 group_widget = self._widgets_by_group[group_name]
             new_widget = group_widget.get_widget_by_item_id(instance_id)
@@ -791,8 +791,8 @@ class InstanceCardView(AbstractInstanceView):
             if instance_id == CONTEXT_ID:
                 remove_group = True
             else:
-                if group_name == LEGACY_ITEM_GROUP:
-                    group_widget = self._legacy_items_group
+                if group_name == CONVERTOR_ITEM_GROUP:
+                    group_widget = self._convertor_items_group
                 else:
                     group_widget = self._widgets_by_group[group_name]
                 if not group_widget.get_selected_widgets():
@@ -906,8 +906,8 @@ class InstanceCardView(AbstractInstanceView):
             if name == CONTEXT_GROUP:
                 sorted_widgets = [self._context_widget]
             else:
-                if name == LEGACY_ITEM_GROUP:
-                    group_widget = self._legacy_items_group
+                if name == CONVERTOR_ITEM_GROUP:
+                    group_widget = self._convertor_items_group
                 else:
                     group_widget = self._widgets_by_group[name]
                 sorted_widgets = group_widget.get_ordered_widgets()
@@ -1034,7 +1034,7 @@ class InstanceCardView(AbstractInstanceView):
             elif isinstance(widget, InstanceCardWidget):
                 instances.append(widget.id)
 
-            elif isinstance(widget, LegacyItemCardWidget):
+            elif isinstance(widget, ConvertorItemCardWidget):
                 convertor_identifiers.append(widget.identifier)
 
         return instances, context_selected, convertor_identifiers
@@ -1066,16 +1066,16 @@ class InstanceCardView(AbstractInstanceView):
             if group_name == CONTEXT_GROUP:
                 continue
 
-            legacy_group = group_name == LEGACY_ITEM_GROUP
-            if legacy_group:
-                group_widget = self._legacy_items_group
+            is_convertor_group = group_name == CONVERTOR_ITEM_GROUP
+            if is_convertor_group:
+                group_widget = self._convertor_items_group
             else:
                 group_widget = self._widgets_by_group[group_name]
 
             group_selected = False
             for widget in group_widget.get_ordered_widgets():
                 select = False
-                if legacy_group:
+                if is_convertor_group:
                     is_in = widget.identifier in s_convertor_identifiers
                 else:
                     is_in = widget.id in s_instance_ids

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -178,7 +178,7 @@ class BaseGroupWidget(QtWidgets.QWidget):
 class LegacyItemsGroupWidget(BaseGroupWidget):
     def update_items(self, items_by_id):
         items_by_label = collections.defaultdict(list)
-        for item_id, item in items_by_id.items():
+        for item in items_by_id.values():
             items_by_label[item.label].append(item)
 
         # Remove instance widgets that are not in passed instances

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -37,7 +37,8 @@ from .widgets import (
 )
 from ..constants import (
     CONTEXT_ID,
-    CONTEXT_LABEL
+    CONTEXT_LABEL,
+    CONTEXT_GROUP,
 )
 
 
@@ -284,7 +285,7 @@ class ContextCardWidget(CardWidget):
         super(ContextCardWidget, self).__init__(parent)
 
         self._id = CONTEXT_ID
-        self._group_identifier = ""
+        self._group_identifier = CONTEXT_GROUP
 
         icon_widget = PublishPixmapLabel(None, self)
         icon_widget.setObjectName("FamilyIconLabel")
@@ -595,7 +596,7 @@ class InstanceCardView(AbstractInstanceView):
                 instances_by_group[group_name]
             )
 
-        ordered_group_names = [""]
+        ordered_group_names = [CONTEXT_GROUP]
         for idx in range(self._content_layout.count()):
             if idx > 0:
                 item = self._content_layout.itemAt(idx)
@@ -749,7 +750,7 @@ class InstanceCardView(AbstractInstanceView):
 
         # If start group is not set then use context item group name
         if start_group is None:
-            start_group = ""
+            start_group = CONTEXT_GROUP
 
         # If start instance id is not filled then use context id (similar to
         #   group)
@@ -777,7 +778,7 @@ class InstanceCardView(AbstractInstanceView):
         # Go through ordered groups (from top to bottom) and change selection
         for name in self._ordered_groups:
             # Prepare sorted instance widgets
-            if name == "":
+            if name == CONTEXT_GROUP:
                 sorted_widgets = [self._context_widget]
             else:
                 group_widget = self._widgets_by_group[name]
@@ -916,13 +917,13 @@ class InstanceCardView(AbstractInstanceView):
         selected_groups = []
         selected_instances = []
         if context_selected:
-            selected_groups.append("")
+            selected_groups.append(CONTEXT_GROUP)
             selected_instances.append(CONTEXT_ID)
 
         self._context_widget.set_selected(context_selected)
 
         for group_name in self._ordered_groups:
-            if group_name == "":
+            if group_name == CONTEXT_GROUP:
                 continue
 
             group_widget = self._widgets_by_group[group_name]

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -353,19 +353,18 @@ class LegacyItemCardWidget(CardWidget):
 
     def __init__(self, item, parent):
         super(LegacyItemCardWidget, self).__init__(parent)
-        self.setObjectName("CardViewLegacyItemWidget")
 
         self._id = item.id
         self.identifier = item.identifier
         self._group_identifier = LEGACY_ITEM_GROUP
 
-        icon_widget = PublishPixmapLabel(None, self)
+        icon_widget = IconValuePixmapLabel("fa.magic", self)
         icon_widget.setObjectName("FamilyIconLabel")
 
         label_widget = QtWidgets.QLabel(item.label, self)
 
         icon_layout = QtWidgets.QHBoxLayout()
-        icon_layout.setContentsMargins(5, 5, 5, 5)
+        icon_layout.setContentsMargins(10, 5, 5, 5)
         icon_layout.addWidget(icon_widget)
 
         layout = QtWidgets.QHBoxLayout(self)

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -35,7 +35,10 @@ from ..constants import (
     SORT_VALUE_ROLE,
     IS_GROUP_ROLE,
     CONTEXT_ID,
-    CONTEXT_LABEL
+    CONTEXT_LABEL,
+    GROUP_ROLE,
+    LEGACY_CONVERTER_IDENTIFIER,
+    LEGACY_ITEM_GROUP,
 )
 
 
@@ -330,6 +333,9 @@ class InstanceTreeView(QtWidgets.QTreeView):
         """Ids of selected instances."""
         instance_ids = set()
         for index in self.selectionModel().selectedIndexes():
+            if index.data(LEGACY_CONVERTER_IDENTIFIER) is not None:
+                continue
+
             instance_id = index.data(INSTANCE_ID_ROLE)
             if instance_id is not None:
                 instance_ids.add(instance_id)
@@ -439,9 +445,15 @@ class InstanceListView(AbstractInstanceView):
         self._group_items = {}
         self._group_widgets = {}
         self._widgets_by_id = {}
+        # Group by instance id for handling of active state
         self._group_by_instance_id = {}
         self._context_item = None
         self._context_widget = None
+
+        self._legacy_group_item = None
+        self._legacy_group_widget = None
+        self._legacy_widgets_by_id = {}
+        self._legacy_items_by_id = {}
 
         self._instance_view = instance_view
         self._instance_delegate = instance_delegate
@@ -449,16 +461,20 @@ class InstanceListView(AbstractInstanceView):
         self._proxy_model = proxy_model
 
     def _on_expand(self, index):
-        group_name = index.data(SORT_VALUE_ROLE)
-        group_widget = self._group_widgets.get(group_name)
-        if group_widget:
-            group_widget.set_expanded(True)
+        self._update_widget_expand_state(index, True)
 
     def _on_collapse(self, index):
-        group_name = index.data(SORT_VALUE_ROLE)
-        group_widget = self._group_widgets.get(group_name)
+        self._update_widget_expand_state(index, False)
+
+    def _update_widget_expand_state(self, index, expanded):
+        group_name = index.data(GROUP_ROLE)
+        if group_name == LEGACY_ITEM_GROUP:
+            group_widget = self._legacy_group_widget
+        else:
+            group_widget = self._group_widgets.get(group_name)
+
         if group_widget:
-            group_widget.set_expanded(False)
+            group_widget.set_expanded(expanded)
 
     def _on_toggle_request(self, toggle):
         selected_instance_ids = self._instance_view.get_selected_instance_ids()
@@ -517,6 +533,16 @@ class InstanceListView(AbstractInstanceView):
 
     def refresh(self):
         """Refresh instances in the view."""
+        # Sort view at the end of refresh
+        # - is turned off until any change in view happens
+        sort_at_the_end = False
+        # Create or use already existing context item
+        # - context widget does not change so we don't have to update anything
+        if self._make_sure_context_item_exists():
+            sort_at_the_end = True
+
+        self._update_legacy_items_group()
+
         # Prepare instances by their groups
         instances_by_group_name = collections.defaultdict(list)
         group_names = set()
@@ -525,75 +551,12 @@ class InstanceListView(AbstractInstanceView):
             group_names.add(group_label)
             instances_by_group_name[group_label].append(instance)
 
-        # Sort view at the end of refresh
-        # - is turned off until any change in view happens
-        sort_at_the_end = False
-
-        # Access to root item of main model
-        root_item = self._instance_model.invisibleRootItem()
-
-        # Create or use already existing context item
-        # - context widget does not change so we don't have to update anything
-        context_item = None
-        if self._context_item is None:
-            sort_at_the_end = True
-            context_item = QtGui.QStandardItem()
-            context_item.setData(0, SORT_VALUE_ROLE)
-            context_item.setData(CONTEXT_ID, INSTANCE_ID_ROLE)
-
-            root_item.appendRow(context_item)
-
-            index = self._instance_model.index(
-                context_item.row(), context_item.column()
-            )
-            proxy_index = self._proxy_model.mapFromSource(index)
-            widget = ListContextWidget(self._instance_view)
-            self._instance_view.setIndexWidget(proxy_index, widget)
-
-            self._context_widget = widget
-            self._context_item = context_item
-
         # Create new groups based on prepared `instances_by_group_name`
-        new_group_items = []
-        for group_name in group_names:
-            if group_name in self._group_items:
-                continue
-
-            group_item = QtGui.QStandardItem()
-            group_item.setData(group_name, SORT_VALUE_ROLE)
-            group_item.setData(True, IS_GROUP_ROLE)
-            group_item.setFlags(QtCore.Qt.ItemIsEnabled)
-            self._group_items[group_name] = group_item
-            new_group_items.append(group_item)
-
-        # Add new group items to root item if there are any
-        if new_group_items:
-            # Trigger sort at the end
+        if self._make_sure_groups_exists(group_names):
             sort_at_the_end = True
-            root_item.appendRows(new_group_items)
-
-        # Create widget for each new group item and store it for future usage
-        for group_item in new_group_items:
-            index = self._instance_model.index(
-                group_item.row(), group_item.column()
-            )
-            proxy_index = self._proxy_model.mapFromSource(index)
-            group_name = group_item.data(SORT_VALUE_ROLE)
-            widget = InstanceListGroupWidget(group_name, self._instance_view)
-            widget.expand_changed.connect(self._on_group_expand_request)
-            widget.toggle_requested.connect(self._on_group_toggle_request)
-            self._group_widgets[group_name] = widget
-            self._instance_view.setIndexWidget(proxy_index, widget)
 
         # Remove groups that are not available anymore
-        for group_name in tuple(self._group_items.keys()):
-            if group_name in group_names:
-                continue
-
-            group_item = self._group_items.pop(group_name)
-            root_item.removeRow(group_item.row())
-            widget = self._group_widgets.pop(group_name)
-            widget.deleteLater()
+        self._remove_groups_except(group_names)
 
         # Store which groups should be expanded at the end
         expand_groups = set()
@@ -652,6 +615,7 @@ class InstanceListView(AbstractInstanceView):
                 # Create new item and store it as new
                 item = QtGui.QStandardItem()
                 item.setData(instance["subset"], SORT_VALUE_ROLE)
+                item.setData(instance["subset"], GROUP_ROLE)
                 item.setData(instance_id, INSTANCE_ID_ROLE)
                 new_items.append(item)
                 new_items_with_instance.append((item, instance))
@@ -717,13 +681,147 @@ class InstanceListView(AbstractInstanceView):
 
             self._instance_view.expand(proxy_index)
 
+    def _make_sure_context_item_exists(self):
+        if self._context_item is not None:
+            return False
+
+        root_item = self._instance_model.invisibleRootItem()
+        context_item = QtGui.QStandardItem()
+        context_item.setData(0, SORT_VALUE_ROLE)
+        context_item.setData(CONTEXT_ID, INSTANCE_ID_ROLE)
+
+        root_item.appendRow(context_item)
+
+        index = self._instance_model.index(
+            context_item.row(), context_item.column()
+        )
+        proxy_index = self._proxy_model.mapFromSource(index)
+        widget = ListContextWidget(self._instance_view)
+        self._instance_view.setIndexWidget(proxy_index, widget)
+
+        self._context_widget = widget
+        self._context_item = context_item
+        return True
+
+    def _update_legacy_items_group(self):
+        created_new_items = False
+        legacy_items_by_id = self._controller.legacy_items
+        group_item = self._legacy_group_item
+        if not legacy_items_by_id and group_item is None:
+            return created_new_items
+
+        root_item = self._instance_model.invisibleRootItem()
+        if not legacy_items_by_id:
+            root_item.removeRow(group_item.row())
+            self._legacy_group_widget.deleteLater()
+            self._legacy_group_widget = None
+            return created_new_items
+
+        if group_item is None:
+            created_new_items = True
+            group_item = QtGui.QStandardItem()
+            group_item.setData(LEGACY_ITEM_GROUP, GROUP_ROLE)
+            group_item.setData(1, SORT_VALUE_ROLE)
+            group_item.setData(True, IS_GROUP_ROLE)
+            group_item.setFlags(QtCore.Qt.ItemIsEnabled)
+
+            root_item.appendRow(group_item)
+
+            index = self._instance_model.index(
+                group_item.row(), group_item.column()
+            )
+            proxy_index = self._proxy_model.mapFromSource(index)
+            widget = InstanceListGroupWidget(
+                LEGACY_ITEM_GROUP, self._instance_view
+            )
+            widget.toggle_checkbox.setVisible(False)
+            widget.expand_changed.connect(self._on_legacy_group_expand_request)
+            self._instance_view.setIndexWidget(proxy_index, widget)
+
+            self._legacy_group_item = group_item
+            self._legacy_group_widget = widget
+
+        for row in reversed(range(group_item.rowCount())):
+            child_item = group_item.child(row)
+            child_identifier = child_item.data(LEGACY_CONVERTER_IDENTIFIER)
+            if child_identifier not in legacy_items_by_id:
+                group_item.removeRows(row, 1)
+
+        new_items = []
+        for identifier, convertor_item in legacy_items_by_id.items():
+            item = self._legacy_items_by_id.get(identifier)
+            if item is None:
+                created_new_items = True
+                item = QtGui.QStandardItem(convertor_item.label)
+                new_items.append(item)
+            item.setData(convertor_item.id, INSTANCE_ID_ROLE)
+            item.setData(convertor_item.label, SORT_VALUE_ROLE)
+            item.setData(LEGACY_ITEM_GROUP, GROUP_ROLE)
+            item.setData(
+                convertor_item.identifier, LEGACY_CONVERTER_IDENTIFIER
+            )
+
+        if new_items:
+            group_item.appendRows(new_items)
+
+        return created_new_items
+
+    def _make_sure_groups_exists(self, group_names):
+        new_group_items = []
+        for group_name in group_names:
+            if group_name in self._group_items:
+                continue
+
+            group_item = QtGui.QStandardItem()
+            group_item.setData(group_name, GROUP_ROLE)
+            group_item.setData(group_name, SORT_VALUE_ROLE)
+            group_item.setData(True, IS_GROUP_ROLE)
+            group_item.setFlags(QtCore.Qt.ItemIsEnabled)
+            self._group_items[group_name] = group_item
+            new_group_items.append(group_item)
+
+        # Add new group items to root item if there are any
+        if not new_group_items:
+            return False
+
+        # Access to root item of main model
+        root_item = self._instance_model.invisibleRootItem()
+        root_item.appendRows(new_group_items)
+
+        # Create widget for each new group item and store it for future usage
+        for group_item in new_group_items:
+            index = self._instance_model.index(
+                group_item.row(), group_item.column()
+            )
+            proxy_index = self._proxy_model.mapFromSource(index)
+            group_name = group_item.data(GROUP_ROLE)
+            widget = InstanceListGroupWidget(group_name, self._instance_view)
+            widget.expand_changed.connect(self._on_group_expand_request)
+            widget.toggle_requested.connect(self._on_group_toggle_request)
+            self._group_widgets[group_name] = widget
+            self._instance_view.setIndexWidget(proxy_index, widget)
+
+        return True
+
+    def _remove_groups_except(self, group_names):
+        # Remove groups that are not available anymore
+        root_item = self._instance_model.invisibleRootItem()
+        for group_name in tuple(self._group_items.keys()):
+            if group_name in group_names:
+                continue
+
+            group_item = self._group_items.pop(group_name)
+            root_item.removeRow(group_item.row())
+            widget = self._group_widgets.pop(group_name)
+            widget.deleteLater()
+
     def refresh_instance_states(self):
         """Trigger update of all instances."""
         for widget in self._widgets_by_id.values():
             widget.update_instance_values()
 
     def _on_active_changed(self, changed_instance_id, new_value):
-        selected_instance_ids, _ = self.get_selected_items()
+        selected_instance_ids, _, _ = self.get_selected_items()
 
         selected_ids = set()
         found = False
@@ -774,6 +872,16 @@ class InstanceListView(AbstractInstanceView):
         proxy_index = self._proxy_model.mapFromSource(group_index)
         self._instance_view.setExpanded(proxy_index, expanded)
 
+    def _on_legacy_group_expand_request(self, _, expanded):
+        group_item = self._legacy_group_item
+        if not group_item:
+            return
+        group_index = self._instance_model.index(
+            group_item.row(), group_item.column()
+        )
+        proxy_index = self._proxy_model.mapFromSource(group_index)
+        self._instance_view.setExpanded(proxy_index, expanded)
+
     def _on_group_toggle_request(self, group_name, state):
         if state == QtCore.Qt.PartiallyChecked:
             return
@@ -807,10 +915,17 @@ class InstanceListView(AbstractInstanceView):
             tuple<list, bool>: Selected instance ids and boolean if context
                 is selected.
         """
+
         instance_ids = []
+        convertor_identifiers = []
         context_selected = False
 
         for index in self._instance_view.selectionModel().selectedIndexes():
+            convertor_identifier = index.data(LEGACY_CONVERTER_IDENTIFIER)
+            if convertor_identifier is not None:
+                convertor_identifiers.append(convertor_identifier)
+                continue
+
             instance_id = index.data(INSTANCE_ID_ROLE)
             if not context_selected and instance_id == CONTEXT_ID:
                 context_selected = True
@@ -818,14 +933,20 @@ class InstanceListView(AbstractInstanceView):
             elif instance_id is not None:
                 instance_ids.append(instance_id)
 
-        return instance_ids, context_selected
+        return instance_ids, context_selected, convertor_identifiers
 
-    def set_selected_items(self, instance_ids, context_selected):
+    def set_selected_items(
+        self, instance_ids, context_selected, convertor_identifiers
+    ):
         s_instance_ids = set(instance_ids)
-        cur_ids, cur_context = self.get_selected_items()
+        s_convertor_identifiers = set(convertor_identifiers)
+        cur_ids, cur_context, cur_convertor_identifiers = (
+            self.get_selected_items()
+        )
         if (
             set(cur_ids) == s_instance_ids
             and cur_context == context_selected
+            and set(cur_convertor_identifiers) == s_convertor_identifiers
         ):
             return
 
@@ -851,20 +972,35 @@ class InstanceListView(AbstractInstanceView):
                         (item.child(row), list(new_parent_items))
                     )
 
-            instance_id = item.data(INSTANCE_ID_ROLE)
-            if not instance_id:
+            convertor_identifier = item.data(LEGACY_CONVERTER_IDENTIFIER)
+
+            select = False
+            expand_parent = True
+            if convertor_identifier is not None:
+                if convertor_identifier in s_convertor_identifiers:
+                    select = True
+            else:
+                instance_id = item.data(INSTANCE_ID_ROLE)
+                if instance_id == CONTEXT_ID:
+                    if context_selected:
+                        select = True
+                        expand_parent = False
+
+                elif instance_id in s_instance_ids:
+                    select = True
+
+            if not select:
                 continue
 
-            if instance_id in s_instance_ids:
-                select_indexes.append(item.index())
-                for parent_item in parent_items:
-                    index = parent_item.index()
-                    proxy_index = proxy_model.mapFromSource(index)
-                    if not view.isExpanded(proxy_index):
-                        view.expand(proxy_index)
+            select_indexes.append(item.index())
+            if not expand_parent:
+                continue
 
-            elif context_selected and instance_id == CONTEXT_ID:
-                select_indexes.append(item.index())
+            for parent_item in parent_items:
+                index = parent_item.index()
+                proxy_index = proxy_model.mapFromSource(index)
+                if not view.isExpanded(proxy_index):
+                    view.expand(proxy_index)
 
         selection_model = view.selectionModel()
         if not select_indexes:

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -452,7 +452,6 @@ class InstanceListView(AbstractInstanceView):
 
         self._legacy_group_item = None
         self._legacy_group_widget = None
-        self._legacy_widgets_by_id = {}
         self._legacy_items_by_id = {}
 
         self._instance_view = instance_view
@@ -715,6 +714,7 @@ class InstanceListView(AbstractInstanceView):
             root_item.removeRow(group_item.row())
             self._legacy_group_widget.deleteLater()
             self._legacy_group_widget = None
+            self._legacy_items_by_id = {}
             return created_new_items
 
         if group_item is None:
@@ -745,6 +745,7 @@ class InstanceListView(AbstractInstanceView):
             child_item = group_item.child(row)
             child_identifier = child_item.data(LEGACY_CONVERTER_IDENTIFIER)
             if child_identifier not in legacy_items_by_id:
+                self._legacy_items_by_id.pop(child_identifier, None)
                 group_item.removeRows(row, 1)
 
         new_items = []
@@ -760,6 +761,7 @@ class InstanceListView(AbstractInstanceView):
             item.setData(
                 convertor_item.identifier, LEGACY_CONVERTER_IDENTIFIER
             )
+            self._legacy_items_by_id[identifier] = item
 
         if new_items:
             group_item.appendRows(new_items)

--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -321,7 +321,7 @@ class OverviewWidget(QtWidgets.QFrame):
 
     def _on_convert_requested(self):
         _, _, convertor_identifiers = self.get_selected_items()
-        self._controller.convert_legacy_items(convertor_identifiers)
+        self._controller.trigger_convertor_items(convertor_identifiers)
 
     def get_selected_items(self):
         view = self._subset_views_layout.currentWidget()

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1486,18 +1486,22 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
 
         # Convert button widget (with layout to handle stretch)
         convert_widget = QtWidgets.QWidget(creator_widget)
-        convert_label = QtWidgets.QLabel(
+        convert_label = QtWidgets.QLabel(creator_widget)
+        # Set the label text with 'setText' to apply html
+        convert_label.setText(
             (
-                "Found instances created with legacy creators."
-                "\nDo you with to convert them?"
-            ),
-            creator_widget
+                "Found old publishable subsets"
+                " incompatible with new publisher."
+                "<br/><br/>Press the <b>update subsets</b> button"
+                " to automatically update them"
+                " to be able to publish again."
+            )
         )
         convert_label.setWordWrap(True)
         convert_label.setAlignment(QtCore.Qt.AlignCenter)
 
         convert_btn = QtWidgets.QPushButton(
-            "Convert legacy instances", convert_widget
+            "Update subsets", convert_widget
         )
         convert_separator = QtWidgets.QFrame(convert_widget)
         convert_separator.setObjectName("Separator")

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1505,8 +1505,8 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
         )
         convert_separator = QtWidgets.QFrame(convert_widget)
         convert_separator.setObjectName("Separator")
-        convert_separator.setMinimumHeight(2)
-        convert_separator.setMaximumHeight(2)
+        convert_separator.setMinimumHeight(1)
+        convert_separator.setMaximumHeight(1)
 
         convert_layout = QtWidgets.QGridLayout(convert_widget)
         convert_layout.setContentsMargins(0, 0, 0, 0)

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1461,6 +1461,7 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
     └───────────────────────────────┘
     """
     instance_context_changed = QtCore.Signal()
+    convert_requested = QtCore.Signal()
 
     def __init__(self, controller, parent):
         super(SubsetAttributesWidget, self).__init__(parent)
@@ -1479,9 +1480,48 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
 
         # BOTTOM PART
         bottom_widget = QtWidgets.QWidget(self)
-        creator_attrs_widget = CreatorAttrsWidget(
-            controller, bottom_widget
+
+        # Wrap Creator attributes to widget to be able add convert button
+        creator_widget = QtWidgets.QWidget(bottom_widget)
+
+        # Convert button widget (with layout to handle stretch)
+        convert_widget = QtWidgets.QWidget(creator_widget)
+        convert_label = QtWidgets.QLabel(
+            (
+                "Found instances created with legacy creators."
+                "\nDo you with to convert them?"
+            ),
+            creator_widget
         )
+        convert_label.setWordWrap(True)
+        convert_label.setAlignment(QtCore.Qt.AlignCenter)
+
+        convert_btn = QtWidgets.QPushButton(
+            "Convert legacy instances", convert_widget
+        )
+        convert_separator = QtWidgets.QFrame(convert_widget)
+        convert_separator.setObjectName("Separator")
+        convert_separator.setMinimumHeight(2)
+        convert_separator.setMaximumHeight(2)
+
+        convert_layout = QtWidgets.QGridLayout(convert_widget)
+        convert_layout.setContentsMargins(0, 0, 0, 0)
+        convert_layout.addWidget(convert_label, 0, 0, 1, 3)
+        convert_layout.addWidget(convert_btn, 1, 1)
+        convert_layout.addWidget(convert_separator, 2, 0, 1, 3)
+        convert_layout.setColumnStretch(0, 1)
+        convert_layout.setColumnStretch(1, 0)
+        convert_layout.setColumnStretch(2, 1)
+
+        # Creator attributes widget
+        creator_attrs_widget = CreatorAttrsWidget(
+            controller, creator_widget
+        )
+        creator_layout = QtWidgets.QVBoxLayout(creator_widget)
+        creator_layout.setContentsMargins(0, 0, 0, 0)
+        creator_layout.addWidget(convert_widget, 0)
+        creator_layout.addWidget(creator_attrs_widget, 1)
+
         publish_attrs_widget = PublishPluginAttrsWidget(
             controller, bottom_widget
         )
@@ -1492,7 +1532,7 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
 
         bottom_layout = QtWidgets.QHBoxLayout(bottom_widget)
         bottom_layout.setContentsMargins(0, 0, 0, 0)
-        bottom_layout.addWidget(creator_attrs_widget, 1)
+        bottom_layout.addWidget(creator_widget, 1)
         bottom_layout.addWidget(bottom_separator, 0)
         bottom_layout.addWidget(publish_attrs_widget, 1)
 
@@ -1505,6 +1545,7 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
         layout.addWidget(top_bottom, 0)
         layout.addWidget(bottom_widget, 1)
 
+        self._convertor_identifiers = None
         self._current_instances = None
         self._context_selected = False
         self._all_instances_valid = True
@@ -1512,8 +1553,11 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
         global_attrs_widget.instance_context_changed.connect(
             self._on_instance_context_changed
         )
+        convert_btn.clicked.connect(self._on_convert_click)
 
         self._controller = controller
+
+        self._convert_widget = convert_widget
 
         self.global_attrs_widget = global_attrs_widget
 
@@ -1537,7 +1581,12 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
 
         self.instance_context_changed.emit()
 
-    def set_current_instances(self, instances, context_selected):
+    def _on_convert_click(self):
+        self.convert_requested.emit()
+
+    def set_current_instances(
+        self, instances, context_selected, convertor_identifiers
+    ):
         """Change currently selected items.
 
         Args:
@@ -1551,10 +1600,13 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
                 all_valid = False
                 break
 
+        s_convertor_identifiers = set(convertor_identifiers)
+        self._convertor_identifiers = s_convertor_identifiers
         self._current_instances = instances
         self._context_selected = context_selected
         self._all_instances_valid = all_valid
 
+        self._convert_widget.setVisible(len(s_convertor_identifiers) > 0)
         self.global_attrs_widget.set_current_instances(instances)
         self.creator_attrs_widget.set_current_instances(instances)
         self.publish_attrs_widget.set_current_instances(

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -1509,7 +1509,8 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
         convert_separator.setMaximumHeight(1)
 
         convert_layout = QtWidgets.QGridLayout(convert_widget)
-        convert_layout.setContentsMargins(0, 0, 0, 0)
+        convert_layout.setContentsMargins(5, 0, 5, 0)
+        convert_layout.setVerticalSpacing(10)
         convert_layout.addWidget(convert_label, 0, 0, 1, 3)
         convert_layout.addWidget(convert_btn, 1, 1)
         convert_layout.addWidget(convert_separator, 2, 0, 1, 3)

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 from Qt import QtWidgets, QtCore, QtGui
 
 from openpype import (
@@ -224,10 +225,10 @@ class PublisherWindow(QtWidgets.QDialog):
         # Floating publish frame
         publish_frame = PublishFrame(controller, self.footer_border, self)
 
-        creators_dialog_message_timer = QtCore.QTimer()
-        creators_dialog_message_timer.setInterval(100)
-        creators_dialog_message_timer.timeout.connect(
-            self._on_creators_message_timeout
+        errors_dialog_message_timer = QtCore.QTimer()
+        errors_dialog_message_timer.setInterval(100)
+        errors_dialog_message_timer.timeout.connect(
+            self._on_errors_message_timeout
         )
 
         help_btn.clicked.connect(self._on_help_click)
@@ -268,16 +269,16 @@ class PublisherWindow(QtWidgets.QDialog):
             "show.card.message", self._on_overlay_message
         )
         controller.event_system.add_callback(
-            "instances.collection.failed", self._instance_collection_failed
+            "instances.collection.failed", self._on_creator_error
         )
         controller.event_system.add_callback(
-            "instances.save.failed", self._instance_save_failed
+            "instances.save.failed", self._on_creator_error
         )
         controller.event_system.add_callback(
-            "instances.remove.failed", self._instance_remove_failed
+            "instances.remove.failed", self._on_creator_error
         )
         controller.event_system.add_callback(
-            "instances.create.failed", self._instance_create_failed
+            "instances.create.failed", self._on_creator_error
         )
 
         # Store extra header widget for TrayPublisher
@@ -325,8 +326,8 @@ class PublisherWindow(QtWidgets.QDialog):
         self._restart_timer = None
         self._publish_frame_visible = None
 
-        self._creators_messages_to_show = collections.deque()
-        self._creators_dialog_message_timer = creators_dialog_message_timer
+        self._error_messages_to_show = collections.deque()
+        self._errors_dialog_message_timer = errors_dialog_message_timer
 
         self._set_publish_visibility(False)
 
@@ -357,7 +358,10 @@ class PublisherWindow(QtWidgets.QDialog):
         self._update_publish_frame_rect()
 
     def _on_overlay_message(self, event):
-        self._overlay_object.add_message(event["message"])
+        self._overlay_object.add_message(
+            event["message"],
+            event.get("message_type")
+        )
 
     def _on_first_show(self):
         self.resize(self.default_width, self.default_height)
@@ -604,37 +608,39 @@ class PublisherWindow(QtWidgets.QDialog):
             0, window_size.height() - height
         )
 
-    def add_message_dialog(self, title, failed_info):
-        self._creators_messages_to_show.append((title, failed_info))
-        self._creators_dialog_message_timer.start()
+    def add_error_message_dialog(self, title, failed_info, message_start=None):
+        self._error_messages_to_show.append(
+            (title, failed_info, message_start)
+        )
+        self._errors_dialog_message_timer.start()
 
-    def _on_creators_message_timeout(self):
-        if not self._creators_messages_to_show:
-            self._creators_dialog_message_timer.stop()
+    def _on_errors_message_timeout(self):
+        if not self._error_messages_to_show:
+            self._errors_dialog_message_timer.stop()
             return
 
-        item = self._creators_messages_to_show.popleft()
-        title, failed_info = item
-        dialog = CreatorsErrorMessageBox(title, failed_info, self)
+        item = self._error_messages_to_show.popleft()
+        title, failed_info, message_start = item
+        dialog = ErrorsMessageBox(
+            title, failed_info, message_start, self
+        )
         dialog.exec_()
         dialog.deleteLater()
 
-    def _instance_collection_failed(self, event):
-        self.add_message_dialog(event["title"], event["failed_info"])
-
-    def _instance_save_failed(self, event):
-        self.add_message_dialog(event["title"], event["failed_info"])
-
-    def _instance_remove_failed(self, event):
-        self.add_message_dialog(event["title"], event["failed_info"])
-
-    def _instance_create_failed(self, event):
-        self.add_message_dialog(event["title"], event["failed_info"])
+    def _on_creator_error(self, event):
+        new_failed_info = []
+        for item in event["failed_info"]:
+            new_item = copy.deepcopy(item)
+            new_item["label"] = new_item.pop("creator_label")
+            new_item["identifier"] = new_item.pop("creator_identifier")
+            new_failed_info.append(new_item)
+        self.add_error_message_dialog(event["title"], new_failed_info, "Creator:")
 
 
-class CreatorsErrorMessageBox(ErrorMessageBox):
-    def __init__(self, error_title, failed_info, parent):
+class ErrorsMessageBox(ErrorMessageBox):
+    def __init__(self, error_title, failed_info, message_start, parent):
         self._failed_info = failed_info
+        self._message_start = message_start
         self._info_with_id = [
             # Id must be string when used in tab widget
             {"id": str(idx), "info": info}
@@ -644,7 +650,7 @@ class CreatorsErrorMessageBox(ErrorMessageBox):
         self._tabs_widget = None
         self._stack_layout = None
 
-        super(CreatorsErrorMessageBox, self).__init__(error_title, parent)
+        super(ErrorsMessageBox, self).__init__(error_title, parent)
 
         layout = self.layout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -659,17 +665,21 @@ class CreatorsErrorMessageBox(ErrorMessageBox):
     def _get_report_data(self):
         output = []
         for info in self._failed_info:
-            creator_label = info["creator_label"]
-            creator_identifier = info["creator_identifier"]
-            report_message = "Creator:"
-            if creator_label:
-                report_message += " {} ({})".format(
-                    creator_label, creator_identifier)
+            item_label = info.get("label")
+            item_identifier = info["identifier"]
+            if item_label:
+                report_message = "{} ({})".format(
+                    item_label, item_identifier)
             else:
-                report_message += " {}".format(creator_identifier)
+                report_message = "{}".format(item_identifier)
+
+            if self._message_start:
+                report_message = "{} {}".format(
+                    self._message_start, report_message
+                )
 
             report_message += "\n\nError: {}".format(info["message"])
-            formatted_traceback = info["traceback"]
+            formatted_traceback = info.get("traceback")
             if formatted_traceback:
                 report_message += "\n\n{}".format(formatted_traceback)
             output.append(report_message)
@@ -686,11 +696,10 @@ class CreatorsErrorMessageBox(ErrorMessageBox):
             item_id = item["id"]
             info = item["info"]
             message = info["message"]
-            formatted_traceback = info["traceback"]
-            creator_label = info["creator_label"]
-            creator_identifier = info["creator_identifier"]
-            if not creator_label:
-                creator_label = creator_identifier
+            formatted_traceback = info.get("traceback")
+            item_label = info.get("label")
+            if not item_label:
+                item_label = info["identifier"]
 
             msg_widget = QtWidgets.QWidget(stack_widget)
             msg_layout = QtWidgets.QVBoxLayout(msg_widget)
@@ -710,7 +719,7 @@ class CreatorsErrorMessageBox(ErrorMessageBox):
 
             msg_layout.addStretch(1)
 
-            tabs_widget.add_tab(creator_label, item_id)
+            tabs_widget.add_tab(item_label, item_id)
             stack_layout.addWidget(msg_widget)
             if first:
                 first = False

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -280,6 +280,12 @@ class PublisherWindow(QtWidgets.QDialog):
         controller.event_system.add_callback(
             "instances.create.failed", self._on_creator_error
         )
+        controller.event_system.add_callback(
+            "convertors.convert.failed", self._on_convertor_error
+        )
+        controller.event_system.add_callback(
+            "convertors.find.failed", self._on_convertor_error
+        )
 
         # Store extra header widget for TrayPublisher
         # - can be used to add additional widgets to header between context
@@ -635,6 +641,16 @@ class PublisherWindow(QtWidgets.QDialog):
             new_item["identifier"] = new_item.pop("creator_identifier")
             new_failed_info.append(new_item)
         self.add_error_message_dialog(event["title"], new_failed_info, "Creator:")
+
+    def _on_convertor_error(self, event):
+        new_failed_info = []
+        for item in event["failed_info"]:
+            new_item = copy.deepcopy(item)
+            new_item["identifier"] = new_item.pop("convertor_identifier")
+            new_failed_info.append(new_item)
+        self.add_error_message_dialog(
+            event["title"], new_failed_info, "Convertor:"
+        )
 
 
 class ErrorsMessageBox(ErrorMessageBox):


### PR DESCRIPTION
## Brief description
Give ability to have convertor plugins for conversion from legacy instances to new creators.

## Description
Added Convertor plugins which can collect `ConvertorItem` into `CreateContext`. These items are shown in UI next to instances with a label that the convertor plugin defines. Convertor collect items after Creator's collection so there should not be a clash if any creator would convert something automatically and also has access to shared data. Has 2 methods `find_instances` and `convert` both without any arguments. Plugin must be in files next to creators (can be in file with creator). In UI is conversion button always before creator attributes. So multiple conversion plugins can be selected and UI does not break when instances are selected too.

## Screenshots
![image](https://user-images.githubusercontent.com/43494761/197575682-8a9f328e-3ee7-41e7-b4aa-5e8940b677a7.png)
![image](https://user-images.githubusercontent.com/43494761/197575744-8b1c4431-9dc4-428d-b6d7-5f4eaa0f0120.png)

## Testing notes:
Create fake convertor in TrayPublisher e.g. `~/openpype/hosts/traypublisher/plugins/create/converter_test.py` with this content.
```python
from openpype.pipeline.create.creator_plugins import SubsetConvertorPlugin


class TestConverted(SubsetConvertorPlugin):
    identifier = "text.converter"

    def find_instances(self):
        # This is called during collection - plugin should create it's item based on some logic
        #  - for example find an instance without 'creator_identifier'
        self.add_convertor_item("My testing legacy item")

    def convert(self):
        # This is method which is triggered from the UI
        # - should update items for new creators and remove item if was successfull
        print("Fake converting. This is when would logic of conversion be.")
        self.remove_convertor_item()
```