### PR TITLE
Nuke: correct detection of viewer and display

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2961,7 +2961,7 @@ def get_viewer_config_from_string(input_string):
         viewer = split[1]
         display = split[0]
     elif "(" in viewer:
-        pattern = r"([\w\d\s]+).*[(](.*)[)]"
+        pattern = r"([\w\d\s\.\-]+).*[(](.*)[)]"
         result = re.findall(pattern, viewer)
         try:
             result = result.pop()


### PR DESCRIPTION
## Brief description
Regex pattern is now correctly detecting viewer

## Description
In case of Aces name convention if Rec.709 was used - regex pattern was falsely detecting Viewer as Rec only. It was causing wrong colorspace settings on OCIODisplay node.

## Testing notes:
1. Go to Nuke ImageIO settings and set `Rec.709 (ACES)` at your ACES project.
2. Publish and stop process during `Exctract Review Data Mov`. Look to OCIODisplay node and see there is Rec.709 set to Viewer.