### PR TITLE
Feature: API token refreshed every week

### DIFF
--- a/openpype/modules/kitsu/utils/sync_service.py
+++ b/openpype/modules/kitsu/utils/sync_service.py
@@ -1,12 +1,9 @@
 import os
+import threading
 
 import gazu
 
-from openpype.client import (
-    get_project,
-    get_assets,
-    get_asset_by_name
-)
+from openpype.client import get_project, get_assets, get_asset_by_name
 from openpype.pipeline import AvalonMongoDB
 from .credentials import validate_credentials
 from .update_op_with_zou import (
@@ -397,6 +394,13 @@ def start_listeners(login: str, password: str):
         login (str): Kitsu user login
         password (str): Kitsu user password
     """
+    # Refresh token every week
+    def refresh_token_every_week():
+        print("Refreshing token...")
+        gazu.refresh_token()
+        threading.Timer(7 * 3600 * 24, refresh_token_every_week).start()
+
+    refresh_token_every_week()
 
     # Connect to server
     listener = Listener(login, password)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Click = "^7"
 dnspython = "^2.1.0"
 ftrack-python-api = "^2.3.3"
 shotgun_api3 = {git = "https://github.com/shotgunsoftware/python-api.git", rev = "v3.3.3"}
-gazu = "^0.8.28"
+gazu = "^0.8.32"
 google-api-python-client = "^1.12.8" # sync server google support (should be separate?)
 jsonschema = "^2.6.0"
 keyring = "^22.0.1"

--- a/website/docs/module_kitsu.md
+++ b/website/docs/module_kitsu.md
@@ -26,6 +26,8 @@ openpype_console module kitsu sync-service -l me@domain.ext -p my_password
 ### Events listening
 Listening to Kitsu events is the key to automation of many tasks like _project/episode/sequence/shot/asset/task create/update/delete_ and some more. Events listening should run at all times to perform the required processing as it is not possible to catch some of them retrospectively with strong reliability. If such timeout has been encountered, you must relaunch the `sync-service` command to run the synchronization step again.
 
+Connection token is refreshed every week.
+
 ### Push to Kitsu
 An utility function is provided to help update Kitsu data (a.k.a Zou database) with OpenPype data if the publishing to the production tracker hasn't been possible for some time. Running `push-to-zou` will create the data on behalf of the user.
 :::caution


### PR DESCRIPTION
## Brief description
gazu API connection token expires after a week. It is refreshed every week.

## Testing notes:
1. Run sync service: `.poetry/bin/poetry run python start.py module kitsu sync-service -l <login> -p <pwd>`
2. It never stops synchronizing