### PR TITLE
General: Find executable enhancement

### DIFF
--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -60,9 +60,10 @@ def find_executable(executable):
             path to file.
 
     Returns:
-        str: Full path to executable with extension (is file).
-        None: When the executable was not found.
+        Union[str, None]: Full path to executable with extension which was
+            found otherwise None.
     """
+
     # Skip if passed path is file
     if is_file_executable(executable):
         return executable
@@ -85,6 +86,21 @@ def find_executable(executable):
 
         else:
             exts |= {".sh"}
+
+    # Executable is a path but there may be missing extension
+    #   - this can happen primarily on windows where
+    #       e.g. "ffmpeg" should be "ffmpeg.exe"
+    exe_dir, exe_filename = os.path.split(executable)
+    if exe_dir and os.path.isdir(exe_dir):
+        for filename in os.listdir(exe_dir):
+            filepath = os.path.join(exe_dir, filename)
+            basename, ext = os.path.splitext(filename)
+            if (
+                basename == exe_filename
+                and ext.lower() in exts
+                and is_file_executable(filepath)
+            ):
+                return filepath
 
     # Get paths where to look for executable
     path_str = os.environ.get("PATH", None)
@@ -114,6 +130,7 @@ def find_executable(executable):
                 and is_file_executable(filepath)
             ):
                 return filepath
+
     return None
 
 

--- a/openpype/lib/vendor_bin_utils.py
+++ b/openpype/lib/vendor_bin_utils.py
@@ -299,8 +299,8 @@ def get_oiio_tools_path(tool="oiiotool"):
         oiio_dir = get_vendor_bin_path("oiio")
         if platform.system().lower() == "linux":
             oiio_dir = os.path.join(oiio_dir, "bin")
-        default_path = os.path.join(oiio_dir, tool)
-        if _oiio_executable_validation(default_path):
+        default_path = find_executable(os.path.join(oiio_dir, tool))
+        if default_path and _oiio_executable_validation(default_path):
             tool_executable_path = default_path
 
     # Look to PATH for the tool


### PR DESCRIPTION
## Brief description
Enhance how executables are found when `find_executable` is called which cause that oiiotools return full path to executable.

## Description
Modified function `find_executable` which can now also fill extension to path to executable if is missing. With this change oiiotools return full path to executable with extension.

## Additional information
Proper fix of previous issue from PR https://github.com/pypeclub/OpenPype/pull/4136 .

## Testing notes:
Open `Tray > Admin > Console` and run this script:
```
from openpype.lib import get_oiio_tools_path

print(get_oiio_tools_path("oiiotool"))
print(get_oiio_tools_path("maketx"))
```
Output on windows should return full path to executabls with extensions. It should also still work on linux and mac (if the executables are available there).