### PR TITLE
Various minor bugfixes

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_first_version_status.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_first_version_status.py
@@ -135,9 +135,9 @@ class FirstVersionStatus(BaseEvent):
 
             new_status = asset_version_statuses.get(found_item["status"])
             if not new_status:
-                self.log.warning(
+                self.log.warning((
                     "AssetVersion doesn't have status `{}`."
-                ).format(found_item["status"])
+                ).format(found_item["status"]))
                 continue
 
             try:

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -915,7 +915,7 @@
                 "current_context": [
                     {
                         "subset_name_filters": [
-                            "\".+[Mm]ain\""
+                            ".+[Mm]ain"
                         ],
                         "families": [
                             "model"

--- a/openpype/tools/standalonepublish/widgets/widget_family.py
+++ b/openpype/tools/standalonepublish/widgets/widget_family.py
@@ -186,16 +186,11 @@ class FamilyWidget(QtWidgets.QWidget):
         if item is None:
             return
 
-        asset_doc = None
-        if asset_name != self.NOT_SELECTED:
-            # Get the assets from the database which match with the name
-            project_name = self.dbcon.active_project()
-            asset_doc = get_asset_by_name(
-                project_name, asset_name, fields=["_id"]
-            )
-
         # Early exit if no asset name
-        if not asset_name.strip():
+        if (
+            asset_name == self.NOT_SELECTED
+            or not asset_name.strip()
+        ):
             self._build_menu([])
             item.setData(ExistsRole, False)
             print("Asset name is required ..")
@@ -207,8 +202,10 @@ class FamilyWidget(QtWidgets.QWidget):
         asset_doc = get_asset_by_name(
             project_name, asset_name, fields=["_id"]
         )
+
         # Get plugin
         plugin = item.data(PluginRole)
+
         if asset_doc and plugin:
             asset_id = asset_doc["_id"]
             task_name = self.dbcon.Session["AVALON_TASK"]

--- a/openpype/tools/standalonepublish/widgets/widget_family.py
+++ b/openpype/tools/standalonepublish/widgets/widget_family.py
@@ -194,9 +194,6 @@ class FamilyWidget(QtWidgets.QWidget):
                 project_name, asset_name, fields=["_id"]
             )
 
-        # Get plugin and family
-        plugin = item.data(PluginRole)
-
         # Early exit if no asset name
         if not asset_name.strip():
             self._build_menu([])


### PR DESCRIPTION
## Minor Bugs

* [Warning log with missing parenthesis.](https://github.com/pypeclub/OpenPype/commit/7772ac7ea9125e2d06d5e31cf5771bb7e2211ca1)
    * String ```format``` applied to ```log.warning``` function instead of its string content.

* Standalone Publish ```widget_family```
    * [Duplicate command to get the plugin from the selected item.](https://github.com/pypeclub/OpenPype/commit/605432cc5db24201a124a4bf220200f672f502bf)
    * [Asset selection check.](https://github.com/pypeclub/OpenPype/commit/ba149de263a5edef4468e9822ee6e44b2f557789)
        * Check if the ```asset_name``` is not empty, but should also check if not equal to  ```NOT_SELECTED```.
        * Steps to reproduce:
            * Without anything selected in asset browser, select a family in the list.
            * The following message is displayed in the logs:
                ```
                Asset '< Nothing is selected >' not found ..
                ```

* Maya Workfile Build Settings
    * [Default value for "Subset name Filters" of "model" family for "Lighting" task contains extra quotes](https://github.com/pypeclub/OpenPype/commit/f9680ccb78ebf2a1addd4f6b76a3cc776f09aff4).
        * Default value is ```".+[Mm]ain"```
        * The quotes should not be part of the regex.
        * Steps to reproduce:
            * Publish a model for the related asset (with subset "modelMain").
            * Switch context to the "Lighting" task.
            * Build first workfile (from "OpenPype" menu).
            * The published model was not imported.
            * By removing the quotes in the settings, the model is imported.
