### PR TITLE
Build:Revert .toml update of Gazu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Click = "^7"
 dnspython = "^2.1.0"
 ftrack-python-api = "^2.3.3"
 shotgun_api3 = {git = "https://github.com/shotgunsoftware/python-api.git", rev = "v3.3.3"}
-gazu = "^0.8.32"
+gazu = "^0.8.28"
 google-api-python-client = "^1.12.8" # sync server google support (should be separate?)
 jsonschema = "^2.6.0"
 keyring = "^22.0.1"


### PR DESCRIPTION
## Brief description
This currently breaks build as `poetry.lock` doesn't match to `pyproject.toml`.

## Additional info
Change to .toml and .lock should not go directly to `develop`, but to `release/3.15.x`, as it would limit us to create additional bugfix release, if necessary.

Question is, if 0.8.32 is required for merged functionality.
