### PR TITLE
Alembic Loader as Arnold Standin

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -50,9 +50,9 @@ class AlembicStandinLoader(load.LoaderPlugin):
         if c is not None:
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                (float(c[0])/255),
-                (float(c[1])/255),
-                (float(c[2])/255)
+                        (float(c[0])/255),
+                        (float(c[1])/255),
+                        (float(c[2])/255)
             )
 
         transform_name = label + "_ABC"

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -98,6 +98,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
         # Update the standin
         standins = list()
         members = pm.sets(container['objectName'], query=True)
+        self.log.info("container:{}".format(container))
         for member in members:
             shape = member.getShape()
             if (shape and shape.type() == "aiStandIn"):
@@ -105,8 +106,11 @@ class AlembicStandinLoader(load.LoaderPlugin):
 
         for standin in standins:
             standin.dso.set(path)
-            standin.useFrameExtension.set(0)
             standin.abcFPS.set(float(fps))
+            if "modelMain" in container['objectName']:
+                standin.useFrameExtension.set(0)
+            else:
+                standin.useFrameExtension.set(1)
 
         container = pm.PyNode(container["objectName"])
         container.representation.set(str(representation["_id"]))

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -55,7 +55,8 @@ class AlembicStandinLoader(load.LoaderPlugin):
         transform_name = label + "_ABC"
 
         standinShape = cmds.ls(mtoa.ui.arnoldmenu.createStandIn())[0]
-        standin = cmds.listRelatives(standinShape, parent=True, typ="transform")
+        standin = cmds.listRelatives(standinShape, parent=True,
+                                     typ="transform")
         standin = cmds.rename(standin, transform_name)
         standinShape = cmds.listRelatives(standin, children=True)[0]
 

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -50,10 +50,10 @@ class AlembicStandinLoader(load.LoaderPlugin):
         if c is not None:
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                        (float(c[0])/255),
-                        (float(c[1])/255),
-                        (float(c[2])/255)
-            )
+                         (float(c[0])/255),
+                         (float(c[1])/255),
+                         (float(c[2])/255)
+                        )
 
         transform_name = label + "_ABC"
 

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -28,11 +28,10 @@ class AlembicStandinLoader(load.LoaderPlugin):
 
         version = context["version"]
         version_data = version.get("data", {})
-
+        family = version["data"]["families"]
         self.log.info("version_data: {}\n".format(version_data))
-
+        self.log.info("family: {}\n".format(family))
         frameStart = version_data.get("frameStart", None)
-        frameEnd = version_data.get("frameEnd", None)
 
         asset = context["asset"]["name"]
         namespace = namespace or unique_namespace(
@@ -48,12 +47,14 @@ class AlembicStandinLoader(load.LoaderPlugin):
         settings = get_project_settings(os.environ['AVALON_PROJECT'])
         colors = settings["maya"]["load"]["colors"]
         fps = legacy_io.Session["AVALON_FPS"]
-
-        c = colors.get('ass')
+        c = colors.get(family[0])
         if c is not None:
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                         c[0], c[1], c[2])
+                (float(c[0])/255),
+                (float(c[1])/255),
+                (float(c[2])/255)
+            )
 
         transform_name = label + "_ABC"
 
@@ -72,7 +73,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
         if frameStart is None:
             cmds.setAttr(standinShape + ".useFrameExtension", 0)
 
-        elif frameStart == 1 and frameEnd == 1:
+        elif "model" in family:
             cmds.setAttr(standinShape + ".useFrameExtension", 0)
 
         else:

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -50,10 +50,10 @@ class AlembicStandinLoader(load.LoaderPlugin):
         if c is not None:
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                         (float(c[0])/255),
-                         (float(c[1])/255),
-                         (float(c[2])/255)
-                        )
+                        (float(c[0])/255),
+                        (float(c[1])/255),
+                        (float(c[2])/255)
+            )
 
         transform_name = label + "_ABC"
 

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -1,6 +1,7 @@
 import os
 
 from openpype.pipeline import (
+    legacy_io,
     load,
     get_representation_path
 )
@@ -46,6 +47,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
 
         settings = get_project_settings(os.environ['AVALON_PROJECT'])
         colors = settings["maya"]["load"]["colors"]
+        fps = legacy_io.Session["AVALON_FPS"]
 
         c = colors.get('ass')
         if c is not None:
@@ -65,12 +67,14 @@ class AlembicStandinLoader(load.LoaderPlugin):
 
         # Set the standin filepath
         cmds.setAttr(standinShape + ".dso", self.fname, type="string")
-        cmds.setAttr(standinShape + ".abcFPS", 25)
+        cmds.setAttr(standinShape + ".abcFPS", float(fps))
 
         if frameStart is None:
             cmds.setAttr(standinShape + ".useFrameExtension", 0)
+
         elif frameStart == 1 and frameEnd == 1:
             cmds.setAttr(standinShape + ".useFrameExtension", 0)
+
         else:
             cmds.setAttr(standinShape + ".useFrameExtension", 1)
 
@@ -89,7 +93,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
         import pymel.core as pm
 
         path = get_representation_path(representation)
-
+        fps = legacy_io.Session["AVALON_FPS"]
         # Update the standin
         standins = list()
         members = pm.sets(container['objectName'], query=True)
@@ -101,7 +105,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
         for standin in standins:
             standin.dso.set(path)
             standin.useFrameExtension.set(0)
-            standin.abcFPS.set(25)
+            standin.abcFPS.set(float(fps))
 
         container = pm.PyNode(container["objectName"])
         container.representation.set(str(representation["_id"]))

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -50,9 +50,9 @@ class AlembicStandinLoader(load.LoaderPlugin):
         if c is not None:
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                        (float(c[0])/255),
-                        (float(c[1])/255),
-                        (float(c[2])/255)
+                (float(c[0])/255),
+                (float(c[1])/255),
+                (float(c[2])/255)
             )
 
         transform_name = label + "_ABC"

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -30,6 +30,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
         version_data = version.get("data", {})
         family = version["data"]["families"]
         self.log.info("version_data: {}\n".format(version_data))
+        self.log.info("family: {}\n".format(family))
         frameStart = version_data.get("frameStart", None)
 
         asset = context["asset"]["name"]
@@ -48,12 +49,12 @@ class AlembicStandinLoader(load.LoaderPlugin):
         fps = legacy_io.Session["AVALON_FPS"]
         c = colors.get(family[0])
         if c is not None:
+            r = (float(c[0]) / 255)
+            g = (float(c[1]) / 255)
+            b = (float(c[2]) / 255)
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                         (float(c[0])/255),
-                         (float(c[1])/255),
-                         (float(c[2])/255)
-                        )
+                         r, g, b)
 
         transform_name = label + "_ABC"
 

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -1,5 +1,4 @@
 import os
-import clique
 
 from openpype.pipeline import (
     load,
@@ -41,7 +40,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
             suffix="_",
         )
 
-        #Root group
+        # Root group
         label = "{}:{}".format(namespace, name)
         root = pm.group(name=label, empty=True)
 

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -30,7 +30,6 @@ class AlembicStandinLoader(load.LoaderPlugin):
         version_data = version.get("data", {})
         family = version["data"]["families"]
         self.log.info("version_data: {}\n".format(version_data))
-        self.log.info("family: {}\n".format(family))
         frameStart = version_data.get("frameStart", None)
 
         asset = context["asset"]["name"]
@@ -51,10 +50,10 @@ class AlembicStandinLoader(load.LoaderPlugin):
         if c is not None:
             cmds.setAttr(root + ".useOutlinerColor", 1)
             cmds.setAttr(root + ".outlinerColor",
-                (float(c[0])/255),
-                (float(c[1])/255),
-                (float(c[2])/255)
-            )
+                         (float(c[0])/255),
+                         (float(c[1])/255),
+                         (float(c[2])/255)
+                        )
 
         transform_name = label + "_ABC"
 

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -1,0 +1,115 @@
+import os
+import clique
+
+from openpype.pipeline import (
+    load,
+    get_representation_path
+)
+from openpype.settings import get_project_settings
+
+
+class AlembicStandinLoader(load.LoaderPlugin):
+    """Load Alembic as Arnold Standin"""
+
+    families = ["model", "pointcache"]
+    representations = ["abc"]
+
+    label = "Import Alembic as Standin"
+    order = -5
+    icon = "code-fork"
+    color = "orange"
+
+    def load(self, context, name, namespace, options):
+
+        import maya.cmds as cmds
+        import pymel.core as pm
+        import mtoa.ui.arnoldmenu
+        from openpype.hosts.maya.api.pipeline import containerise
+        from openpype.hosts.maya.api.lib import unique_namespace
+
+        version = context["version"]
+        version_data = version.get("data", {})
+
+        self.log.info("version_data: {}\n".format(version_data))
+
+        frameStart = version_data.get("frameStart", None)
+
+        asset = context["asset"]["name"]
+        namespace = namespace or unique_namespace(
+            asset + "_",
+            prefix="_" if asset[0].isdigit() else "",
+            suffix="_",
+        )
+
+        #Root group
+        label = "{}:{}".format(namespace, name)
+        root = pm.group(name=label, empty=True)
+
+        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        colors = settings["maya"]["load"]["colors"]
+
+        c = colors.get('ass')
+        if c is not None:
+            cmds.setAttr(root + ".useOutlinerColor", 1)
+            cmds.setAttr(root + ".outlinerColor",
+                         c[0], c[1], c[2])
+
+        transform_name = label + "_ABC"
+
+        standinShape = pm.PyNode(mtoa.ui.arnoldmenu.createStandIn())
+        standin = standinShape.getParent()
+        standin.rename(transform_name)
+
+        pm.parent(standin, root)
+
+        # Set the standin filepath
+        standinShape.dso.set(self.fname)
+        if frameStart is not None:
+            standinShape.useFrameExtension.set(1)
+
+        nodes = [root, standin]
+        self[:] = nodes
+
+        return containerise(
+            name=name,
+            namespace=namespace,
+            nodes=nodes,
+            context=context,
+            loader=self.__class__.__name__)
+
+    def update(self, container, representation):
+
+        import pymel.core as pm
+
+        path = get_representation_path(representation)
+
+        # Update the standin
+        standins = list()
+        members = pm.sets(container['objectName'], query=True)
+        for member in members:
+            shape = member.getShape()
+            if (shape and shape.type() == "aiStandIn"):
+                standins.append(shape)
+
+        for standin in standins:
+            standin.dso.set(path)
+            standin.useFrameExtension.set(1)
+
+        container = pm.PyNode(container["objectName"])
+        container.representation.set(str(representation["_id"]))
+
+    def switch(self, container, representation):
+        self.update(container, representation)
+
+    def remove(self, container):
+        import maya.cmds as cmds
+        members = cmds.sets(container['objectName'], query=True)
+        cmds.lockNode(members, lock=False)
+        cmds.delete([container['objectName']] + members)
+
+        # Clean up the namespace
+        try:
+            cmds.namespace(removeNamespace=container['namespace'],
+                           deleteNamespaceContent=True)
+        except RuntimeError:
+            pass

--- a/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
+++ b/openpype/hosts/maya/plugins/load/load_abc_to_standin.py
@@ -13,7 +13,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
     families = ["model", "pointcache"]
     representations = ["abc"]
 
-    label = "Import Alembic as Standin"
+    label = "Import Alembic as Arnold Standin"
     order = -5
     icon = "code-fork"
     color = "orange"
@@ -21,7 +21,6 @@ class AlembicStandinLoader(load.LoaderPlugin):
     def load(self, context, name, namespace, options):
 
         import maya.cmds as cmds
-        import pymel.core as pm
         import mtoa.ui.arnoldmenu
         from openpype.hosts.maya.api.pipeline import containerise
         from openpype.hosts.maya.api.lib import unique_namespace
@@ -42,7 +41,7 @@ class AlembicStandinLoader(load.LoaderPlugin):
 
         # Root group
         label = "{}:{}".format(namespace, name)
-        root = pm.group(name=label, empty=True)
+        root = cmds.group(name=label, empty=True)
 
         settings = get_project_settings(os.environ['AVALON_PROJECT'])
         colors = settings["maya"]["load"]["colors"]
@@ -55,16 +54,17 @@ class AlembicStandinLoader(load.LoaderPlugin):
 
         transform_name = label + "_ABC"
 
-        standinShape = pm.PyNode(mtoa.ui.arnoldmenu.createStandIn())
-        standin = standinShape.getParent()
-        standin.rename(transform_name)
+        standinShape = cmds.ls(mtoa.ui.arnoldmenu.createStandIn())[0]
+        standin = cmds.listRelatives(standinShape, parent=True, typ="transform")
+        standin = cmds.rename(standin, transform_name)
+        standinShape = cmds.listRelatives(standin, children=True)[0]
 
-        pm.parent(standin, root)
+        cmds.parent(standin, root)
 
         # Set the standin filepath
-        standinShape.dso.set(self.fname)
+        cmds.setAttr(standinShape + ".dso", self.fname, type="string")
         if frameStart is not None:
-            standinShape.useFrameExtension.set(1)
+            cmds.setAttr(standinShape + ".useFrameExtension", 1)
 
         nodes = [root, standin]
         self[:] = nodes


### PR DESCRIPTION
## Brief description
Adding Alembic Loader as Arnold Standin function as the Openpype Plugin

## Description
The user can load the published workfileswith abc format as Arnold Standin if the pusblished workfiles belong to model and pointcache family.
![image](https://user-images.githubusercontent.com/64118225/199001222-d0daa412-c2d1-4937-8302-08b3126dabc8.png)
![image](https://user-images.githubusercontent.com/64118225/199001571-83ef7592-9f43-4b94-95fb-b7897a642fd5.png)


## Additional info
Doesn't have any for the current stage

## Testing notes:
1. Start maya in Openpype
2. Click "Load" from Openpype in maya
3. Right-click the workfiles which belongs to either model or pointcache family
4. Click Import Alembic as Standin
5. It will load the abc file as an arnold standin