### PR TITLE
Changed the UOpenPypePublishInstance to use the UDataAsset class

### DIFF
--- a/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Private/OpenPypePublishInstance.cpp
+++ b/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Private/OpenPypePublishInstance.cpp
@@ -2,107 +2,147 @@
 
 #include "OpenPypePublishInstance.h"
 #include "AssetRegistryModule.h"
+#include "NotificationManager.h"
+#include "SNotificationList.h"
 
+//Moves all the invalid pointers to the end to prepare them for the shrinking
+#define REMOVE_INVALID_ENTRIES(VAR) VAR.CompactStable(); \
+									VAR.Shrink();
 
 UOpenPypePublishInstance::UOpenPypePublishInstance(const FObjectInitializer& ObjectInitializer)
-	: UObject(ObjectInitializer)
+	: UPrimaryDataAsset(ObjectInitializer)
 {
-	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
-	FString path = UOpenPypePublishInstance::GetPathName();
+	const FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<
+		FAssetRegistryModule>("AssetRegistry");
+
+	FString Left, Right;
+	GetPathName().Split("/" + GetName(), &Left, &Right);
+
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(*path));
+	Filter.PackagePaths.Emplace(FName(Left));
 
-	AssetRegistryModule.Get().OnAssetAdded().AddUObject(this, &UOpenPypePublishInstance::OnAssetAdded);
+	TArray<FAssetData> FoundAssets;
+	AssetRegistryModule.GetRegistry().GetAssets(Filter, FoundAssets);
+
+	for (const FAssetData& AssetData : FoundAssets)
+		OnAssetCreated(AssetData);
+
+	REMOVE_INVALID_ENTRIES(AssetDataInternal)
+	REMOVE_INVALID_ENTRIES(AssetDataExternal)
+
+	AssetRegistryModule.Get().OnAssetAdded().AddUObject(this, &UOpenPypePublishInstance::OnAssetCreated);
 	AssetRegistryModule.Get().OnAssetRemoved().AddUObject(this, &UOpenPypePublishInstance::OnAssetRemoved);
-	AssetRegistryModule.Get().OnAssetRenamed().AddUObject(this, &UOpenPypePublishInstance::OnAssetRenamed);
+	AssetRegistryModule.Get().OnAssetUpdated().AddUObject(this, &UOpenPypePublishInstance::OnAssetUpdated);
+	
 }
 
-void UOpenPypePublishInstance::OnAssetAdded(const FAssetData& AssetData)
+void UOpenPypePublishInstance::OnAssetCreated(const FAssetData& InAssetData)
 {
 	TArray<FString> split;
 
-	// get directory of current container
-	FString selfFullPath = UOpenPypePublishInstance::GetPathName();
-	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+	UObject* Asset = InAssetData.GetAsset();
 
-	// get asset path and class
-	FString assetPath = AssetData.GetFullName();
-	FString assetFName = AssetData.AssetClass.ToString();
-
-	// split path
-	assetPath.ParseIntoArray(split, TEXT(" "), true);
-
-	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
-
-	// take interest only in paths starting with path of current container
-	if (assetDir.StartsWith(*selfDir))
+	if (!IsValid(Asset))
 	{
-		// exclude self
-		if (assetFName != "OpenPypePublishInstance")
+		UE_LOG(LogAssetData, Warning, TEXT("Asset \"%s\" is not valid! Skipping the addition."),
+		       *InAssetData.ObjectPath.ToString());
+		return;
+	}
+
+	const bool result = IsUnderSameDir(Asset) && Cast<UOpenPypePublishInstance>(Asset) == nullptr;
+
+	if (result)
+	{
+		AssetDataInternal.Emplace(Asset);
+		UE_LOG(LogTemp, Log, TEXT("Added an Asset to PublishInstance - Publish Instance: %s, Asset %s"),
+		       *this->GetName(), *Asset->GetName());
+	}
+}
+
+void UOpenPypePublishInstance::OnAssetRemoved(const FAssetData& InAssetData)
+{
+	if (Cast<UOpenPypePublishInstance>(InAssetData.GetAsset()) == nullptr)
+	{
+		if (AssetDataInternal.Contains(NULL))
 		{
-			assets.Add(assetPath);
-			UE_LOG(LogTemp, Log, TEXT("%s: asset added to %s"), *selfFullPath, *selfDir);
+			AssetDataInternal.Remove(NULL);
+			REMOVE_INVALID_ENTRIES(AssetDataInternal)
+		}
+		else
+		{
+			AssetDataExternal.Remove(NULL);
+			REMOVE_INVALID_ENTRIES(AssetDataExternal)
 		}
 	}
 }
 
-void UOpenPypePublishInstance::OnAssetRemoved(const FAssetData& AssetData)
+void UOpenPypePublishInstance::OnAssetUpdated(const FAssetData& InAssetData)
 {
-	TArray<FString> split;
+	REMOVE_INVALID_ENTRIES(AssetDataInternal);
+	REMOVE_INVALID_ENTRIES(AssetDataExternal);
+}
 
-	// get directory of current container
-	FString selfFullPath = UOpenPypePublishInstance::GetPathName();
-	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+bool UOpenPypePublishInstance::IsUnderSameDir(const UObject* InAsset) const
+{
+	FString ThisLeft, ThisRight;
+	this->GetPathName().Split(this->GetName(), &ThisLeft, &ThisRight);
 
-	// get asset path and class
-	FString assetPath = AssetData.GetFullName();
-	FString assetFName = AssetData.AssetClass.ToString();
+	return InAsset->GetPathName().StartsWith(ThisLeft);
+}
 
-	// split path
-	assetPath.ParseIntoArray(split, TEXT(" "), true);
+#ifdef WITH_EDITOR
 
-	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
+void UOpenPypePublishInstance::SendNotification(const FString& Text) const
+{
+	FNotificationInfo Info{FText::FromString(Text)};
 
-	// take interest only in paths starting with path of current container
-	FString path = UOpenPypePublishInstance::GetPathName();
-	FString lpp = FPackageName::GetLongPackagePath(*path);
+	Info.bFireAndForget = true;
+	Info.bUseLargeFont = false;
+	Info.bUseThrobber = false;
+	Info.bUseSuccessFailIcons = false;
+	Info.ExpireDuration = 4.f;
+	Info.FadeOutDuration = 2.f;
 
-	if (assetDir.StartsWith(*selfDir))
+	FSlateNotificationManager::Get().AddNotification(Info);
+
+	UE_LOG(LogAssetData, Warning,
+	       TEXT(
+		       "Removed duplicated asset from the AssetsDataExternal in Container \"%s\", Asset is already included in the AssetDataInternal!"
+	       ), *GetName()
+	)
+}
+
+
+void UOpenPypePublishInstance::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+
+	if (PropertyChangedEvent.ChangeType == EPropertyChangeType::ValueSet &&
+		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(
+			UOpenPypePublishInstance, AssetDataExternal))
 	{
-		// exclude self
-		if (assetFName != "OpenPypePublishInstance")
+
+		// Check for duplicated assets
+		for (const auto& Asset : AssetDataInternal)
 		{
-			// UE_LOG(LogTemp, Warning, TEXT("%s: asset removed"), *lpp);
-			assets.Remove(assetPath);
+			if (AssetDataExternal.Contains(Asset))
+			{
+				AssetDataExternal.Remove(Asset);
+				return SendNotification("You are not allowed to add assets into AssetDataExternal which are already included in AssetDataInternal!");
+			}
+			
+		}
+
+		// Check if no UOpenPypePublishInstance type assets are included
+		for (const auto& Asset : AssetDataExternal)
+		{
+			if (Cast<UOpenPypePublishInstance>(Asset) != nullptr)
+			{
+				AssetDataExternal.Remove(Asset);
+				return SendNotification("You are not allowed to add publish instances!");
+			}
 		}
 	}
 }
 
-void UOpenPypePublishInstance::OnAssetRenamed(const FAssetData& AssetData, const FString& str)
-{
-	TArray<FString> split;
-
-	// get directory of current container
-	FString selfFullPath = UOpenPypePublishInstance::GetPathName();
-	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
-
-	// get asset path and class
-	FString assetPath = AssetData.GetFullName();
-	FString assetFName = AssetData.AssetClass.ToString();
-
-	// split path
-	assetPath.ParseIntoArray(split, TEXT(" "), true);
-
-	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
-	if (assetDir.StartsWith(*selfDir))
-	{
-		// exclude self
-		if (assetFName != "AssetContainer")
-		{
-
-			assets.Remove(str);
-			assets.Add(assetPath);
-			// UE_LOG(LogTemp, Warning, TEXT("%s: asset renamed %s"), *lpp, *str);
-		}
-	}
-}
+#endif

--- a/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Private/OpenPypePublishInstanceFactory.cpp
+++ b/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Private/OpenPypePublishInstanceFactory.cpp
@@ -9,10 +9,10 @@ UOpenPypePublishInstanceFactory::UOpenPypePublishInstanceFactory(const FObjectIn
 	bEditorImport = true;
 }
 
-UObject* UOpenPypePublishInstanceFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
+UObject* UOpenPypePublishInstanceFactory::FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
 {
-	UOpenPypePublishInstance* OpenPypePublishInstance = NewObject<UOpenPypePublishInstance>(InParent, Class, Name, Flags);
-	return OpenPypePublishInstance;
+	check(InClass->IsChildOf(UOpenPypePublishInstance::StaticClass()));
+	return NewObject<UOpenPypePublishInstance>(InParent, InClass, InName, Flags);
 }
 
 bool UOpenPypePublishInstanceFactory::ShouldShowInNewMenu() const {

--- a/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Public/OpenPypePublishInstance.h
+++ b/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Public/OpenPypePublishInstance.h
@@ -11,32 +11,80 @@ class OPENPYPE_API UOpenPypePublishInstance : public UPrimaryDataAsset
 	
 public:
 	
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
-	TSet<UObject*> AssetDataInternal;
+	/**
+	/**
+	 *	Retrieves all the assets which are monitored by the Publish Instance (Monitors assets in the directory which is
+	 *	placed in)
+	 *
+	 *	@return - Set of UObjects. Careful! They are returning raw pointers. Seems like an issue in UE5
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure)
+	TSet<UObject*> GetInternalAssets() const
+	{
+		//For some reason it can only return Raw Pointers? Seems like an issue which they haven't fixed.
+		TSet<UObject*> ResultSet;
+
+		for (const auto& Asset : AssetDataInternal)
+			ResultSet.Add(Asset.LoadSynchronous());
+
+		return ResultSet;
+	}
+
+	/**
+	 *	Retrieves all the assets which have been added manually by the Publish Instance
+	 *
+	 *	@return - TSet of assets (UObjects). Careful! They are returning raw pointers. Seems like an issue in UE5
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure)
+	TSet<UObject*> GetExternalAssets() const
+	{
+		//For some reason it can only return Raw Pointers? Seems like an issue which they haven't fixed.
+		TSet<UObject*> ResultSet;
+
+		for (const auto& Asset : AssetDataExternal)
+			ResultSet.Add(Asset.LoadSynchronous());
+
+		return ResultSet;
+	}
+
+	/**
+	 * Function for returning all the assets in the container combined.
+	 * 
+	 * @return Returns all the internal and externally added assets into one set (TSet of UObjects). Careful! They are
+	 * returning raw pointers. Seems like an issue in UE5
+	 *
+	 * @attention If the bAddExternalAssets variable is false, external assets won't be included!
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure)
+	TSet<UObject*> GetAllAssets() const
+	{
+		const TSet<TSoftObjectPtr<UObject>>& IteratedSet = bAddExternalAssets ? AssetDataInternal.Union(AssetDataExternal) : AssetDataInternal;
+		
+		//Create a new TSet only with raw pointers.
+		TSet<UObject*> ResultSet;
+
+		for (auto& Asset : IteratedSet)
+			ResultSet.Add(Asset.LoadSynchronous());
+
+		return ResultSet;
+	}
+
+
+private:
+
+	UPROPERTY(VisibleAnywhere, Category="Assets")
+	TSet<TSoftObjectPtr<UObject>> AssetDataInternal;
 	
 	/**
 	 * This property allows exposing the array to include other assets from any other directory than what it's currently
 	 * monitoring. NOTE: that these assets have to be added manually! They are not automatically registered or added!
 	 */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, Category = "Assets")
 	bool bAddExternalAssets = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta=(EditCondition="bAddExternalAssets"))
-	TSet<UObject*> AssetDataExternal;
+	UPROPERTY(EditAnywhere, meta=(EditCondition="bAddExternalAssets"), Category="Assets")
+	TSet<TSoftObjectPtr<UObject>> AssetDataExternal;
 
-	/**
-	 * Function for returning all the assets in the container.
-	 * 
-	 * @return Returns all the internal and externally added assets into one set (TSet).
-	 */
-	UFUNCTION(BlueprintCallable, Category = Python)
-	TSet<UObject*> GetAllAssets() const
-	{
-		return AssetDataInternal.Union(AssetDataExternal);
-	};
-
-
-private:
 
 	void OnAssetCreated(const FAssetData& InAssetData);
 	void OnAssetRemoved(const FAssetData& InAssetData);

--- a/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Public/OpenPypePublishInstance.h
+++ b/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Public/OpenPypePublishInstance.h
@@ -5,17 +5,51 @@
 
 
 UCLASS(Blueprintable)
-class OPENPYPE_API UOpenPypePublishInstance : public UObject
+class OPENPYPE_API UOpenPypePublishInstance : public UPrimaryDataAsset
 {
-	GENERATED_BODY()
-
+	GENERATED_UCLASS_BODY()
+	
 public:
-	UOpenPypePublishInstance(const FObjectInitializer& ObjectInitalizer);
-
+	
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
+	TSet<UObject*> AssetDataInternal;
+	
+	/**
+	 * This property allows exposing the array to include other assets from any other directory than what it's currently
+	 * monitoring. NOTE: that these assets have to be added manually! They are not automatically registered or added!
+	 */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-		TArray<FString> assets;
+	bool bAddExternalAssets = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta=(EditCondition="bAddExternalAssets"))
+	TSet<UObject*> AssetDataExternal;
+
+	/**
+	 * Function for returning all the assets in the container.
+	 * 
+	 * @return Returns all the internal and externally added assets into one set (TSet).
+	 */
+	UFUNCTION(BlueprintCallable, Category = Python)
+	TSet<UObject*> GetAllAssets() const
+	{
+		return AssetDataInternal.Union(AssetDataExternal);
+	};
+
+
 private:
-	void OnAssetAdded(const FAssetData& AssetData);
-	void OnAssetRemoved(const FAssetData& AssetData);
-	void OnAssetRenamed(const FAssetData& AssetData, const FString& str);
+
+	void OnAssetCreated(const FAssetData& InAssetData);
+	void OnAssetRemoved(const FAssetData& InAssetData);
+	void OnAssetUpdated(const FAssetData& InAssetData);
+
+	bool IsUnderSameDir(const UObject* InAsset) const;
+
+#ifdef WITH_EDITOR
+	
+	void SendNotification(const FString& Text) const;
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+
+#endif
+	
 };
+

--- a/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Public/OpenPypePublishInstanceFactory.h
+++ b/openpype/hosts/unreal/integration/UE_4.7/Source/OpenPype/Public/OpenPypePublishInstanceFactory.h
@@ -14,6 +14,6 @@ class OPENPYPE_API UOpenPypePublishInstanceFactory : public UFactory
 
 public:
 	UOpenPypePublishInstanceFactory(const FObjectInitializer& ObjectInitializer);
-	virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
 	virtual bool ShouldShowInNewMenu() const override;
 };

--- a/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstance.cpp
+++ b/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstance.cpp
@@ -35,6 +35,7 @@ UOpenPypePublishInstance::UOpenPypePublishInstance(const FObjectInitializer& Obj
 	AssetRegistryModule.Get().OnAssetRemoved().AddUObject(this, &UOpenPypePublishInstance::OnAssetRemoved);
 	AssetRegistryModule.Get().OnAssetUpdated().AddUObject(this, &UOpenPypePublishInstance::OnAssetUpdated);
 	
+	
 }
 
 void UOpenPypePublishInstance::OnAssetCreated(const FAssetData& InAssetData)
@@ -54,9 +55,11 @@ void UOpenPypePublishInstance::OnAssetCreated(const FAssetData& InAssetData)
 
 	if (result)
 	{
-		AssetDataInternal.Emplace(Asset);
-		UE_LOG(LogTemp, Log, TEXT("Added an Asset to PublishInstance - Publish Instance: %s, Asset %s"),
-		       *this->GetName(), *Asset->GetName());
+		if (AssetDataInternal.Emplace(Asset).IsValidId())
+		{
+			UE_LOG(LogTemp, Log, TEXT("Added an Asset to PublishInstance - Publish Instance: %s, Asset %s"),
+				*this->GetName(), *Asset->GetName());
+		}
 	}
 }
 
@@ -124,7 +127,7 @@ void UOpenPypePublishInstance::PostEditChangeProperty(FPropertyChangedEvent& Pro
 	{
 
 		// Check for duplicated assets
-		for (const TObjectPtr<UObject>& Asset : AssetDataInternal)
+		for (const auto& Asset : AssetDataInternal)
 		{
 			if (AssetDataExternal.Contains(Asset))
 			{
@@ -135,9 +138,9 @@ void UOpenPypePublishInstance::PostEditChangeProperty(FPropertyChangedEvent& Pro
 		}
 
 		// Check if no UOpenPypePublishInstance type assets are included
-		for (const TObjectPtr<UObject>& Asset : AssetDataExternal)
+		for (const auto& Asset : AssetDataExternal)
 		{
-			if (Cast<UOpenPypePublishInstance>(Asset) != nullptr)
+			if (Cast<UOpenPypePublishInstance>(Asset.Get()) != nullptr)
 			{
 				AssetDataExternal.Remove(Asset);
 				return SendNotification("You are not allowed to add publish instances!");

--- a/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstance.cpp
+++ b/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstance.cpp
@@ -2,107 +2,148 @@
 
 #include "OpenPypePublishInstance.h"
 #include "AssetRegistryModule.h"
+#include "AssetToolsModule.h"
+#include "NotificationManager.h"
+#include "SNotificationList.h"
 
+//Moves all the invalid pointers to the end to prepare them for the shrinking
+#define REMOVE_INVALID_ENTRIES(VAR) VAR.CompactStable(); \
+									VAR.Shrink();
 
 UOpenPypePublishInstance::UOpenPypePublishInstance(const FObjectInitializer& ObjectInitializer)
-	: UObject(ObjectInitializer)
+	: UPrimaryDataAsset(ObjectInitializer)
 {
-	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
-	FString path = UOpenPypePublishInstance::GetPathName();
+	const FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<
+		FAssetRegistryModule>("AssetRegistry");
+
+	FString Left, Right;
+	GetPathName().Split(GetName(), &Left, &Right);
+
 	FARFilter Filter;
-	Filter.PackagePaths.Add(FName(*path));
+	Filter.PackagePaths.Emplace(FName(Left));
 
-	AssetRegistryModule.Get().OnAssetAdded().AddUObject(this, &UOpenPypePublishInstance::OnAssetAdded);
+	TArray<FAssetData> FoundAssets;
+	AssetRegistryModule.GetRegistry().GetAssets(Filter, FoundAssets);
+
+	for (const FAssetData& AssetData : FoundAssets)
+		OnAssetCreated(AssetData);
+
+	REMOVE_INVALID_ENTRIES(AssetDataInternal)
+	REMOVE_INVALID_ENTRIES(AssetDataExternal)
+
+	AssetRegistryModule.Get().OnAssetAdded().AddUObject(this, &UOpenPypePublishInstance::OnAssetCreated);
 	AssetRegistryModule.Get().OnAssetRemoved().AddUObject(this, &UOpenPypePublishInstance::OnAssetRemoved);
-	AssetRegistryModule.Get().OnAssetRenamed().AddUObject(this, &UOpenPypePublishInstance::OnAssetRenamed);
+	AssetRegistryModule.Get().OnAssetUpdated().AddUObject(this, &UOpenPypePublishInstance::OnAssetUpdated);
+	
 }
 
-void UOpenPypePublishInstance::OnAssetAdded(const FAssetData& AssetData)
+void UOpenPypePublishInstance::OnAssetCreated(const FAssetData& InAssetData)
 {
 	TArray<FString> split;
 
-	// get directory of current container
-	FString selfFullPath = UOpenPypePublishInstance::GetPathName();
-	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+	const TObjectPtr<UObject> Asset = InAssetData.GetAsset();
 
-	// get asset path and class
-	FString assetPath = AssetData.GetFullName();
-	FString assetFName = AssetData.AssetClass.ToString();
-
-	// split path
-	assetPath.ParseIntoArray(split, TEXT(" "), true);
-
-	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
-
-	// take interest only in paths starting with path of current container
-	if (assetDir.StartsWith(*selfDir))
+	if (!IsValid(Asset))
 	{
-		// exclude self
-		if (assetFName != "OpenPypePublishInstance")
+		UE_LOG(LogAssetData, Warning, TEXT("Asset \"%s\" is not valid! Skipping the addition."),
+		       *InAssetData.ObjectPath.ToString());
+		return;
+	}
+
+	const bool result = IsUnderSameDir(Asset) && Cast<UOpenPypePublishInstance>(Asset) == nullptr;
+
+	if (result)
+	{
+		AssetDataInternal.Emplace(Asset);
+		UE_LOG(LogTemp, Log, TEXT("Added an Asset to PublishInstance - Publish Instance: %s, Asset %s"),
+		       *this->GetName(), *Asset->GetName());
+	}
+}
+
+void UOpenPypePublishInstance::OnAssetRemoved(const FAssetData& InAssetData)
+{
+	if (Cast<UOpenPypePublishInstance>(InAssetData.GetAsset()) == nullptr)
+	{
+		if (AssetDataInternal.Contains(nullptr))
 		{
-			assets.Add(assetPath);
-			UE_LOG(LogTemp, Log, TEXT("%s: asset added to %s"), *selfFullPath, *selfDir);
+			AssetDataInternal.Remove(nullptr);
+			REMOVE_INVALID_ENTRIES(AssetDataInternal)
+		}
+		else
+		{
+			AssetDataExternal.Remove(nullptr);
+			REMOVE_INVALID_ENTRIES(AssetDataExternal)
 		}
 	}
 }
 
-void UOpenPypePublishInstance::OnAssetRemoved(const FAssetData& AssetData)
+void UOpenPypePublishInstance::OnAssetUpdated(const FAssetData& InAssetData)
 {
-	TArray<FString> split;
+	REMOVE_INVALID_ENTRIES(AssetDataInternal);
+	REMOVE_INVALID_ENTRIES(AssetDataExternal);
+}
 
-	// get directory of current container
-	FString selfFullPath = UOpenPypePublishInstance::GetPathName();
-	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
+bool UOpenPypePublishInstance::IsUnderSameDir(const TObjectPtr<UObject>& InAsset) const
+{
+	FString ThisLeft, ThisRight;
+	this->GetPathName().Split(this->GetName(), &ThisLeft, &ThisRight);
 
-	// get asset path and class
-	FString assetPath = AssetData.GetFullName();
-	FString assetFName = AssetData.AssetClass.ToString();
+	return InAsset->GetPathName().StartsWith(ThisLeft);
+}
 
-	// split path
-	assetPath.ParseIntoArray(split, TEXT(" "), true);
+#ifdef WITH_EDITOR
 
-	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
+void UOpenPypePublishInstance::SendNotification(const FString& Text) const
+{
+	FNotificationInfo Info{FText::FromString(Text)};
 
-	// take interest only in paths starting with path of current container
-	FString path = UOpenPypePublishInstance::GetPathName();
-	FString lpp = FPackageName::GetLongPackagePath(*path);
+	Info.bFireAndForget = true;
+	Info.bUseLargeFont = false;
+	Info.bUseThrobber = false;
+	Info.bUseSuccessFailIcons = false;
+	Info.ExpireDuration = 4.f;
+	Info.FadeOutDuration = 2.f;
 
-	if (assetDir.StartsWith(*selfDir))
+	FSlateNotificationManager::Get().AddNotification(Info);
+
+	UE_LOG(LogAssetData, Warning,
+	       TEXT(
+		       "Removed duplicated asset from the AssetsDataExternal in Container \"%s\", Asset is already included in the AssetDataInternal!"
+	       ), *GetName()
+	)
+}
+
+
+void UOpenPypePublishInstance::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+
+	if (PropertyChangedEvent.ChangeType == EPropertyChangeType::ValueSet &&
+		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(
+			UOpenPypePublishInstance, AssetDataExternal))
 	{
-		// exclude self
-		if (assetFName != "OpenPypePublishInstance")
+
+		// Check for duplicated assets
+		for (const TObjectPtr<UObject>& Asset : AssetDataInternal)
 		{
-			// UE_LOG(LogTemp, Warning, TEXT("%s: asset removed"), *lpp);
-			assets.Remove(assetPath);
+			if (AssetDataExternal.Contains(Asset))
+			{
+				AssetDataExternal.Remove(Asset);
+				return SendNotification("You are not allowed to add assets into AssetDataExternal which are already included in AssetDataInternal!");
+			}
+			
+		}
+
+		// Check if no UOpenPypePublishInstance type assets are included
+		for (const TObjectPtr<UObject>& Asset : AssetDataExternal)
+		{
+			if (Cast<UOpenPypePublishInstance>(Asset) != nullptr)
+			{
+				AssetDataExternal.Remove(Asset);
+				return SendNotification("You are not allowed to add publish instances!");
+			}
 		}
 	}
 }
 
-void UOpenPypePublishInstance::OnAssetRenamed(const FAssetData& AssetData, const FString& str)
-{
-	TArray<FString> split;
-
-	// get directory of current container
-	FString selfFullPath = UOpenPypePublishInstance::GetPathName();
-	FString selfDir = FPackageName::GetLongPackagePath(*selfFullPath);
-
-	// get asset path and class
-	FString assetPath = AssetData.GetFullName();
-	FString assetFName = AssetData.AssetClass.ToString();
-
-	// split path
-	assetPath.ParseIntoArray(split, TEXT(" "), true);
-
-	FString assetDir = FPackageName::GetLongPackagePath(*split[1]);
-	if (assetDir.StartsWith(*selfDir))
-	{
-		// exclude self
-		if (assetFName != "AssetContainer")
-		{
-
-			assets.Remove(str);
-			assets.Add(assetPath);
-			// UE_LOG(LogTemp, Warning, TEXT("%s: asset renamed %s"), *lpp, *str);
-		}
-	}
-}
+#endif

--- a/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstance.cpp
+++ b/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstance.cpp
@@ -3,7 +3,7 @@
 #include "OpenPypePublishInstance.h"
 #include "AssetRegistryModule.h"
 #include "AssetToolsModule.h"
-#include "NotificationManager.h"
+#include "Framework/Notifications/NotificationManager.h"
 #include "SNotificationList.h"
 
 //Moves all the invalid pointers to the end to prepare them for the shrinking

--- a/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstanceFactory.cpp
+++ b/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Private/OpenPypePublishInstanceFactory.cpp
@@ -9,10 +9,10 @@ UOpenPypePublishInstanceFactory::UOpenPypePublishInstanceFactory(const FObjectIn
 	bEditorImport = true;
 }
 
-UObject* UOpenPypePublishInstanceFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
+UObject* UOpenPypePublishInstanceFactory::FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
 {
-	UOpenPypePublishInstance* OpenPypePublishInstance = NewObject<UOpenPypePublishInstance>(InParent, Class, Name, Flags);
-	return OpenPypePublishInstance;
+	check(InClass->IsChildOf(UOpenPypePublishInstance::StaticClass()));
+	return NewObject<UOpenPypePublishInstance>(InParent, InClass, InName, Flags);
 }
 
 bool UOpenPypePublishInstanceFactory::ShouldShowInNewMenu() const {

--- a/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Public/OpenPypePublishInstance.h
+++ b/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Public/OpenPypePublishInstance.h
@@ -1,21 +1,62 @@
 #pragma once
 
+#include "EditorTutorial.h"
 #include "Engine.h"
 #include "OpenPypePublishInstance.generated.h"
 
 
 UCLASS(Blueprintable)
-class OPENPYPE_API UOpenPypePublishInstance : public UObject
+class OPENPYPE_API UOpenPypePublishInstance : public UPrimaryDataAsset
 {
-	GENERATED_BODY()
-
+	GENERATED_UCLASS_BODY()
+	
 public:
-	UOpenPypePublishInstance(const FObjectInitializer& ObjectInitalizer);
-
+	
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
+	TSet<TObjectPtr<UObject>> AssetDataInternal;
+	
+	/**
+	 * This property allows exposing the array to include other assets from any other directory than what it's currently
+	 * monitoring. NOTE: that these assets have to be added manually! They are not automatically registered or added!
+	 */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-		TArray<FString> assets;
+	bool bAddExternalAssets = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta=(EditCondition="bAddExternalAssets"))
+	TSet<TObjectPtr<UObject>> AssetDataExternal;
+
+	/**
+	 * Function for returning all the assets in the container.
+	 * 
+	 * @return Returns all the internal and externally added assets into one set (TSet).
+	 */
+	UFUNCTION(BlueprintCallable, Category = Python)
+	TSet<UObject*> GetAllAssets() const
+	{
+		TSet<TObjectPtr<UObject>> Unionized = AssetDataInternal.Union(AssetDataExternal);
+
+		TSet<UObject*> ResultSet;
+		
+		for (auto& Asset : Unionized)
+			ResultSet.Add(Asset.Get());
+
+		return ResultSet;
+	}
+
 private:
-	void OnAssetAdded(const FAssetData& AssetData);
-	void OnAssetRemoved(const FAssetData& AssetData);
-	void OnAssetRenamed(const FAssetData& AssetData, const FString& str);
+
+	void OnAssetCreated(const FAssetData& InAssetData);
+	void OnAssetRemoved(const FAssetData& InAssetData);
+	void OnAssetUpdated(const FAssetData& InAssetData);
+
+	bool IsUnderSameDir(const TObjectPtr<UObject>& InAsset) const;
+
+#ifdef WITH_EDITOR
+	
+	void SendNotification(const FString& Text) const;
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+
+#endif
+	
 };
+

--- a/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Public/OpenPypePublishInstanceFactory.h
+++ b/openpype/hosts/unreal/integration/UE_5.0/Source/OpenPype/Public/OpenPypePublishInstanceFactory.h
@@ -14,6 +14,6 @@ class OPENPYPE_API UOpenPypePublishInstanceFactory : public UFactory
 
 public:
 	UOpenPypePublishInstanceFactory(const FObjectInitializer& ObjectInitializer);
-	virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
 	virtual bool ShouldShowInNewMenu() const override;
 };


### PR DESCRIPTION
## Brief description
The UOpenPypePublishInstance now uses the UDataAsset to store references to saved assets.

## Description

- UOpenPypePublishInstance derives from the UPrimaryDataAsset.
- Assets are now either Internal (UOpenPypePublishInstance monitors it's own directory and subdirectories for changes) or external (Assets which can be added in from other locations).
- Created new functions to get external, internal or all assets combined.
- AssetData variables use TSets to ensure there are no duplicate assets being added. A check is also implemented between the external and internal TSets which also monitor, if a user isn't trying to add an duplicate asset to external container, if it already exists in the internal one.
- There is also a check to make sure the user doesn't include the UOpenPypePublishInstance itself.

## Additional info
To allow to edit the external asset container (TSet), user has to tick the 'Add External Assets' to allow him to expose the container. Note that externally added are not managed automatically whatsoever. They are managed manually! Also if the variable is unticked, the GetAllAssets() function behaves differently (It will not include the External Assets).

The TSets also use TSoftObjectPtrs. That means it references the assets on the drive, not the memory. The getter functions already take care of initializing into memory though.

## Testing notes:

Creation of the Publish Instance
1. Open the Unreal Project
2. Create a new Camera through the OpenPype Creator {A new UOpenPypePublishInstance should be created)
3. Check in the UOpenPypePublishInstance Asset, if the newly created "cameraDefault.uasset" is automatically included in the 'AssetDataInternal'. Make sure to also save the newly created asset "cameraDefault.uasset".

Monitoring of newly added assets
1. When a UOPPublishInstance is created, create a new asset in the same directory or subdirectory where the UOPPublishInstance asset is located (for instance Material)
2. Check in the details panel of UOPPublishInstance, if the newly created asset is added into the "AssetDataInternal"

Checking if the UOPPublishInstance can not be added into the "AssetDataExternal" Container.
1. Open the details panel in UOPPublishInstance
2. Try to add the the same or other UOPPublishInstance asset.
3. Editor shouldn't allow the user to add this kind of asset, and is warned by a notification.

Prohibition of adding a duplicate asset into 'AssetDataExternal', which is already contained in 'AssetDataInternal'.
1. UOPPublishInstance has to have at least one asset included in 'AssetDataInternal'.
2. Try to add a duplicate asset contained in 'AssetDataInternal' to 'AssetDataExternal'.
3. User should be notified by the editor, that he can not add Assets to the external container which are already contained in the Internal container.
