### PR TITLE
Settings UI: Don't create QApplication if already exists

### DIFF
--- a/openpype/tools/settings/__init__.py
+++ b/openpype/tools/settings/__init__.py
@@ -24,7 +24,9 @@ def main(user_role=None):
             user_role, ", ".join(allowed_roles)
         ))
 
-    app = QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication.instance()
+    if not app:
+        app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon(style.app_icon_path()))
 
     widget = MainWidget(user_role)


### PR DESCRIPTION
## Brief description
Settings tool does not crash if igniter is showed first.

## Description
Settings tool always created new QApplication in main function which caused crashes if any QApplication was create before that point (e.g. in igniter). It is first check if application was created.

## Testing notes:
1. Make sure that igniter will show (e.g. by temporary closing mongo server) when openpype is started with settings argument
2. After filling mongo url should the settings UI show without any issues

Resolves https://github.com/pypeclub/OpenPype/issues/4155