### PR TITLE
Online family for Tray Publisher

### DIFF
--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -389,8 +389,8 @@ def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
             returned if 'None' is passed.
 
     Returns:
-        Union[None, Dict[str, Any]]: None if subset with specified filters was not found.
-            or dict subset document which can be reduced to
+        Union[None, Dict[str, Any]]: None if subset with specified filters was
+            not found or dict subset document which can be reduced to
             specified 'fields'.
 
     """

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -389,10 +389,11 @@ def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
             returned if 'None' is passed.
 
     Returns:
-        None: If subset with specified filters was not found.
-        Dict: Subset document which can be reduced to specified 'fields'.
-    """
+        Union[str, Dict]: None if subset with specified filters was not found.
+            or dict subset document which can be reduced to
+            specified 'fields'.
 
+    """
     if not subset_name:
         return None
 

--- a/openpype/client/entities.py
+++ b/openpype/client/entities.py
@@ -389,7 +389,7 @@ def get_subset_by_name(project_name, subset_name, asset_id, fields=None):
             returned if 'None' is passed.
 
     Returns:
-        Union[str, Dict]: None if subset with specified filters was not found.
+        Union[None, Dict[str, Any]]: None if subset with specified filters was not found.
             or dict subset document which can be reduced to
             specified 'fields'.
 

--- a/openpype/hosts/traypublisher/plugins/create/create_online.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_online.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Creator of online files.
+
+Online file retain their original name and use it as subset name. To
+avoid conflicts, this creator checks if subset with this name already
+exists under selected asset.
+"""
+import copy
+import os
+import re
+from pathlib import Path
+
+from openpype.client import get_subset_by_name, get_asset_by_name
+from openpype.lib.attribute_definitions import FileDef
+from openpype.pipeline import (
+    CreatedInstance,
+    CreatorError
+)
+from openpype.pipeline.create import (
+    get_subset_name,
+    TaskNotSetError,
+)
+
+from openpype.hosts.traypublisher.api.plugin import TrayPublishCreator
+
+
+class OnlineCreator(TrayPublishCreator):
+    """Creates instance from file and retains its original name."""
+
+    identifier = "io.openpype.creators.traypublisher.online"
+    label = "Online"
+    family = "online"
+    description = "Publish file retaining its original file name"
+    extensions = [".mov", ".mp4", ".mfx", ".m4v", ".mpg"]
+
+    def get_detail_description(self):
+        return """# Publish batch of .mov to multiple assets.
+
+        File names must then contain only asset name, or asset name + version.
+        (eg. 'chair.mov', 'chair_v001.mov', not really safe `my_chair_v001.mov`
+        """
+
+    def get_icon(self):
+        return "fa.file"
+
+    def create(self, subset_name, instance_data, pre_create_data):
+        if not pre_create_data.get("representation_file")["filenames"]:
+            raise CreatorError("No files specified")
+
+        asset = get_asset_by_name(self.project_name, instance_data["asset"])
+        origin_basename = Path(pre_create_data.get(
+            "representation_file")["filenames"][0]).stem
+
+        if get_subset_by_name(
+                self.project_name, origin_basename, asset["_id"]):
+            raise CreatorError(f"subset with {origin_basename} already "
+                               "exists in selected asset")
+
+        instance_data["originalBasename"] = origin_basename
+        subset_name = origin_basename
+        path = (Path(
+            pre_create_data.get(
+                "representation_file")["directory"]
+        ) / pre_create_data.get(
+                "representation_file")["filenames"][0]).as_posix()
+
+        instance_data["creator_attributes"] = {"path": path}
+
+        # Create new instance
+        new_instance = CreatedInstance(self.family, subset_name,
+                                       instance_data, self)
+        self._store_new_instance(new_instance)
+
+    def get_pre_create_attr_defs(self):
+        return [
+            FileDef(
+                "representation_file",
+                folders=False,
+                extensions=self.extensions,
+                allow_sequences=False,
+                single_item=True,
+                label="Representation",
+            )
+        ]
+
+    def get_subset_name(
+        self,
+        variant,
+        task_name,
+        asset_doc,
+        project_name,
+        host_name=None,
+        instance=None
+    ):
+        if instance is None:
+            return "{originalBasename}"
+
+        return instance.data["subset"]

--- a/openpype/hosts/traypublisher/plugins/create/create_online.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_online.py
@@ -30,7 +30,7 @@ class OnlineCreator(TrayPublishCreator):
 
         This will publish files using template helping to retain original
         file name and that file name is used as subset name.
-        
+
         Bz default it tries to guard against multiple publishes of the same
         file."""
 
@@ -52,11 +52,11 @@ class OnlineCreator(TrayPublishCreator):
 
         instance_data["originalBasename"] = origin_basename
         subset_name = origin_basename
-        path = (Path(
-            pre_create_data.get(
-                "representation_file")["directory"]
-        ) / pre_create_data.get(
-                "representation_file")["filenames"][0]).as_posix()
+        path = (
+                Path(
+                    pre_create_data.get("representation_file")["directory"]
+                ) / pre_create_data.get("representation_file")["filenames"][0]
+        ).as_posix()
 
         instance_data["creator_attributes"] = {"path": path}
 

--- a/openpype/hosts/traypublisher/plugins/create/create_online.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_online.py
@@ -5,9 +5,6 @@ Online file retain their original name and use it as subset name. To
 avoid conflicts, this creator checks if subset with this name already
 exists under selected asset.
 """
-import copy
-import os
-import re
 from pathlib import Path
 
 from openpype.client import get_subset_by_name, get_asset_by_name
@@ -16,11 +13,6 @@ from openpype.pipeline import (
     CreatedInstance,
     CreatorError
 )
-from openpype.pipeline.create import (
-    get_subset_name,
-    TaskNotSetError,
-)
-
 from openpype.hosts.traypublisher.api.plugin import TrayPublishCreator
 
 
@@ -31,14 +23,16 @@ class OnlineCreator(TrayPublishCreator):
     label = "Online"
     family = "online"
     description = "Publish file retaining its original file name"
-    extensions = [".mov", ".mp4", ".mfx", ".m4v", ".mpg"]
+    extensions = [".mov", ".mp4", ".mxf", ".m4v", ".mpg"]
 
     def get_detail_description(self):
-        return """# Publish batch of .mov to multiple assets.
+        return """# Create file retaining its original file name.
 
-        File names must then contain only asset name, or asset name + version.
-        (eg. 'chair.mov', 'chair_v001.mov', not really safe `my_chair_v001.mov`
-        """
+        This will publish files using template helping to retain original
+        file name and that file name is used as subset name.
+        
+        Bz default it tries to guard against multiple publishes of the same
+        file."""
 
     def get_icon(self):
         return "fa.file"

--- a/openpype/hosts/traypublisher/plugins/create/create_online.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_online.py
@@ -52,11 +52,7 @@ class OnlineCreator(TrayPublishCreator):
 
         instance_data["originalBasename"] = origin_basename
         subset_name = origin_basename
-        path = (
-                Path(
-                    pre_create_data.get("representation_file")["directory"]
-                ) / pre_create_data.get("representation_file")["filenames"][0]
-        ).as_posix()
+        path = (Path(pre_create_data.get("representation_file")["directory"]) / pre_create_data.get("representation_file")["filenames"][0]).as_posix()  # noqa
 
         instance_data["creator_attributes"] = {"path": path}
 

--- a/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
@@ -13,12 +13,11 @@ class CollectOnlineFile(pyblish.api.InstancePlugin):
     def process(self, instance):
         file = Path(instance.data["creator_attributes"]["path"])
 
-        if not instance.data.get("representations"):
-            instance.data["representations"] = [
-                {
+        instance.data["representations"].append(
+            {
                     "name": file.suffix.lstrip("."),
                     "ext": file.suffix.lstrip("."),
                     "files": file.name,
                     "stagingDir": file.parent.as_posix()
-                }
-            ]
+            }
+        )

--- a/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
@@ -15,9 +15,9 @@ class CollectOnlineFile(pyblish.api.InstancePlugin):
 
         instance.data["representations"].append(
             {
-                    "name": file.suffix.lstrip("."),
-                    "ext": file.suffix.lstrip("."),
-                    "files": file.name,
-                    "stagingDir": file.parent.as_posix()
+                "name": file.suffix.lstrip("."),
+                "ext": file.suffix.lstrip("."),
+                "files": file.name,
+                "stagingDir": file.parent.as_posix()
             }
         )

--- a/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+from pathlib import Path
+
+
+class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
+    """Collect online file and retain its file name."""
+    label = "Collect online file"
+    families = ["online"]
+    hosts = ["traypublisher"]
+
+    def process(self, instance):
+        file = Path(instance.data["creator_attributes"]["path"])
+
+        if not instance.data.get("representations"):
+            instance.data["representations"] = [
+                {
+                    "name": file.suffix.lstrip("."),
+                    "ext": file.suffix.lstrip("."),
+                    "files": file.name,
+                    "stagingDir": file.parent.as_posix()
+                }
+            ]
+

--- a/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
+++ b/openpype/hosts/traypublisher/plugins/publish/collect_online_file.py
@@ -3,9 +3,10 @@ import pyblish.api
 from pathlib import Path
 
 
-class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
+class CollectOnlineFile(pyblish.api.InstancePlugin):
     """Collect online file and retain its file name."""
-    label = "Collect online file"
+    label = "Collect Online File"
+    order = pyblish.api.CollectorOrder
     families = ["online"]
     hosts = ["traypublisher"]
 
@@ -21,4 +22,3 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
                     "stagingDir": file.parent.as_posix()
                 }
             ]
-

--- a/openpype/hosts/traypublisher/plugins/publish/validate_online_file.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_online_file.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+
+from openpype.pipeline.publish import (
+    ValidateContentsOrder,
+    PublishValidationError,
+    OptionalPyblishPluginMixin,
+)
+from openpype.client import get_subset_by_name, get_asset_by_name
+
+
+class ValidateOnlineFile(OptionalPyblishPluginMixin,
+                         pyblish.api.InstancePlugin):
+    """Validate that subset doesn't exist yet."""
+    label = "Validate Existing Online Files"
+    hosts = ["traypublisher"]
+    families = ["online"]
+    order = ValidateContentsOrder
+
+    optional = True
+
+    def process(self, instance):
+        project_name = instance.context.data["projectName"]
+        asset_id = instance.data["assetEntity"]["_id"]
+        subset = get_subset_by_name(
+            project_name, instance.data["subset"], asset_id)
+
+        if subset:
+            raise PublishValidationError(
+                "Subset to be published already exists.",
+                title=self.label
+            )

--- a/openpype/hosts/traypublisher/plugins/publish/validate_online_file.py
+++ b/openpype/hosts/traypublisher/plugins/publish/validate_online_file.py
@@ -6,7 +6,7 @@ from openpype.pipeline.publish import (
     PublishValidationError,
     OptionalPyblishPluginMixin,
 )
-from openpype.client import get_subset_by_name, get_asset_by_name
+from openpype.client import get_subset_by_name
 
 
 class ValidateOnlineFile(OptionalPyblishPluginMixin,

--- a/openpype/pipeline/create/creator_plugins.py
+++ b/openpype/pipeline/create/creator_plugins.py
@@ -393,8 +393,9 @@ class BaseCreator:
             asset_doc(dict): Asset document for which subset is created.
             project_name(str): Project name.
             host_name(str): Which host creates subset.
-            instance(str|None): Object of 'CreatedInstance' for which is
-                subset name updated. Passed only on subset name update.
+            instance(CreatedInstance|None): Object of 'CreatedInstance' for
+                which is subset name updated. Passed only on subset name
+                update.
         """
 
         dynamic_data = self.get_dynamic_data(

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -129,7 +129,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "mvUsd",
                 "mvUsdComposition",
                 "mvUsdOverride",
-                "simpleUnrealTexture"
+                "simpleUnrealTexture",
+                "online"
                 ]
 
     default_template_name = "publish"

--- a/openpype/settings/defaults/project_anatomy/templates.json
+++ b/openpype/settings/defaults/project_anatomy/templates.json
@@ -48,10 +48,16 @@
             "file": "{originalBasename}_{@version}.{ext}",
             "path": "{@folder}/{@file}"
         },
+        "online": {
+            "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/{@version}",
+            "file": "{originalBasename}<.{@frame}><_{udim}>.{ext}",
+            "path": "{@folder}/{@file}"
+        },
         "__dynamic_keys_labels__": {
             "maya2unreal": "Maya to Unreal",
             "simpleUnrealTextureHero": "Simple Unreal Texture - Hero",
-            "simpleUnrealTexture": "Simple Unreal Texture"
+            "simpleUnrealTexture": "Simple Unreal Texture",
+            "online": "online"
         }
     }
 }

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -483,7 +483,19 @@
             ]
         },
         "publish": {
-            "template_name_profiles": [],
+            "template_name_profiles": [
+                {
+                    "families": [
+                        "online"
+                    ],
+                    "hosts": [
+                        "traypublisher"
+                    ],
+                    "task_types": [],
+                    "task_names": [],
+                    "template_name": "online"
+                }
+            ],
             "hero_template_name_profiles": []
         }
     },


### PR DESCRIPTION
## Online Family

This PR is adding new creator/workflow for Tray Publisher called **Online** - it is using specific template to retain original file name of the published file - it is designed for video files. That original file name is also used for subset name. By default it will prevent publishing if file already exists, but there is optional validator that can be disabled if necessary.

> **Note**
> This is very workflow specific file that can be useful but should be in v4 probably moved out from the code base to custom repository.