### PR TITLE
Flame: Loading clip with native colorspace resolved from mapping

### DIFF
--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -4,13 +4,13 @@ import shutil
 from copy import deepcopy
 from xml.etree import ElementTree as ET
 
+import qargparse
 from Qt import QtCore, QtWidgets
 
-import qargparse
 from openpype import style
-from openpype.settings import get_current_project_settings
 from openpype.lib import Logger
 from openpype.pipeline import LegacyCreator, LoaderPlugin
+from openpype.settings import get_current_project_settings
 
 from . import constants
 from . import lib as flib
@@ -692,8 +692,42 @@ class ClipLoader(LoaderPlugin):
 
     _mapping = None
 
+    def get_colorspace(self, context):
+        """Get colorspace name
+
+        Look either to version data or representation data.
+
+        Args:
+            context (dict): version context data
+
+        Returns:
+            str: colorspace name or None
+        """
+        version = context['version']
+        version_data = version.get("data", {})
+        colorspace = version_data.get(
+            "colorspace", None
+        )
+
+        if (
+            not colorspace
+            or colorspace == "Unknown"
+        ):
+            colorspace = context["representation"]["data"].get(
+                "colorspace", None)
+
+        return colorspace
+
     @classmethod
     def get_native_colorspace(cls, input_colorspace):
+        """Return native colorspace name.
+
+        Args:
+            input_colorspace (str | None): colorspace name
+
+        Returns:
+            str: native colorspace name defined in mapping or None
+        """
         if not cls._mapping:
             settings = get_current_project_settings()["flame"]
             mapping = settings["imageio"]["profilesMapping"]["inputs"]

--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -692,16 +692,17 @@ class ClipLoader(LoaderPlugin):
 
     _mapping = None
 
-    def get_native_colorspace(self, input_colorspace):
-        if not self._mapping:
+    @classmethod
+    def get_native_colorspace(cls, input_colorspace):
+        if not cls._mapping:
             settings = get_current_project_settings()["flame"]
             mapping = settings["imageio"]["profilesMapping"]["inputs"]
-            self._mapping = {
+            cls._mapping = {
                 input["ocioName"]: input["flameName"]
                 for input in mapping
             }
 
-        return self._mapping.get(input_colorspace)
+        return cls._mapping.get(input_colorspace)
 
 
 class OpenClipSolver(flib.MediaInfoFile):

--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -690,6 +690,19 @@ class ClipLoader(LoaderPlugin):
         )
     ]
 
+    _mapping = None
+
+    def get_native_colorspace(self, input_colorspace):
+        if not self._mapping:
+            settings = get_current_project_settings()["flame"]
+            mapping = settings["imageio"]["profilesMapping"]["inputs"]
+            self._mapping = {
+                input["ocioName"]: input["flameName"]
+                for input in mapping
+            }
+
+        return self._mapping.get(input_colorspace)
+
 
 class OpenClipSolver(flib.MediaInfoFile):
     create_new_clip = False

--- a/openpype/hosts/flame/plugins/load/load_clip.py
+++ b/openpype/hosts/flame/plugins/load/load_clip.py
@@ -40,10 +40,10 @@ class LoadClip(opfapi.ClipLoader):
         clip_name = StringTemplate(self.clip_name_template).format(
             context["representation"]["context"])
 
-        # TODO: settings in imageio
         # convert colorspace with ocio to flame mapping
         # in imageio flame section
-        colorspace = colorspace
+        colorspace = self.get_native_colorspace(colorspace)
+        self.log.info("Loading with colorspace: `{}`".format(colorspace))
 
         # create workfile path
         workfile_dir = os.environ["AVALON_WORKDIR"]

--- a/openpype/hosts/flame/plugins/load/load_clip.py
+++ b/openpype/hosts/flame/plugins/load/load_clip.py
@@ -36,7 +36,8 @@ class LoadClip(opfapi.ClipLoader):
         version = context['version']
         version_data = version.get("data", {})
         version_name = version.get("name", None)
-        colorspace = version_data.get("colorspace", None)
+        colorspace = self.get_colorspace(context)
+
         clip_name = StringTemplate(self.clip_name_template).format(
             context["representation"]["context"])
 

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -43,10 +43,10 @@ class LoadClipBatch(opfapi.ClipLoader):
         clip_name = StringTemplate(self.clip_name_template).format(
             context["representation"]["context"])
 
-        # TODO: settings in imageio
         # convert colorspace with ocio to flame mapping
         # in imageio flame section
-        colorspace = colorspace
+        colorspace = self.get_native_colorspace(colorspace)
+        self.log.info("Loading with colorspace: `{}`".format(colorspace))
 
         # create workfile path
         workfile_dir = options.get("workdir") or os.environ["AVALON_WORKDIR"]

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -35,7 +35,7 @@ class LoadClipBatch(opfapi.ClipLoader):
         version = context['version']
         version_data = version.get("data", {})
         version_name = version.get("name", None)
-        colorspace = version_data.get("colorspace", None)
+        colorspace = self.get_colorspace(context)
 
         # in case output is not in context replace key to representation
         if not context["representation"]["context"].get("output"):


### PR DESCRIPTION
## Brief description
Flame is loading clips with correct colorspace mapping

## Description
Mapping can be added at Studio settings/Project tab: `project_settings/flame/imageio/profilesMapping`. 

## Testing notes:
1. Make sure mapping is set in `project_settings/flame/imageio/profilesMapping`
2. Load any published subset version 
3. See the colorspace is correctly set