### PR TITLE
Maya: pointcache

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -128,13 +128,18 @@ def get_main_window():
 
 @contextlib.contextmanager
 def suspended_refresh(suspend=True):
-    """Suspend viewport refreshes"""
-    original_state = cmds.refresh(query=True, suspend=True)
+    """Suspend viewport refreshes
+
+    cmds.ogs(pause=True) is a toggle so we cant pass False.
+    """
+    original_state = cmds.ogs(query=True, pause=True)
     try:
-        cmds.refresh(suspend=suspend)
+        if suspend and not original_state:
+            cmds.ogs(pause=True)
         yield
     finally:
-        cmds.refresh(suspend=original_state)
+        if suspend and not original_state:
+            cmds.ogs(pause=True)
 
 
 @contextlib.contextmanager

--- a/openpype/hosts/maya/plugins/publish/extract_pointcache.py
+++ b/openpype/hosts/maya/plugins/publish/extract_pointcache.py
@@ -86,7 +86,8 @@ class ExtractAlembic(publish.Extractor):
                                                      start=start,
                                                      end=end))
 
-        with suspended_refresh(suspend=instance.data.get("refresh", False)):
+        suspend = not instance.data.get("refresh", False)
+        with suspended_refresh(suspend=suspend):
             with maintained_selection():
                 cmds.select(nodes, noExpand=True)
                 extract_alembic(


### PR DESCRIPTION
This is a fix for `cmds.refresh` not being queryable. See https://github.com/pypeclub/OpenPype/pull/4144

Gone with the `cmds.ogs` route but slightly confusing that its a toggle.