### PR TITLE
StandalonePublisher: Fix thumbnail publishing

### DIFF
--- a/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/standalonepublisher/plugins/publish/extract_thumbnail.py
@@ -118,6 +118,7 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
             'files': filename,
             "stagingDir": staging_dir,
             "tags": ["thumbnail", "delete"],
+            "thumbnail": True
         }
         if width and height:
             representation["width"] = width

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_instances.py
@@ -151,7 +151,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         first_thumbnail_component = None
         first_thumbnail_component_repre = None
 
-        if has_movie_review:
+        if not review_representations or has_movie_review:
             for repre in thumbnail_representations:
                 repre_path = self._get_repre_path(instance, repre, False)
                 if not repre_path:


### PR DESCRIPTION
## Brief description
Thumbnail is not integrated as reviewable component and thumbnail to ftrack because of missing `"thumbnail"` key on representation.

## Testing notes:
1. Thumbnails from standalone publisher should be integrated to ftrack as thumbnails