### PR TITLE
Global: adding imageio to settings

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -1,4 +1,24 @@
 {
+    "imageio": {
+        "ocio_config": {
+            "enabled": true,
+            "filepath": {
+                "windows": "{OPENPYPE_ROOT}/vendor/bin/ocioconfig/OpenColorIOConfigs/aces_1.2/config.ocio",
+                "darwin": "{OPENPYPE_ROOT}/vendor/bin/ocioconfig/OpenColorIOConfigs/aces_1.2/config.ocio",
+                "linux": "{OPENPYPE_ROOT}/vendor/bin/ocioconfig/OpenColorIOConfigs/aces_1.2/config.ocio"
+            }
+        },
+        "file_rules": {
+            "enabled": false,
+            "rules": {
+                "example": {
+                    "pattern": ".*(beauty).*",
+                    "colorspace": "ACES - ACEScg",
+                    "ext": "exr"
+                }
+            }
+        }
+    },
     "publish": {
         "CollectAnatomyInstanceData": {
             "follow_workfile_version": false

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_global.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_global.json
@@ -6,6 +6,74 @@
     "is_file": true,
     "children": [
         {
+            "key": "imageio",
+            "type": "dict",
+            "label": "Color Management (ImageIO)",
+            "is_group": true,
+            "children": [
+                {
+                    "key": "ocio_config",
+                    "type": "dict",
+                    "label": "OCIO config",
+                    "collapsible": true,
+                    "checkbox_key": "enabled",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled"
+                        },
+                        {
+                            "type": "path",
+                            "key": "filepath",
+                            "label": "Config path",
+                            "multiplatform": true,
+                            "multipath": false
+                        }
+                    ]
+                },
+                {
+                    "key": "file_rules",
+                    "type": "dict",
+                    "label": "File Rules",
+                    "collapsible": true,
+                    "checkbox_key": "enabled",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled"
+                        },
+                        {
+                            "key": "rules",
+                            "label": "Rules",
+                            "type": "dict-modifiable",
+                            "highlight_content": true,
+                            "collapsible": false,
+                            "object_type": {
+                                "type": "dict",
+                                "children": [
+                                    {
+                                        "key": "pattern",
+                                        "label": "Regex pattern",
+                                        "type": "text"
+                                    },
+                                    {
+                                        "key": "colorspace",
+                                        "label": "Colorspace name",
+                                        "type": "text"
+                                    },
+                                    {
+                                        "key": "ext",
+                                        "label": "File extension",
+                                        "type": "text"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "type": "schema",
             "name": "schema_global_publish"
         },


### PR DESCRIPTION
## Brief description
OCIO config with file rules at global settings

## Description
Default path is pointing to our distributed aces_1.2 config. File rules are disabled by default as those are usually used on hosts, but times to times we could need to use them for some OIIO conversions. 

## Techical notes
This is a first step towards color managed OpenPype. There is at the moment none functionality yet connected to these settings. 

## Testing notes:
1. open settings and look to Global ImageIO