### PR TITLE
Maya: Soft fail when applying capture preset

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -133,7 +133,7 @@ class ExtractPlayblast(publish.Extractor):
                 preset.update(panel_preset)
                 cmds.setFocus(panel)
 
-            path = capture.capture(**preset)
+            path = capture.capture(log=self.log, **preset)
 
         self.log.debug("playblast path  {}".format(path))
 


### PR DESCRIPTION
## Fix

This is partially solving issues with capture presets when incompatible flags broke publishing process of reviews. It will only print warning when capute couldn't apply the whole present, but it won't stop publishing.

Might close #4033 