### PR TITLE
Loader: Fix comparison of repre name

### DIFF
--- a/openpype/tools/loader/widgets.py
+++ b/openpype/tools/loader/widgets.py
@@ -515,7 +515,7 @@ class SubsetWidget(QtWidgets.QWidget):
         if not one_item_selected:
             # Filter loaders from first subset by intersected combinations
             for repre, loader in first_loaders:
-                if (repre["name"], loader) not in found_combinations:
+                if (repre["name"].lower(), loader) not in found_combinations:
                     continue
 
                 loaders.append((repre, loader))


### PR DESCRIPTION
## Brief description
Fix the comparison of representation names to match stored representation names in found combinations.

## Testing notes:
1. Make sure you have 2 or more subsets with representation that has at least one capital character in name
    - e.g. "someRepre"
2. Open loader in DCC where you have available Loader plugin that can load the representation
3. Select group of subsets in loader view a right-click to shown context menu
4. The loader should be visible there