### PR TITLE
Draft: Feature: Handling workfile out of date in blender

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -16,9 +16,22 @@ import bpy
 import bpy.utils.previews
 
 from openpype import style
-from openpype.pipeline import legacy_io
+from openpype.client.entities import (
+    get_subset_by_id,
+    get_version_by_id,
+    match_subset_id,
+    get_representation_by_task,
+)
+from openpype.pipeline import legacy_io, Anatomy
 from openpype.tools.utils import host_tools
-
+from openpype.modules.sync_server.sync_server import (
+    get_last_published_workfile_path,
+    download_last_published_workfile,
+)
+from openpype.client.entities import (
+    get_last_version_by_subset_id,
+    get_asset_by_name,
+)
 from .workio import OpenFileCacher
 
 PREVIEW_COLLECTIONS: Dict = dict()
@@ -344,6 +357,135 @@ class LaunchWorkFiles(LaunchQtApp):
         self._window.refresh()
 
 
+class DownloadLastWorkfile(bpy.types.Operator):
+    """Downloads Last Workfile."""
+
+    bl_idname = "wm.download_last_workfile"
+    bl_label = "Download Latest Workfile"
+
+    @classmethod
+    def poll(cls, context):
+        """Returns if this operator is available or not."""
+        return context.window_manager.is_workfile_out_of_date
+
+    def execute(self, context):
+        """Executes this operator."""
+        session = legacy_io.Session
+        project_name = session.get("AVALON_PROJECT")
+        task_name = session.get("AVALON_TASK")
+        asset_name = session.get("AVALON_ASSET")
+        anatomy = Anatomy(project_name)
+        asset_doc = get_asset_by_name(
+            project_name,
+            session.get("AVALON_ASSET"),
+        )
+
+        # Get subset id
+        subset_id = match_subset_id(
+            project_name, task_name, "workfile", asset_doc
+        )
+        if subset_id is None:
+            print(
+                f"Not any matched subset for task '{task_name}'"
+                f" of '{asset_name}'"
+            )
+            return {"CANCELLED"}
+
+        # Get workfile representation
+        last_version_doc = get_last_version_by_subset_id(
+            project_name, subset_id, fields=["_id", "name"]
+        )
+        if not last_version_doc:
+            print("Subset does not have any version")
+            return {"CANCELLED"}
+
+        workfile_representation = get_representation_by_task(
+            project_name,
+            task_name,
+            last_version_doc,
+        )
+        if not workfile_representation:
+            print(
+                "No published workfile for task "
+                f"'{task_name}' and host blender"
+            )
+            return {"CANCELLED"}
+
+        bpy.ops.wm.open_mainfile(
+            filepath=download_last_published_workfile(
+                "blender",
+                project_name,
+                asset_name,
+                task_name,
+                get_last_published_workfile_path(
+                    "blender",
+                    project_name,
+                    task_name,
+                    workfile_representation,
+                    anatomy=anatomy,
+                ),
+                workfile_representation,
+                subset_id,
+                last_version_doc,
+                anatomy=anatomy,
+                asset_doc=asset_doc,
+            )
+        )
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+
+
+class DrawWorkFileOutOfDateWarning(bpy.types.Operator):
+    """Displays a warning message about the workfile being out of date.
+    Either the user chooses to willingly proceed with their out of date
+    workfile, or blender will be closed after clicking on `OK`."""
+
+    bl_idname = "wm.workfile_out_of_date"
+    bl_label = "WARNING: Workfile is out of date"
+
+    action_enum: bpy.props.EnumProperty(
+        name="Action Enum",
+        items=(
+            ("DL", "Download last workfile", "Download last workfile"),
+            ("QUIT", "Quit blender", "Quit blender"),
+            ("PROC", "Proceed anyway", "Proceed anyway AT YOUR OWN RISK"),
+        ),
+    )
+
+    def execute(self, context):
+        """Executes this operator."""
+        if self.action_enum == "DL":
+            bpy.ops.wm.download_last_workfile("EXEC_DEFAULT")
+        elif self.action_enum == "QUIT":
+            bpy.ops.wm.quit_blender()
+        elif self.action_enum != "PROC":
+            print("Undefined enum value error")
+            return {"CANCELLED"}
+        return {"FINISHED"}
+
+    def cancel(self, context):
+        """Runs when this operator is cancelled."""
+        bpy.ops.wm.workfile_out_of_date("INVOKE_DEFAULT")
+
+    def invoke(self, context, event):
+        """Invokes this operator."""
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        """Draws UI."""
+        col = self.layout.column()
+
+        # Display alert
+        row = col.row()
+        row.alert = True
+        row.label(text="Your workfile is out of date.")
+
+        # Display enum
+        col.prop(self, "action_enum", expand=True)
+
+
 class TOPBAR_MT_avalon(bpy.types.Menu):
     """Avalon menu."""
 
@@ -384,12 +526,19 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
         # TODO (jasper): maybe add 'Reload Pipeline', 'Reset Frame Range' and
         #                'Reset Resolution'?
+        layout.operator(DownloadLastWorkfile.bl_idname, text="Update Workfile")
 
 
 def draw_avalon_menu(self, context):
     """Draw the Avalon menu in the top bar."""
 
-    self.layout.menu(TOPBAR_MT_avalon.bl_idname)
+    self.layout.menu(
+        TOPBAR_MT_avalon.bl_idname,
+        icon="ERROR"
+        if bpy.context.window_manager.is_workfile_out_of_date
+        else "NONE",
+    )
+
 
 
 classes = [
@@ -399,6 +548,8 @@ classes = [
     LaunchManager,
     LaunchLibrary,
     LaunchWorkFiles,
+    DownloadLastWorkfile,
+    DrawWorkFileOutOfDateWarning,
     TOPBAR_MT_avalon,
 ]
 

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -358,18 +358,18 @@ class LaunchWorkFiles(LaunchQtApp):
 
 
 class DownloadLastWorkfile(bpy.types.Operator):
-    """Downloads Last Workfile."""
+    """Download Last Workfile."""
 
     bl_idname = "wm.download_last_workfile"
     bl_label = "Download Latest Workfile"
 
     @classmethod
     def poll(cls, context):
-        """Returns if this operator is available or not."""
+        """Return if this operator is available or not."""
         return context.window_manager.is_workfile_out_of_date
 
     def execute(self, context):
-        """Executes this operator."""
+        """Execute this operator."""
         session = legacy_io.Session
         project_name = session.get("AVALON_PROJECT")
         task_name = session.get("AVALON_TASK")
@@ -434,11 +434,12 @@ class DownloadLastWorkfile(bpy.types.Operator):
         return {"FINISHED"}
 
     def invoke(self, context, event):
+        """Invoke this operator."""
         return self.execute(context)
 
 
 class DrawWorkFileOutOfDateWarning(bpy.types.Operator):
-    """Displays a warning message about the workfile being out of date.
+    """Display a warning message about the workfile being out of date.
     Either the user chooses to willingly proceed with their out of date
     workfile, or blender will be closed after clicking on `OK`."""
 
@@ -455,7 +456,7 @@ class DrawWorkFileOutOfDateWarning(bpy.types.Operator):
     )
 
     def execute(self, context):
-        """Executes this operator."""
+        """Execute this operator."""
         if self.action_enum == "DL":
             bpy.ops.wm.download_last_workfile("EXEC_DEFAULT")
         elif self.action_enum == "QUIT":
@@ -466,15 +467,15 @@ class DrawWorkFileOutOfDateWarning(bpy.types.Operator):
         return {"FINISHED"}
 
     def cancel(self, context):
-        """Runs when this operator is cancelled."""
+        """Run when this operator is cancelled."""
         bpy.ops.wm.workfile_out_of_date("INVOKE_DEFAULT")
 
     def invoke(self, context, event):
-        """Invokes this operator."""
+        """Invoke this operator."""
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context):
-        """Draws UI."""
+        """Draw UI."""
         col = self.layout.column()
 
         # Display alert

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -11,6 +11,9 @@ from . import ops
 import pyblish.api
 
 from openpype.client import get_asset_by_name
+from openpype.hosts.blender.utility_scripts.is_workfile_out_of_date import (
+    is_work_file_out_of_date,
+)
 from openpype.pipeline import (
     schema,
     legacy_io,
@@ -124,10 +127,17 @@ def set_start_end_frames():
 
 def on_new():
     set_start_end_frames()
+    bpy.types.WindowManager.is_workfile_out_of_date = bpy.props.BoolProperty(
+        name="Is Workfile Out Of Date",
+    )
 
 
 def on_open():
     set_start_end_frames()
+    if is_work_file_out_of_date():
+        bpy.context.window_manager.is_workfile_out_of_date = True
+        bpy.ops.wm.workfile_out_of_date("INVOKE_DEFAULT")
+
 
 
 @bpy.app.handlers.persistent

--- a/openpype/hosts/blender/plugins/publish/validate_workfile_up_to_date.py
+++ b/openpype/hosts/blender/plugins/publish/validate_workfile_up_to_date.py
@@ -1,0 +1,25 @@
+import pyblish.api
+import bpy
+
+from openpype.hosts.blender.utility_scripts.is_workfile_out_of_date import (
+    is_work_file_out_of_date,
+)
+
+
+class ValidateWorkfileUpToDate(pyblish.api.Validator):
+    """Validate that the current workfile is up to date."""
+
+    hosts = ["blender"]
+    families = ["workfile"]
+    label = "Validate Workfile Up To Date"
+    optional = True
+
+    def process(self):
+        if (
+            is_work_file_out_of_date()
+            or bpy.context.window_manager.is_workfile_out_of_date
+        ):
+            raise RuntimeError(
+                "Current workfile is out of date! "
+                "Please download last workfile."
+            )

--- a/openpype/hosts/blender/utility_scripts/is_workfile_out_of_date.py
+++ b/openpype/hosts/blender/utility_scripts/is_workfile_out_of_date.py
@@ -8,10 +8,10 @@ from openpype.hosts.blender.api.workio import current_file
 
 
 def is_work_file_out_of_date() -> bool:
-    """Checks if the current workfile is out of date.
-    This is based on last modification date, so if a user modifies an out of date
-    workfile, this will return `False`. Also, in case of partial publish, this will
-    return `True`.
+    """Check if the current workfile is out of date.
+    This is based on last modification date, so if a user modifies an out of 
+    date workfile, this will return `False`. Also, in case of partial publish, 
+    this will return `True`.
 
     Returns:
         bool: True if the current workfile is out of date.

--- a/openpype/hosts/blender/utility_scripts/is_workfile_out_of_date.py
+++ b/openpype/hosts/blender/utility_scripts/is_workfile_out_of_date.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from datetime import datetime
+
+from openpype.lib.dateutils import get_timestamp
+from openpype.client.entities import get_last_version_by_subset_name
+from openpype.pipeline import legacy_io
+from openpype.hosts.blender.api.workio import current_file
+
+
+def is_work_file_out_of_date() -> bool:
+    """Checks if the current workfile is out of date.
+    This is based on last modification date, so if a user modifies an out of date
+    workfile, this will return `False`. Also, in case of partial publish, this will
+    return `True`.
+
+    Returns:
+        bool: True if the current workfile is out of date.
+    """
+
+    session = legacy_io.Session
+
+    # Getting date and time of the latest published workfile
+    last_published_time = get_last_version_by_subset_name(
+        legacy_io.active_project(),
+        f"workfile{session.get('AVALON_TASK')}",
+        asset_name=session.get("AVALON_ASSET"),
+    )["data"]["time"]
+
+    # Getting date and time of the latest locally installed workfile
+    # Time is converted to use the same format as for `last_publishd_time`
+    workfile_time = get_timestamp(
+        datetime.fromtimestamp(Path(current_file()).stat().st_mtime)
+    )
+
+    return last_published_time > workfile_time


### PR DESCRIPTION
Draft: This PR depends on this other PR: https://github.com/pypeclub/OpenPype/pull/4102

# Description
Added warning and validator when workfile is out of file.
The warning shows up as a props dialog that user cannot ignore as it will be reinvoked on cancel (So if they click anywhere outside of the dialog, it reappears). This props dialog has an enum to select what action to perform, then they can click "OK" to execute.

There are three actions provided:
- Download last workfile
- Quit blender
- Proceed anyway

There is also a variable set when the workfile has been detected as out of date. The validator checks it, so if user decide to proceed anyway, they won't be able to publish, unless they explicitly untick this box.
A warning sign will appear next to the OpenPype menu as well, and there is also an Update workfile button in the OpenPype menu, which is grayed out if the workfile is up to date.
This system however presents a limitation: As the workfile is determined as up to date, or out of date based on modification time, if it is modified and saved then it will always be considered up to date. This brings a few unwanted behavior. For instance if the users proceeds anyway, then closes blender, as the file is saved when making paths absolute, it will always be considered up to date from now on.


# Testing
## General
- Have a local workfile (blender) with its datetime older than the last published workfile
- Open it in blender using OpenPype launcher
- Notice the props dialog popping, try to click somewhere else and see that it reappears whatever you do
- Select an option in the enum and click ok to test it.

## Download last workfile using the props dialog
- Select `Download last workfile` in the enum and click ok
- The last workfile should now download and be automatically opened, with the correct version number
- Confirm props dialog does not reopen
- Confirm OpenPype menu does not have a warning sign
- Confirm `Update workfile` in the OpenPype menu is grayed out
- Open pyblish and do a publish test (at least test the validators)

## Quit blender using props dialog
- Select `Quit blender` in the enum and click ok
- Blender should close

## Proceed anyway
- Select `proceed anyway` in the enum and click ok
- You should now be able to work
- OpenPype menu should have a warning sign
- Try to publish, the workfile up to date validator should fail
- Reset pyblish, untick the workfile up to date validator, and do a publish test again (at least test validators)
- Confirm `Update workfile` is available in the OpenPype menu and has the same behavior as the `Download last workfile` option in the props dialog

## Workfile is up to date case
- Confirm props dialog does not display
- Confirm OpenPype menu should does not have a warning sign
- Confirm `Update workfile` in the OpenPype menu is grayed out
- Confirm you can publish (at least test validators)