### PR TITLE
Slack: notification fail in new tray publisher

### DIFF
--- a/openpype/modules/slack/plugins/publish/collect_slack_family.py
+++ b/openpype/modules/slack/plugins/publish/collect_slack_family.py
@@ -18,15 +18,15 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin):
     profiles = None
 
     def process(self, instance):
-        task_name = legacy_io.Session.get("AVALON_TASK")
+        task_data = instance.data["anatomyData"].get("task", {})
         family = self.main_family_from_instance(instance)
         key_values = {
             "families": family,
-            "tasks": task_name,
+            "tasks": task_data.get("name"),
+            "task_types": task_data.get("type"),
             "hosts": instance.data["anatomyData"]["app"],
             "subsets": instance.data["subset"]
         }
-
         profile = filter_profiles(self.profiles, key_values,
                                   logger=self.log)
 

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -142,13 +142,19 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
 
     def _get_thumbnail_path(self, instance):
         """Returns abs url for thumbnail if present in instance repres"""
-        published_path = None
+        thumbnail_path = None
         for repre in instance.data.get("representations", []):
             if repre.get('thumbnail') or "thumbnail" in repre.get('tags', []):
-                if os.path.exists(repre["published_path"]):
-                    published_path = repre["published_path"]
+                self.log.info(repre)
+                repre_thumbnail_path = (
+                    repre.get("published_path") or
+                    os.path.join(repre["stagingDir"], repre["files"])
+                )
+                if os.path.exists(repre_thumbnail_path):
+                    self.log.info("exists")
+                    thumbnail_path = repre_thumbnail_path
                 break
-        return published_path
+        return thumbnail_path
 
     def _get_review_path(self, instance):
         """Returns abs url for review if present in instance repres"""

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -112,7 +112,13 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         if review_path:
             fill_pairs.append(("review_filepath", review_path))
 
-        task_data = fill_data.get("task")
+        task_data = (
+                copy.deepcopy(instance.data.get("anatomyData", [])).get("task")
+                or fill_data.get("task")
+        )
+        if not isinstance(task_data, dict):
+            # fallback for legacy - if task_data is only task name
+            task_data["name"] = task_data
         if task_data:
             if (
                 "{task}" in message_templ
@@ -121,13 +127,10 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             ):
                 fill_pairs.append(("task", task_data["name"]))
 
-            elif isinstance(task_data, dict):
+            else:
                 for key, value in task_data.items():
                     fill_key = "task[{}]".format(key)
                     fill_pairs.append((fill_key, value))
-            else:
-                # fallback for legacy - if task_data is only task name
-                fill_pairs.append(("task", task_data))
 
         self.log.debug("fill_pairs ::{}".format(fill_pairs))
         multiple_case_variants = prepare_template_data(fill_pairs)

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -148,13 +148,11 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         thumbnail_path = None
         for repre in instance.data.get("representations", []):
             if repre.get('thumbnail') or "thumbnail" in repre.get('tags', []):
-                self.log.info(repre)
                 repre_thumbnail_path = (
                     repre.get("published_path") or
                     os.path.join(repre["stagingDir"], repre["files"])
                 )
                 if os.path.exists(repre_thumbnail_path):
-                    self.log.info("exists")
                     thumbnail_path = repre_thumbnail_path
                 break
         return thumbnail_path

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -113,7 +113,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             fill_pairs.append(("review_filepath", review_path))
 
         task_data = (
-                copy.deepcopy(instance.data.get("anatomyData", [])).get("task")
+                copy.deepcopy(instance.data.get("anatomyData", {})).get("task")
                 or fill_data.get("task")
         )
         if not isinstance(task_data, dict):

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -188,10 +188,17 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                         channel=channel,
                         title=os.path.basename(p_file)
                     )
-                    attachment_str += "\n<{}|{}>".format(
-                        response["file"]["permalink"],
-                        os.path.basename(p_file))
-                    file_ids.append(response["file"]["id"])
+                    if response.get("error"):
+                        error_str = self._enrich_error(
+                            str(response.get("error")),
+                            channel)
+                        self.log.warning(
+                            "Error happened: {}".format(error_str))
+                    else:
+                        attachment_str += "\n<{}|{}>".format(
+                            response["file"]["permalink"],
+                            os.path.basename(p_file))
+                        file_ids.append(response["file"]["id"])
 
             if publish_files:
                 message += attachment_str

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -121,10 +121,13 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             ):
                 fill_pairs.append(("task", task_data["name"]))
 
-            else:
+            elif isinstance(task_data, dict):
                 for key, value in task_data.items():
                     fill_key = "task[{}]".format(key)
                     fill_pairs.append((fill_key, value))
+            else:
+                # fallback for legacy - if task_data is only task name
+                fill_pairs.append(("task", task_data))
 
         self.log.debug("fill_pairs ::{}".format(fill_pairs))
         multiple_case_variants = prepare_template_data(fill_pairs)


### PR DESCRIPTION
## Brief description
This handles issue with missing 'published_path' key caused by not publishing thumbnail.

## Additional info
It also handles task better, it takes task info from instance first, handles legacy case when task data is only string and not dict as expected.


## Testing notes:
1. Enable Slack module
2. Prepare `project_settings/slack/publish/CollectSlackFamilies/profiles/0/channel_messages/0/channels/0`
![slack_message](https://user-images.githubusercontent.com/4457962/203319766-6f0ddb36-a3ef-4702-a2f2-1dda8cc5e060.png)
3. Make sure that thumbnail won't get published in `project_settings/global/publish/PreIntegrateThumbnails`
4. Publish 