### PR TITLE
Igniter: handle missing directory

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -815,6 +815,13 @@ class BootstrapRepos:
             except Exception as e:
                 self._print(str(e), LOG_ERROR, exc_info=True)
                 return None
+        if not destination_dir.exists():
+            destination_dir.mkdir(parents=True)
+        elif not destination_dir.is_dir():
+            self._print(
+                "Destination exists but is not directory.", LOG_ERROR)
+            return None
+
         try:
             shutil.move(zip_file.as_posix(), destination_dir.as_posix())
         except shutil.Error as e:


### PR DESCRIPTION
## Bug

Fixing bug where if on vanilla machine you install completely new version and you enter correct mongo into Igniter dialog, installation will fail because it was not checking for presence of `{major}.{minor}` folder. If that folder was missing, move renamed the zip file to its name and everything crashed.

### Testing
- Delete every localised version in `%LOCALAPPDATA%`.
- Delete mongodb record from Credentials Manager/Keyring.
- Build OpenPype
- Run `openpype_console`
- Enter correct mongodb
- **Everything should work as expected**