### PR TITLE
Nuke: fixed imageio node overrides subset filter

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -611,7 +611,7 @@ def get_created_node_imageio_setting_legacy(nodeclass, creator, subset):
 
         if (
             onode["subsets"]
-            and not any(re.search(s, subset.lower()) for s in onode["subsets"])
+            and not any(re.search(s.lower(), subset.lower()) for s in onode["subsets"])
         ):
             continue
 
@@ -704,7 +704,7 @@ def get_imageio_node_override_setting(
 
         if (
             onode["subsets"]
-            and not any(re.search(s, subset.lower()) for s in onode["subsets"])
+            and not any(re.search(s.lower(), subset.lower()) for s in onode["subsets"])
         ):
             continue
 

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -611,7 +611,10 @@ def get_created_node_imageio_setting_legacy(nodeclass, creator, subset):
 
         if (
             onode["subsets"]
-            and not any(re.search(s.lower(), subset.lower()) for s in onode["subsets"])
+            and not any(
+                re.search(s.lower(), subset.lower())
+                for s in onode["subsets"]
+            )
         ):
             continue
 
@@ -704,7 +707,10 @@ def get_imageio_node_override_setting(
 
         if (
             onode["subsets"]
-            and not any(re.search(s.lower(), subset.lower()) for s in onode["subsets"])
+            and not any(
+                re.search(s.lower(), subset.lower())
+                for s in onode["subsets"]
+            )
         ):
             continue
 

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -611,7 +611,7 @@ def get_created_node_imageio_setting_legacy(nodeclass, creator, subset):
 
         if (
             onode["subsets"]
-            and not any(re.search(s, subset) for s in onode["subsets"])
+            and not any(re.search(s, subset.lower()) for s in onode["subsets"])
         ):
             continue
 
@@ -694,7 +694,8 @@ def get_imageio_node_override_setting(
     # find matching override node
     override_imageio_node = None
     for onode in override_nodes:
-        log.info(onode)
+        log.debug("__ onode: {}".format(onode))
+        log.debug("__ subset: {}".format(subset))
         if node_class not in onode["nukeNodeClass"]:
             continue
 
@@ -703,7 +704,7 @@ def get_imageio_node_override_setting(
 
         if (
             onode["subsets"]
-            and not any(re.search(s, subset) for s in onode["subsets"])
+            and not any(re.search(s, subset.lower()) for s in onode["subsets"])
         ):
             continue
 


### PR DESCRIPTION
## Brief description
Subset filter works even mixture of letter sizes in subset name.

## Description
Once mixture of sizes was used (ex. `_this_ButThat`), subset filter was not able to detect correctly node override from imageio nodes preset.

## Testing notes:
1. Create new preset in `project_settings/nuke/imageio/nodes/overrideNodes`, which would override the **CreateWriteRender** plugin, with Node Node Class to `Write` from `project_settings/nuke/imageio/nodes/requiredNodes`
![image](https://user-images.githubusercontent.com/40640033/206695134-73410fe2-b6fa-45ab-9ee1-1d4f70d7de01.png)

2. add subset name filter to `_bla_BlaBla`
3. add the `_bla_BlaBla` also to `project_settings/nuke/create/CreateWriteRender/defaults`
![image](https://user-images.githubusercontent.com/40640033/206695447-6e588c34-a912-42bc-8a0a-a018690dccd4.png)

4. Open nuke, select a node, Create Render node and set Variant to _bla_BlaBla
5. created node should be pink