### PR TITLE
Ftrack: Fix occational double parents issue

### DIFF
--- a/openpype/modules/ftrack/lib/avalon_sync.py
+++ b/openpype/modules/ftrack/lib/avalon_sync.py
@@ -1556,7 +1556,7 @@ class SyncEntitiesFactory:
             deleted_entities.append(mongo_id)
 
             av_ent = self.avalon_ents_by_id[mongo_id]
-            av_ent_path_items = [p for p in av_ent["data"]["parents"]]
+            av_ent_path_items = list(av_ent["data"]["parents"])
             av_ent_path_items.append(av_ent["name"])
             self.log.debug("Deleted <{}>".format("/".join(av_ent_path_items)))
 
@@ -1855,7 +1855,7 @@ class SyncEntitiesFactory:
                 _vis_par = _avalon_ent["data"]["visualParent"]
                 _name = _avalon_ent["name"]
                 if _name in self.all_ftrack_names:
-                    av_ent_path_items = _avalon_ent["data"]["parents"]
+                    av_ent_path_items = list(_avalon_ent["data"]["parents"])
                     av_ent_path_items.append(_name)
                     av_ent_path = "/".join(av_ent_path_items)
                     # TODO report
@@ -1997,7 +1997,7 @@ class SyncEntitiesFactory:
                 {"_id": mongo_id},
                 item
             ))
-            av_ent_path_items = item["data"]["parents"]
+            av_ent_path_items = list(item["data"]["parents"])
             av_ent_path_items.append(item["name"])
             av_ent_path = "/".join(av_ent_path_items)
             self.log.debug(
@@ -2110,6 +2110,7 @@ class SyncEntitiesFactory:
 
         entity_dict = self.entities_dict[ftrack_id]
 
+        final_parents = entity_dict["final_entity"]["data"]["parents"]
         if archived_by_id:
             # if is changeable then unarchive (nothing to check here)
             if self.changeability_by_mongo_id[mongo_id]:
@@ -2123,10 +2124,8 @@ class SyncEntitiesFactory:
             archived_name = archived_by_id["name"]
 
             if (
-                archived_name != entity_dict["name"] or
-                archived_parents != entity_dict["final_entity"]["data"][
-                    "parents"
-                ]
+                archived_name != entity_dict["name"]
+                or archived_parents != final_parents
             ):
                 return None
 
@@ -2136,11 +2135,7 @@ class SyncEntitiesFactory:
         for archived in archived_by_name:
             mongo_id = str(archived["_id"])
             archived_parents = archived.get("data", {}).get("parents")
-            if (
-                archived_parents == entity_dict["final_entity"]["data"][
-                    "parents"
-                ]
-            ):
+            if archived_parents == final_parents:
                 return mongo_id
 
         # Secondly try to find more close to current ftrack entity
@@ -2350,8 +2345,7 @@ class SyncEntitiesFactory:
                 continue
 
             changed = True
-            parents = [par for par in _parents]
-            hierarchy = "/".join(parents)
+            parents = list(_parents)
             self.entities_dict[ftrack_id][
                 "final_entity"]["data"]["parents"] = parents
 


### PR DESCRIPTION
## Brief description
Fix issue when asset has doubled last parent.

## Description
The issue happens when mongo id is not filled in ftrack but entity exists in mongo. Source of issue is because of loggins path of entity which adds parent's name to parens to log it's path but did not create copy of parents list.

## Additional information
The issue happened in most of cases during editorial publishing where both ftrack and mongo entities are created and ftrack did not fill mongo id in custom attributes.

## Testing notes:
1. Sync a project from ftrack
2. Remove Avalon Mongo ID value from entities in ftrack
3. Remove `ftrackId` from assets data in mongo
4. Sync project again
5. Check mongo values where should be all parents right
NOTE: Second sync form ftrack would fix the issue so make sure you sync only once after values removement.