### PR TITLE
Publisher: Settings for validate frame range

### DIFF
--- a/openpype/settings/defaults/project_settings/traypublisher.json
+++ b/openpype/settings/defaults/project_settings/traypublisher.json
@@ -303,5 +303,12 @@
         "extensions": [
             ".mov"
         ]
+    },
+    "publish": {
+        "ValidateFrameRange": {
+            "enabled": true,
+            "optional": true,
+            "active": true
+        }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
@@ -311,6 +311,24 @@
                     "object_type": "text"
                 }
             ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
+            "key": "publish",
+            "label": "Publish plugins",
+            "children": [
+                {
+                    "type": "schema_template",
+                    "name": "template_validate_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateFrameRange",
+                            "label": "Validate frame range"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/openpype/settings/entities/schemas/projects_schema/schemas/template_validate_plugin.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/template_validate_plugin.json
@@ -1,0 +1,26 @@
+[
+    {
+        "type": "dict",
+        "collapsible": true,
+        "key": "{key}",
+        "label": "{label}",
+        "checkbox_key": "enabled",
+        "children": [
+            {
+                "type": "boolean",
+                "key": "enabled",
+                "label": "Enabled"
+            },
+            {
+                "type": "boolean",
+                "key": "optional",
+                "label": "Optional"
+            },
+            {
+                "type": "boolean",
+                "key": "active",
+                "label": "Active"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Brief description
Added settings for validate frame range plugin in tray publisher.

## Testing notes:
It should be possible to enable/disable make optional/required and active/inactive Publish validate frame range plugin in tray publisher.