### PR TITLE
remove underscore from subset name

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -457,9 +457,15 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
             cam = [c for c in cameras if c in col.head]
             if cam:
-                subset_name = '{}_{}_{}'.format(group_name, cam, aov)
+                if aov:
+                    subset_name = '{}_{}_{}'.format(group_name, cam, aov)
+                else:
+                    subset_name = '{}_{}'.format(group_name, cam)
             else:
-                subset_name = '{}_{}'.format(group_name, aov)
+                if aov:
+                    subset_name = '{}_{}'.format(group_name, aov)
+                else:
+                    subset_name = '{}'.format(group_name)
 
             if isinstance(col, (list, tuple)):
                 staging = os.path.dirname(col[0])


### PR DESCRIPTION
## Brief description
remove unnecessary underscore from subset name when rendering without AOVs

## Description
When publishing the render with the empty AOV name, it will create subset name with underscore at the end. (See the screenshot below)
![image](https://user-images.githubusercontent.com/64118225/199483200-31f9e377-5925-41fe-829c-4c0660146625.png)

This PR will fix the issue of adding extra underscore at the end when publishing the render.
![image](https://user-images.githubusercontent.com/64118225/199485984-faf6c719-46a2-4701-85e9-33862b126bd3.png)

## Additional info
This is only tested in maya Host.

## Testing notes:
1. Launch Maya in Openpype
2.  Create Render Main
3. In Render Setting, add an AOV and empties the AOV name
4. Save and Publish the scene.