### PR TITLE
Ftrack: Reset session before instance processing

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -46,8 +46,9 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
             return
 
         session = context.data["ftrackSession"]
-        # Reset session and reconfigure locations
-        session.reset()
+        # Reset session operations and reconfigure locations
+        session.recorded_operations.clear()
+        session._configure_locations()
 
         try:
             self.integrate_to_ftrack(


### PR DESCRIPTION
## Brief description
~Integrate ftrack api is reseting ftrack api session on integration.~ Integrate ftrack api is re-configuring ftrack api locations on integration.

## Description
~Reset session before each instance is processed to trigger recache of locations which should help to fix the issue.~
Reset of session caused loose of local cache data which would require to requery all information again and again.

## Additional information
First fix was to create new session for each processed instance and close it afterwards but the closing of session cause closing of all sessions in process.

## Testing notes:
Since I wasn't able to reproduce source issue I cannot describe testing notes for source issue.
- Ftrack integration should work at least the same way as did