### PR TITLE
gltf extractor for Maya

### DIFF
--- a/openpype/hosts/maya/api/gltf.py
+++ b/openpype/hosts/maya/api/gltf.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Tools to work with GLTF."""
+import logging
+
+from maya import cmds, mel  # noqa
+
+log = logging.getLogger(__name__)
+
+_gltf_options = {
+    "of": str,                  # outputFolder
+    "cpr": str,                 # copyright
+    "sno": bool,                # selectedNodeOnly
+    "sn": str,                  # sceneName
+    "glb": bool,                # binary
+    "nbu": bool,                # niceBufferURIs
+    "hbu": bool,                # hashBufferURI
+    "ext": bool,                # externalTextures
+    "ivt": int,                 # initialValuesTime
+    "acn": str,                 # animationClipName
+    "ast": int,                 # animationClipStartTime
+    "aet": int,                 # animationClipEndTime
+    "afr": float,               # animationClipFrameRate
+    "dsa": int,                 # detectStepAnimations
+    "mpa": str,                 # meshPrimitiveAttributes
+    "bpa": str,                 # blendPrimitiveAttributes
+    "i32": bool,                # force32bitIndices
+    "ssm": bool,                # skipStandardMaterials
+    "eut": bool,                 # excludeUnusedTexcoord
+    "dm": bool,                 # defaultMaterial
+    "cm": bool,                 # colorizeMaterials
+    "dmy": str,                 # dumpMaya
+    "dgl": str,                 # dumpGLTF
+    "imd": str,                 # ignoreMeshDeformers
+    "ssc": bool,                # skipSkinClusters
+    "sbs": bool,                # skipBlendShapes
+    "rvp": bool,                # redrawViewport
+    "vno": bool                 # visibleNodesOnly
+}
+
+
+def extract_gltf(parent_dir,
+                 filename,
+                 **kwargs):
+
+    """Sets GLTF export options from data in the instance.
+    """
+
+    cmds.loadPlugin('maya2glTF', quiet=True)
+    # load the UI to run mel command
+    mel.eval("maya2glTF_UI()")
+
+    parent_dir = parent_dir.replace('\\', '/')
+    options = {
+        "dsa": 1,
+        "glb": True
+    }
+    options.update(kwargs)
+
+    for key, value in options.copy().items():
+        if key not in _gltf_options:
+            log.warning("extract_gltf() does not support option '%s'. "
+                        "Flag will be ignored..", key)
+            options.pop(key)
+            options.pop(value)
+            continue
+
+    job_args = list()
+    default_opt = "maya2glTF -of \"{0}\" -sn \"{1}\"".format(parent_dir, filename) # noqa
+    job_args.append(default_opt)
+
+    for key, value in options.items():
+        if isinstance(value, str):
+            job_args.append("-{0} \"{1}\"".format(key, value))
+        elif isinstance(value, bool):
+            if value:
+                job_args.append("-{0}".format(key))
+        else:
+            job_args.append("-{0} {1}".format(key, value))
+
+    job_str = " ".join(job_args)
+    log.info("{}".format(job_str))
+    mel.eval(job_str)
+
+    # close the gltf export after finish the export
+    gltf_UI = "maya2glTF_exporter_window"
+    if cmds.window(gltf_UI, q=True, exists=True):
+        cmds.deleteUI(gltf_UI)

--- a/openpype/hosts/maya/plugins/publish/collect_gltf.py
+++ b/openpype/hosts/maya/plugins/publish/collect_gltf.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+
+
+class CollectGLTF(pyblish.api.InstancePlugin):
+    """Collect Assets for GLTF/GLB export."""
+
+    order = pyblish.api.CollectorOrder + 0.2
+    label = "Collect Asset for GLTF/GLB export"
+    families = ["model", "animation", "pointcache"]
+
+    def process(self, instance):
+        if not instance.data.get("families"):
+            instance.data["families"] = []
+
+        if "fbx" not in instance.data["families"]:
+            instance.data["families"].append("gltf")

--- a/openpype/hosts/maya/plugins/publish/extract_gltf.py
+++ b/openpype/hosts/maya/plugins/publish/extract_gltf.py
@@ -1,0 +1,65 @@
+import os
+
+from maya import cmds, mel
+import pyblish.api
+
+from openpype.pipeline import publish
+from openpype.hosts.maya.api import lib
+from openpype.hosts.maya.api.gltf import extract_gltf
+
+
+class ExtractGLB(publish.Extractor):
+
+    order = pyblish.api.ExtractorOrder
+    hosts = ["maya"]
+    label = "Extract GLB"
+    families = ["gltf"]
+
+    def process(self, instance):
+        staging_dir = self.staging_dir(instance)
+        filename = "{0}.glb".format(instance.name)
+        path = os.path.join(staging_dir, filename)
+
+        self.log.info("Extracting GLB to: {}".format(path))
+
+        nodes = instance[:]
+
+        self.log.info("Instance: {0}".format(nodes))
+
+        start_frame = instance.data('frameStart') or \
+                      int(cmds.playbackOptions(query=True,
+                                               animationStartTime=True))# noqa
+        end_frame = instance.data('frameEnd') or \
+                    int(cmds.playbackOptions(query=True,
+                                             animationEndTime=True)) # noqa
+        fps = mel.eval('currentTimeUnitToFPS()')
+
+        options = {
+            "sno": True,    # selectedNodeOnly
+            "nbu": True,    # .bin instead of .bin0
+            "ast": start_frame,
+            "aet": end_frame,
+            "afr": fps,
+            "dsa": 1,
+            "acn": instance.name,
+            "glb": True,
+            "vno": True    # visibleNodeOnly
+        }
+        with lib.maintained_selection():
+            cmds.select(nodes, hi=True, noExpand=True)
+            extract_gltf(staging_dir,
+                         instance.name,
+                         **options)
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        representation = {
+            'name': 'glb',
+            'ext': 'glb',
+            'files': filename,
+            "stagingDir": staging_dir,
+        }
+        instance.data["representations"].append(representation)
+
+        self.log.info("Extract GLB successful to: {0}".format(path))

--- a/openpype/plugins/publish/collect_resources_path.py
+++ b/openpype/plugins/publish/collect_resources_path.py
@@ -50,6 +50,7 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
                 "source",
                 "assembly",
                 "fbx",
+                "gltf",
                 "textures",
                 "action",
                 "background",

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -111,6 +111,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "image",
                 "assembly",
                 "fbx",
+                "gltf",
                 "textures",
                 "action",
                 "harmony.template",

--- a/openpype/plugins/publish/integrate_legacy.py
+++ b/openpype/plugins/publish/integrate_legacy.py
@@ -106,6 +106,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 "image",
                 "assembly",
                 "fbx",
+                "gltf",
                 "textures",
                 "action",
                 "harmony.template",

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -250,6 +250,9 @@
         "CollectFbxCamera": {
             "enabled": false
         },
+        "CollectGLTF": {
+            "enabled": false
+        },
         "ValidateInstanceInContext": {
             "enabled": true,
             "optional": true,

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -36,6 +36,20 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "CollectGLTF",
+            "label": "Collect Assets for GLTF/GLB export",
+            "checkbox_key": "enabled",
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "enabled",
+                    "label": "Enabled"
+                }
+            ]
+        },
+        {
             "type": "splitter"
         },
         {
@@ -62,7 +76,7 @@
                 }
             ]
         },
-        {   
+        {
             "type": "dict",
             "collapsible": true,
             "key": "ValidateFrameRange",


### PR DESCRIPTION
## Brief description
Allows user to use the extrator to export static or animated glb with Maya2glTF, see https://github.com/pypeclub/OpenPype/pull/4142

## Description
Allows user to use the extrator to export static or animated glb with Maya2glTF. After enabling the extractor, you can export glb by creating either model, animation or point cache instance.

You need to enable the extractor in Openpype settings
![image](https://user-images.githubusercontent.com/64118225/204078654-1cfa749c-0fc9-4a7f-bde6-185e2f8b2de1.png)

## Additional info
You need to install the maya2glTF first so that the extractor can run correctly.
See the link: https://github.com/iimachines/Maya2glTF 

## Limitation
The UI of maya2glTF would pop up for seconds and close because the system needs to open the UI first to allow run the mel scriptl library from maya2glTF

## Testing notes:
1. install the maya2glTF
2. enable the extractor in Openpype setting
3. create instance which is associated to the extractor(model, animation, point cache)
4. pubish it
5. you will find the glb file in the folder(s) of the related instance in the publish folder