### PR TITLE
Maya: Looks - add all connections

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_look.py
+++ b/openpype/hosts/maya/plugins/publish/collect_look.py
@@ -403,13 +403,13 @@ class CollectLook(pyblish.api.InstancePlugin):
             # history = cmds.listHistory(look_sets)
             history = []
             for material in materials:
-                history.extend(cmds.listHistory(material))
+                history.extend(cmds.listHistory(material, ac=True))
 
             # handle VrayPluginNodeMtl node - see #1397
             vray_plugin_nodes = cmds.ls(
                 history, type="VRayPluginNodeMtl", long=True)
             for vray_node in vray_plugin_nodes:
-                history.extend(cmds.listHistory(vray_node))
+                history.extend(cmds.listHistory(vray_node, ac=True))
 
             # handling render attribute sets
             render_set_types = [


### PR DESCRIPTION
## Bug

If file node was connected not using its "primary data" plug, look collector was ignoring it - for example file node driving only with `Alpha Out` something down the line was missed by collector.

### Fix

This is adding `allConnection` or `ac` flag to `cmds.listHistory` to get even those.

### Testing

Create shader with texture using `Alpha Out` to drive something in the material. Look collector should pick it up correctly.