### PR TITLE
Deadline: Extract environment subprocess failure

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -164,7 +164,7 @@ def inject_openpype_environment(deadlinePlugin):
         args = [
             exe,
             "--headless",
-            'extractenvironments',
+            "extractenvironments",
             export_url
         ]
 

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -193,10 +193,17 @@ def inject_openpype_environment(deadlinePlugin):
         env["AVALON_TIMEOUT"] = "5000"
 
         print(">>> Executing: {}".format(" ".join(args)))
-        std_output = subprocess.check_output(args,
-                                             cwd=os.path.dirname(exe),
-                                             env=env)
-        print(">>> Process result {}".format(std_output))
+        proc = subprocess.Popen(
+            args,
+            cwd=os.path.dirname(exe),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        std_output, std_err = proc.communicate()
+        print(">>> Process result {}\n".format(std_output, std_err))
+        if proc.returncode != 0:
+            raise RuntimeError("OpenPype process failed.")
 
         print(">>> Loading file ...")
         with open(export_url) as fp:

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -189,7 +189,6 @@ def inject_openpype_environment(deadlinePlugin):
             print(">>> Missing OPENPYPE_MONGO env var, process won't work")
 
         env = os.environ
-        env["OPENPYPE_HEADLESS_MODE"] = "1"
         env["AVALON_TIMEOUT"] = "5000"
 
         print(">>> Executing: {}".format(" ".join(args)))

--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -196,7 +196,9 @@ def inject_openpype_environment(deadlinePlugin):
 
         args_str = subprocess.list2cmdline(args)
         print(">>> Executing: {} {}".format(exe, args_str))
-        process = ProcessUtils.SpawnProcess(exe, args_str, os.path.dirname(exe))
+        process = ProcessUtils.SpawnProcess(
+            exe, args_str, os.path.dirname(exe)
+        )
         ProcessUtils.WaitForExit(process, -1)
         if process.ExitCode != 0:
             raise RuntimeError(


### PR DESCRIPTION
## Brief description
Fix occational issue on Deadline where `subprocess.check_output` is crashing.

## Description
We expect deadline has modified some functionality in `check_output` which cause crashes. Changed to use deadline process utils to run the process instead of subprocess.

## Testing notes:
1. Copy the plugin to deadline plugins
2. Run publishing

Resolves https://github.com/pypeclub/OpenPype/issues/3998