### PR TITLE
Igniter: fix regex to match semver better

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -63,7 +63,8 @@ class OpenPypeVersion(semver.VersionInfo):
     """
     staging = False
     path = None
-    _VERSION_REGEX = re.compile(r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")  # noqa: E501
+    # this should match any string complying with https://semver.org/
+    _VERSION_REGEX = re.compile(r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>[a-zA-Z\d\-.]*))?(?:\+(?P<buildmetadata>[a-zA-Z\d\-.]*))?")  # noqa: E501
     _installed_version = None
 
     def __init__(self, *args, **kwargs):
@@ -211,6 +212,8 @@ class OpenPypeVersion(semver.VersionInfo):
             OpenPypeVersion: of detected or None.
 
         """
+        # strip .zip ext if present
+        string = re.sub(r"\.zip$", "", string, flags=re.IGNORECASE)
         m = re.search(OpenPypeVersion._VERSION_REGEX, string)
         if not m:
             return None


### PR DESCRIPTION
## Fix

This should fix the case where multiple hyphens were used in staging version pre-release part.

`foo-v3.14.6-nightly.2-x-y-x+staging` were not matched properly and so the staging status of the version couldn't be determined.

This happened with `--list-versions --use-staging` and when staging version was not set in the Settings (so the latest compatible with the build should be used)

## How to test

Create multiple versions in update repository like

```
foo-3.14.6+staging
goo-3.14.6-something.1+staging
hoo-3.14.6-something-else.1+staging.boo
```
then
```sh
openpype-console --list-versions --use-staging
```
 should list them all

> **Note**
> This will be probably obsolete in 3.15 where staging logic will be dropped. See #3979