### PR TITLE
General: Allow higher numbers in frames and clips

### DIFF
--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_attributes.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_attributes.json
@@ -16,22 +16,26 @@
         {
             "type": "number",
             "key": "frameStart",
-            "label": "Frame Start"
+            "label": "Frame Start",
+            "maximum": 999999999
         },
         {
             "type": "number",
             "key": "frameEnd",
-            "label": "Frame End"
+            "label": "Frame End",
+            "maximum": 999999999
         },
         {
             "type": "number",
             "key": "clipIn",
-            "label": "Clip In"
+            "label": "Clip In",
+            "maximum": 999999999
         },
         {
             "type": "number",
             "key": "clipOut",
-            "label": "Clip Out"
+            "label": "Clip Out",
+            "maximum": 999999999
         },
         {
             "type": "number",

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -28,7 +28,7 @@ class NameDef:
 class NumberDef:
     def __init__(self, minimum=None, maximum=None, decimals=None):
         self.minimum = 0 if minimum is None else minimum
-        self.maximum = 999999 if maximum is None else maximum
+        self.maximum = 999999999 if maximum is None else maximum
         self.decimals = 0 if decimals is None else decimals
 
 

--- a/openpype/tools/settings/settings/constants.py
+++ b/openpype/tools/settings/settings/constants.py
@@ -24,7 +24,6 @@ __all__ = (
 
     "SETTINGS_PATH_KEY",
     "ROOT_KEY",
-    "SETTINGS_PATH_KEY",
     "VALUE_KEY",
     "SAVE_TIME_KEY",
     "PROJECT_NAME_KEY",


### PR DESCRIPTION
## Brief description
Define max number of frame start/end and clip in/out to 9 digits number in anatomy settings and project manager tool.

## Testing notes:
- Open project manager and change some frame or clip value to really high number.
- Open settings, go to a project anatomy and change some frame or clip value to really high number