### PR TITLE
General: Extract review does not crash with old settings overrides

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -1731,38 +1731,33 @@ class ExtractReview(pyblish.api.InstancePlugin):
         Returns:
             list: Containg all output definitions matching entered tags.
         """
+
         filtered_outputs = []
         repre_c_tags_low = [tag.lower() for tag in (custom_tags or [])]
         for output_def in outputs:
-            valid = False
             tag_filters = output_def.get("filter", {}).get("custom_tags")
 
-            if (
-                # if any of tag filter is empty, skip
-                custom_tags and not tag_filters
-                or not custom_tags and tag_filters
-            ):
-                continue
-            elif not custom_tags and not tag_filters:
+            if not custom_tags and not tag_filters:
+                # Definition is valid if both tags are empty
                 valid = True
 
-            # lower all filter tags
-            tag_filters_low = [tag.lower() for tag in tag_filters]
+            elif not custom_tags or not tag_filters:
+                # Invalid if one is empty
+                valid = False
 
-            self.log.debug("__ tag_filters: {}".format(tag_filters))
-            self.log.debug("__ repre_c_tags_low: {}".format(
-                repre_c_tags_low))
+            else:
+                # Check if output definition tags are in representation tags
+                valid = False
+                # lower all filter tags
+                tag_filters_low = [tag.lower() for tag in tag_filters]
+                # check if any repre tag is not in filter tags
+                for tag in repre_c_tags_low:
+                    if tag in tag_filters_low:
+                        valid = True
+                        break
 
-            # check if any repre tag is not in filter tags
-            for tag in repre_c_tags_low:
-                if tag in tag_filters_low:
-                    valid = True
-                    break
-
-            if not valid:
-                continue
-
-            filtered_outputs.append(output_def)
+            if valid:
+                filtered_outputs.append(output_def)
 
         self.log.debug("__ filtered_outputs: {}".format(
             [_o["filename_suffix"] for _o in filtered_outputs]


### PR DESCRIPTION
## Brief description
Avoid crashes in extract review with older settings overrides.

## Description
[This PR](https://github.com/pypeclub/OpenPype/pull/4009) caused that extract review would crash with older settings overrides where `custom_tags` key is not available on output definitions so iteration over `None` is invalid operation. The tags validation also happened in all cases even if the valid state was already known. Removed unnecessary log messages.

## Testing notes:
1. Use extract review with older settings overrides on project and it should not crash.