### PR TITLE
Nuke: load image first frame

### DIFF
--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -62,7 +62,9 @@ class LoadImage(load.LoaderPlugin):
 
     def load(self, context, name, namespace, options):
         self.log.info("__ options: `{}`".format(options))
-        frame_number = options.get("frame_number", 1)
+        frame_number = options.get(
+            "frame_number", int(nuke.root()["first_frame"].getValue())
+        )
 
         version = context['version']
         version_data = version.get("data", {})


### PR DESCRIPTION
## Brief description
Nuke load image is setting correctly first frame

## Description
Start frame is taken from script first frame.

## Testing notes:
1. Open testing script in Nuke
2. open loader and point to subset with image sequence
3. chose Load Image and do not set anything in options
4. notice it loads first script frame and sets it to first/last frame