### PR TITLE
Unreal: Support for Unreal Engine 5.1

### DIFF
--- a/openpype/hosts/unreal/api/pipeline.py
+++ b/openpype/hosts/unreal/api/pipeline.py
@@ -2,6 +2,7 @@
 import os
 import logging
 from typing import List
+import semver
 
 import pyblish.api
 
@@ -21,6 +22,8 @@ import unreal  # noqa
 
 logger = logging.getLogger("openpype.hosts.unreal")
 OPENPYPE_CONTAINERS = "OpenPypeContainers"
+UNREAL_VERSION = semver.VersionInfo(
+            *os.getenv("OPENPYPE_UNREAL_VERSION").split("."))
 
 HOST_DIR = os.path.dirname(os.path.abspath(openpype.hosts.unreal.__file__))
 PLUGINS_DIR = os.path.join(HOST_DIR, "plugins")
@@ -40,6 +43,7 @@ class UnrealHost(HostBase, ILoadHost):
     name = "unreal"
 
     def install(self):
+        version = UNREAL_VERSION
         install()
 
     def get_containers(self):
@@ -111,7 +115,9 @@ def ls():
 
     """
     ar = unreal.AssetRegistryHelpers.get_asset_registry()
-    openpype_containers = ar.get_assets_by_class("AssetContainer", True)
+    # UE 5.1 changed how class name is specified
+    class_name = ["/Script", "AssetContainer"] if UNREAL_VERSION.major == 5 and UNREAL_VERSION.minor > 0 else "AssetContainer"  # noqa
+    openpype_containers = ar.get_assets_by_class(class_name, True)
 
     # get_asset_by_class returns AssetData. To get all metadata we need to
     # load asset. get_tag_values() work only on metadata registered in

--- a/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
+++ b/openpype/hosts/unreal/hooks/pre_workfile_preparation.py
@@ -150,6 +150,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
                 engine_path=Path(engine_path)
             )
 
+        self.launch_context.env["OPENPYPE_UNREAL_VERSION"] = engine_version
         # Append project file to launch arguments
         self.launch_context.launch_args.append(
             f"\"{project_file.as_posix()}\"")

--- a/openpype/hosts/unreal/plugins/publish/collect_instances.py
+++ b/openpype/hosts/unreal/plugins/publish/collect_instances.py
@@ -3,6 +3,8 @@
 import ast
 import unreal  # noqa
 import pyblish.api
+from openpype.hosts.unreal.api.pipeline import UNREAL_VERSION
+from openpype.pipeline.publish import KnownPublishError
 
 
 class CollectInstances(pyblish.api.ContextPlugin):
@@ -23,8 +25,10 @@ class CollectInstances(pyblish.api.ContextPlugin):
     def process(self, context):
 
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
-        instance_containers = ar.get_assets_by_class(
-            "OpenPypePublishInstance", True)
+        class_name = ["/Script",
+                      "AssetContainer"] if UNREAL_VERSION.major == 5 and \
+                                           UNREAL_VERSION.minor > 0 else "OpenPypePublishInstance"  # noqa
+        instance_containers = ar.get_assets_by_class(class_name, True)
 
         for container_data in instance_containers:
             asset = container_data.get_asset()
@@ -32,9 +36,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
             data["objectName"] = container_data.asset_name
             # convert to strings
             data = {str(key): str(value) for (key, value) in data.items()}
-            assert data.get("family"), (
-                "instance has no family"
-            )
+            if not data.get("family"):
+                raise KnownPublishError("instance has no family")
 
             # content of container
             members = ast.literal_eval(data.get("members"))


### PR DESCRIPTION
## Brief description

Unreal 5.1 changed some of its API so class names are specified with path and name separately. Listing of instances (either loaded or for publishing) didn't work. This PR is fixing it with backwards compatibility in mind.

### Testing

- In Unreal 5.1 project try to open Asset Loader - it should be able to list published assets
- Publishing should work too