### PR TITLE
Fix: Hero version not restored when downloading representation

### DIFF
--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -153,7 +153,7 @@ async def download(module, project_name, file, representation, provider_name,
             "path"
         ]
         hero_dirname = os.path.dirname(hero_file_path)
-        
+
         # Ensure clean hero directory
         if os.path.exists(hero_dirname):
             shutil.rmtree(hero_dirname)


### PR DESCRIPTION
## Brief description
Hero version is not created on remote site when a representation is downloaded. This copies the last version downloaded using the loader.

Fix #4154 
