### PR TITLE
Fix: Standalone Publish Directories

### DIFF
--- a/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -178,7 +178,7 @@ class DropDataFrame(QtWidgets.QFrame):
         paths = self._get_all_paths(in_paths)
         collectionable_paths = []
         non_collectionable_paths = []
-        for path in in_paths:
+        for path in paths:
             ext = os.path.splitext(path)[1]
             if ext in self.image_extensions or ext in self.sequence_types:
                 collectionable_paths.append(path)


### PR DESCRIPTION
## Brief description
Dropped directories in the Standalone Publish tool are not handled.

## Description
When dropping a directory in the Standalone Publish tool, the content of the directory is not expanded.

The publish then crashes during the integration (in the "integrate_new" plugin) with an "Access Denied" error.

The fix is however already present, but not used (call to the ```_get_all_paths``` function).

## Additional info
The error is due to the ```copyfile``` function being called with a directory as the ```src``` parameter (though a file is expected).

The code already contains the fix to expand the directories:
```
paths = self._get_all_paths(in_paths)
```
However, the newly created list ```paths``` is not used in the following ```for``` loop:
```
for path in in_paths:
   ...
```

## Testing notes:
1. Open the Standalone Publish tool.
2. Select a project, asset, task and family.
3. Drop a directory in the "drop zone".
4. Publish
5. The error ```[WinError -2147024891] Access Denied``` (in Windows using "speedcopy") or ```[WinError 13] Access Denied``` is raised.