### PR TITLE
layout publish more than one container issue

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_layout.py
+++ b/openpype/hosts/maya/plugins/create/create_layout.py
@@ -8,6 +8,7 @@ class CreateLayout(plugin.Creator):
     label = "Layout"
     family = "layout"
     icon = "cubes"
+
     def __init__(self, *args, **kwargs):
         super(CreateLayout, self).__init__(*args, **kwargs)
 

--- a/openpype/hosts/maya/plugins/create/create_layout.py
+++ b/openpype/hosts/maya/plugins/create/create_layout.py
@@ -8,3 +8,10 @@ class CreateLayout(plugin.Creator):
     label = "Layout"
     family = "layout"
     icon = "cubes"
+    def __init__(self, *args, **kwargs):
+        super(CreateLayout, self).__init__(*args, **kwargs)
+
+
+        # enable this when you want to
+        # publish group of loaded asset
+        self.data["groupLoadedAssets"] = False

--- a/openpype/hosts/maya/plugins/create/create_layout.py
+++ b/openpype/hosts/maya/plugins/create/create_layout.py
@@ -11,8 +11,6 @@ class CreateLayout(plugin.Creator):
 
     def __init__(self, *args, **kwargs):
         super(CreateLayout, self).__init__(*args, **kwargs)
-
-
         # enable this when you want to
         # publish group of loaded asset
         self.data["groupLoadedAssets"] = False

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -38,14 +38,19 @@ class ExtractLayout(publish.Extractor):
             container_list = cmds.ls(project_container)
             assert len(container_list) == 1, \
                 "Please create instance with loaded asset!"
-            # list the children of the containers
-            grp_name = asset.split(':')[0]
-            container_sel = cmds.ls("{}*_CON".format(grp_name))
-            if not container_sel:
-                assert container_sel == [], \
-                    "Use all loaded contents without renaming and grouping!" # noqa
-            for con in container_sel:
-                container = con
+
+            grp_loaded_ass = instance.data.get("groupLoadedAssets", False)
+            if grp_loaded_ass:
+                asset_list = cmds.listRelatives(asset, children=True)
+                for asset in asset_list:
+                    grp_name = asset.split(':')[0]
+            else:
+                grp_name = asset.split(':')[0]
+            containers = cmds.ls("{}*_CON".format(grp_name))
+            assert len(containers) > 0, \
+                    "Use all loaded contents without renaming" \
+                    "(and/or grouping if groupLoadedAssets disabled)" # noqa
+            container = containers[0]
 
             representation_id = cmds.getAttr(
                 "{}.representation".format(container))

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -15,6 +15,7 @@ class ExtractLayout(publish.Extractor):
     label = "Extract Layout"
     hosts = ["maya"]
     families = ["layout"]
+    project_container = "AVALON_CONTAINERS"
     optional = True
 
     def process(self, instance):
@@ -33,13 +34,17 @@ class ExtractLayout(publish.Extractor):
 
         for asset in cmds.sets(str(instance), query=True):
             # Find the container
-            grp_name = asset.split(':')[0]
-            containers = cmds.ls("{}*_CON".format(grp_name))
-
-            assert len(containers) == 1, \
-                "More than one container found for {}".format(asset)
-
-            container = containers[0]
+            project_container = self.project_container
+            container_list = cmds.ls(project_container)
+            assert len(container_list) == 1, \
+                "No project container found for {} " \
+                "Please create instance with loaded asset".format(asset)
+            containers = cmds.sets(project_container, query=True)
+            for con in containers:
+                if "_CON" not in con:
+                    assert containers == [], \
+                    "No container found for {}".format(asset)
+                container = con
 
             representation_id = cmds.getAttr(
                 "{}.representation".format(container))

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -39,10 +39,15 @@ class ExtractLayout(publish.Extractor):
             assert len(container_list) == 1, \
                 "Please create instance with loaded asset"
             containers = cmds.sets(project_container, query=True)
+            load_asset = asset.split(':')[0]
             for con in containers:
-                if "_CON" not in con:
+                ass_transform = cmds.listRelatives(con, allParents=True)[0]
+                if load_asset not in ass_transform:
                     assert containers == [], \
                         "No container found for {}".format(asset)
+                if "_CON" not in con:
+                    assert containers == [], \
+                        "Container missing for {}".format(asset)
                 container = con
 
             representation_id = cmds.getAttr(

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -39,15 +39,17 @@ class ExtractLayout(publish.Extractor):
             assert len(container_list) == 1, \
                 "Please create instance with loaded asset"
             containers = cmds.sets(project_container, query=True)
-            load_asset = asset.split(':')[0]
+            # list the children of the containers
+            ass_transform = cmds.listRelatives(containers, allParents=True)
+            ass = cmds.listRelatives(asset, children=True, type="transform")
+            # compare the group of the asset with
+            # the children list of the container
+            # to find the content which is not loaded from the loader
+            for a in ass:
+                if a not in ass_transform:
+                    assert containers == [], \
+                        "no container found in {}".format(a)
             for con in containers:
-                ass_transform = cmds.listRelatives(con, allParents=True)[0]
-                if load_asset not in ass_transform:
-                    assert containers == [], \
-                        "No container found for {}".format(asset)
-                if "_CON" not in con:
-                    assert containers == [], \
-                        "Container missing for {}".format(asset)
                 container = con
 
             representation_id = cmds.getAttr(

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -37,13 +37,12 @@ class ExtractLayout(publish.Extractor):
             project_container = self.project_container
             container_list = cmds.ls(project_container)
             assert len(container_list) == 1, \
-                "No project container found for {} " \
-                "Please create instance with loaded asset".format(asset)
+                "Please create instance with loaded asset"
             containers = cmds.sets(project_container, query=True)
             for con in containers:
                 if "_CON" not in con:
                     assert containers == [], \
-                    "No container found for {}".format(asset)
+                        "No container found for {}".format(asset)
                 container = con
 
             representation_id = cmds.getAttr(

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -40,11 +40,11 @@ class ExtractLayout(publish.Extractor):
                 "Please create instance with loaded asset!"
             # list the children of the containers
             grp_name = asset.split(':')[0]
-            con_sel = cmds.ls("{}*_CON".format(grp_name))
-            if not con_sel:
+            containers = cmds.ls("{}*_CON".format(grp_name))
+            if not containers:
                     assert containers == [], \
                         "Use all loaded contents without renaming and grouping!" # noqa
-            for con in con_sel:
+            for con in containers:
                 container = con
 
             representation_id = cmds.getAttr(

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -40,11 +40,11 @@ class ExtractLayout(publish.Extractor):
                 "Please create instance with loaded asset!"
             # list the children of the containers
             grp_name = asset.split(':')[0]
-            containers = cmds.ls("{}*_CON".format(grp_name))
-            if not containers:
-                    assert containers == [], \
+            container_sel = cmds.ls("{}*_CON".format(grp_name))
+            if not container_sel:
+                    assert container_sel == [], \
                         "Use all loaded contents without renaming and grouping!" # noqa
-            for con in containers:
+            for con in container_sel:
                 container = con
 
             representation_id = cmds.getAttr(

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -36,8 +36,10 @@ class ExtractLayout(publish.Extractor):
             # Find the container
             project_container = self.project_container
             container_list = cmds.ls(project_container)
-            assert len(container_list) == 1, \
-                "Please create instance with loaded asset!"
+            if len(container_list) == 0:
+                self.log.warning("Project container is not found!")
+                self.log.warning("The asset(s) may not be properly loaded after published") # noqa
+                continue
 
             grp_loaded_ass = instance.data.get("groupLoadedAssets", False)
             if grp_loaded_ass:
@@ -47,9 +49,10 @@ class ExtractLayout(publish.Extractor):
             else:
                 grp_name = asset.split(':')[0]
             containers = cmds.ls("{}*_CON".format(grp_name))
-            assert len(containers) > 0, \
-                    "Use all loaded contents without renaming" \
-                    "(and/or grouping if groupLoadedAssets disabled)" # noqa
+            if len(containers) == 0:
+                self.log.warning("{} isn't from the loader".format(asset))
+                self.log.warning("It may not be properly loaded after published") # noqa
+                continue
             container = containers[0]
 
             representation_id = cmds.getAttr(

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -42,8 +42,8 @@ class ExtractLayout(publish.Extractor):
             grp_name = asset.split(':')[0]
             container_sel = cmds.ls("{}*_CON".format(grp_name))
             if not container_sel:
-                    assert container_sel == [], \
-                        "Use all loaded contents without renaming and grouping!" # noqa
+                assert container_sel == [], \
+                    "Use all loaded contents without renaming and grouping!" # noqa
             for con in container_sel:
                 container = con
 

--- a/openpype/hosts/maya/plugins/publish/extract_layout.py
+++ b/openpype/hosts/maya/plugins/publish/extract_layout.py
@@ -37,19 +37,14 @@ class ExtractLayout(publish.Extractor):
             project_container = self.project_container
             container_list = cmds.ls(project_container)
             assert len(container_list) == 1, \
-                "Please create instance with loaded asset"
-            containers = cmds.sets(project_container, query=True)
+                "Please create instance with loaded asset!"
             # list the children of the containers
-            ass_transform = cmds.listRelatives(containers, allParents=True)
-            ass = cmds.listRelatives(asset, children=True, type="transform")
-            # compare the group of the asset with
-            # the children list of the container
-            # to find the content which is not loaded from the loader
-            for a in ass:
-                if a not in ass_transform:
+            grp_name = asset.split(':')[0]
+            con_sel = cmds.ls("{}*_CON".format(grp_name))
+            if not con_sel:
                     assert containers == [], \
-                        "no container found in {}".format(a)
-            for con in containers:
+                        "Use all loaded contents without renaming and grouping!" # noqa
+            for con in con_sel:
                 container = con
 
             representation_id = cmds.getAttr(


### PR DESCRIPTION
## Brief description
fix the assertion error shown in` extract_layout.py `when publishing layout.

## Description
fix the assertion error shown in` extract_layout.py `when publishing layout.
![image](https://user-images.githubusercontent.com/64118225/201927161-b1c4e55f-23d1-4723-8594-155434289983.png)

If the user creates instance for the content which is not loaded from the workfile loader, it will have an assertion error to warn the user to use the loaded content. Unlike the previous version, it wont show an asset with more than one containers as the assertion error.
![image](https://user-images.githubusercontent.com/64118225/201926483-8a3b4e2f-81cf-4a13-a1c5-fffb4c007c8f.png)

## Additional info
N/A


## Testing notes:
1. load the content from any families
2. rename the content
3. create layout instance for the loaded content(s)
4. publish it
5. uses the loader to load the layout content.
### Testing Notes 2:
1. create a new geometry or load a scene with geometry
2. create layout instance for the new geometry
3. publish it
4. it will trigger the assertion issue to tell you to use the loaded content