### PR TITLE
General: Default command for headless mode is interactive

### DIFF
--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -34,7 +34,8 @@ def main(ctx):
         # Default command for headless openpype is 'interactive' command
         #   otherwise 'tray' is used.
         if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
-            ctx.invoke(interactive)
+            print(ctx.get_help())
+            sys.exit(0)
         else:
             ctx.invoke(tray)
 

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -29,8 +29,14 @@ def main(ctx):
 
     It wraps different commands together.
     """
+
     if ctx.invoked_subcommand is None:
-        ctx.invoke(tray)
+        # Default command for headless openpype is 'interactive' command
+        #   otherwise 'tray' is used.
+        if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
+            ctx.invoke(interactive)
+        else:
+            ctx.invoke(tray)
 
 
 @main.command()

--- a/openpype/cli.py
+++ b/openpype/cli.py
@@ -31,8 +31,7 @@ def main(ctx):
     """
 
     if ctx.invoked_subcommand is None:
-        # Default command for headless openpype is 'interactive' command
-        #   otherwise 'tray' is used.
+        # Print help if headless mode is used
         if os.environ.get("OPENPYPE_HEADLESS_MODE") == "1":
             print(ctx.get_help())
             sys.exit(0)


### PR DESCRIPTION
## Brief description
Print help instead of running `tray` by default if headless mode is enabled and no command is entered.

## Additional info
The only reason is that trying to launch tray when `headless` is explicitly defined is "not right".

The command won't do anything if `openpype_gui` executable is used on windows (there is no right command to run in that case).

## Testing notes:
1. Start openpype executable with only `--headless` argument