### PR TITLE
Files Widget: Ignore case sensitivity of extensions

### DIFF
--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -542,6 +542,13 @@ class FileDefItem(object):
         return None
 
     @property
+    def lower_ext(self):
+        ext = self.ext
+        if ext is not None:
+            return ext.lower()
+        return ext
+
+    @property
     def is_dir(self):
         if self.is_empty:
             return False

--- a/openpype/tools/attribute_defs/files_widget.py
+++ b/openpype/tools/attribute_defs/files_widget.py
@@ -349,7 +349,7 @@ class FilesModel(QtGui.QStandardItemModel):
         item.setData(file_item.filenames, FILENAMES_ROLE)
         item.setData(file_item.directory, DIRPATH_ROLE)
         item.setData(icon_pixmap, ITEM_ICON_ROLE)
-        item.setData(file_item.ext, EXT_ROLE)
+        item.setData(file_item.lower_ext, EXT_ROLE)
         item.setData(file_item.is_dir, IS_DIR_ROLE)
         item.setData(file_item.is_sequence, IS_SEQUENCE_ROLE)
 
@@ -463,7 +463,7 @@ class FilesProxyModel(QtCore.QSortFilterProxyModel):
         for filepath in filepaths:
             if os.path.isfile(filepath):
                 _, ext = os.path.splitext(filepath)
-                if ext in self._allowed_extensions:
+                if ext.lower() in self._allowed_extensions:
                     return True
 
             elif self._allow_folders:
@@ -475,7 +475,7 @@ class FilesProxyModel(QtCore.QSortFilterProxyModel):
         for filepath in filepaths:
             if os.path.isfile(filepath):
                 _, ext = os.path.splitext(filepath)
-                if ext in self._allowed_extensions:
+                if ext.lower() in self._allowed_extensions:
                     filtered_paths.append(filepath)
 
             elif self._allow_folders:


### PR DESCRIPTION
## Brief description
Files widget is not case sensitive about dropped files.

## Description
Files widget validation of dropped files use extension as one of filters, but extensions dropped files were not lowered so the validation didn't allow to enter e.g. `.PNG` files.

## Testing notes:
1. Prepare e.g. png file with upper case extensions
2. Open TrayPublisher
3. Select `Image` family and tray drop the file to file input
4. It should allow you to drop it and publishing should finish successfully