### PR TITLE
Maya: Enable thumbnail transparency on extraction.

### DIFF
--- a/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/maya/plugins/publish/extract_thumbnail.py
@@ -105,6 +105,11 @@ class ExtractThumbnail(publish.Extractor):
         pm.currentTime(refreshFrameInt - 1, edit=True)
         pm.currentTime(refreshFrameInt, edit=True)
 
+        # Override transparency if requested.
+        transparency = instance.data.get("transparency", 0)
+        if transparency != 0:
+            preset["viewport2_options"]["transparencyAlgorithm"] = transparency
+
         # Isolate view is requested by having objects in the set besides a
         # camera.
         if preset.pop("isolate_view", False) and instance.data.get("isolate"):


### PR DESCRIPTION
## Brief description
Enable thumbnail transparency on extraction.

## Description
Missing transparency feature from playblast extraction.

## Additional info
The rest will be ignored in changelog and should contain any additional
technical information.

## Documentation (add _"type: documentation"_ label)
[feature_documentation](future_url_after_it_will_be_merged)

## Testing notes:
1. start with this step
2. follow this step