### PR TITLE
General: Extract review single frame output

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -279,7 +279,10 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
             try:
                 self._render_output_definitions(
-                    instance, repre, src_repre_staging_dir, filtered_output_defs
+                    instance,
+                    repre,
+                    src_repre_staging_dir,
+                    filtered_output_defs
                 )
 
             finally:

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -53,6 +53,62 @@
                     "families": [],
                     "hosts": [],
                     "outputs": {
+                        "png": {
+                            "ext": "png",
+                            "tags": [
+                                "ftrackreview"
+                            ],
+                            "burnins": [],
+                            "ffmpeg_args": {
+                                "video_filters": [],
+                                "audio_filters": [],
+                                "input": [],
+                                "output": []
+                            },
+                            "filter": {
+                                "families": [
+                                    "render",
+                                    "review",
+                                    "ftrack"
+                                ],
+                                "subsets": [],
+                                "custom_tags": [],
+                                "single_frame_filter": "single_frame"
+                            },
+                            "overscan_crop": "",
+                            "overscan_color": [
+                                0,
+                                0,
+                                0,
+                                255
+                            ],
+                            "width": 1920,
+                            "height": 1080,
+                            "scale_pixel_aspect": true,
+                            "bg_color": [
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "letter_box": {
+                                "enabled": false,
+                                "ratio": 0.0,
+                                "fill_color": [
+                                    0,
+                                    0,
+                                    0,
+                                    255
+                                ],
+                                "line_thickness": 0,
+                                "line_color": [
+                                    255,
+                                    0,
+                                    0,
+                                    255
+                                ]
+                            }
+                        },
                         "h264": {
                             "ext": "mp4",
                             "tags": [
@@ -80,7 +136,7 @@
                                 ],
                                 "subsets": [],
                                 "custom_tags": [],
-                                "single_frame_filter": "everytime"
+                                "single_frame_filter": "multi_frame"
                             },
                             "overscan_crop": "",
                             "overscan_color": [

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -79,7 +79,8 @@
                                     "ftrack"
                                 ],
                                 "subsets": [],
-                                "custom_tags": []
+                                "custom_tags": [],
+                                "single_frame_filter": "everytime"
                             },
                             "overscan_crop": "",
                             "overscan_color": [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -304,6 +304,20 @@
                                                     "label": "Custom Tags",
                                                     "type": "list",
                                                     "object_type": "text"
+                                                },
+                                                {
+                                                    "type": "label",
+                                                    "label": "Use output <b>always</b> / only if input <b>is 1 frame</b> image / only if has <b>2+ frames</b> or <b>is video</b>"
+                                                },
+                                                {
+                                                    "type": "enum",
+                                                    "key": "single_frame_filter",
+                                                    "default": "everytime",
+                                                    "enum_items": [
+                                                        {"everytime": "Always"},
+                                                        {"single_frame": "On 1 frame input"},
+                                                        {"multi_frame": "On 2+ frame input"}
+                                                    ]
                                                 }
                                             ]
                                         },

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -315,8 +315,8 @@
                                                     "default": "everytime",
                                                     "enum_items": [
                                                         {"everytime": "Always"},
-                                                        {"single_frame": "On 1 frame input"},
-                                                        {"multi_frame": "On 2+ frame input"}
+                                                        {"single_frame": "Only if input has 1 image frame"},
+                                                        {"multi_frame": "Only if input is video or sequence of frames"}
                                                     ]
                                                 }
                                             ]

--- a/website/docs/project_settings/settings_project_global.md
+++ b/website/docs/project_settings/settings_project_global.md
@@ -135,6 +135,12 @@ Profile may generate multiple outputs from a single input. Each output must defi
         - set alpha to `0` to not use this option at all (in most of cases background stays black)
         - other than `0` alpha will draw color as background
 
+- **`Additional filtering`**
+    - Profile filtering defines which group of output definitions is used but output definitions may require more specific filters on their own.
+    - They may filter by subset name (regex can be used) or publish families. Publish families are more complex as are based on knowing code base.
+    - Filtering by custom tags -> this is used for targeting to output definitions from other extractors using settings (at this moment only Nuke bake extractor can target using custom tags).
+        - Nuke extractor settings path: `project_settings/nuke/publish/ExtractReviewDataMov/outputs/baking/add_custom_tags`
+    - Filtering by input length. Input may be video, sequence or single image. It is possible that `.mp4` should be created only when input is video or sequence and to create review `.png` when input is single frame. In some cases the output should be created even if it's single frame or multi frame input.
 
 ### IntegrateAssetNew
 


### PR DESCRIPTION
## Brief description
Extract review have different outputs when input is single frame.

## Description
The goal is to avoid creating of single frame movie files but also give ability to create different review output and define it's resolution and tags. We've added one more additional filtering to output defintinions. It is possible to tell that the output will be created always (no matter how many frames input has), when input has 1 frame image or when input has 2+ images (or is movie).

Added default output definition to create HD png output if input is single frame and h264 is created only if input is video or has multiple frames.

## Testing notes:
Your current settings should work as they did before (nothing should break with older settings).

To test the feature: Change your settings to create an output definition on single frame, another output definition on multi frame and another output definition which is created always. You can add letterboxes with different colors to know which is which.

Run publishing in all of those cases e.g. by using tray publisher where can be passed reviewable.