### PR TITLE
General: Extract review handle start offset of sequences

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -602,9 +602,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
             start_number = temp_data["first_sequence_frame"]
             if temp_data["without_handles"] and temp_data["handles_are_set"]:
                 start_number += temp_data["handle_start"]
-            ffmpeg_input_args.extend(
-                ["-start_number", str(start_number)]
-            )
+            ffmpeg_input_args.extend([
+                "-start_number", str(start_number)
+            ])
 
             # TODO add fps mapping `{fps: fraction}` ?
             # - e.g.: {

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -616,6 +616,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
             ffmpeg_input_args.extend([
                 "-framerate", str(temp_data["fps"])
             ])
+            # Add duration of an input sequence if output is video
+            if not temp_data["output_is_sequence"]:
+                ffmpeg_input_args.extend([
+                    "-to", "{:0.10f}".format(duration_seconds)
+                ])
 
         if temp_data["output_is_sequence"]:
             # Set start frame of output sequence (just frame in filename)
@@ -627,6 +632,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
         # Change output's duration and start point if should not contain
         # handles
         if temp_data["without_handles"] and temp_data["handles_are_set"]:
+            # Set output duration in seconds
+            ffmpeg_output_args.extend([
+                "-t", "{:0.10}".format(duration_seconds)
+            ])
+
             # Add -ss (start offset in seconds) if input is not sequence
             if not temp_data["input_is_sequence"]:
                 start_sec = float(temp_data["handle_start"]) / temp_data["fps"]
@@ -637,24 +647,10 @@ class ExtractReview(pyblish.api.InstancePlugin):
                         "-ss", "{:0.10f}".format(start_sec)
                     ])
 
-            # Set output duration inn seconds
-            ffmpeg_output_args.extend([
-                "-t", "{:0.10}".format(duration_seconds)
-            ])
-
         # Set frame range of output when input or output is sequence
         elif temp_data["output_is_sequence"]:
             ffmpeg_output_args.extend([
                 "-frames:v", str(output_frames_len)
-            ])
-
-        # Add duration of an input sequence if output is video
-        if (
-            temp_data["input_is_sequence"]
-            and not temp_data["output_is_sequence"]
-        ):
-            ffmpeg_input_args.extend([
-                "-to", "{:0.10f}".format(duration_seconds)
             ])
 
         # Add video/image input path

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -598,9 +598,13 @@ class ExtractReview(pyblish.api.InstancePlugin):
         if temp_data["input_is_sequence"]:
             # Set start frame of input sequence (just frame in filename)
             # - definition of input filepath
-            ffmpeg_input_args.extend([
-                "-start_number", str(temp_data["first_sequence_frame"])
-            ])
+            # - add handle start if output should be without handles
+            start_number = temp_data["first_sequence_frame"]
+            if temp_data["without_handles"] and temp_data["handles_are_set"]:
+                start_number += temp_data["handle_start"]
+            ffmpeg_input_args.extend(
+                ["-start_number", str(start_number)]
+            )
 
             # TODO add fps mapping `{fps: fraction}` ?
             # - e.g.: {
@@ -609,49 +613,54 @@ class ExtractReview(pyblish.api.InstancePlugin):
             #     "23.976": "24000/1001"
             # }
             # Add framerate to input when input is sequence
-            ffmpeg_input_args.append(
-                "-framerate {}".format(temp_data["fps"])
-            )
+            ffmpeg_input_args.extend([
+                "-framerate", str(temp_data["fps"])
+            ])
 
         if temp_data["output_is_sequence"]:
             # Set start frame of output sequence (just frame in filename)
             # - this is definition of an output
-            ffmpeg_output_args.append(
-                "-start_number {}".format(temp_data["output_frame_start"])
-            )
+            ffmpeg_output_args.extend([
+                "-start_number", str(temp_data["output_frame_start"])
+            ])
 
         # Change output's duration and start point if should not contain
         # handles
-        start_sec = 0
         if temp_data["without_handles"] and temp_data["handles_are_set"]:
-            # Set start time without handles
-            # - check if handle_start is bigger than 0 to avoid zero division
-            if temp_data["handle_start"] > 0:
+            # Add -ss (start offset in seconds) if input is not sequence
+            if not temp_data["input_is_sequence"]:
                 start_sec = float(temp_data["handle_start"]) / temp_data["fps"]
-                ffmpeg_input_args.append("-ss {:0.10f}".format(start_sec))
+                # Set start time without handles
+                # - Skip if start sec is 0.0
+                if start_sec > 0.0:
+                    ffmpeg_input_args.extend([
+                        "-ss", "{:0.10f}".format(start_sec)
+                    ])
 
             # Set output duration inn seconds
-            ffmpeg_output_args.append("-t {:0.10}".format(duration_seconds))
+            ffmpeg_output_args.extend([
+                "-t", "{:0.10}".format(duration_seconds)
+            ])
 
         # Set frame range of output when input or output is sequence
         elif temp_data["output_is_sequence"]:
-            ffmpeg_output_args.append("-frames:v {}".format(output_frames_len))
+            ffmpeg_output_args.extend([
+                "-frames:v", str(output_frames_len)
+            ])
 
         # Add duration of an input sequence if output is video
         if (
             temp_data["input_is_sequence"]
             and not temp_data["output_is_sequence"]
         ):
-            ffmpeg_input_args.append("-to {:0.10f}".format(
-                duration_seconds + start_sec
-            ))
+            ffmpeg_input_args.extend([
+                "-to", "{:0.10f}".format(duration_seconds)
+            ])
 
         # Add video/image input path
-        ffmpeg_input_args.append(
-            "-i {}".format(
-                path_to_subprocess_arg(temp_data["full_input_path"])
-            )
-        )
+        ffmpeg_input_args.extend([
+            "-i", path_to_subprocess_arg(temp_data["full_input_path"])
+        ])
 
         # Add audio arguments if there are any. Skipped when output are images.
         if not temp_data["output_ext_is_image"] and temp_data["with_audio"]:


### PR DESCRIPTION
## Brief description
Extract review can handle handles offset if input is sequence.

## Description
Source of the issue comes when extract review has set tag `no-handles` and input is sequence of images in that case are combined arguments `-start_number` and `-ss` and it seems that `-ss` should not be used with sequence but is better to change `-start_number` value instead.

## Testing notes:
Validate if output of extract review is ok. Prepare asset with handles and settings with same output but one have `no-handles` tag
- [ ] input is sequence, output is sequence [with handles]
- [ ] input is sequence, output is sequence [without handles]
- [ ] input is sequence, output is movie [with handles]
- [ ] input is sequence, output is movie [without handles]
- [ ] input is movie, output is anything [with handles]
- [ ] input is movie, output is anything [without handles]