### PR TITLE
Houdini: Use new interface class name for publish host

### DIFF
--- a/openpype/hosts/houdini/api/pipeline.py
+++ b/openpype/hosts/houdini/api/pipeline.py
@@ -7,7 +7,7 @@ import contextlib
 
 import hou  # noqa
 
-from openpype.host import HostBase, IWorkfileHost, ILoadHost, INewPublisher
+from openpype.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
 
 import pyblish.api
 
@@ -40,7 +40,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 
-class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, INewPublisher):
+class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "houdini"
 
     def __init__(self):


### PR DESCRIPTION
## Brief description
Changed import and usage of `INewPublisher` to `IPublishHost` in houdini.

## Testing notes:
1. Houdini should work as did before