### PR TITLE
Deadline: Build version resolving

### DIFF
--- a/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/openpype/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -192,7 +192,7 @@ def get_openpype_executable():
     return exe_list, dir_list
 
 
-def get_openpype_versions(exe_list, dir_list):
+def get_openpype_versions(dir_list):
     print(">>> Getting OpenPype executable ...")
     openpype_versions = []
 


### PR DESCRIPTION
## Brief description
Deadline prelaunch plugin have more sofisticated build version resolving to be used.

## Description
Before this PR deadline global pre launch plugin always used last openpype build it found (without comparing prerelease part of version string) which cause issues if the requested version from job lead to older build version.

## Additional info
This is fixing edge case usages and development testing. Before this PR the deadline could find for example 3 build versions `3.14.5`, `3.14.6-nightly.5` and `3.14.6` from that point both builds `3.14.6-nightly.5` and `3.14.6` were considered as same versions and if job requested version `3.14.5` the environments injection would fail because build `3.14.6` could not find the zip for `3.14.5`.

## Testing notes:
1. Prepare multiple build with different versions for deadline plugin
2. Submit multiple jobs for those different builds
3. All of them should find correct build