### PR TITLE
Maya: aov filtering

### DIFF
--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1110,7 +1110,7 @@ class RenderProductsRedshift(ARenderProducts):
         if light_groups_enabled:
             return products
 
-        beauty_name = "Beauty_other" if has_beauty_aov else ""
+        beauty_name = "BeautyAux" if has_beauty_aov else ""
         for camera in cameras:
             products.insert(0,
                             RenderProduct(productName=beauty_name,

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -536,7 +536,11 @@ class RenderProductsArnold(ARenderProducts):
 
         products = []
         aov_name = self._get_attr(aov, "name")
-        multipart = bool(self._get_attr("defaultArnoldDriver.multipart"))
+        multipart = False
+        multilayer = bool(self._get_attr("defaultArnoldDriver.multipart"))
+        merge_AOVs = bool(self._get_attr("defaultArnoldDriver.mergeAOVs"))
+        if multilayer or merge_AOVs:
+            multipart = True
         ai_drivers = cmds.listConnections("{}.outputs".format(aov),
                                           source=True,
                                           destination=False,
@@ -1018,9 +1022,11 @@ class RenderProductsRedshift(ARenderProducts):
         # due to some AOVs still being written into separate files,
         # like Cryptomatte.
         # AOVs are merged in multi-channel file
-
-        multipart = bool(self._get_attr("redshiftOptions.exrForceMultilayer")) \
-                    or bool(self._get_attr("redshiftOptions.exrMultipart"))
+        multipart = False
+        force_layer = bool(self._get_attr("redshiftOptions.exrForceMultilayer"))
+        exMultipart = bool(self._get_attr("redshiftOptions.exrMultipart"))
+        if exMultipart or force_layer:
+            multipart = True
 
         # Get Redshift Extension from image format
         image_format = self._get_attr("redshiftOptions.imageFormat")  # integer
@@ -1048,7 +1054,7 @@ class RenderProductsRedshift(ARenderProducts):
 
             # Any AOVs that still get processed, like Cryptomatte
             # by themselves are not multipart files.
-            aov_multipart = not multipart
+            # aov_multipart = not multipart
 
             # Redshift skips rendering of masterlayer without AOV suffix
             # when a Beauty AOV is rendered. It overrides the main layer.
@@ -1079,7 +1085,7 @@ class RenderProductsRedshift(ARenderProducts):
                             productName=aov_light_group_name,
                             aov=aov_name,
                             ext=ext,
-                            multipart=aov_multipart,
+                            multipart=multipart,
                             camera=camera)
                         products.append(product)
 
@@ -1093,7 +1099,7 @@ class RenderProductsRedshift(ARenderProducts):
                 product = RenderProduct(productName=aov_name,
                                         aov=aov_name,
                                         ext=ext,
-                                        multipart=aov_multipart,
+                                        multipart=multipart,
                                         camera=camera)
                 products.append(product)
 

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -536,6 +536,7 @@ class RenderProductsArnold(ARenderProducts):
 
         products = []
         aov_name = self._get_attr(aov, "name")
+        multipart = bool(self._get_attr("defaultArnoldDriver.multipart"))
         ai_drivers = cmds.listConnections("{}.outputs".format(aov),
                                           source=True,
                                           destination=False,
@@ -589,6 +590,7 @@ class RenderProductsArnold(ARenderProducts):
                                             ext=ext,
                                             aov=aov_name,
                                             driver=ai_driver,
+                                            multipart=multipart,
                                             camera=camera)
                     products.append(product)
 
@@ -1016,9 +1018,9 @@ class RenderProductsRedshift(ARenderProducts):
         # due to some AOVs still being written into separate files,
         # like Cryptomatte.
         # AOVs are merged in multi-channel file
+
         multipart = bool(self._get_attr("redshiftOptions.exrForceMultilayer")) \
-                    or \
-                    bool(self._get_attr("redshiftOptions.exrMultipart"))
+                    or bool(self._get_attr("redshiftOptions.exrMultipart"))
 
         # Get Redshift Extension from image format
         image_format = self._get_attr("redshiftOptions.imageFormat")  # integer

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1023,7 +1023,7 @@ class RenderProductsRedshift(ARenderProducts):
         # like Cryptomatte.
         # AOVs are merged in multi-channel file
         multipart = False
-        force_layer = bool(self._get_attr("redshiftOptions.exrForceMultilayer"))
+        force_layer = bool(self._get_attr("redshiftOptions.exrForceMultilayer")) # noqa
         exMultipart = bool(self._get_attr("redshiftOptions.exrMultipart"))
         if exMultipart or force_layer:
             multipart = True

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1016,7 +1016,8 @@ class RenderProductsRedshift(ARenderProducts):
         # due to some AOVs still being written into separate files,
         # like Cryptomatte.
         # AOVs are merged in multi-channel file
-        multipart = bool(self._get_attr("redshiftOptions.exrForceMultilayer"))
+        multipart = bool(self._get_attr("redshiftOptions.exrForceMultilayer")) or \
+                    bool(self._get_attr("redshiftOptions.exrMultipart"))
 
         # Get Redshift Extension from image format
         image_format = self._get_attr("redshiftOptions.imageFormat")  # integer

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1054,7 +1054,6 @@ class RenderProductsRedshift(ARenderProducts):
 
             # Any AOVs that still get processed, like Cryptomatte
             # by themselves are not multipart files.
-            # aov_multipart = not multipart
 
             # Redshift skips rendering of masterlayer without AOV suffix
             # when a Beauty AOV is rendered. It overrides the main layer.

--- a/openpype/hosts/maya/api/lib_renderproducts.py
+++ b/openpype/hosts/maya/api/lib_renderproducts.py
@@ -1016,7 +1016,8 @@ class RenderProductsRedshift(ARenderProducts):
         # due to some AOVs still being written into separate files,
         # like Cryptomatte.
         # AOVs are merged in multi-channel file
-        multipart = bool(self._get_attr("redshiftOptions.exrForceMultilayer")) or \
+        multipart = bool(self._get_attr("redshiftOptions.exrForceMultilayer")) \
+                    or \
                     bool(self._get_attr("redshiftOptions.exrMultipart"))
 
         # Get Redshift Extension from image format

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -154,6 +154,16 @@ class RenderSettings(object):
 
         self._set_global_output_settings()
         cmds.setAttr("redshiftOptions.imageFormat", img_ext)
+        if redshift_render_presets["multilayer_exr"]:
+            cmds.setAttr("redshiftOptions.exrMultipart", 1)
+        else:
+            cmds.setAttr("redshiftOptions.exrMultipart", 0)
+
+        if redshift_render_presets["force_combine"]:
+            cmds.setAttr("redshiftOptions.exrForceMultilayer", 1)
+        else:
+            cmds.setAttr("redshiftOptions.exrForceMultilayer", 0)
+
         cmds.setAttr("defaultResolution.width", width)
         cmds.setAttr("defaultResolution.height", height)
         self._additional_attribs_setter(additional_options)

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -154,16 +154,6 @@ class RenderSettings(object):
 
         self._set_global_output_settings()
         cmds.setAttr("redshiftOptions.imageFormat", img_ext)
-        if redshift_render_presets["multilayer_exr"]:
-            cmds.setAttr("redshiftOptions.exrMultipart", 1)
-        else:
-            cmds.setAttr("redshiftOptions.exrMultipart", 0)
-
-        if redshift_render_presets["force_combine"]:
-            cmds.setAttr("redshiftOptions.exrForceMultilayer", 1)
-        else:
-            cmds.setAttr("redshiftOptions.exrForceMultilayer", 0)
-
         cmds.setAttr("defaultResolution.width", width)
         cmds.setAttr("defaultResolution.height", height)
         self._additional_attribs_setter(additional_options)

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -494,13 +494,13 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             else:
                 render_file_name = os.path.basename(col)
             aov_patterns = self.aov_filter
-            self.log.info("aov_pattern:{}".format(aov_patterns))
+
             # toggle preview on if multipart is on
             preview = match_aov_pattern(app, aov_patterns, render_file_name)
-            if "Cryptomatte" in render_file_name: # for redshift
+
+            if instance_data.get("multipartExr"):
                 preview = True
 
-            self.log.info("preview:{}".format(preview))
             new_instance = deepcopy(instance_data)
             new_instance["subset"] = subset_name
             new_instance["subsetGroup"] = group_name

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -500,7 +500,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
             if instance_data.get("multipartExr"):
                 preview = True
-            self.log.info("preview:{}".format(preview))
+            self.log.debug("preview:{}".format(preview))
             new_instance = deepcopy(instance_data)
             new_instance["subset"] = subset_name
             new_instance["subsetGroup"] = group_name
@@ -543,7 +543,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             if new_instance.get("extendFrames", False):
                 self._copy_extend_frames(new_instance, rep)
             instances.append(new_instance)
-            self.log.info("instances:{}".format(instances))
+            self.log.debug("instances:{}".format(instances))
         return instances
 
     def _get_representations(self, instance, exp_files):

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -500,7 +500,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
             if instance_data.get("multipartExr"):
                 preview = True
-
+            self.log.info("preview:{}".format(preview))
             new_instance = deepcopy(instance_data)
             new_instance["subset"] = subset_name
             new_instance["subsetGroup"] = group_name

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -497,7 +497,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             self.log.info("aov_pattern:{}".format(aov_patterns))
             # toggle preview on if multipart is on
             preview = match_aov_pattern(app, aov_patterns, render_file_name)
-            #if instance_data.get("multipartExr"):
             if "Cryptomatte" in render_file_name: # for redshift
                 preview = True
 

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -495,8 +495,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 render_file_name = os.path.basename(col)
             aov_patterns = self.aov_filter
 
-            # toggle preview on if multipart is on
             preview = match_aov_pattern(app, aov_patterns, render_file_name)
+            # toggle preview on if multipart is on
 
             if instance_data.get("multipartExr"):
                 preview = True

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -494,12 +494,14 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             else:
                 render_file_name = os.path.basename(col)
             aov_patterns = self.aov_filter
-            preview = match_aov_pattern(app, aov_patterns, render_file_name)
-
+            self.log.info("aov_pattern:{}".format(aov_patterns))
             # toggle preview on if multipart is on
-            if instance_data.get("multipartExr"):
+            preview = match_aov_pattern(app, aov_patterns, render_file_name)
+            #if instance_data.get("multipartExr"):
+            if "Cryptomatte" in render_file_name: # for redshift
                 preview = True
 
+            self.log.info("preview:{}".format(preview))
             new_instance = deepcopy(instance_data)
             new_instance["subset"] = subset_name
             new_instance["subsetGroup"] = group_name
@@ -542,7 +544,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             if new_instance.get("extendFrames", False):
                 self._copy_extend_frames(new_instance, rep)
             instances.append(new_instance)
-
+            self.log.info("instances:{}".format(instances))
         return instances
 
     def _get_representations(self, instance, exp_files):


### PR DESCRIPTION
## Brief description
fixing the bug for the regex filter not excluding the aov in RedShift
See(https://github.com/pypeclub/OpenPype/issues/4057)

## Description
Multipart boolean option of the renderers (RedShift and Arnold) is broken in lib_renderproduct.py, which submits a wrong information to collect_render.py(i.e. multipart is always True even when it is being turned off..), This cause the review option not working with regex filters, which depends on whether multipart is on /off.

For this fix, 
if “force combine beauty and AOVs into single file” or “multipart EXR” in Redshift Render Setting is off, it will filter out the renderpass according to the regex filter set in the Openpype Setting. (I set .*([Bb]eauty).* as filter)
![image](https://user-images.githubusercontent.com/64118225/201312219-26a8f939-8705-4646-87fb-d06b481ee16d.png)

If either one is on, it will show both beauty and Cryptomatte pass.

![image](https://user-images.githubusercontent.com/64118225/201313875-315cca2d-2a8e-484e-be13-8b569b8d7efe.png)

If mergeAOVs or multipart in Arnold Render Setting is off, it will filter out the renderpass in regards to the regex filter set in the Openpype setting. .

![image](https://user-images.githubusercontent.com/64118225/201313411-1e26128b-6baa-454f-a4b4-e56c126f3b07.png)

 If multipart is on, it will render all the passes for the multipart option (I am not sure if it’s a good idea. so let me know if you also want the filter option included here.) 
![image](https://user-images.githubusercontent.com/64118225/201313377-3e3f382c-b55d-4f59-bab7-a193e1a267b1.png)

while it will just only render beauty pass for mergeAOVs
![image](https://user-images.githubusercontent.com/64118225/201313529-f7aa7204-8838-4768-aa83-32b4fb607422.png)


## Additional info
No Additional Info

## Testing Notes
1. check if you have disable the "multipart" or "force combine beauty and AOVs" in Redshift Render Setting  OR
   check if you have disable the "mutlipart" or "Merge AOVs" in Arnold Render Setting.
![image](https://user-images.githubusercontent.com/64118225/201312122-ba0c461f-7d76-4834-a3b8-8d8fb9ce7c7c.png)
![image](https://user-images.githubusercontent.com/64118225/201313202-7ec3b311-4ff5-43fe-a58b-fa4f41d6262a.png)


2. set your regex filter in deadline setting
![image](https://user-images.githubusercontent.com/64118225/200810701-8c81dcb7-108d-40f9-8a8f-4a4c66bef6e9.png)
3. add the AOV maps
![image](https://user-images.githubusercontent.com/64118225/200810522-a1ad25d3-7b64-4eae-84af-61062b7a20d8.png)
4. Create the render instance and run the publisher



