### PR TITLE
Nuke: loaded nodes set to first tab

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -364,6 +364,9 @@ def containerise(node,
 
     set_avalon_knob_data(node, data)
 
+    # set tab to first native
+    node.setTab(0)
+
     return node
 
 

--- a/openpype/hosts/nuke/plugins/load/load_camera_abc.py
+++ b/openpype/hosts/nuke/plugins/load/load_camera_abc.py
@@ -65,6 +65,9 @@ class AlembicCameraLoader(load.LoaderPlugin):
                     object_name, file),
                 inpanel=False
             )
+            # hide property panel
+            camera_node.hideControlPanel()
+
             camera_node.forceValidate()
             camera_node["frame_rate"].setValue(float(fps))
 

--- a/openpype/hosts/nuke/plugins/load/load_clip.py
+++ b/openpype/hosts/nuke/plugins/load/load_clip.py
@@ -145,6 +145,9 @@ class LoadClip(plugin.NukeLoader):
             "Read",
             "name {}".format(read_name))
 
+        # hide property panel
+        read_node.hideControlPanel()
+
         # to avoid multiple undo steps for rest of process
         # we will switch off undo-ing
         with viewer_update_and_undo_stop():

--- a/openpype/hosts/nuke/plugins/load/load_effects.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects.py
@@ -89,6 +89,9 @@ class LoadEffects(load.LoaderPlugin):
             "Group",
             "name {}_1".format(object_name))
 
+        # hide property panel
+        GN.hideControlPanel()
+
         # adding content to the group node
         with GN:
             pre_node = nuke.createNode("Input")

--- a/openpype/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/openpype/hosts/nuke/plugins/load/load_effects_ip.py
@@ -90,6 +90,9 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
             "Group",
             "name {}_1".format(object_name))
 
+        # hide property panel
+        GN.hideControlPanel()
+
         # adding content to the group node
         with GN:
             pre_node = nuke.createNode("Input")

--- a/openpype/hosts/nuke/plugins/load/load_image.py
+++ b/openpype/hosts/nuke/plugins/load/load_image.py
@@ -112,6 +112,10 @@ class LoadImage(load.LoaderPlugin):
             r = nuke.createNode(
                 "Read",
                 "name {}".format(read_name))
+
+            # hide property panel
+            r.hideControlPanel()
+
             r["file"].setValue(file)
 
             # Set colorspace defined in version data

--- a/openpype/hosts/nuke/plugins/load/load_model.py
+++ b/openpype/hosts/nuke/plugins/load/load_model.py
@@ -63,6 +63,10 @@ class AlembicModelLoader(load.LoaderPlugin):
                     object_name, file),
                 inpanel=False
             )
+
+            # hide property panel
+            model_node.hideControlPanel()
+
             model_node.forceValidate()
 
             # Ensure all items are imported and selected.

--- a/openpype/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/openpype/hosts/nuke/plugins/load/load_script_precomp.py
@@ -71,6 +71,9 @@ class LinkAsGroup(load.LoaderPlugin):
             "Precomp",
             "file {}".format(file))
 
+        # hide property panel
+        P.hideControlPanel()
+
         # Set colorspace defined in version data
         colorspace = context["version"]["data"].get("colorspace", None)
         self.log.info("colorspace: {}\n".format(colorspace))


### PR DESCRIPTION
## Brief description
Loaded nodes are opening to first tab

## Description
OpenPype tab was not important to see and user always needed to switch back to native first tab.

## Additional info
Also every created node was also opening property panel in bin and users were mentioning it would be improvement ux if we had closed them.

## Testing notes:
1. start testing script in nuke
2. Open loader and load anything
3. notice property bin is closed
4. also open created node and notice first tab is opening.