### PR TITLE
Publisher: Open on specific tab

### DIFF
--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -674,9 +674,9 @@ class InstanceCardView(AbstractInstanceView):
                 instances_by_group[group_name]
             )
 
-        self._update_ordered_group_nameS()
+        self._update_ordered_group_names()
 
-    def _update_ordered_group_nameS(self):
+    def _update_ordered_group_names(self):
         ordered_group_names = [CONTEXT_GROUP]
         for idx in range(self._content_layout.count()):
             if idx > 0:

--- a/openpype/tools/publisher/widgets/card_view_widgets.py
+++ b/openpype/tools/publisher/widgets/card_view_widgets.py
@@ -676,6 +676,13 @@ class InstanceCardView(AbstractInstanceView):
 
         self._update_ordered_group_names()
 
+    def has_items(self):
+        if self._convertor_items_group is not None:
+            return True
+        if self._widgets_by_group:
+            return True
+        return False
+
     def _update_ordered_group_names(self):
         ordered_group_names = [CONTEXT_GROUP]
         for idx in range(self._content_layout.count()):

--- a/openpype/tools/publisher/widgets/list_view_widgets.py
+++ b/openpype/tools/publisher/widgets/list_view_widgets.py
@@ -912,6 +912,13 @@ class InstanceListView(AbstractInstanceView):
         if not self._instance_view.isExpanded(proxy_index):
             self._instance_view.expand(proxy_index)
 
+    def has_items(self):
+        if self._convertor_group_widget is not None:
+            return True
+        if self._group_items:
+            return True
+        return False
+
     def get_selected_items(self):
         """Get selected instance ids and context selection.
 

--- a/openpype/tools/publisher/widgets/overview_widget.py
+++ b/openpype/tools/publisher/widgets/overview_widget.py
@@ -205,6 +205,10 @@ class OverviewWidget(QtWidgets.QFrame):
             self._subset_views_widget.height()
         )
 
+    def has_items(self):
+        view = self._subset_views_layout.currentWidget()
+        return view.has_items()
+
     def _on_create_clicked(self):
         """Pass signal to parent widget which should care about changing state.
 

--- a/openpype/tools/publisher/widgets/tabs_widget.py
+++ b/openpype/tools/publisher/widgets/tabs_widget.py
@@ -54,6 +54,9 @@ class PublisherTabsWidget(QtWidgets.QFrame):
         self._buttons_by_identifier = {}
 
     def is_current_tab(self, identifier):
+        if isinstance(identifier, int):
+            identifier = self.get_tab_by_index(identifier)
+
         if isinstance(identifier, PublisherTabBtn):
             identifier = identifier.identifier
         return self._current_identifier == identifier
@@ -69,10 +72,10 @@ class PublisherTabsWidget(QtWidgets.QFrame):
         return button
 
     def get_tab_by_index(self, index):
-        if index < 0 or index > self._btns_layout.count():
-            return None
-        item = self._btns_layout.itemAt(index)
-        return item.widget()
+        if 0 >= index < self._btns_layout.count():
+            item = self._btns_layout.itemAt(index)
+            return item.widget()
+        return None
 
     def set_current_tab(self, identifier):
         if isinstance(identifier, int):

--- a/openpype/tools/publisher/widgets/tabs_widget.py
+++ b/openpype/tools/publisher/widgets/tabs_widget.py
@@ -68,7 +68,16 @@ class PublisherTabsWidget(QtWidgets.QFrame):
             self.set_current_tab(identifier)
         return button
 
+    def get_tab_by_index(self, index):
+        if index < 0 or index > self._btns_layout.count():
+            return None
+        item = self._btns_layout.itemAt(index)
+        return item.widget()
+
     def set_current_tab(self, identifier):
+        if isinstance(identifier, int):
+            identifier = self.get_tab_by_index(identifier)
+
         if isinstance(identifier, PublisherTabBtn):
             identifier = identifier.identifier
 

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -578,6 +578,11 @@ class TasksCombobox(QtWidgets.QComboBox):
 
         self._text = None
 
+        # Make sure combobox is extended horizontally
+        size_policy = self.sizePolicy()
+        size_policy.setHorizontalPolicy(size_policy.MinimumExpanding)
+        self.setSizePolicy(size_policy)
+
     def set_invalid_empty_task(self, invalid=True):
         self._proxy_model.set_filter_empty(invalid)
         if invalid:

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -305,6 +305,20 @@ class AbstractInstanceView(QtWidgets.QWidget):
             "{} Method 'refresh' is not implemented."
         ).format(self.__class__.__name__))
 
+    def has_items(self):
+        """View has at least one item.
+
+        This is more a question for controller but is called from widget
+        which should probably should not use controller.
+
+        Returns:
+            bool: There is at least one instance or conversion item.
+        """
+
+        raise NotImplementedError((
+          "{} Method 'has_items' is not implemented."
+        ).format(self.__class__.__name__))
+
     def get_selected_items(self):
         """Selected instances required for callbacks.
 
@@ -1185,7 +1199,7 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         """Set currently selected instances.
 
         Args:
-            instances(list<CreatedInstance>): List of selected instances.
+            instances(List[CreatedInstance]): List of selected instances.
                 Empty instances tells that nothing or context is selected.
         """
         self._set_btns_visible(False)
@@ -1619,6 +1633,7 @@ class SubsetAttributesWidget(QtWidgets.QWidget):
             instances(List[CreatedInstance]): List of currently selected
                 instances.
             context_selected(bool): Is context selected.
+            convertor_identifiers(List[str]): Identifiers of convert items.
         """
 
         all_valid = True

--- a/openpype/tools/publisher/widgets/widgets.py
+++ b/openpype/tools/publisher/widgets/widgets.py
@@ -316,7 +316,7 @@ class AbstractInstanceView(QtWidgets.QWidget):
         """
 
         raise NotImplementedError((
-          "{} Method 'has_items' is not implemented."
+            "{} Method 'has_items' is not implemented."
         ).format(self.__class__.__name__))
 
     def get_selected_items(self):

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -539,6 +539,18 @@ class PublisherWindow(QtWidgets.QDialog):
     def _go_to_report_tab(self):
         self._set_current_tab("report")
 
+    def _is_on_create_tab(self):
+        self._is_current_tab("create")
+
+    def _is_on_publish_tab(self):
+        self._is_current_tab("publish")
+
+    def _is_on_details_tab(self):
+        self._is_current_tab("details")
+
+    def _is_on_report_tab(self):
+        self._is_current_tab("report")
+
     def _set_publish_overlay_visibility(self, visible):
         if visible:
             widget = self._publish_overlay

--- a/openpype/tools/publisher/window.py
+++ b/openpype/tools/publisher/window.py
@@ -432,7 +432,7 @@ class PublisherWindow(QtWidgets.QDialog):
 
         self._update_create_overlay_size()
         self._update_create_overlay_visibility()
-        if self._is_current_tab("create"):
+        if self._is_on_create_tab():
             self._install_app_event_listener()
 
         # Reset if requested
@@ -450,7 +450,7 @@ class PublisherWindow(QtWidgets.QDialog):
         self._context_label.setText(label)
 
     def _update_publish_details_widget(self, force=False):
-        if not force and not self._is_current_tab("details"):
+        if not force and not self._is_on_details_tab():
             return
 
         report_data = self.controller.get_publish_report()
@@ -540,16 +540,16 @@ class PublisherWindow(QtWidgets.QDialog):
         self._set_current_tab("report")
 
     def _is_on_create_tab(self):
-        self._is_current_tab("create")
+        return self._is_current_tab("create")
 
     def _is_on_publish_tab(self):
-        self._is_current_tab("publish")
+        return self._is_current_tab("publish")
 
     def _is_on_details_tab(self):
-        self._is_current_tab("details")
+        return self._is_current_tab("details")
 
     def _is_on_report_tab(self):
-        self._is_current_tab("report")
+        return self._is_current_tab("report")
 
     def _set_publish_overlay_visibility(self, visible):
         if visible:
@@ -601,11 +601,8 @@ class PublisherWindow(QtWidgets.QDialog):
         self._set_publish_visibility(False)
         self._set_footer_enabled(False)
         self._update_publish_details_widget()
-        if (
-            not self._is_current_tab("create")
-            and not self._is_current_tab("publish")
         ):
-            self._set_current_tab("publish")
+            self._go_to_publish_tab()
 
     def _on_publish_start(self):
         self._create_tab.setEnabled(False)
@@ -621,8 +618,8 @@ class PublisherWindow(QtWidgets.QDialog):
 
         self._publish_details_widget.close_details_popup()
 
-        if self._is_current_tab(self._create_tab):
-            self._set_current_tab("publish")
+        if self._is_on_create_tab():
+            self._go_to_publish_tab()
 
     def _on_publish_validated_change(self, event):
         if event["value"]:
@@ -635,7 +632,7 @@ class PublisherWindow(QtWidgets.QDialog):
         publish_has_crashed = self._controller.publish_has_crashed
         validate_enabled = not publish_has_crashed
         publish_enabled = not publish_has_crashed
-        if self._is_current_tab("publish"):
+        if self._is_on_publish_tab():
             self._go_to_report_tab()
 
         if validate_enabled:

--- a/openpype/tools/utils/host_tools.py
+++ b/openpype/tools/utils/host_tools.py
@@ -285,14 +285,12 @@ class HostToolsHelper:
 
         return self._publisher_tool
 
-    def show_publisher_tool(self, parent=None, controller=None):
+    def show_publisher_tool(self, parent=None, controller=None, tab=None):
         with qt_app_context():
-            dialog = self.get_publisher_tool(parent, controller)
-
-            dialog.show()
-            dialog.raise_()
-            dialog.activateWindow()
-            dialog.showNormal()
+            window = self.get_publisher_tool(parent, controller)
+            if tab:
+                window.set_current_tab(tab)
+            window.make_sure_is_visible()
 
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.
@@ -446,8 +444,8 @@ def show_publish(parent=None):
     _SingletonPoint.show_tool_by_name("publish", parent)
 
 
-def show_publisher(parent=None):
-    _SingletonPoint.show_tool_by_name("publisher", parent)
+def show_publisher(parent=None, **kwargs):
+    _SingletonPoint.show_tool_by_name("publisher", parent, **kwargs)
 
 
 def show_experimental_tools_dialog(parent=None):


### PR DESCRIPTION
## Brief description
Publisher has option to be opened on specific tab when showed.

## Description
It is possible to show publisher window on specific tab. Added option to open publisher on create/publish tab on first restart when there is at least one instance. Tasks combobox is extended to full width.

## Testing notes:
1. Pass `tab` keyword argument with value `"create"` or `"publish"` when opening publisher.
2. Check if the tab is set to what was passed