### PR TITLE
Publisher: Hide unknown publish values

### DIFF
--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -253,6 +253,26 @@ class UnknownDef(AbtractAttrDef):
         return value
 
 
+class HiddenDef(AbtractAttrDef):
+    """Hidden value of Any type.
+
+    This attribute can be used for UI purposes to pass values related
+    to other attributes (e.g. in multi-page UIs).
+
+    Keep in mind the value should be possible to parse by json parser.
+    """
+
+    type = "hidden"
+
+    def __init__(self, key, default=None, **kwargs):
+        kwargs["default"] = default
+        kwargs["hidden"] = True
+        super(UnknownDef, self).__init__(key, **kwargs)
+
+    def convert_value(self, value):
+        return value
+
+
 class NumberDef(AbtractAttrDef):
     """Number definition.
 

--- a/openpype/lib/attribute_definitions.py
+++ b/openpype/lib/attribute_definitions.py
@@ -105,11 +105,14 @@ class AbtractAttrDef(object):
     How to force to set `key` attribute?
 
     Args:
-        key(str): Under which key will be attribute value stored.
-        label(str): Attribute label.
-        tooltip(str): Attribute tooltip.
-        is_label_horizontal(bool): UI specific argument. Specify if label is
+        key (str): Under which key will be attribute value stored.
+        default (Any): Default value of an attribute.
+        label (str): Attribute label.
+        tooltip (str): Attribute tooltip.
+        is_label_horizontal (bool): UI specific argument. Specify if label is
             next to value input or ahead.
+        hidden (bool): Will be item hidden (for UI purposes).
+        disabled (bool): Item will be visible but disabled (for UI purposes).
     """
 
     type_attributes = []
@@ -117,16 +120,29 @@ class AbtractAttrDef(object):
     is_value_def = True
 
     def __init__(
-        self, key, default, label=None, tooltip=None, is_label_horizontal=None
+        self,
+        key,
+        default,
+        label=None,
+        tooltip=None,
+        is_label_horizontal=None,
+        hidden=False,
+        disabled=False
     ):
         if is_label_horizontal is None:
             is_label_horizontal = True
+
+        if hidden is None:
+            hidden = False
+
         self.key = key
         self.label = label
         self.tooltip = tooltip
         self.default = default
         self.is_label_horizontal = is_label_horizontal
-        self._id = uuid.uuid4()
+        self.hidden = hidden
+        self.disabled = disabled
+        self._id = uuid.uuid4().hex
 
         self.__init__class__ = AbtractAttrDef
 
@@ -173,7 +189,9 @@ class AbtractAttrDef(object):
             "label": self.label,
             "tooltip": self.tooltip,
             "default": self.default,
-            "is_label_horizontal": self.is_label_horizontal
+            "is_label_horizontal": self.is_label_horizontal,
+            "hidden": self.hidden,
+            "disabled": self.disabled
         }
         for attr in self.type_attributes:
             data[attr] = getattr(self, attr)

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -23,6 +23,16 @@ from .files_widget import FilesWidget
 
 
 def create_widget_for_attr_def(attr_def, parent=None):
+    widget = _create_widget_for_attr_def(attr_def, parent)
+    if attr_def.hidden:
+        widget.setVisible(False)
+
+    if attr_def.disabled:
+        widget.setEnabled(False)
+    return widget
+
+
+def _create_widget_for_attr_def(attr_def, parent=None):
     if not isinstance(attr_def, AbtractAttrDef):
         raise TypeError("Unexpected type \"{}\" expected \"{}\"".format(
             str(type(attr_def)), AbtractAttrDef
@@ -42,6 +52,9 @@ def create_widget_for_attr_def(attr_def, parent=None):
 
     if isinstance(attr_def, UnknownDef):
         return UnknownAttrWidget(attr_def, parent)
+
+    if isinstance(attr_def, HiddenDef):
+        return HiddenAttrWidget(attr_def, parent)
 
     if isinstance(attr_def, FileDef):
         return FileAttrWidget(attr_def, parent)
@@ -116,6 +129,10 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 
                 self._current_keys.add(attr_def.key)
             widget = create_widget_for_attr_def(attr_def, self)
+            self._widgets.append(widget)
+
+            if attr_def.hidden:
+                continue
 
             expand_cols = 2
             if attr_def.is_value_def and attr_def.is_label_horizontal:
@@ -134,7 +151,6 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
             layout.addWidget(
                 widget, row, col_num, 1, expand_cols
             )
-            self._widgets.append(widget)
             row += 1
 
     def set_value(self, value):

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -6,6 +6,7 @@ from Qt import QtWidgets, QtCore
 from openpype.lib.attribute_definitions import (
     AbtractAttrDef,
     UnknownDef,
+    HiddenDef,
     NumberDef,
     TextDef,
     EnumDef,
@@ -457,6 +458,29 @@ class UnknownAttrWidget(_BaseAttrDefWidget):
         if str_value != self._value:
             self._value = str_value
             self._input_widget.setText(str_value)
+
+
+class HiddenAttrWidget(_BaseAttrDefWidget):
+    def _ui_init(self):
+        self.setVisible(False)
+        self._value = None
+        self._multivalue = False
+
+    def setVisible(self, visible):
+        if visible:
+            visible = False
+        super(HiddenAttrWidget, self).setVisible(visible)
+
+    def current_value(self):
+        if self._multivalue:
+            raise ValueError(
+                "{} can't output for multivalue.".format(self.__class__.__name__)
+            )
+        return self._value
+
+    def set_value(self, value, multivalue=False):
+        self._value = copy.deepcopy(value)
+        self._multivalue = multivalue
 
 
 class FileAttrWidget(_BaseAttrDefWidget):

--- a/openpype/tools/attribute_defs/widgets.py
+++ b/openpype/tools/attribute_defs/widgets.py
@@ -489,9 +489,9 @@ class HiddenAttrWidget(_BaseAttrDefWidget):
 
     def current_value(self):
         if self._multivalue:
-            raise ValueError(
-                "{} can't output for multivalue.".format(self.__class__.__name__)
-            )
+            raise ValueError("{} can't output for multivalue.".format(
+                self.__class__.__name__
+            ))
         return self._value
 
     def set_value(self, value, multivalue=False):


### PR DESCRIPTION
## Brief description
Hide unknown publish plugin values to avoid user's confusion.

## Description
We showed unknown attributes stored on instance to user which could easily cause confusion because the showed key would not tell user (or us) almost nothing. But it make sense to show the unknown attribute on instances thus there were kept untouched. Mostly visible after changing optional validators as required.

Added option to define attribute definition as "hidden" or "disabled" (both only for UI purposes). Also was added option to define hidden attribute definition that hold any value defined by code.

## Testing notes:
1. Set validator supported by Publisher tool as optional
2. Open a host which support Publisher tool and create an instance where the validator would show
3. Close the host and change settings of the validator to be required
4. Open host again and open Publisher tool
5. The `active` value of validator should not be visible on the instance anymore

Resolves https://github.com/pypeclub/OpenPype/issues/4099