### PR TITLE
General: Oiio conversion multipart fix

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -111,6 +111,7 @@ def get_oiio_info_for_input(filepath, logger=None):
 
 class RationalToInt:
     """Rational value stored as division of 2 integers using string."""
+
     def __init__(self, string_value):
         parts = string_value.split("/")
         top = float(parts[0])
@@ -157,16 +158,16 @@ def convert_value_by_type_name(value_type, value, logger=None):
     if value_type == "int":
         return int(value)
 
-    if value_type == "float":
+    if value_type in ("float", "double"):
         return float(value)
 
     # Vectors will probably have more types
-    if value_type in ("vec2f", "float2"):
+    if value_type in ("vec2f", "float2", "float2d"):
         return [float(item) for item in value.split(",")]
 
     # Matrix should be always have square size of element 3x3, 4x4
     # - are returned as list of lists
-    if value_type == "matrix":
+    if value_type in ("matrix", "matrixd"):
         output = []
         current_index = -1
         parts = value.split(",")
@@ -198,7 +199,7 @@ def convert_value_by_type_name(value_type, value, logger=None):
     if value_type == "rational2i":
         return RationalToInt(value)
 
-    if value_type == "vector":
+    if value_type in ("vector", "vectord"):
         parts = [part.strip() for part in value.split(",")]
         output = []
         for part in parts:

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -96,7 +96,7 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
     output = output.replace("\r\n", "\n")
 
     xml_started = False
-    subimages = []
+    subimages_lines = []
     lines = []
     for line in output.split("\n"):
         if not xml_started:
@@ -107,7 +107,7 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
         if xml_started:
             lines.append(line)
             if line == "</ImageSpec>":
-                subimages.append(lines)
+                subimages_lines.append(lines)
                 lines = []
 
     if not xml_started:
@@ -118,8 +118,8 @@ def get_oiio_info_for_input(filepath, logger=None, subimages=False):
         )
 
     output = []
-    for subimage in subimages:
-        xml_text = "\n".join(subimage)
+    for subimage_lines in subimages_lines:
+        xml_text = "\n".join(subimage_lines)
         output.append(parse_oiio_xml_output(xml_text, logger=logger))
 
     if subimages:
@@ -651,7 +651,7 @@ def convert_input_paths_for_ffmpeg(
         # Tell oiiotool which channels should be loaded
         # - other channels are not loaded to memory so helps to avoid memory
         #       leak issues
-        # - this option is crashing if used on multipart/subimages exrs
+        # - this option is crashing if used on multipart exrs
         input_arg += ":ch={}".format(input_channels_str)
 
     for input_path in input_paths:

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -476,7 +476,7 @@ def convert_for_ffmpeg(
     if input_frame_start is not None and input_frame_end is not None:
         is_sequence = int(input_frame_end) != int(input_frame_start)
 
-    input_info = get_oiio_info_for_input(first_input_path)
+    input_info = get_oiio_info_for_input(first_input_path, logger=logger)
 
     # Change compression only if source compression is "dwaa" or "dwab"
     #   - they're not supported in ffmpeg
@@ -524,10 +524,8 @@ def convert_for_ffmpeg(
         input_arg, first_input_path,
         # Tell oiiotool which channels should be put to top stack (and output)
         "--ch", channels_arg,
-        # WARNING: This is commented out because ffmpeg won't be able to
-        #   render proper output when only one subimage is outputed with oiio
         # Use first subimage
-        # "--subimage", "0"
+        "--subimage", "0"
     ])
 
     # Add frame definitions to arguments
@@ -621,7 +619,7 @@ def convert_input_paths_for_ffmpeg(
             " \".exr\" extension. Got \"{}\"."
         ).format(ext))
 
-    input_info = get_oiio_info_for_input(first_input_path)
+    input_info = get_oiio_info_for_input(first_input_path, logger=logger)
 
     # Change compression only if source compression is "dwaa" or "dwab"
     #   - they're not supported in ffmpeg
@@ -639,6 +637,7 @@ def convert_input_paths_for_ffmpeg(
 
     red, green, blue, alpha = review_channels
     input_channels = [red, green, blue]
+    # TODO find subimage inder where rgba is available for multipart exrs
     channels_arg = "R={},G={},B={}".format(red, green, blue)
     if alpha is not None:
         channels_arg += ",A={}".format(alpha)
@@ -671,11 +670,8 @@ def convert_input_paths_for_ffmpeg(
             # Tell oiiotool which channels should be put to top stack
             #   (and output)
             "--ch", channels_arg,
-            # WARNING: This is commented out because ffmpeg won't be able to
-            #   render proper output when only one subimage is outputed
-            #   with oiiotool
             # Use first subimage
-            # "--subimage", "0"
+            "--subimage", "0"
         ])
 
         for attr_name, attr_value in input_info["attribs"].items():

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -672,7 +672,8 @@ def convert_input_paths_for_ffmpeg(
             #   (and output)
             "--ch", channels_arg,
             # WARNING: This is commented out because ffmpeg won't be able to
-            #   render proper output when only one subimage is outputed with oiio
+            #   render proper output when only one subimage is outputed
+            #   with oiiotool
             # Use first subimage
             # "--subimage", "0"
         ])

--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -524,10 +524,10 @@ def convert_for_ffmpeg(
         input_arg, first_input_path,
         # Tell oiiotool which channels should be put to top stack (and output)
         "--ch", channels_arg,
+        # WARNING: This is commented out because ffmpeg won't be able to
+        #   render proper output when only one subimage is outputed with oiio
         # Use first subimage
-        # TODO we should look for all subimages and try (somehow) find the
-        #   best candidate for output
-        "--subimage", "0"
+        # "--subimage", "0"
     ])
 
     # Add frame definitions to arguments
@@ -671,9 +671,10 @@ def convert_input_paths_for_ffmpeg(
             # Tell oiiotool which channels should be put to top stack
             #   (and output)
             "--ch", channels_arg,
+            # WARNING: This is commented out because ffmpeg won't be able to
+            #   render proper output when only one subimage is outputed with oiio
             # Use first subimage
-            # TODO we should look for all subimages and try (somehow) find the
-            "--subimage", "0"
+            # "--subimage", "0"
         ])
 
         for attr_name, attr_value in input_info["attribs"].items():


### PR DESCRIPTION
## Brief description
Don't define input channels if input is multipart exr.

## Description
When converting multipart exr for ffmpeg it can't handle definition of channels on input because there are multiple subimages which cause crash if oiiotool.

Extended few types in xml info result parsing and added ability to receive information about every subimage in exr.

## Additional information
The output has all subimages (which can be big exr) that is because ffmpeg then created transparent image without any content. Not sure why but it's an issue. Also if any subimage in the exr has attributes with invalid characters or too long value it would cause issues in ffmpeg too -> future enhancements.

## Testing notes:
1. It should be possible to convert multipart exr for ffmpeg (e.g. in extract review)