### PR TITLE
Settings UI: Locked setting can't bypass lock

### DIFF
--- a/openpype/tools/settings/settings/categories.py
+++ b/openpype/tools/settings/settings/categories.py
@@ -892,6 +892,10 @@ class ProjectWidget(SettingsCategoryWidget):
     def __init__(self, *args, **kwargs):
         super(ProjectWidget, self).__init__(*args, **kwargs)
 
+    def set_edit_mode(self, enabled):
+        super(ProjectWidget, self).set_edit_mode(enabled)
+        self.project_list_widget.set_edit_mode(enabled)
+
     def _check_last_saved_info(self):
         if self.is_modifying_defaults:
             return True

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -1009,6 +1009,7 @@ class ProjectListWidget(QtWidgets.QWidget):
 
         self._entity = None
         self.current_project = None
+        self._edit_mode = True
 
         super(ProjectListWidget, self).__init__(parent)
         self.setObjectName("ProjectListWidget")
@@ -1061,6 +1062,10 @@ class ProjectListWidget(QtWidgets.QWidget):
         self.project_model = project_model
         self.inactive_chk = inactive_chk
 
+    def set_edit_mode(self, enabled):
+        if self._edit_mode is not enabled:
+            self._edit_mode = enabled
+
     def set_entity(self, entity):
         self._entity = entity
 
@@ -1112,7 +1117,7 @@ class ProjectListWidget(QtWidgets.QWidget):
 
         save_changes = False
         change_project = False
-        if self.validate_context_change():
+        if not self._edit_mode or self.validate_context_change():
             change_project = True
 
         else:

--- a/openpype/tools/settings/settings/widgets.py
+++ b/openpype/tools/settings/settings/widgets.py
@@ -646,6 +646,9 @@ class UnsavedChangesDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None):
         super(UnsavedChangesDialog, self).__init__(parent)
+
+        self.setWindowTitle("Unsaved changes")
+
         message_label = QtWidgets.QLabel(self.message)
 
         btns_widget = QtWidgets.QWidget(self)


### PR DESCRIPTION
## Brief description
Avoid to show unsaved changes dialog if settings are in view only mode.

## Description
Even if settings UI is in view only mode change of project may trigger unsaved changes dialog which can allow to save settings. This PR makes sure the dialog is not showed.

## Testing notes:
1. Open settings UI
2. Open second settings UI -> should ask to view only mode -> accept view only mode
3. Do some changes in project settings
4. Go to different project
5. No dialog should appear