### PR TITLE
Ensure Mongo database directory exists in Windows.

### DIFF
--- a/tools/run_mongo.ps1
+++ b/tools/run_mongo.ps1
@@ -112,4 +112,6 @@ $mongoPath = Find-Mongo $preferred_version
 Write-Color -Text ">>> ", "Using DB path: ", "[ ", "$($dbpath)", " ]" -Color Green, Gray, Cyan, White, Cyan
 Write-Color -Text ">>> ", "Port: ", "[ ", "$($port)", " ]" -Color Green, Gray, Cyan, White, Cyan
 
+New-Item -ItemType Directory -Force -Path $($dbpath)
+
 Start-Process -FilePath $mongopath "--dbpath $($dbpath) --port $($port)" -PassThru | Out-Null


### PR DESCRIPTION
## Description
If mongo database directory was missing, the tool would exit without description.

## Testing notes:
1. Ensure mongo database does not exist.
2. Run `tools/run_mongo.ps1`.