### PR TITLE
Publish Report Viewer: Fix small bugs

### DIFF
--- a/openpype/tools/publisher/publish_report_viewer/widgets.py
+++ b/openpype/tools/publisher/publish_report_viewer/widgets.py
@@ -27,6 +27,9 @@ class PluginLoadReportModel(QtGui.QStandardItemModel):
         parent = self.invisibleRootItem()
         parent.removeRows(0, parent.rowCount())
 
+        if report is None:
+            return
+
         new_items = []
         new_items_by_filepath = {}
         for filepath in report.crashed_plugin_paths.keys():

--- a/openpype/tools/publisher/publish_report_viewer/window.py
+++ b/openpype/tools/publisher/publish_report_viewer/window.py
@@ -367,6 +367,7 @@ class LoadedFilesView(QtWidgets.QTreeView):
     def _on_rows_inserted(self):
         header = self.header()
         header.resizeSections(header.ResizeToContents)
+        self._update_remove_btn()
 
     def resizeEvent(self, event):
         super(LoadedFilesView, self).resizeEvent(event)


### PR DESCRIPTION
## Brief description
Small fixes in publish report viewer.

## Description
Fix delete button position on row insert. The button was offset on first item insert because of outdate viewport size. Fix issue when all report items are removed. In that case it set report as `None` which was not checked.

## Testing notes:
- adding first report item should not offset remove button
- removing last remaining item from report tool should not cause crash