### PR TITLE
General: Extend 'IPluginPaths' to have more available methods

### DIFF
--- a/openpype/modules/base.py
+++ b/openpype/modules/base.py
@@ -786,29 +786,68 @@ class ModulesManager:
             ).format(expected_keys, " | ".join(msg_items)))
         return output
 
-    def collect_creator_plugin_paths(self, host_name):
-        """Helper to collect creator plugin paths from modules.
-
-        Args:
-            host_name (str): For which host are creators meants.
-
-        Returns:
-            list: List of creator plugin paths.
-        """
-        # Output structure
+    def _collect_plugin_paths(self, method_name, *args, **kwargs):
         output = []
         for module in self.get_enabled_modules():
             # Skip module that do not inherit from `IPluginPaths`
             if not isinstance(module, IPluginPaths):
                 continue
 
-            paths = module.get_creator_plugin_paths(host_name)
+            method = getattr(module, method_name)
+            paths = method(*args, **kwargs)
             if paths:
                 # Convert to list if value is not list
                 if not isinstance(paths, (list, tuple, set)):
                     paths = [paths]
                 output.extend(paths)
         return output
+
+    def collect_create_plugin_paths(self, host_name):
+        """Helper to collect creator plugin paths from modules.
+
+        Args:
+            host_name (str): For which host are creators meant.
+
+        Returns:
+            list: List of creator plugin paths.
+        """
+
+        return self._collect_plugin_paths(
+            "get_create_plugin_paths",
+            host_name
+        )
+
+    collect_creator_plugin_paths = collect_create_plugin_paths
+
+    def collect_load_plugin_paths(self, host_name):
+        """Helper to collect load plugin paths from modules.
+
+        Args:
+            host_name (str): For which host are load plugins meant.
+
+        Returns:
+            list: List of load plugin paths.
+        """
+
+        return self._collect_plugin_paths(
+            "get_load_plugin_paths",
+            host_name
+        )
+
+    def collect_publish_plugin_paths(self, host_name):
+        """Helper to collect load plugin paths from modules.
+
+        Args:
+            host_name (str): For which host are load plugins meant.
+
+        Returns:
+            list: List of pyblish plugin paths.
+        """
+
+        return self._collect_plugin_paths(
+            "get_publish_plugin_paths",
+            host_name
+        )
 
     def get_host_module(self, host_name):
         """Find host module by host name.

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -70,6 +70,13 @@ class IPluginPaths(OpenPypeInterface):
             host_name (str): For which host are the plugins meant.
         """
 
+        if hasattr(self, "get_creator_plugin_paths"):
+            # TODO remove in 3.16
+            self.log.warning((
+                "DEPRECATION WARNING: Using method 'get_creator_plugin_paths'"
+                " which was renamed to 'get_create_plugin_paths'."
+            ))
+            return self.get_creator_plugin_paths(host_name)
         return self._get_plugin_paths_by_type("create")
 
     def get_load_plugin_paths(self, host_name):

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -24,7 +24,7 @@ class OpenPypeInterface:
 
     Child classes of OpenPypeInterface may be used as mixin in different
     OpenPype modules which means they have to have implemented methods defined
-    in the interface. By default interface does not have any abstract parts.
+    in the interface. By default, interface does not have any abstract parts.
     """
 
     pass
@@ -44,40 +44,71 @@ class IPluginPaths(OpenPypeInterface):
     def get_plugin_paths(self):
         pass
 
-    def get_creator_plugin_paths(self, host_name):
-        """Retreive creator plugin paths.
+    def _get_plugin_paths_by_type(self, plugin_type):
+        paths = self.get_plugin_paths()
+        if not paths or plugin_type not in paths:
+            return []
 
-        Give addons ability to add creator plugin paths based on host name.
+        paths = paths[plugin_type]
+        if not paths:
+            return []
 
-        NOTES:
-        - Default implementation uses 'get_plugin_paths' and always return
-            all creator plugins.
-        - Host name may help to organize plugins by host, but each creator
-            alsomay have host filtering.
+        if not isinstance(paths, (list, tuple, set)):
+            paths = [paths]
+        return paths
+
+    def get_create_plugin_paths(self, host_name):
+        """Receive create plugin paths.
+
+        Give addons ability to add create plugin paths based on host name.
+
+        Notes:
+            Default implementation uses 'get_plugin_paths' and always return
+                all create plugin paths.
 
         Args:
             host_name (str): For which host are the plugins meant.
         """
 
-        paths = self.get_plugin_paths()
-        if not paths or "create" not in paths:
-            return []
+        return self._get_plugin_paths_by_type("create")
 
-        create_paths = paths["create"]
-        if not create_paths:
-            return []
+    def get_load_plugin_paths(self, host_name):
+        """Receive load plugin paths.
 
-        if not isinstance(create_paths, (list, tuple, set)):
-            create_paths = [create_paths]
-        return create_paths
+        Give addons ability to add load plugin paths based on host name.
+
+        Notes:
+            Default implementation uses 'get_plugin_paths' and always return
+                all load plugin paths.
+
+        Args:
+            host_name (str): For which host are the plugins meant.
+        """
+
+        return self._get_plugin_paths_by_type("load")
+
+    def get_publish_plugin_paths(self, host_name):
+        """Receive publish plugin paths.
+
+        Give addons ability to add publish plugin paths based on host name.
+
+        Notes:
+           Default implementation uses 'get_plugin_paths' and always return
+               all publish plugin paths.
+
+        Args:
+           host_name (str): For which host are the plugins meant.
+        """
+
+        return self._get_plugin_paths_by_type("publish")
 
 
 class ILaunchHookPaths(OpenPypeInterface):
     """Module has launch hook paths to return.
 
-    Modules does not have to inherit from this interface (changed 8.11.2022).
-    Module just have to have implemented 'get_launch_hook_paths' to be able use
-    the advantage.
+    Modules don't have to inherit from this interface (changed 8.11.2022).
+    Module just have to have implemented 'get_launch_hook_paths' to be able to
+    use the advantage.
 
     Expected result is list of paths.
     ["path/to/launch_hooks_dir"]

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -158,17 +158,24 @@ def install_openpype_plugins(project_name=None, host_name=None):
     pyblish.api.register_discovery_filter(filter_pyblish_plugins)
     register_loader_plugin_path(LOAD_PATH)
 
-    modules_manager = _get_modules_manager()
-    publish_plugin_dirs = modules_manager.collect_plugin_paths()["publish"]
-    for path in publish_plugin_dirs:
-        pyblish.api.register_plugin_path(path)
-
     if host_name is None:
         host_name = os.environ.get("AVALON_APP")
 
-    creator_paths = modules_manager.collect_creator_plugin_paths(host_name)
-    for creator_path in creator_paths:
-        register_creator_plugin_path(creator_path)
+    modules_manager = _get_modules_manager()
+    publish_plugin_dirs = modules_manager.collect_publish_plugin_paths(
+        host_name)
+    for path in publish_plugin_dirs:
+        pyblish.api.register_plugin_path(path)
+
+    create_plugin_paths = modules_manager.collect_create_plugin_paths(
+        host_name)
+    for path in create_plugin_paths:
+        register_creator_plugin_path(path)
+
+    load_plugin_paths = modules_manager.collect_load_plugin_paths(
+        host_name)
+    for path in load_plugin_paths:
+        register_loader_plugin_path(path)
 
     if project_name is None:
         project_name = os.environ.get("AVALON_PROJECT")


### PR DESCRIPTION
## Brief description
Extended abilities of `IPluginPaths` to have methods for load, create and publish plugin paths. Use new methods to register plugins from addons.

## Description
Added more methods to collect paths to load, create and publish plugin paths. These methods are called on OpenPype plugins installation (was used only for create plugins before).

## Additional info
Renamed `collect_creator_plugin_paths` -> `collect_create_plugin_paths` on `ModulesManager` and `get_creator_plugin_paths` -> `get_create_plugin_paths` (added backwards compatibility and warning).

## Testing notes:
1. Loader plugins can be registered by addons

Resolves https://github.com/pypeclub/OpenPype/issues/4194