### PR TITLE
General: Comment per instance in Publisher

### DIFF
--- a/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
+++ b/openpype/hosts/nuke/plugins/publish/extract_slate_frame.py
@@ -298,7 +298,7 @@ class ExtractSlateFrame(publish.Extractor):
 
     def add_comment_slate_node(self, instance, node):
 
-        comment = instance.context.data.get("comment")
+        comment = instance.data["comment"]
         intent = instance.context.data.get("intent")
         if not isinstance(intent, dict):
             intent = {

--- a/openpype/modules/deadline/plugins/publish/submit_celaction_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_celaction_deadline.py
@@ -38,7 +38,7 @@ class CelactionSubmitDeadline(pyblish.api.InstancePlugin):
         assert deadline_url, "Requires Deadline Webservice URL"
 
         self.deadline_url = "{}/api/jobs".format(deadline_url)
-        self._comment = context.data.get("comment", "")
+        self._comment = instance.data["comment"]
         self._deadline_user = context.data.get(
             "deadlineUser", getpass.getuser())
         self._frame_start = int(instance.data["frameStart"])

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -777,6 +777,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "handleEnd": handle_end,
             "frameStartHandle": start - handle_start,
             "frameEndHandle": end + handle_end,
+            "comment": instance.data["comment"],
             "fps": fps,
             "source": source,
             "extendFrames": data.get("extendFrames"),

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_description.py
@@ -38,7 +38,7 @@ class IntegrateFtrackDescription(pyblish.api.InstancePlugin):
             self.log.info("There are any integrated AssetVersions")
             return
 
-        comment = (instance.context.data.get("comment") or "").strip()
+        comment = instance.data["comment"]
         if not comment:
             self.log.info("Comment is not set.")
         else:

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_note.py
@@ -45,7 +45,7 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
         host_name = context.data["hostName"]
         app_name = context.data["appName"]
         app_label = context.data["appLabel"]
-        comment = (context.data.get("comment") or "").strip()
+        comment = instance.data["comment"]
         if not comment:
             self.log.info("Comment is not set.")
         else:

--- a/openpype/pipeline/publish/publish_plugins.py
+++ b/openpype/pipeline/publish/publish_plugins.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABCMeta
 
 import pyblish.api
@@ -132,6 +133,25 @@ class OpenPypePyblishPluginMixin:
                 )
         return attribute_values
 
+    @staticmethod
+    def get_attr_values_from_data_for_plugin(plugin, data):
+        """Get attribute values for attribute definitions from data.
+
+        Args:
+            plugin (Union[publish.api.Plugin, Type[publish.api.Plugin]]): The
+                plugin for which attributes are extracted.
+            data(dict): Data from instance or context.
+        """
+
+        if not inspect.isclass(plugin):
+            plugin = plugin.__class__
+
+        return (
+            data
+            .get("publish_attributes", {})
+            .get(plugin.__name__, {})
+        )
+
     def get_attr_values_from_data(self, data):
         """Get attribute values for attribute definitions from data.
 
@@ -139,11 +159,7 @@ class OpenPypePyblishPluginMixin:
             data(dict): Data from instance or context.
         """
 
-        return (
-            data
-            .get("publish_attributes", {})
-            .get(self.__class__.__name__, {})
-        )
+        return self.get_attr_values_from_data_for_plugin(self.__class__, data)
 
 
 class OptionalPyblishPluginMixin(OpenPypePyblishPluginMixin):

--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -1,8 +1,26 @@
-"""
-Requires:
-    None
-Provides:
-    context -> comment (str)
+"""Collect comment and add option to enter comment per instance.
+
+Combination of plugins. One define optional input for instances in Publisher
+UI (CollectInstanceCommentDef) and second cares that each instance during
+collection has available "comment" key in data (CollectComment).
+
+Plugin 'CollectInstanceCommentDef' define "comment" attribute which won't be
+filled with any value if instance does not match families filter or when
+plugin is disabled.
+
+Plugin 'CollectComment' makes sure that each instance in context has
+available "comment" key in data which can be set to 'str' or 'None' if is not
+set.
+- In case instance already has filled comment the plugin's logic is skipped
+- The comment is always set and value should be always 'str' even if is empty
+
+Why are separated:
+- 'CollectInstanceCommentDef' can have specific settings to show comment
+    attribute only to defined families in publisher UI
+- 'CollectComment' will run all the time
+
+Todos:
+    The comment per instance is not sent via farm.
 """
 
 import pyblish.api
@@ -31,11 +49,59 @@ class CollectInstanceCommentDef(
 
 
 class CollectComment(pyblish.api.ContextPlugin):
-    """This plug-ins displays the comment dialog box per default"""
+    """Collect comment per each instance.
 
-    label = "Collect Comment"
-    order = pyblish.api.CollectorOrder
+    Plugin makes sure each instance to publish has set "comment" in data so any
+    further plugin can use it directly.
+    """
+
+    label = "Collect Instance Comment"
+    order = pyblish.api.CollectorOrder + 0.49
 
     def process(self, context):
-        comment = (context.data.get("comment") or "").strip()
-        context.data["comment"] = comment
+        context_comment = self.cleanup_comment(context.data.get("comment"))
+        # Set it back
+        context.data["comment"] = context_comment
+        for instance in context:
+            instance_label = str(instance)
+            # Check if comment is already set
+            instance_comment = self.cleanup_comment(
+                instance.data.get("comment"))
+
+            # If comment on instance is not set then look for attributes
+            if not instance_comment:
+                attr_values = self.get_attr_values_from_data_for_plugin(
+                    CollectInstanceCommentDef, instance.data
+                )
+                instance_comment = self.cleanup_comment(
+                    attr_values.get("comment")
+                )
+
+            # Use context comment if instance has all options of comment
+            #   empty
+            if not instance_comment:
+                instance_comment = context_comment
+
+            instance.data["comment"] = instance_comment
+            if instance_comment:
+                msg_end = " has comment set to: \"{}\"".format(
+                    instance_comment)
+            else:
+                msg_end = " does not have set comment"
+            self.log.debug("Instance {} {}".format(instance_label, msg_end))
+
+    def cleanup_comment(self, comment):
+        """Cleanup comment value.
+
+        Args:
+            comment (Union[str, None]): Comment value from data.
+
+        Returns:
+            str: Cleaned comment which is stripped or empty string if input
+                was 'None'.
+        """
+
+        if comment:
+            return comment.strip()
+        return ""
+

--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -6,6 +6,28 @@ Provides:
 """
 
 import pyblish.api
+from openpype.lib.attribute_definitions import TextDef
+from openpype.pipeline.publish import OpenPypePyblishPluginMixin
+
+
+class CollectInstanceCommentDef(
+    pyblish.api.ContextPlugin,
+    OpenPypePyblishPluginMixin
+):
+    label = "Comment per instance"
+    targets = ["local"]
+    # Disable plugin by default
+    families = ["*"]
+    enabled = True
+
+    def process(self, instance):
+        pass
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            TextDef("comment", label="Comment")
+        ]
 
 
 class CollectComment(pyblish.api.ContextPlugin):

--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -35,11 +35,25 @@ class CollectInstanceCommentDef(
     label = "Comment per instance"
     targets = ["local"]
     # Disable plugin by default
-    families = ["*"]
-    enabled = True
+    families = []
+    enabled = False
 
     def process(self, instance):
         pass
+
+    @classmethod
+    def apply_settings(cls, project_setting, _):
+        plugin_settings = project_setting["global"]["publish"].get(
+            "collect_comment_per_instance"
+        )
+        if not plugin_settings:
+            return
+
+        if plugin_settings.get("enabled") is not None:
+            cls.enabled = plugin_settings["enabled"]
+
+        if plugin_settings.get("families") is not None:
+            cls.families = plugin_settings["families"]
 
     @classmethod
     def get_attribute_defs(cls):

--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -62,7 +62,10 @@ class CollectInstanceCommentDef(
         ]
 
 
-class CollectComment(pyblish.api.ContextPlugin):
+class CollectComment(
+    pyblish.api.ContextPlugin,
+    OpenPypePyblishPluginMixin
+):
     """Collect comment per each instance.
 
     Plugin makes sure each instance to publish has set "comment" in data so any

--- a/openpype/plugins/publish/collect_comment.py
+++ b/openpype/plugins/publish/collect_comment.py
@@ -121,4 +121,3 @@ class CollectComment(
         if comment:
             return comment.strip()
         return ""
-

--- a/openpype/plugins/publish/extract_burnin.py
+++ b/openpype/plugins/publish/extract_burnin.py
@@ -468,7 +468,7 @@ class ExtractBurnin(publish.Extractor):
 
         burnin_data.update({
             "version": int(version),
-            "comment": context.data.get("comment") or ""
+            "comment": instance.data["comment"]
         })
 
         intent_label = context.data.get("intent") or ""

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -772,7 +772,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             "time": context.data["time"],
             "author": context.data["user"],
             "source": source,
-            "comment": context.data.get("comment"),
+            "comment": instance.data["comment"],
             "machine": context.data.get("machine"),
             "fps": instance.data.get("fps", context.data.get("fps"))
         }

--- a/openpype/plugins/publish/integrate_legacy.py
+++ b/openpype/plugins/publish/integrate_legacy.py
@@ -968,7 +968,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             "time": context.data["time"],
             "author": context.data["user"],
             "source": source,
-            "comment": context.data.get("comment"),
+            "comment": instance.data["comment"],
             "machine": context.data.get("machine"),
             "fps": context.data.get(
                 "fps", instance.data.get("fps")

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -24,6 +24,10 @@
             ],
             "skip_hosts_headless_publish": []
         },
+        "collect_comment_per_instance": {
+            "enabled": false,
+            "families": []
+        },
         "ValidateEditorialAssetName": {
             "enabled": true,
             "optional": false

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -63,6 +63,27 @@
         {
             "type": "dict",
             "collapsible": true,
+            "key": "collect_comment_per_instance",
+            "label": "Collect comment per instance",
+            "checkbox_key": "enabled",
+            "is_group": true,
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                },
+                {
+                    "key": "families",
+                    "label": "Families",
+                    "type": "list",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
+            "type": "dict",
+            "collapsible": true,
             "checkbox_key": "enabled",
             "key": "ValidateEditorialAssetName",
             "label": "Validate Editorial Asset Name",


### PR DESCRIPTION
## Brief description
Instances in publisher can have ability to set comment per instance.

## Description
Collect comment plugin also store comment to each instance in context (so all plugins using it can access it directly). Added plugin which define "comment" attribute per instance and have settings for which families is available. By default is disabled and for none families.

The same should work when instance is sent to farm. Comment should stay on instances (didn't test).

## Additional information
Modified instance data sent to farm to contain comment per instance to persist comment from UI.

## Testing notes:
1. Enable the `Collect Comment per instance` in settings and fill families by your choice (`project_settings/global/publish/collect_comment_per_instance`)
2. Run host which use new Publisher tool (e.g. TrayPublisher)
3. Create instance with family from settings
4. Select instance and fill it's comment
5. Publish
6. Validate that the comment on instance was used where should be (e.g. in ftrack -> make sure comment can be used in note/description)