### PR TITLE
Maya: Disable viewport Pan/Zoom on playblast extraction.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -115,6 +115,10 @@ class ExtractPlayblast(publish.Extractor):
         else:
             preset["viewport_options"] = {"imagePlane": image_plane}
 
+        # Disable Pan/Zoom.
+        pan_zoom = cmds.getAttr("{}.panZoomEnabled".format(preset["camera"]))
+        cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), False)
+        
         with lib.maintained_time():
             filename = preset.get("filename", "%TEMP%")
 
@@ -135,6 +139,8 @@ class ExtractPlayblast(publish.Extractor):
 
             path = capture.capture(log=self.log, **preset)
 
+        cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), pan_zoom)
+        
         self.log.debug("playblast path  {}".format(path))
 
         collected_files = os.listdir(stagingdir)

--- a/openpype/hosts/maya/plugins/publish/extract_playblast.py
+++ b/openpype/hosts/maya/plugins/publish/extract_playblast.py
@@ -118,7 +118,7 @@ class ExtractPlayblast(publish.Extractor):
         # Disable Pan/Zoom.
         pan_zoom = cmds.getAttr("{}.panZoomEnabled".format(preset["camera"]))
         cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), False)
-        
+
         with lib.maintained_time():
             filename = preset.get("filename", "%TEMP%")
 
@@ -140,7 +140,7 @@ class ExtractPlayblast(publish.Extractor):
             path = capture.capture(log=self.log, **preset)
 
         cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), pan_zoom)
-        
+
         self.log.debug("playblast path  {}".format(path))
 
         collected_files = os.listdir(stagingdir)

--- a/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
@@ -117,6 +117,10 @@ class ExtractThumbnail(publish.Extractor):
         else:
             preset["viewport_options"] = {"imagePlane": image_plane}
 
+        # Disable Pan/Zoom.
+        pan_zoom = cmds.getAttr("{}.panZoomEnabled".format(preset["camera"]))
+        cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), False)
+
         with lib.maintained_time():
             # Force viewer to False in call to capture because we have our own
             # viewer opening call to allow a signal to trigger between
@@ -136,6 +140,7 @@ class ExtractThumbnail(publish.Extractor):
 
         _, thumbnail = os.path.split(playblast)
 
+        cmds.setAttr("{}.panZoomEnabled".format(preset["camera"]), pan_zoom)
 
         self.log.info("file list  {}".format(thumbnail))
 


### PR DESCRIPTION
## Brief description
Disable viewport Pan/Zoom on playblast extraction.

## Additional info
The rest will be ignored in changelog and should contain any additional
technical information.

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. Create camera with Pan/Zoom enabled in Maya.
2. Create review.
3. Publish and check Pan/Zoom was disabled in review.