### PR TITLE
General: More specific error in burnins script

### DIFF
--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -113,11 +113,20 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         if not ffprobe_data:
             ffprobe_data = _get_ffprobe_data(source)
 
+        # Validate 'streams' before calling super to raise more specific
+        #   error
+        source_streams = ffprobe_data.get("streams")
+        if not source_streams:
+            raise ValueError((
+                "Input file \"{}\" does not contain any streams"
+                " with image/video content."
+            ).format(source))
+
         self.ffprobe_data = ffprobe_data
         self.first_frame = first_frame
         self.input_args = []
 
-        super().__init__(source, ffprobe_data["streams"])
+        super().__init__(source, source_streams)
 
         if options_init:
             self.options_init.update(options_init)

--- a/openpype/scripts/otio_burnin.py
+++ b/openpype/scripts/otio_burnin.py
@@ -22,10 +22,6 @@ FFMPEG = (
     '"{}"%(input_args)s -i "%(input)s" %(filters)s %(args)s%(output)s'
 ).format(ffmpeg_path)
 
-FFPROBE = (
-    '"{}" -v quiet -print_format json -show_format -show_streams "%(source)s"'
-).format(ffprobe_path)
-
 DRAWTEXT = (
     "drawtext=fontfile='%(font)s':text=\\'%(text)s\\':"
     "x=%(x)s:y=%(y)s:fontcolor=%(color)s@%(opacity).1f:fontsize=%(size)d"
@@ -48,8 +44,15 @@ def _get_ffprobe_data(source):
     :param str source: source media file
     :rtype: [{}, ...]
     """
-    command = FFPROBE % {'source': source}
-    proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    command = [
+        ffprobe_path,
+        "-v", "quiet",
+        "-print_format", "json",
+        "-show_format",
+        "-show_streams",
+        source
+    ]
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
     out = proc.communicate()[0]
     if proc.returncode != 0:
         raise RuntimeError("Failed to run: %s" % command)


### PR DESCRIPTION
## Brief description
Raise more specific error in burnins script when input does not have streams before otio ffprobe is called.

## Description
It would crash anyway but with cryptic error that subprocess failed to run in otio adapters. This can happen when input does not have any streams (invalid movie file).

## Additional information
Not sure how the movie file can be invalid (seems like `skip-handles` tag on single frame can cause it?). Issue created https://github.com/pypeclub/OpenPype/issues/4028

## Testing notes:
1. Invalid input movie file in burnins should cause error with more specific information.