### PR TITLE
Ftrack: Editorial asset sync issue

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -229,10 +229,10 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
 
     def import_to_ftrack(self, project_name, hierarchy_context):
         # Prequery hiearchical custom attributes
-        hier_custom_attributes = get_pype_attr(self.session)[1]
+        hier_attrs = get_pype_attr(self.session)[1]
         hier_attr_by_key = {
             attr["key"]: attr
-            for attr in hier_custom_attributes
+            for attr in hier_attrs
         }
         # Query user entity (for comments)
         user = self.session.query(
@@ -244,6 +244,19 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
                     self.session.api_user
                 )
             )
+
+        # Query ftrack hierarchy with parenting
+        ftrack_hierarchy = self.query_ftrack_entitites(
+            self.session, self.ft_project)
+
+        # Fill ftrack entities to hierarchy context
+        # - there is no need to query entities again
+        matching_entities = self.find_matching_ftrack_entities(
+            hierarchy_context, ftrack_hierarchy)
+        # Query custom attribute values of each entity
+        custom_attr_values_by_id = self.query_custom_attribute_values(
+            self.session, matching_entities, hier_attrs)
+
         # Get ftrack api module (as they are different per python version)
         ftrack_api = self.context.data["ftrackPythonModule"]
 
@@ -260,75 +273,87 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
 
             entity_type = entity_data['entity_type']
             self.log.debug(entity_data)
-            self.log.debug(entity_type)
 
-            if entity_type.lower() == 'project':
-                entity = self.ft_project
-
-            elif self.ft_project is None or parent is None:
+            entity = entity_data.get("ft_entity")
+            if entity is None and entity_type.lower() == "project":
                 raise AssertionError(
                     "Collected items are not in right order!"
                 )
 
-            # try to find if entity already exists
-            else:
-                query = (
-                    'TypedContext where name is "{0}" and '
-                    'project_id is "{1}"'
-                ).format(entity_name, self.ft_project["id"])
-                try:
-                    entity = self.session.query(query).one()
-                except Exception:
-                    entity = None
-
             # Create entity if not exists
             if entity is None:
-                entity = self.create_entity(
-                    name=entity_name,
-                    type=entity_type,
-                    parent=parent
-                )
+                entity = self.session.create(entity_type, {
+                    "name": entity_name,
+                    "parent": parent
+                })
+                entity_data["ft_entity"] = entity
+
             # self.log.info('entity: {}'.format(dict(entity)))
             # CUSTOM ATTRIBUTES
-            custom_attributes = entity_data.get('custom_attributes', [])
-            instances = [
-                instance
-                for instance in self.context
-                if instance.data.get("asset") == entity["name"]
-            ]
+            custom_attributes = entity_data.get('custom_attributes', {})
+            instances = []
+            for instance in self.context:
+                instance_asset_name = instance.data.get("asset")
+                if (
+                    instance_asset_name
+                    and instance_asset_name.lower() == entity["name"].lower()
+                ):
+                    instances.append(instance)
 
             for instance in instances:
                 instance.data["ftrackEntity"] = entity
 
-            for key in custom_attributes:
+            for key, cust_attr_value in custom_attributes.items():
+                if cust_attr_value is None:
+                    continue
+
                 hier_attr = hier_attr_by_key.get(key)
                 # Use simple method if key is not hierarchical
                 if not hier_attr:
-                    assert (key in entity['custom_attributes']), (
-                        'Missing custom attribute key: `{0}` in attrs: '
-                        '`{1}`'.format(key, entity['custom_attributes'].keys())
+                    if key not in entity["custom_attributes"]:
+                        raise KnownPublishError((
+                            "Missing custom attribute in ftrack with name '{}'"
+                        ).format(key))
+
+                    entity['custom_attributes'][key] = cust_attr_value
+                    continue
+
+                attr_id = hier_attr["id"]
+                entity_values = custom_attr_values_by_id.get(entity["id"], {})
+                # New value is defined by having id in values
+                # - it can be set to 'None' (ftrack allows that using API)
+                is_new_value = attr_id not in entity_values
+                attr_value = entity_values.get(attr_id)
+
+                # Use ftrack operations method to set hiearchical
+                # attribute value.
+                # - this is because there may be non hiearchical custom
+                #   attributes with different properties
+                entity_key = collections.OrderedDict((
+                    ("configuration_id", hier_attr["id"]),
+                    ("entity_id", entity["id"])
+                ))
+                op = None
+                if is_new_value:
+                    op = ftrack_api.operation.CreateEntityOperation(
+                        "CustomAttributeValue",
+                        entity_key,
+                        {"value": cust_attr_value}
                     )
 
-                    entity['custom_attributes'][key] = custom_attributes[key]
-
-                else:
-                    # Use ftrack operations method to set hiearchical
-                    # attribute value.
-                    # - this is because there may be non hiearchical custom
-                    #   attributes with different properties
-                    entity_key = collections.OrderedDict()
-                    entity_key["configuration_id"] = hier_attr["id"]
-                    entity_key["entity_id"] = entity["id"]
-                    self.session.recorded_operations.push(
-                        ftrack_api.operation.UpdateEntityOperation(
-                            "ContextCustomAttributeValue",
-                            entity_key,
-                            "value",
-                            ftrack_api.symbol.NOT_SET,
-                            custom_attributes[key]
-                        )
+                elif attr_value != cust_attr_value:
+                    op = ftrack_api.operation.UpdateEntityOperation(
+                        "CustomAttributeValue",
+                        entity_key,
+                        "value",
+                        attr_value,
+                        cust_attr_value
                     )
 
+                if op is not None:
+                    self.session.recorded_operations.push(op)
+
+            if self.session.recorded_operations:
                 try:
                     self.session.commit()
                 except Exception:
@@ -342,7 +367,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
             for instance in instances:
                 task_name = instance.data.get("task")
                 if task_name:
-                    instances_by_task_name[task_name].append(instance)
+                    instances_by_task_name[task_name.lower()].append(instance)
 
             tasks = entity_data.get('tasks', [])
             existing_tasks = []
@@ -500,21 +525,6 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
 
         return task
 
-    def create_entity(self, name, type, parent):
-        entity = self.session.create(type, {
-            'name': name,
-            'parent': parent
-        })
-        try:
-            self.session.commit()
-        except Exception:
-            tp, value, tb = sys.exc_info()
-            self.session.rollback()
-            self.session._configure_locations()
-            six.reraise(tp, value, tb)
-
-        return entity
-
     def _get_active_assets(self, context):
         """ Returns only asset dictionary.
             Usually the last part of deep dictionary which
@@ -536,19 +546,17 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
 
         hierarchy_context = context.data["hierarchyContext"]
 
-        active_assets = []
+        active_assets = set()
         # filter only the active publishing insatnces
         for instance in context:
             if instance.data.get("publish") is False:
                 continue
 
-            if not instance.data.get("asset"):
-                continue
-
-            active_assets.append(instance.data["asset"])
+            asset_name = instance.data.get("asset")
+            if asset_name:
+                active_assets.add(asset_name)
 
         # remove duplicity in list
-        active_assets = list(set(active_assets))
-        self.log.debug("__ active_assets: {}".format(active_assets))
+        self.log.debug("__ active_assets: {}".format(list(active_assets)))
 
         return get_pure_hierarchy_data(hierarchy_context)

--- a/openpype/modules/ftrack/plugins/publish/integrate_hierarchy_ftrack.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_hierarchy_ftrack.py
@@ -8,9 +8,6 @@ import pyblish.api
 from openpype.client import get_asset_by_id
 from openpype.lib import filter_profiles
 
-
-# Copy of constant `openpype_modules.ftrack.lib.avalon_sync.CUST_ATTR_AUTO_SYNC`
-CUST_ATTR_AUTO_SYNC = "avalon_auto_sync"
 CUST_ATTR_GROUP = "openpype"
 
 
@@ -97,18 +94,9 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
         self.task_types = self.get_all_task_types(project)
         self.task_statuses = self.get_task_statuses(project)
 
-        # disable termporarily ftrack project's autosyncing
-        if auto_sync_state:
-            self.auto_sync_off(project)
+        # import ftrack hierarchy
+        self.import_to_ftrack(project_name, hierarchy_context)
 
-        try:
-            # import ftrack hierarchy
-            self.import_to_ftrack(project_name, hierarchy_context)
-        except Exception:
-            raise
-        finally:
-            if auto_sync_state:
-                self.auto_sync_on(project)
 
     def import_to_ftrack(self, project_name, input_data, parent=None):
         # Prequery hiearchical custom attributes
@@ -380,33 +368,6 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
             six.reraise(tp, value, tb)
 
         return entity
-
-    def auto_sync_off(self, project):
-        project["custom_attributes"][CUST_ATTR_AUTO_SYNC] = False
-
-        self.log.info("Ftrack autosync swithed off")
-
-        try:
-            self.session.commit()
-        except Exception:
-            tp, value, tb = sys.exc_info()
-            self.session.rollback()
-            self.session._configure_locations()
-            six.reraise(tp, value, tb)
-
-    def auto_sync_on(self, project):
-
-        project["custom_attributes"][CUST_ATTR_AUTO_SYNC] = True
-
-        self.log.info("Ftrack autosync swithed on")
-
-        try:
-            self.session.commit()
-        except Exception:
-            tp, value, tb = sys.exc_info()
-            self.session.rollback()
-            self.session._configure_locations()
-            six.reraise(tp, value, tb)
 
     def _get_active_assets(self, context):
         """ Returns only asset dictionary.


### PR DESCRIPTION
## Brief description
Probably fixing most of current issue with editorial publishing. Auto sync is not turned off (and back to on) during ftrack hierarchy integration which caused that assets without unavailable entities were marked as archived and at the same time were created new assets which lead to double asset documents and subsets created during editorial publishing lead to the archived one.

## Description
Auto sync is not turned on/off. Entities for filling ftrack entities are prequeried for whole project instead of querying all entities separatelly. Custom attributes are "created" or "updated" to table `"CustomAttributeValue"` instead of `"ContextCustomAttributeValue"` (which could cause that entity did not have filled the value as expected. Recursive functions were modified to queu based. Avoid requery of data from ftrack.

## Additional info
There is still room for improvement in the hierarchy plugin and some change on ftrack event sync but for now this should fix most of current issues.

## Testing notes:
Editorial publishing should work the same or better way.
1. Publish editorial which would create at least 15 shots (assets)
2. None of that should cause issues and none of that should at the end be marked as archived in openpype mongo
3. Custom attributes should be propagated to new created entities on ftrack