### PR TITLE
Maya: Optional viewport refresh on pointcache extraction

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -127,14 +127,14 @@ def get_main_window():
 
 
 @contextlib.contextmanager
-def suspended_refresh():
+def suspended_refresh(suspend=True):
     """Suspend viewport refreshes"""
-
+    original_state = cmds.refresh(query=True, suspend=True)
     try:
-        cmds.refresh(suspend=True)
+        cmds.refresh(suspend=suspend)
         yield
     finally:
-        cmds.refresh(suspend=False)
+        cmds.refresh(suspend=original_state)
 
 
 @contextlib.contextmanager

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -28,6 +28,7 @@ class CreatePointCache(plugin.Creator):
         self.data["visibleOnly"] = False     # only nodes that are visible
         self.data["includeParentHierarchy"] = False  # Include parent groups
         self.data["worldSpace"] = True       # Default to exporting world-space
+        self.data["refresh"] = False       # Default to suspend refresh.
 
         # Add options for custom attributes
         self.data["attr"] = ""

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -86,13 +86,21 @@ class ExtractAlembic(publish.Extractor):
                                                      start=start,
                                                      end=end))
 
-        with suspended_refresh():
+        if instance.data.get("refresh", False):
             with maintained_selection():
                 cmds.select(nodes, noExpand=True)
                 extract_alembic(file=path,
                                 startFrame=start,
                                 endFrame=end,
                                 **options)
+        else:
+            with suspended_refresh():
+                with maintained_selection():
+                    cmds.select(nodes, noExpand=True)
+                    extract_alembic(file=path,
+                                    startFrame=start,
+                                    endFrame=end,
+                                    **options)
 
         if "representations" not in instance.data:
             instance.data["representations"] = []

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -86,21 +86,15 @@ class ExtractAlembic(publish.Extractor):
                                                      start=start,
                                                      end=end))
 
-        if instance.data.get("refresh", False):
+        with suspended_refresh(suspend=instance.data.get("refresh", False)):
             with maintained_selection():
                 cmds.select(nodes, noExpand=True)
-                extract_alembic(file=path,
-                                startFrame=start,
-                                endFrame=end,
-                                **options)
-        else:
-            with suspended_refresh():
-                with maintained_selection():
-                    cmds.select(nodes, noExpand=True)
-                    extract_alembic(file=path,
-                                    startFrame=start,
-                                    endFrame=end,
-                                    **options)
+                extract_alembic(
+                    file=path,
+                    startFrame=start,
+                    endFrame=end,
+                    **options
+                )
 
         if "representations" not in instance.data:
             instance.data["representations"] = []


### PR DESCRIPTION
## Brief description
Optional viewport refresh on pointcache extraction.

## Description
Sometimes you need the viewport to refresh for example when dealing with the bullet plugin.

## Additional info
The rest will be ignored in changelog and should contain any additional
technical information.

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. Create pointcache.
2. Enabled refresh.
3. See the viewport update as extraction is done.