### PR TITLE
General: Direct interfaces import

### DIFF
--- a/openpype/hosts/aftereffects/addon.py
+++ b/openpype/hosts/aftereffects/addon.py
@@ -1,5 +1,4 @@
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 
 class AfterEffectsAddon(OpenPypeModule, IHostAddon):

--- a/openpype/hosts/blender/addon.py
+++ b/openpype/hosts/blender/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 BLENDER_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/flame/addon.py
+++ b/openpype/hosts/flame/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 HOST_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/fusion/addon.py
+++ b/openpype/hosts/fusion/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 FUSION_HOST_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/harmony/addon.py
+++ b/openpype/hosts/harmony/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 HARMONY_HOST_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/hiero/addon.py
+++ b/openpype/hosts/hiero/addon.py
@@ -1,7 +1,6 @@
 import os
 import platform
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 HIERO_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/houdini/addon.py
+++ b/openpype/hosts/houdini/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 HOUDINI_HOST_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/maya/addon.py
+++ b/openpype/hosts/maya/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 MAYA_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/nuke/addon.py
+++ b/openpype/hosts/nuke/addon.py
@@ -1,7 +1,6 @@
 import os
 import platform
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 NUKE_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/photoshop/addon.py
+++ b/openpype/hosts/photoshop/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 PHOTOSHOP_HOST_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/resolve/addon.py
+++ b/openpype/hosts/resolve/addon.py
@@ -1,7 +1,6 @@
 import os
 
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 from .utils import RESOLVE_ROOT_DIR
 

--- a/openpype/hosts/standalonepublisher/addon.py
+++ b/openpype/hosts/standalonepublisher/addon.py
@@ -4,8 +4,7 @@ import click
 
 from openpype.lib import get_openpype_execute_args
 from openpype.lib.execute import run_detached_process
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import ITrayAction, IHostAddon
+from openpype.modules import OpenPypeModule, ITrayAction, IHostAddon
 
 STANDALONEPUBLISH_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/traypublisher/addon.py
+++ b/openpype/hosts/traypublisher/addon.py
@@ -4,8 +4,7 @@ import click
 
 from openpype.lib import get_openpype_execute_args
 from openpype.lib.execute import run_detached_process
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import ITrayAction, IHostAddon
+from openpype.modules import OpenPypeModule, ITrayAction, IHostAddon
 
 TRAYPUBLISH_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/tvpaint/addon.py
+++ b/openpype/hosts/tvpaint/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 TVPAINT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/unreal/addon.py
+++ b/openpype/hosts/unreal/addon.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 UNREAL_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/hosts/webpublisher/addon.py
+++ b/openpype/hosts/webpublisher/addon.py
@@ -2,8 +2,7 @@ import os
 
 import click
 
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IHostAddon
+from openpype.modules import OpenPypeModule, IHostAddon
 
 WEBPUBLISHER_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/modules/__init__.py
+++ b/openpype/modules/__init__.py
@@ -1,4 +1,14 @@
 # -*- coding: utf-8 -*-
+from .interfaces import (
+    ILaunchHookPaths,
+    IPluginPaths,
+    ITrayModule,
+    ITrayAction,
+    ITrayService,
+    ISettingsChangeListener,
+    IHostAddon,
+)
+
 from .base import (
     OpenPypeModule,
     OpenPypeAddOn,
@@ -17,6 +27,14 @@ from .base import (
 
 
 __all__ = (
+    "ILaunchHookPaths",
+    "IPluginPaths",
+    "ITrayModule",
+    "ITrayAction",
+    "ITrayService",
+    "ISettingsChangeListener",
+    "IHostAddon",
+
     "OpenPypeModule",
     "OpenPypeAddOn",
 

--- a/openpype/modules/avalon_apps/avalon_app.py
+++ b/openpype/modules/avalon_apps/avalon_app.py
@@ -1,7 +1,6 @@
 import os
 
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayModule
+from openpype.modules import OpenPypeModule, ITrayModule
 
 
 class AvalonModule(OpenPypeModule, ITrayModule):

--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -9,6 +9,7 @@ import logging
 import platform
 import threading
 import collections
+import traceback
 from uuid import uuid4
 from abc import ABCMeta, abstractmethod
 import six
@@ -139,6 +140,15 @@ class _InterfacesClass(_ModuleClass):
                 "cannot import name '{}' from 'openpype_interfaces'"
             ).format(attr_name))
 
+        if _LoadCache.interfaces_loaded and attr_name != "log":
+            stack = list(traceback.extract_stack())
+            stack.pop(-1)
+            self.log.warning((
+                "Using deprecated import of \"{}\" from 'openpype_interfaces'."
+                " Please switch to use import"
+                " from 'openpype.modules.interfaces'"
+                " (will be removed after 3.16.x).{}"
+            ).format(attr_name, "".join(traceback.format_list(stack))))
         return self.__attributes__[attr_name]
 
 

--- a/openpype/modules/clockify/clockify_module.py
+++ b/openpype/modules/clockify/clockify_module.py
@@ -2,15 +2,16 @@ import os
 import threading
 import time
 
+from openpype.modules import (
+    OpenPypeModule,
+    ITrayModule,
+    IPluginPaths
+)
+
 from .clockify_api import ClockifyAPI
 from .constants import (
     CLOCKIFY_FTRACK_USER_PATH,
     CLOCKIFY_FTRACK_SERVER_PATH
-)
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import (
-    ITrayModule,
-    IPluginPaths
 )
 
 

--- a/openpype/modules/deadline/deadline_module.py
+++ b/openpype/modules/deadline/deadline_module.py
@@ -4,8 +4,7 @@ import six
 import sys
 
 from openpype.lib import requests_get, Logger
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import IPluginPaths
+from openpype.modules import OpenPypeModule, IPluginPaths
 
 
 class DeadlineWebserviceError(Exception):

--- a/openpype/modules/example_addons/example_addon/addon.py
+++ b/openpype/modules/example_addons/example_addon/addon.py
@@ -13,10 +13,7 @@ import click
 from openpype.modules import (
     JsonFilesSettingsDef,
     OpenPypeAddOn,
-    ModulesManager
-)
-# Import interface defined by this addon to be able find other addons using it
-from openpype_interfaces import (
+    ModulesManager,
     IPluginPaths,
     ITrayAction
 )

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -5,8 +5,8 @@ import platform
 
 import click
 
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import (
+from openpype.modules import (
+    OpenPypeModule,
     ITrayModule,
     IPluginPaths,
     ISettingsChangeListener

--- a/openpype/modules/kitsu/kitsu_module.py
+++ b/openpype/modules/kitsu/kitsu_module.py
@@ -3,8 +3,11 @@
 import click
 import os
 
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import IPluginPaths, ITrayAction
+from openpype.modules import (
+    OpenPypeModule,
+    IPluginPaths,
+    ITrayAction,
+)
 
 
 class KitsuModule(OpenPypeModule, IPluginPaths, ITrayAction):

--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -1,5 +1,7 @@
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayAction
+from openpype.modules import (
+    OpenPypeModule,
+    ITrayAction,
+)
 
 
 class LauncherAction(OpenPypeModule, ITrayAction):

--- a/openpype/modules/log_viewer/log_view_module.py
+++ b/openpype/modules/log_viewer/log_view_module.py
@@ -1,5 +1,4 @@
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayModule
+from openpype.modules import OpenPypeModule, ITrayModule
 
 
 class LogViewModule(OpenPypeModule, ITrayModule):

--- a/openpype/modules/muster/muster.py
+++ b/openpype/modules/muster/muster.py
@@ -2,8 +2,7 @@ import os
 import json
 import appdirs
 import requests
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayModule
+from openpype.modules import OpenPypeModule, ITrayModule
 
 
 class MusterModule(OpenPypeModule, ITrayModule):

--- a/openpype/modules/project_manager_action.py
+++ b/openpype/modules/project_manager_action.py
@@ -1,5 +1,4 @@
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayAction
+from openpype.modules import OpenPypeModule, ITrayAction
 
 
 class ProjectManagerAction(OpenPypeModule, ITrayAction):

--- a/openpype/modules/python_console_interpreter/module.py
+++ b/openpype/modules/python_console_interpreter/module.py
@@ -1,5 +1,4 @@
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayAction
+from openpype.modules import OpenPypeModule, ITrayAction
 
 
 class PythonInterpreterAction(OpenPypeModule, ITrayAction):

--- a/openpype/modules/royalrender/royal_render_module.py
+++ b/openpype/modules/royalrender/royal_render_module.py
@@ -2,8 +2,7 @@
 """Module providing support for Royal Render."""
 import os
 import openpype.modules
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import IPluginPaths
+from openpype.modules import OpenPypeModule, IPluginPaths
 
 
 class RoyalRenderModule(OpenPypeModule, IPluginPaths):

--- a/openpype/modules/settings_action.py
+++ b/openpype/modules/settings_action.py
@@ -1,5 +1,4 @@
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayAction
+from openpype.modules import OpenPypeModule, ITrayAction
 
 
 class SettingsAction(OpenPypeModule, ITrayAction):

--- a/openpype/modules/shotgrid/shotgrid_module.py
+++ b/openpype/modules/shotgrid/shotgrid_module.py
@@ -1,11 +1,10 @@
 import os
 
-from openpype_interfaces import (
+from openpype.modules import (
+    OpenPypeModule,
     ITrayModule,
     IPluginPaths,
 )
-
-from openpype.modules import OpenPypeModule
 
 SHOTGRID_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/modules/slack/slack_module.py
+++ b/openpype/modules/slack/slack_module.py
@@ -1,6 +1,5 @@
 import os
-from openpype.modules import OpenPypeModule
-from openpype.modules.interfaces import IPluginPaths
+from openpype.modules import OpenPypeModule, IPluginPaths
 
 SLACK_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -11,9 +11,12 @@ from collections import deque, defaultdict
 import click
 from bson.objectid import ObjectId
 
-from openpype.client import get_projects
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayModule
+from openpype.client import (
+    get_projects,
+    get_representations,
+    get_representation_by_id,
+)
+from openpype.modules import OpenPypeModule, ITrayModule
 from openpype.settings import (
     get_project_settings,
     get_system_settings,
@@ -29,9 +32,6 @@ from .providers.local_drive import LocalDriveHandler
 from .providers import lib
 
 from .utils import time_function, SyncStatus, SiteAlreadyPresentError
-
-from openpype.client import get_representations, get_representation_by_id
-
 
 log = Logger.get_logger("SyncServer")
 

--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -3,7 +3,7 @@ import platform
 
 
 from openpype.client import get_asset_by_name
-from openpype.modules.interfaces import (
+from openpype.modules import (
     OpenPypeModule,
     ITrayService,
     IPluginPaths

--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -3,8 +3,8 @@ import platform
 
 
 from openpype.client import get_asset_by_name
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import (
+from openpype.modules.interfaces import (
+    OpenPypeModule,
     ITrayService,
     IPluginPaths
 )

--- a/openpype/modules/webserver/host_console_listener.py
+++ b/openpype/modules/webserver/host_console_listener.py
@@ -5,7 +5,7 @@ import logging
 from concurrent.futures import CancelledError
 from Qt import QtWidgets
 
-from openpype_interfaces import ITrayService
+from openpype.modules import ITrayService
 
 log = logging.getLogger(__name__)
 

--- a/openpype/modules/webserver/webserver_module.py
+++ b/openpype/modules/webserver/webserver_module.py
@@ -24,8 +24,7 @@ import os
 import socket
 
 from openpype import resources
-from openpype.modules import OpenPypeModule
-from openpype_interfaces import ITrayService
+from openpype.modules import OpenPypeModule, ITrayService
 
 
 class WebServerModule(OpenPypeModule, ITrayService):

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -138,8 +138,7 @@ def save_studio_settings(data):
         SaveWarningExc: If any module raises the exception.
     """
     # Notify Pype modules
-    from openpype.modules import ModulesManager
-    from openpype_interfaces import ISettingsChangeListener
+    from openpype.modules import ModulesManager, ISettingsChangeListener
 
     old_data = get_system_settings()
     default_values = get_default_settings()[SYSTEM_SETTINGS_KEY]
@@ -186,8 +185,7 @@ def save_project_settings(project_name, overrides):
         SaveWarningExc: If any module raises the exception.
     """
     # Notify Pype modules
-    from openpype.modules import ModulesManager
-    from openpype_interfaces import ISettingsChangeListener
+    from openpype.modules import ModulesManager, ISettingsChangeListener
 
     default_values = get_default_settings()[PROJECT_SETTINGS_KEY]
     if project_name:
@@ -248,8 +246,7 @@ def save_project_anatomy(project_name, anatomy_data):
         SaveWarningExc: If any module raises the exception.
     """
     # Notify Pype modules
-    from openpype.modules import ModulesManager
-    from openpype_interfaces import ISettingsChangeListener
+    from openpype.modules import ModulesManager, ISettingsChangeListener
 
     default_values = get_default_settings()[PROJECT_ANATOMY_KEY]
     if project_name:

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -401,7 +401,7 @@ class TrayManager:
 
     def initialize_modules(self):
         """Add modules to tray."""
-        from openpype_interfaces import (
+        from openpype.modules import (
             ITrayAction,
             ITrayService
         )


### PR DESCRIPTION
## Brief description
Replace import from dynamic python module `openpype_interfaces` with direct import `openpype.modules`.

## Description
Idea in past was that interfaces should be possible to add dynamically but after a time we got to point when it's not used anymore and only base/core interfaces are used thus dynamic module `openpype_interfaces` is not needed anymore.

Interfaces are imported to top level of `openpype.modules` to simplify module specific imports. All imports in existing modules are replaced with new source. Dynamic module `openpype_interfaces` still works but import from it will cause warning that it's using deprecated approach.

## Testing notes:
1. All modules are loaded correctly
2. All host integration are loaded correctly