### PR TITLE
Nuke: resolve hashes in file name only for frame token

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -1,5 +1,6 @@
 import nuke
 import qargparse
+from pprint import pformat
 from copy import deepcopy
 from openpype.lib import Logger
 from openpype.client import (
@@ -22,14 +23,13 @@ from openpype.hosts.nuke.api import (
 )
 from openpype.hosts.nuke.api import plugin
 
-log = Logger.get_logger(__name__)
-
 
 class LoadClip(plugin.NukeLoader):
     """Load clip into Nuke
 
     Either it is image sequence or video file.
     """
+    log = Logger.get_logger(__name__)
 
     families = [
         "source",
@@ -99,7 +99,7 @@ class LoadClip(plugin.NukeLoader):
                 representation
             )
         filepath = get_representation_path(representation).replace("\\", "/")
-        log.debug("_ filepath: {}".format(filepath))
+        self.log.debug("_ filepath: {}".format(filepath))
 
         start_at_workfile = options.get(
             "start_at_workfile", self.options_defaults["start_at_workfile"])
@@ -111,8 +111,9 @@ class LoadClip(plugin.NukeLoader):
         version_data = version.get("data", {})
         repre_id = representation["_id"]
 
-        log.info("version_data: {}\n".format(version_data))
-        log.debug(
+        self.log.debug("_ version_data: {}\n".format(
+            pformat(version_data)))
+        self.log.debug(
             "Representation id `{}` ".format(repre_id))
 
         self.handle_start = version_data.get("handleStart", 0)
@@ -133,7 +134,7 @@ class LoadClip(plugin.NukeLoader):
             namespace = context['asset']['name']
 
         if not filepath:
-            log.warning(
+            self.log.warning(
                 "Representation id `{}` is failing to load".format(repre_id))
             return
 
@@ -238,7 +239,7 @@ class LoadClip(plugin.NukeLoader):
                 representation
             )
         filepath = get_representation_path(representation).replace("\\", "/")
-        log.debug("_ filepath: {}".format(filepath))
+        self.log.debug("_ filepath: {}".format(filepath))
 
         start_at_workfile = "start at" in read_node['frame_mode'].value()
 
@@ -271,7 +272,7 @@ class LoadClip(plugin.NukeLoader):
             last = first + duration
 
         if not filepath:
-            log.warning(
+            self.log.warning(
                 "Representation id `{}` is failing to load".format(repre_id))
             return
 
@@ -321,7 +322,7 @@ class LoadClip(plugin.NukeLoader):
                 read_node,
                 updated_dict
             )
-            log.info(
+            self.log.info(
                 "updated to version: {}".format(version_doc.get("name"))
             )
 
@@ -357,8 +358,10 @@ class LoadClip(plugin.NukeLoader):
         time_warp_nodes = version_data.get('timewarps', [])
         last_node = None
         source_id = self.get_container_id(parent_node)
-        log.info("__ source_id: {}".format(source_id))
-        log.info("__ members: {}".format(self.get_members(parent_node)))
+        self.log.debug("__ source_id: {}".format(source_id))
+        self.log.debug("__ members: {}".format(
+            self.get_members(parent_node)))
+
         dependent_nodes = self.clear_members(parent_node)
 
         with maintained_selection():

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -1,7 +1,7 @@
-import os
 import nuke
 import qargparse
-
+from copy import deepcopy
+from openpype.lib import Logger
 from openpype.client import (
     get_version_by_id,
     get_last_version_by_subset_id,
@@ -21,6 +21,8 @@ from openpype.hosts.nuke.api import (
     colorspace_exists_on_node
 )
 from openpype.hosts.nuke.api import plugin
+
+log = Logger.get_logger(__name__)
 
 
 class LoadClip(plugin.NukeLoader):
@@ -85,24 +87,19 @@ class LoadClip(plugin.NukeLoader):
             + plugin.get_review_presets_config()
         )
 
-    def _fix_path_for_knob(self, filepath, repre_cont):
-        basename = os.path.basename(filepath)
-        dirname = os.path.dirname(filepath)
-        frame = repre_cont.get("frame")
-        assert frame, "Representation is not sequence"
-
-        padding = len(str(frame))
-        basename = basename.replace(frame, "#" * padding)
-        return os.path.join(dirname, basename).replace("\\", "/")
-
     def load(self, context, name, namespace, options):
-        repre = context["representation"]
+        representation = context["representation"]
         # reste container id so it is always unique for each instance
         self.reset_container_id()
 
-        is_sequence = len(repre["files"]) > 1
+        is_sequence = len(representation["files"]) > 1
 
-        filepath = self.fname.replace("\\", "/")
+        if is_sequence:
+            representation = self._representation_with_hash_in_frame(
+                representation
+            )
+        filepath = get_representation_path(representation).replace("\\", "/")
+        log.debug("_ filepath: {}".format(filepath))
 
         start_at_workfile = options.get(
             "start_at_workfile", self.options_defaults["start_at_workfile"])
@@ -112,12 +109,10 @@ class LoadClip(plugin.NukeLoader):
 
         version = context['version']
         version_data = version.get("data", {})
-        repre_id = repre["_id"]
+        repre_id = representation["_id"]
 
-        repre_cont = repre["context"]
-
-        self.log.info("version_data: {}\n".format(version_data))
-        self.log.debug(
+        log.info("version_data: {}\n".format(version_data))
+        log.debug(
             "Representation id `{}` ".format(repre_id))
 
         self.handle_start = version_data.get("handleStart", 0)
@@ -132,19 +127,17 @@ class LoadClip(plugin.NukeLoader):
             duration = last - first
             first = 1
             last = first + duration
-        elif "#" not in filepath:
-            filepath = self._fix_path_for_knob(filepath, repre_cont)
 
         # Fallback to asset name when namespace is None
         if namespace is None:
             namespace = context['asset']['name']
 
         if not filepath:
-            self.log.warning(
+            log.warning(
                 "Representation id `{}` is failing to load".format(repre_id))
             return
 
-        read_name = self._get_node_name(repre)
+        read_name = self._get_node_name(representation)
 
         # Create the Loader with the filename path set
         read_node = nuke.createNode(
@@ -157,7 +150,7 @@ class LoadClip(plugin.NukeLoader):
             read_node["file"].setValue(filepath)
 
             used_colorspace = self._set_colorspace(
-                read_node, version_data, repre["data"])
+                read_node, version_data, representation["data"])
 
             self._set_range_to_node(read_node, first, last, start_at_workfile)
 
@@ -179,7 +172,7 @@ class LoadClip(plugin.NukeLoader):
                         data_imprint[k] = version
 
                 elif k == 'colorspace':
-                    colorspace = repre["data"].get(k)
+                    colorspace = representation["data"].get(k)
                     colorspace = colorspace or version_data.get(k)
                     data_imprint["db_colorspace"] = colorspace
                     if used_colorspace:
@@ -213,6 +206,20 @@ class LoadClip(plugin.NukeLoader):
     def switch(self, container, representation):
         self.update(container, representation)
 
+    def _representation_with_hash_in_frame(self, representation):
+        """Convert frame key value to padded hash
+
+        Args:
+            representation (dict): representation data
+
+        Returns:
+            dict: altered representation data
+        """
+        representation = deepcopy(representation)
+        frame = representation["context"]["frame"]
+        representation["context"]["frame"] = "#" * len(str(frame))
+        return representation
+
     def update(self, container, representation):
         """Update the Loader's path
 
@@ -225,7 +232,13 @@ class LoadClip(plugin.NukeLoader):
         is_sequence = len(representation["files"]) > 1
 
         read_node = nuke.toNode(container['objectName'])
+
+        if is_sequence:
+            representation = self._representation_with_hash_in_frame(
+                representation
+            )
         filepath = get_representation_path(representation).replace("\\", "/")
+        log.debug("_ filepath: {}".format(filepath))
 
         start_at_workfile = "start at" in read_node['frame_mode'].value()
 
@@ -239,8 +252,6 @@ class LoadClip(plugin.NukeLoader):
 
         version_data = version_doc.get("data", {})
         repre_id = representation["_id"]
-
-        repre_cont = representation["context"]
 
         # colorspace profile
         colorspace = representation["data"].get("colorspace")
@@ -258,11 +269,9 @@ class LoadClip(plugin.NukeLoader):
             duration = last - first
             first = 1
             last = first + duration
-        elif "#" not in filepath:
-            filepath = self._fix_path_for_knob(filepath, repre_cont)
 
         if not filepath:
-            self.log.warning(
+            log.warning(
                 "Representation id `{}` is failing to load".format(repre_id))
             return
 
@@ -312,7 +321,7 @@ class LoadClip(plugin.NukeLoader):
                 read_node,
                 updated_dict
             )
-            self.log.info(
+            log.info(
                 "updated to version: {}".format(version_doc.get("name"))
             )
 
@@ -348,8 +357,8 @@ class LoadClip(plugin.NukeLoader):
         time_warp_nodes = version_data.get('timewarps', [])
         last_node = None
         source_id = self.get_container_id(parent_node)
-        self.log.info("__ source_id: {}".format(source_id))
-        self.log.info("__ members: {}".format(self.get_members(parent_node)))
+        log.info("__ source_id: {}".format(source_id))
+        log.info("__ members: {}".format(self.get_members(parent_node)))
         dependent_nodes = self.clear_members(parent_node)
 
         with maintained_selection():


### PR DESCRIPTION
## Brief description
Resolving path to image sequence with hashes only at frame token.

## Description
Solving issue with resolving name to hashes even in other parts of name.

## Testing notes:
1. Open your testing workfile in Nuke
2. Open Loader and load image sequence, and some video file
3. It should load as excepted