### PR TITLE
Fix: Template path wrong normpath for cross platform

### DIFF
--- a/openpype/lib/path_templates.py
+++ b/openpype/lib/path_templates.py
@@ -422,7 +422,7 @@ class TemplateResult(str):
 
         cls = self.__class__
         return cls(
-            os.path.normpath(self),
+            os.path.normpath(self.replace("\\", "/")),
             self.template,
             self.solved,
             self.used_values,

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -555,7 +555,7 @@ def get_representation_path_with_anatomy(repre_doc, anatomy):
     """
 
     try:
-        template = repre_doc["data"]["template"].replace("\\", "/")
+        template = repre_doc["data"]["template"]
 
     except KeyError:
         raise InvalidRepresentationContext((

--- a/openpype/pipeline/load/utils.py
+++ b/openpype/pipeline/load/utils.py
@@ -555,7 +555,7 @@ def get_representation_path_with_anatomy(repre_doc, anatomy):
     """
 
     try:
-        template = repre_doc["data"]["template"]
+        template = repre_doc["data"]["template"].replace("\\", "/")
 
     except KeyError:
         raise InvalidRepresentationContext((


### PR DESCRIPTION
## Brief description
When a representation is published from windows, the `data.template` is filled with backslashs (`{root[main]}\_OpenPype\PUBLISH\{hierarchy}\{asset}\{family}\{subset}\v…`). When trying to open this file on Linux, the root is resolved with forward slashes and if in case your local root ends with a forward slash (`/my/root/path/`), `os.path.normpath` returns `/my/root/path/\\_OpenPype\\PUBLISH...`, which is not a valid path.

This fix ensures this case doesn't happen by replacing all backslashes with forward slashes.