### PR TITLE
hiero: creator from settings with set maximum

### DIFF
--- a/openpype/hosts/hiero/api/plugin.py
+++ b/openpype/hosts/hiero/api/plugin.py
@@ -170,7 +170,10 @@ class CreatorWidget(QtWidgets.QDialog):
         for func, val in kwargs.items():
             if getattr(item, func):
                 func_attr = getattr(item, func)
-                func_attr(val)
+                if isinstance(val, tuple):
+                    func_attr(*val)
+                else:
+                    func_attr(val)
 
         # add to layout
         layout.addRow(label, item)
@@ -273,8 +276,8 @@ class CreatorWidget(QtWidgets.QDialog):
             elif v["type"] == "QSpinBox":
                 data[k]["value"] = self.create_row(
                     content_layout, "QSpinBox", v["label"],
-                    setValue=v["value"], setMinimum=0,
-                    setMaximum=100000, setToolTip=tool_tip)
+                    setRange=(1, 9999999), setValue=v["value"],
+                    setToolTip=tool_tip)
         return data
 
 


### PR DESCRIPTION
## Brief description
Fixing wrong value in ui set from settings

## Description
Settings value was not correctly transferred onto creator ui. 

## Testing notes:
1. Open Hiero workfile
2. select a clip and hit OP Creator
3. Look to down to workfile start frame and it should be 1001