### PR TITLE
Flame - loading multilayer with controlled layer names

### DIFF
--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -858,6 +858,7 @@ class OpenClipSolver(flib.MediaInfoFile):
                 return xml_track
 
     def _rename_track_name(self, xml_track_data):
+        layer_uid = xml_track_data.get("uid")
         name_obj = xml_track_data.find("name")
         layer_name = name_obj.text
 
@@ -871,7 +872,8 @@ class OpenClipSolver(flib.MediaInfoFile):
             return
 
         formating_data = self._update_formating_data(
-            layer=layer_name
+            layerName=layer_name,
+            layerUID=layer_uid
         )
         name_obj.text = StringTemplate(
             self.layer_rename_template

--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -8,7 +8,7 @@ import qargparse
 from Qt import QtCore, QtWidgets
 
 from openpype import style
-from openpype.lib import Logger
+from openpype.lib import Logger, StringTemplate
 from openpype.pipeline import LegacyCreator, LoaderPlugin
 from openpype.settings import get_current_project_settings
 
@@ -775,6 +775,11 @@ class OpenClipSolver(flib.MediaInfoFile):
         self.feed_colorspace = feed_data.get("colorspace")
         self.log.debug("feed_version_name: {}".format(self.feed_version_name))
 
+        # layer rename variables
+        self.layer_rename_template = feed_data["layer_rename_template"]
+        self.layer_rename_patterns = feed_data["layer_rename_patterns"]
+        self.context_data = feed_data["context_data"]
+
         # derivate other feed variables
         self.feed_basename = os.path.basename(feed_path)
         self.feed_dir = os.path.dirname(feed_path)
@@ -813,9 +818,11 @@ class OpenClipSolver(flib.MediaInfoFile):
 
     def _create_new_open_clip(self):
         self.log.info("Building new openClip")
-        self.log.debug(">> self.clip_data: {}".format(self.clip_data))
 
         for tmp_xml_track in self.clip_data.iter("track"):
+            # solve track (layer) name
+            self._rename_track_name(tmp_xml_track)
+
             tmp_xml_feeds = tmp_xml_track.find('feeds')
             tmp_xml_feeds.set('currentVersion', self.feed_version_name)
 
@@ -850,6 +857,46 @@ class OpenClipSolver(flib.MediaInfoFile):
             if uid == track_uid:
                 return xml_track
 
+    def _rename_track_name(self, xml_track_data):
+        name_obj = xml_track_data.find("name")
+        layer_name = name_obj.text
+
+        if (
+            self.layer_rename_patterns
+            and not any(
+                re.search(lp_.lower(), layer_name.lower())
+                for lp_ in self.layer_rename_patterns
+            )
+        ):
+            return
+
+        formating_data = self._update_formating_data(
+            layer=layer_name
+        )
+        name_obj.text = StringTemplate(
+            self.layer_rename_template
+        ).format(formating_data)
+
+    def _update_formating_data(self, **kwargs):
+        """ Updating formating data for layer rename
+
+        Attributes:
+            key=value (optional): will be included to formating data
+                                  as {key: value}
+        Returns:
+            dict: anatomy context data for formating
+        """
+        self.log.debug(">> self.clip_data: {}".format(self.clip_data))
+        clip_name_obj = self.clip_data.find("name")
+        data = {
+            "originalBasename": clip_name_obj.text
+        }
+        # include version context data
+        data.update(self.context_data)
+        # include input kwargs data
+        data.update(kwargs)
+        return data
+
     def _update_open_clip(self):
         self.log.info("Updating openClip ..")
 
@@ -857,11 +904,12 @@ class OpenClipSolver(flib.MediaInfoFile):
         out_xml = out_xml.getroot()
 
         self.log.debug(">> out_xml: {}".format(out_xml))
-        self.log.debug(">> self.clip_data: {}".format(self.clip_data))
-
         # loop tmp tracks
         updated_any = False
         for tmp_xml_track in self.clip_data.iter("track"):
+            # solve track (layer) name
+            self._rename_track_name(tmp_xml_track)
+
             # get tmp track uid
             tmp_track_uid = tmp_xml_track.get("uid")
             self.log.debug(">> tmp_track_uid: {}".format(tmp_track_uid))

--- a/openpype/hosts/flame/plugins/load/load_clip.py
+++ b/openpype/hosts/flame/plugins/load/load_clip.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 import flame
 from pprint import pformat
@@ -25,6 +26,14 @@ class LoadClip(opfapi.ClipLoader):
     reel_name = "Loaded"
     clip_name_template = "{asset}_{subset}<_{output}>"
 
+    """ Anatomy keys from version context data and dynamically added:
+        - {layerName} - original layer name token
+        - {layerUID} - original layer UID token
+        - {originalBasename} - original clip name taken from file
+    """
+    layer_rename_template = "{asset}_{subset}<_{output}>"
+    layer_rename_patterns = []
+
     def load(self, context, name, namespace, options):
 
         # get flame objects
@@ -38,8 +47,14 @@ class LoadClip(opfapi.ClipLoader):
         version_name = version.get("name", None)
         colorspace = self.get_colorspace(context)
 
+        # in case output is not in context replace key to representation
+        if not context["representation"]["context"].get("output"):
+            self.clip_name_template.replace("output", "representation")
+            self.layer_rename_template.replace("output", "representation")
+
+        formating_data = deepcopy(context["representation"]["context"])
         clip_name = StringTemplate(self.clip_name_template).format(
-            context["representation"]["context"])
+            formating_data)
 
         # convert colorspace with ocio to flame mapping
         # in imageio flame section
@@ -62,6 +77,9 @@ class LoadClip(opfapi.ClipLoader):
             "path": self.fname.replace("\\", "/"),
             "colorspace": colorspace,
             "version": "v{:0>3}".format(version_name),
+            "layer_rename_template": self.layer_rename_template,
+            "layer_rename_patterns": self.layer_rename_patterns,
+            "context_data": formating_data
         }
         self.log.debug(pformat(
             loading_context

--- a/openpype/hosts/flame/plugins/load/load_clip.py
+++ b/openpype/hosts/flame/plugins/load/load_clip.py
@@ -49,8 +49,10 @@ class LoadClip(opfapi.ClipLoader):
 
         # in case output is not in context replace key to representation
         if not context["representation"]["context"].get("output"):
-            self.clip_name_template.replace("output", "representation")
-            self.layer_rename_template.replace("output", "representation")
+            self.clip_name_template = self.clip_name_template.replace(
+                "output", "representation")
+            self.layer_rename_template = self.layer_rename_template.replace(
+                "output", "representation")
 
         formating_data = deepcopy(context["representation"]["context"])
         clip_name = StringTemplate(self.clip_name_template).format(

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -25,6 +25,13 @@ class LoadClipBatch(opfapi.ClipLoader):
     reel_name = "OP_LoadedReel"
     clip_name_template = "{batch}_{asset}_{subset}<_{output}>"
 
+    """ Anatomy keys from version context data and dynamically added:
+        - {layer} - original layer name token
+        - {originalBasename} - original clip name taken from file
+    """
+    layer_rename_template = "{asset}_{subset}<_{output}>"
+    layer_rename_patterns = []
+
     def load(self, context, name, namespace, options):
 
         # get flame objects
@@ -40,6 +47,7 @@ class LoadClipBatch(opfapi.ClipLoader):
         # in case output is not in context replace key to representation
         if not context["representation"]["context"].get("output"):
             self.clip_name_template.replace("output", "representation")
+            self.layer_rename_template.replace("output", "representation")
 
         formating_data = deepcopy(context["representation"]["context"])
         formating_data["batch"] = self.batch.name.get_value()
@@ -69,6 +77,9 @@ class LoadClipBatch(opfapi.ClipLoader):
             "path": self.fname.replace("\\", "/"),
             "colorspace": colorspace,
             "version": "v{:0>3}".format(version_name),
+            "layer_rename_template": self.layer_rename_template,
+            "layer_rename_patterns": self.layer_rename_patterns,
+            "context_data": formating_data
         }
         self.log.debug(pformat(
             loading_context

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -47,8 +47,10 @@ class LoadClipBatch(opfapi.ClipLoader):
 
         # in case output is not in context replace key to representation
         if not context["representation"]["context"].get("output"):
-            self.clip_name_template.replace("output", "representation")
-            self.layer_rename_template.replace("output", "representation")
+            self.clip_name_template = self.clip_name_template.replace(
+                "output", "representation")
+            self.layer_rename_template = self.layer_rename_template.replace(
+                "output", "representation")
 
         formating_data = deepcopy(context["representation"]["context"])
         formating_data["batch"] = self.batch.name.get_value()

--- a/openpype/hosts/flame/plugins/load/load_clip_batch.py
+++ b/openpype/hosts/flame/plugins/load/load_clip_batch.py
@@ -26,7 +26,8 @@ class LoadClipBatch(opfapi.ClipLoader):
     clip_name_template = "{batch}_{asset}_{subset}<_{output}>"
 
     """ Anatomy keys from version context data and dynamically added:
-        - {layer} - original layer name token
+        - {layerName} - original layer name token
+        - {layerUID} - original layer UID token
         - {originalBasename} - original clip name taken from file
     """
     layer_rename_template = "{asset}_{subset}<_{output}>"

--- a/openpype/settings/defaults/project_settings/flame.json
+++ b/openpype/settings/defaults/project_settings/flame.json
@@ -119,7 +119,11 @@
             ],
             "reel_group_name": "OpenPype_Reels",
             "reel_name": "Loaded",
-            "clip_name_template": "{asset}_{subset}<_{output}>"
+            "clip_name_template": "{asset}_{subset}<_{output}>",
+            "layer_rename_template": "{asset}_{subset}<_{output}>",
+            "layer_rename_patterns": [
+                "rgba"
+            ]
         },
         "LoadClipBatch": {
             "enabled": true,

--- a/openpype/settings/defaults/project_settings/flame.json
+++ b/openpype/settings/defaults/project_settings/flame.json
@@ -142,7 +142,11 @@
                 "exr16fpdwaa"
             ],
             "reel_name": "OP_LoadedReel",
-            "clip_name_template": "{batch}_{asset}_{subset}<_{output}>"
+            "clip_name_template": "{batch}_{asset}_{subset}<_{output}>",
+            "layer_rename_template": "{asset}_{subset}<_{output}>",
+            "layer_rename_patterns": [
+                "rgba"
+            ]
         }
     }
 }

--- a/openpype/settings/defaults/project_settings/flame.json
+++ b/openpype/settings/defaults/project_settings/flame.json
@@ -122,6 +122,7 @@
             "clip_name_template": "{asset}_{subset}<_{output}>",
             "layer_rename_template": "{asset}_{subset}<_{output}>",
             "layer_rename_patterns": [
+                "rgb",
                 "rgba"
             ]
         },
@@ -149,6 +150,7 @@
             "clip_name_template": "{batch}_{asset}_{subset}<_{output}>",
             "layer_rename_template": "{asset}_{subset}<_{output}>",
             "layer_rename_patterns": [
+                "rgb",
                 "rgba"
             ]
         }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_flame.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_flame.json
@@ -554,6 +554,17 @@
                             "type": "text",
                             "key": "clip_name_template",
                             "label": "Clip name template"
+                        },
+                        {
+                            "type": "text",
+                            "key": "layer_rename_template",
+                            "label": "Layer name template"
+                        },
+                        {
+                            "type": "list",
+                            "key": "layer_rename_patterns",
+                            "label": "Layer rename patters",
+                            "object_type": "text"
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_flame.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_flame.json
@@ -512,6 +512,17 @@
                             "type": "text",
                             "key": "clip_name_template",
                             "label": "Clip name template"
+                        },
+                        {
+                            "type": "text",
+                            "key": "layer_rename_template",
+                            "label": "Layer name template"
+                        },
+                        {
+                            "type": "list",
+                            "key": "layer_rename_patterns",
+                            "label": "Layer rename patters",
+                            "object_type": "text"
                         }
                     ]
                 },


### PR DESCRIPTION
## Brief description
Layers can be renamed dynamically during loading to batch

## Description
Folowing settings were created for layer template and layer rename patterns:
- `project_settings/flame/load/LoadClipBatch/layer_rename_template`
- `project_settings/flame/load/LoadClipBatch/layer_rename_patterns`
![image](https://user-images.githubusercontent.com/40640033/206745905-04ed4bf7-2742-4a01-856b-bda22efea609.png)

Regular expression patterns could be used for detecting name patterns in loaded layers and if any match is found, then the layer is renamed to use of version context data and additional formatting keys found if the context of loading file and its layer. For example layer with name `rgba` and layer uid `BEAUTY:MasterBeauty` can be now renamed with template `{asset}_{subset} [{layerUID}]` to new name `shot01_renderMain [BEAUTY:MasterBeauty]`. 
![image](https://user-images.githubusercontent.com/40640033/206746081-9434a9b5-11dd-4319-b91f-f1985d6ab9da.png)


This had been requested by a client who is using Flame for metadata slates. The metadata key layer will now show more than just `rgba`.