### PR TITLE
Nuke/Hiero: Remove tkinter library paths before launch

### DIFF
--- a/openpype/hosts/hiero/addon.py
+++ b/openpype/hosts/hiero/addon.py
@@ -27,7 +27,12 @@ class HieroAddon(OpenPypeModule, IHostAddon):
                 new_hiero_paths.append(norm_path)
 
         env["HIERO_PLUGIN_PATH"] = os.pathsep.join(new_hiero_paths)
+        # Remove auto screen scale factor for Qt
+        # - let Hiero decide it's value
         env.pop("QT_AUTO_SCREEN_SCALE_FACTOR", None)
+        # Remove tkinter library paths if are set
+        env.pop("TK_LIBRARY", None)
+        env.pop("TCL_LIBRARY", None)
 
         # Add vendor to PYTHONPATH
         python_path = env["PYTHONPATH"]

--- a/openpype/hosts/nuke/addon.py
+++ b/openpype/hosts/nuke/addon.py
@@ -27,7 +27,12 @@ class NukeAddon(OpenPypeModule, IHostAddon):
                 new_nuke_paths.append(norm_path)
 
         env["NUKE_PATH"] = os.pathsep.join(new_nuke_paths)
+        # Remove auto screen scale factor for Qt
+        # - let Nuke decide it's value
         env.pop("QT_AUTO_SCREEN_SCALE_FACTOR", None)
+        # Remove tkinter library paths if are set
+        env.pop("TK_LIBRARY", None)
+        env.pop("TCL_LIBRARY", None)
 
         # Add vendor to PYTHONPATH
         python_path = env["PYTHONPATH"]


### PR DESCRIPTION
## Brief description
Nuke/Hiero started from Builded OpenPype on Windows does not have issues with unicode by removing `TCL_LIBRARY` and `TK_LIBRARY` environment variables before start of Nuke and Hiero.

## Description
Issue is described in https://github.com/pypeclub/OpenPype/issues/4170 . The environments are forced to be removed before application start.

## Testing notes:
Follow steps from the issue.

Resolves https://github.com/pypeclub/OpenPype/issues/4170