### PR TITLE
General: Collect entities plugin minor changes

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_instance_frames.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instance_frames.py
@@ -6,7 +6,7 @@ class CollectOutputFrameRange(pyblish.api.ContextPlugin):
 
     When instances are collected context does not contain `frameStart` and
     `frameEnd` keys yet. They are collected in global plugin
-    `CollectAvalonEntities`.
+    `CollectContextEntities`.
     """
     label = "Collect output frame range"
     order = pyblish.api.CollectorOrder

--- a/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
@@ -39,7 +39,7 @@ class ValidateMarks(pyblish.api.ContextPlugin):
     def get_expected_data(context):
         scene_mark_in = context.data["sceneMarkIn"]
 
-        # Data collected in `CollectAvalonEntities`
+        # Data collected in `CollectContextEntities`
         frame_end = context.data["frameEnd"]
         frame_start = context.data["frameStart"]
         handle_start = context.data["handleStart"]

--- a/openpype/hosts/webpublisher/plugins/publish/validate_tvpaint_workfile_data.py
+++ b/openpype/hosts/webpublisher/plugins/publish/validate_tvpaint_workfile_data.py
@@ -13,7 +13,7 @@ class ValidateWorkfileData(pyblish.api.ContextPlugin):
     targets = ["tvpaint_worker"]
 
     def process(self, context):
-        # Data collected in `CollectAvalonEntities`
+        # Data collected in `CollectContextEntities`
         frame_start = context.data["frameStart"]
         frame_end = context.data["frameEnd"]
         handle_start = context.data["handleStart"]

--- a/openpype/plugins/publish/collect_anatomy_context_data.py
+++ b/openpype/plugins/publish/collect_anatomy_context_data.py
@@ -15,7 +15,6 @@ Provides:
 import json
 import pyblish.api
 
-from openpype.pipeline import legacy_io
 from openpype.pipeline.template_data import get_template_data
 
 
@@ -53,7 +52,7 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
         asset_entity = context.data.get("assetEntity")
         task_name = None
         if asset_entity:
-            task_name = legacy_io.Session["AVALON_TASK"]
+            task_name = context.data["task"]
 
         anatomy_data = get_template_data(
             project_entity, asset_entity, task_name, host_name, system_settings

--- a/openpype/plugins/publish/collect_context_entities.py
+++ b/openpype/plugins/publish/collect_context_entities.py
@@ -3,6 +3,8 @@
 Requires:
     session -> AVALON_ASSET
     context -> projectName
+    context -> asset
+    context -> task
 
 Provides:
     context -> projectEntity - Project document from database.
@@ -13,20 +15,19 @@ Provides:
 import pyblish.api
 
 from openpype.client import get_project, get_asset_by_name
-from openpype.pipeline import legacy_io, KnownPublishError
+from openpype.pipeline import KnownPublishError
 
 
 class CollectContextEntities(pyblish.api.ContextPlugin):
-    """Collect Anatomy into Context."""
+    """Collect entities into Context."""
 
     order = pyblish.api.CollectorOrder - 0.1
     label = "Collect Context Entities"
 
     def process(self, context):
-        legacy_io.install()
         project_name = context.data["projectName"]
-        asset_name = legacy_io.Session["AVALON_ASSET"]
-        task_name = legacy_io.Session["AVALON_TASK"]
+        asset_name = context.data["asset"]
+        task_name = context.data["task"]
 
         project_entity = get_project(project_name)
         if not project_entity:

--- a/openpype/plugins/publish/collect_context_entities.py
+++ b/openpype/plugins/publish/collect_context_entities.py
@@ -16,11 +16,11 @@ from openpype.client import get_project, get_asset_by_name
 from openpype.pipeline import legacy_io, KnownPublishError
 
 
-class CollectAvalonEntities(pyblish.api.ContextPlugin):
+class CollectContextEntities(pyblish.api.ContextPlugin):
     """Collect Anatomy into Context."""
 
     order = pyblish.api.CollectorOrder - 0.1
-    label = "Collect Avalon Entities"
+    label = "Collect Context Entities"
 
     def process(self, context):
         legacy_io.install()


### PR DESCRIPTION
## Brief description
Renamed collector `CollectAvalonEntities` to `CollectContextEntities` and changed how asset and task names are received.

## Description
Renamed the plugin and asset/task name is taken from `context.data` instead of `legacy_io.Session`.

## Additionl information
We should change all remaining publish plugins to use context from `instance.data` (or `context.data` if is context based) instead of using `legacy_io.Session`.

## Testing notes:
In theory nothing should change or break. I'm not worried about local publishing, issues could come on farm or webpublisher. Please check if integration is going to right context (asset and task) in:
- [x] farm publishing
- [ ] webpublisher