### PR TITLE
General: Integrate thumbnail looks for thumbnail to multiple places

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail_from_source.py
+++ b/openpype/plugins/publish/extract_thumbnail_from_source.py
@@ -73,6 +73,7 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
             "Adding thumbnail representation: {}".format(new_repre)
         )
         instance.data["representations"].append(new_repre)
+        instance.data["thumbnailPath"] = dst_filepath
 
     def _create_thumbnail(self, context, thumbnail_source):
         if not thumbnail_source:

--- a/openpype/plugins/publish/integrate_thumbnail.py
+++ b/openpype/plugins/publish/integrate_thumbnail.py
@@ -102,8 +102,56 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
             thumbnail_root
         )
 
+    def _get_thumbnail_from_instance(self, instance):
+        # 1. Look for thumbnail path on instance in 'thumbnailPath'
+        thumbnail_path = instance.data.get("thumbnailPath")
+        if thumbnail_path and os.path.exists(thumbnail_path):
+            return thumbnail_path
+
+        # 2. Look for thumbnail in published representations
+        published_repres = instance.data.get("published_representations")
+        path = self._get_thumbnail_path_from_published(published_repres)
+        if path and os.path.exists(path):
+            return path
+
+        if path:
+            self.log.warning(
+                "Could not find published thumbnail path {}".format(path)
+            )
+
+        # 3. Look for thumbnail in "not published" representations
+        repres = instance.data.get("representations")
+        if not repres:
+            return None
+
+        thumbnail_repre = next(
+            (
+                repre
+                for repre in repres
+                if repre["name"] == "thumbnail"
+            ),
+            None
+        )
+        if not thumbnail_repre:
+            return None
+
+        staging_dir = thumbnail_repre.get("stagingDir")
+        if not staging_dir:
+            staging_dir = instance.data.get("stagingDir")
+
+        filename = thumbnail_repre.get("files")
+        if not staging_dir or not filename:
+            return None
+
+        if isinstance(filename, (list, tuple, set)):
+            filename = filename[0]
+        thumbnail_path = os.path.join(staging_dir, filename)
+        if os.path.exists(thumbnail_path):
+            return thumbnail_path
+        return None
+
     def _prepare_instances(self, context):
-        context_thumbnail_path = context.get("thumbnailPath")
+        context_thumbnail_path = context.data.get("thumbnailPath")
         valid_context_thumbnail = False
         if context_thumbnail_path and os.path.exists(context_thumbnail_path):
             valid_context_thumbnail = True
@@ -122,8 +170,7 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
                 continue
 
             # Find thumbnail path on instance
-            thumbnail_path = self._get_instance_thumbnail_path(
-                published_repres)
+            thumbnail_path = self._get_thumbnail_from_instance(instance)
             if thumbnail_path:
                 self.log.debug((
                     "Found thumbnail path for instance \"{}\"."
@@ -157,7 +204,10 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
         for repre_info in published_representations.values():
             return repre_info["representation"]["parent"]
 
-    def _get_instance_thumbnail_path(self, published_representations):
+    def _get_thumbnail_path_from_published(self, published_representations):
+        if not published_representations:
+            return None
+
         thumb_repre_doc = None
         for repre_info in published_representations.values():
             repre_doc = repre_info["representation"]

--- a/openpype/plugins/publish/integrate_thumbnail.py
+++ b/openpype/plugins/publish/integrate_thumbnail.py
@@ -103,12 +103,7 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
         )
 
     def _get_thumbnail_from_instance(self, instance):
-        # 1. Look for thumbnail path on instance in 'thumbnailPath'
-        thumbnail_path = instance.data.get("thumbnailPath")
-        if thumbnail_path and os.path.exists(thumbnail_path):
-            return thumbnail_path
-
-        # 2. Look for thumbnail in published representations
+        # 1. Look for thumbnail in published representations
         published_repres = instance.data.get("published_representations")
         path = self._get_thumbnail_path_from_published(published_repres)
         if path and os.path.exists(path):
@@ -119,34 +114,33 @@ class IntegrateThumbnails(pyblish.api.ContextPlugin):
                 "Could not find published thumbnail path {}".format(path)
             )
 
-        # 3. Look for thumbnail in "not published" representations
+        # 2. Look for thumbnail in "not published" representations
         repres = instance.data.get("representations")
-        if not repres:
-            return None
-
         thumbnail_repre = next(
             (
                 repre
-                for repre in repres
+                for repre in repres or []
                 if repre["name"] == "thumbnail"
             ),
             None
         )
-        if not thumbnail_repre:
-            return None
+        if thumbnail_repre:
+            staging_dir = thumbnail_repre.get("stagingDir")
+            if not staging_dir:
+                staging_dir = instance.data.get("stagingDir")
 
-        staging_dir = thumbnail_repre.get("stagingDir")
-        if not staging_dir:
-            staging_dir = instance.data.get("stagingDir")
+            filename = thumbnail_repre.get("files")
+            if isinstance(filename, (list, tuple, set)):
+                filename = filename[0]
 
-        filename = thumbnail_repre.get("files")
-        if not staging_dir or not filename:
-            return None
+            if staging_dir and filename:
+                thumbnail_path = os.path.join(staging_dir, filename)
+                if os.path.exists(thumbnail_path):
+                    return thumbnail_path
 
-        if isinstance(filename, (list, tuple, set)):
-            filename = filename[0]
-        thumbnail_path = os.path.join(staging_dir, filename)
-        if os.path.exists(thumbnail_path):
+        # 3. Look for thumbnail path on instance in 'thumbnailPath'
+        thumbnail_path = instance.data.get("thumbnailPath")
+        if thumbnail_path and os.path.exists(thumbnail_path):
             return thumbnail_path
         return None
 


### PR DESCRIPTION
## Brief description
Integrate thumbnail can look to more places where thumbnail for instance could be found.

## Description
Before this PR was thumbnail found only on published representations or from context thumbnail. There are 2 missing sources: First is at key `"thumbnailPath"` on instance data and second is on not integrated representations. Added these 2 options.

## Order of thumbnail path resolving
1. Look for published representation with name `"thumbnail"`
2. Look for not published representation with name `"thumbnail"`
3. Look into instance data for key `"thumbnailPath"`
If any step has available value but the path is not valid then go to next step until hit end.

## Testing notes:
1. Thumbnails are integrated even if it's representation is not