### PR TITLE
General: Maketx executable issue

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_look.py
+++ b/openpype/hosts/maya/plugins/publish/extract_look.py
@@ -90,7 +90,7 @@ def maketx(source, destination, args, logger):
 
     maketx_path = get_oiio_tools_path("maketx")
 
-    if not os.path.exists(maketx_path):
+    if not maketx_path:
         print(
             "OIIO tool not found in {}".format(maketx_path))
         raise AssertionError("OIIO tool not found")


### PR DESCRIPTION
## Brief description
Fix validation of maketx executable in maya.

## Description
Extract look validated if executable returned from `get_oiio_tools_path` exists which did not on windows because of missing extension but that should not cause issues.

## Additional info
We should fix the source issue in `get_oiio_tools_path` but that would require more time.

## Testing notes:
1. ExtractLook in Maya should work on windows