### PR TITLE
Deadline: improve environment processing

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -127,10 +127,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                   "celaction": [r".*"]}
 
     environ_job_filter = [
-        "OPENPYPE_METADATA_FILE",
-        "OPENPYPE_PUBLISH_JOB",
-        "OPENPYPE_RENDER_JOB",
-        "OPENPYPE_LOG_NO_COLORS"
+        "OPENPYPE_METADATA_FILE"
     ]
 
     environ_keys = [
@@ -238,10 +235,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "AVALON_PROJECT": legacy_io.Session["AVALON_PROJECT"],
             "AVALON_ASSET": legacy_io.Session["AVALON_ASSET"],
             "AVALON_TASK": legacy_io.Session["AVALON_TASK"],
-            "OPENPYPE_LOG_NO_COLORS": "1",
             "OPENPYPE_USERNAME": instance.context.data["user"],
             "OPENPYPE_PUBLISH_JOB": "1",
-            "OPENPYPE_RENDER_JOB": "0"
+            "OPENPYPE_RENDER_JOB": "0",
+            "OPENPYPE_REMOTE_JOB": "0",
+            "OPENPYPE_LOG_NO_COLORS": "1"
         }
 
         # add environments from self.environ_keys

--- a/openpype/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/publish/submit_publish_job.py
@@ -126,14 +126,14 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                   "harmony": [r".*"],  # for everything from AE
                   "celaction": [r".*"]}
 
-    enviro_job_filter = [
+    environ_job_filter = [
         "OPENPYPE_METADATA_FILE",
         "OPENPYPE_PUBLISH_JOB",
         "OPENPYPE_RENDER_JOB",
         "OPENPYPE_LOG_NO_COLORS"
     ]
 
-    enviro_keys = [
+    environ_keys = [
         "FTRACK_API_USER",
         "FTRACK_API_KEY",
         "FTRACK_SERVER",
@@ -232,7 +232,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         # Transfer the environment from the original job to this dependent
         # job so they use the same environment
         metadata_path, roothless_metadata_path = \
-                self._create_metadata_path(instance)
+            self._create_metadata_path(instance)
 
         environment = {
             "AVALON_PROJECT": legacy_io.Session["AVALON_PROJECT"],
@@ -244,14 +244,14 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "OPENPYPE_RENDER_JOB": "0"
         }
 
-        # add environments from self.enviro_keys
-        for env_key in self.enviro_keys:
+        # add environments from self.environ_keys
+        for env_key in self.environ_keys:
             if os.getenv(env_key):
                 environment[env_key] = os.environ[env_key]
 
-        # pass environment keys from self.enviro_job_filter
+        # pass environment keys from self.environ_job_filter
         job_environ = job["Props"].get("Env", {})
-        for env_j_key in self.enviro_job_filter:
+        for env_j_key in self.environ_job_filter:
             if job_environ.get(env_j_key):
                 environment[env_j_key] = job_environ[env_j_key]
 


### PR DESCRIPTION
## Brief description
Better way of passing environments.

## Description
In some occasions there was need for having default keys in job, even those were not yet used in previous dependency job so they could not be passed with list of filtered keys. 

The procedure is working now following way.
1. default set of environment variables are compiled
2. next class attribute `enviro_keys` is iterated and found keys are included or overridden from 1. step
3. last step is taking class attribute  `environ_job_filter` is iterated and available keys in previous job are included or overridden from 2. step

## Testing notes:
1. publish to farm to your favourite host
2. all should work as before