### PR TITLE
Publisher: Ignore escape button

### DIFF
--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -361,6 +361,13 @@ class PublisherWindow(QtWidgets.QDialog):
         super(PublisherWindow, self).resizeEvent(event)
         self._update_publish_frame_rect()
 
+    def keyPressEvent(self, event):
+        # Ignore escape button to close window
+        if event.key() == QtCore.Qt.Key_Escape:
+            event.accept()
+            return
+        super(PublisherWindow, self).keyPressEvent(event)
+
     def _on_overlay_message(self, event):
         self._overlay_object.add_message(
             event["message"],


### PR DESCRIPTION
## Brief description
Don't close publisher window on press of escape button.

## Testing notes:
1. Open publisher in host or open tray publisher
2. Hit escape on keyboard
3. Nothing should happen