### PR TITLE
Publisher: Fix cache of asset docs

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -90,9 +90,9 @@ class AssetDocsCache:
             return
 
         project_name = self._controller.project_name
-        asset_docs = get_assets(
+        asset_docs = list(get_assets(
             project_name, fields=self.projection.keys()
-        )
+        ))
         asset_docs_by_name = {}
         task_names_by_asset_name = {}
         for asset_doc in asset_docs:


### PR DESCRIPTION
## Brief description
Asset docs cache may store generator instead of list of asset documents.

## Description
This is future proof change that makes sure the output of `get_assets` is converted to list if is generator.

## Testing notes:
1. Nothing should change visually
2. Assets should be loaded in publisher UI