### PR TITLE
Photoshop: bug with pop-up window on Instance Creator

### DIFF
--- a/openpype/hosts/photoshop/plugins/create/create_legacy_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_legacy_image.py
@@ -29,7 +29,8 @@ class CreateImage(create.LegacyCreator):
             if len(selection) > 1:
                 # Ask user whether to create one image or image per selected
                 # item.
-                msg_box = QtWidgets.QMessageBox()
+                active_window = QtWidgets.QApplication.activeWindow()
+                msg_box = QtWidgets.QMessageBox(parent=active_window)
                 msg_box.setIcon(QtWidgets.QMessageBox.Warning)
                 msg_box.setText(
                     "Multiple layers selected."
@@ -102,7 +103,7 @@ class CreateImage(create.LegacyCreator):
             if group.long_name:
                 for directory in group.long_name[::-1]:
                     name = directory.replace(stub.PUBLISH_ICON, '').\
-                                      replace(stub.LOADED_ICON, '')
+                        replace(stub.LOADED_ICON, '')
                     long_names.append(name)
 
             self.data.update({"subset": subset_name})


### PR DESCRIPTION
## Brief description
In photoshop on Windows when we select multiple layers to create an instance, there's a pop-up window that appears behind the Instance Creator window, but we can't select this window.

## Description
The pop-up asks the users if they want to create one instance per layer or not, but we can't select what to do since it's not the active window (the Instance Creator window is). So the solution seems to make the Creator Instance window the parent of the pop-up window.

With the pop-up stuck behind the Instance Creator window:
![image](https://user-images.githubusercontent.com/51854004/203353673-a0507881-5651-498b-8bcb-4ac455d7edd4.png)

With the Instance Creator window as parent of the pop-up:
![image](https://user-images.githubusercontent.com/51854004/203354189-2b8b711e-4489-4317-86b2-31e49585df32.png)
