### PR TITLE
Flame/Flare: Loading to multiple batches

### DIFF
--- a/openpype/hosts/flame/api/menu.py
+++ b/openpype/hosts/flame/api/menu.py
@@ -225,7 +225,8 @@ class FlameMenuUniversal(_FlameMenuApp):
 
         menu['actions'].append({
             "name": "Load...",
-            "execute": lambda x: self.tools_helper.show_loader()
+            "execute": lambda x: callback_selection(
+                x, self.tools_helper.show_loader)
         })
         menu['actions'].append({
             "name": "Manage...",

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 import flame
 from pprint import pformat
@@ -22,7 +23,7 @@ class LoadClipBatch(opfapi.ClipLoader):
 
     # settings
     reel_name = "OP_LoadedReel"
-    clip_name_template = "{asset}_{subset}<_{output}>"
+    clip_name_template = "{batch}_{asset}_{subset}<_{output}>"
 
     def load(self, context, name, namespace, options):
 
@@ -40,6 +41,9 @@ class LoadClipBatch(opfapi.ClipLoader):
         if not context["representation"]["context"].get("output"):
             self.clip_name_template.replace("output", "representation")
 
+        formating_data = deepcopy(context["representation"]["context"])
+        formating_data["batch"] = self.batch.name.get_value()
+
         clip_name = StringTemplate(self.clip_name_template).format(
             context["representation"]["context"])
 
@@ -56,6 +60,7 @@ class LoadClipBatch(opfapi.ClipLoader):
         openclip_path = os.path.join(
             openclip_dir, clip_name + ".clip"
         )
+
         if not os.path.exists(openclip_dir):
             os.makedirs(openclip_dir)
 

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -45,7 +45,7 @@ class LoadClipBatch(opfapi.ClipLoader):
         formating_data["batch"] = self.batch.name.get_value()
 
         clip_name = StringTemplate(self.clip_name_template).format(
-            context["representation"]["context"])
+            formating_data)
 
         # TODO: settings in imageio
         # convert colorspace with ocio to flame mapping

--- a/openpype/settings/defaults/project_settings/flame.json
+++ b/openpype/settings/defaults/project_settings/flame.json
@@ -142,7 +142,7 @@
                 "exr16fpdwaa"
             ],
             "reel_name": "OP_LoadedReel",
-            "clip_name_template": "{asset}_{subset}<_{output}>"
+            "clip_name_template": "{batch}_{asset}_{subset}<_{output}>"
         }
     }
 }


### PR DESCRIPTION
## Brief description
Loading to multiple batches within a project is supported.

## Description
Using name of active Batch it is loading into, as part of name of loaded clip. 
Known issue is, there is no way it would load, multiply into one Batch.

## Testing notes:
1. Activate a Batch and then RMB click at Project manager, OpenPype/Load
2. Find a subset you want to load and RMB click select `Load to active batch`
3. Activate other Batch and repeate 2. on the same subset with the same representation. 
4. Notice it is loading with name of Batch in clip name. 