### PR TITLE
TvPaint: Upload only main review file on kitsu from TvPaint

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -127,9 +127,9 @@ class ExtractSequence(pyblish.api.Extractor):
             output_frame_start
         )
 
-        # Fill tags and new families
+        # Fill tags and new families from project settings
         tags = []
-        if family_lowered in ("review", "renderlayer", "renderscene"):
+        if family_lowered in self.families_to_upload:
             tags.append("review")
 
         # Sequence of one frame

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -19,6 +19,7 @@ class ExtractSequence(pyblish.api.Extractor):
     label = "Extract Sequence"
     hosts = ["tvpaint"]
     families = ["review", "renderPass", "renderLayer", "renderScene"]
+    families_to_review = ["review"]
 
     # Modifiable with settings
     review_bg = [255, 255, 255, 255]
@@ -129,7 +130,7 @@ class ExtractSequence(pyblish.api.Extractor):
 
         # Fill tags and new families from project settings
         tags = []
-        if family_lowered in self.families_to_upload:
+        if family_lowered in self.families_to_review:
             tags.append("review")
 
         # Sequence of one frame

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -32,13 +32,8 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
                 continue
 
             review_path = representation.get("published_path")
-            file_name, file_extension = os.path.splitext(review_path)
-
-            if instance.data.get('name') != 'reviewMain' \
-                    or file_extension != '.mp4':
-                continue
-
             self.log.debug("Found review at: {}".format(review_path))
+
             gazu.task.add_preview(
                 task, comment, review_path, normalize_movie=True
             )

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import gazu
 import pyblish.api
 

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import gazu
 import pyblish.api
 
@@ -31,9 +32,13 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
                 continue
 
             review_path = representation.get("published_path")
+            file_name, file_extension = os.path.splitext(review_path)
+
+            if instance.data.get('name') != 'reviewMain' \
+                    or file_extension != '.mp4':
+                continue
 
             self.log.debug("Found review at: {}".format(review_path))
-
             gazu.task.add_preview(
                 task, comment, review_path, normalize_movie=True
             )

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -12,11 +12,10 @@
                 255,
                 255
             ],
-            "families_to_upload": [
+            "families_to_review": [
                 "review",
                 "renderpass",
-                "renderlayer",
-                "renderscene"
+                "renderlayer"
             ]
         },
         "ValidateProjectSettings": {

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -14,8 +14,8 @@
             ],
             "families_to_review": [
                 "review",
-                "renderpass",
-                "renderlayer"
+                "renderlayer",
+                "renderscene"
             ]
         },
         "ValidateProjectSettings": {

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -11,6 +11,12 @@
                 255,
                 255,
                 255
+            ],
+            "families_to_upload": [
+                "review",
+                "renderpass",
+                "renderlayer",
+                "renderscene"
             ]
         },
         "ValidateProjectSettings": {

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -56,6 +56,18 @@
                             "key": "review_bg",
                             "label": "Review BG color",
                             "use_alpha": false
+                        },
+                        {
+                            "type": "enum",
+                            "key": "families_to_upload",
+                            "label": "Families to upload",
+                            "multiselection": true,
+                            "enum_items": [
+                                {"review": "review"},
+                                {"renderpass": "renderPass"},
+                                {"renderlayer": "renderLayer"},
+                                {"renderscene": "renderScene"}
+                            ]
                         }
                     ]
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -59,8 +59,8 @@
                         },
                         {
                             "type": "enum",
-                            "key": "families_to_upload",
-                            "label": "Families to upload",
+                            "key": "families_to_review",
+                            "label": "Families to review",
                             "multiselection": true,
                             "enum_items": [
                                 {"review": "review"},


### PR DESCRIPTION
## Brief description
When publishing, upload only the review file on kitsu.

## Description
We realized that when publishing exports from TvPaint, all the files are uploaded to Kitsu (all reviews for renderLayers and renderPasses) but the only one we really need is the main review. Is our logic correct or are all the files are necessary for Kitsu to work properly ?