### PR TITLE
Tools: Use qtpy instead of Qt in standalone tools

### DIFF
--- a/openpype/tools/context_dialog/window.py
+++ b/openpype/tools/context_dialog/window.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import style
 from openpype.pipeline import AvalonMongoDB

--- a/openpype/tools/launcher/actions.py
+++ b/openpype/tools/launcher/actions.py
@@ -1,6 +1,6 @@
 import os
 
-from Qt import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui
 
 from openpype import PLUGINS_DIR
 from openpype import style

--- a/openpype/tools/launcher/constants.py
+++ b/openpype/tools/launcher/constants.py
@@ -1,4 +1,4 @@
-from Qt import QtCore
+from qtpy import QtCore
 
 
 ACTION_ROLE = QtCore.Qt.UserRole

--- a/openpype/tools/launcher/delegates.py
+++ b/openpype/tools/launcher/delegates.py
@@ -1,5 +1,5 @@
 import time
-from Qt import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtWidgets, QtGui
 from .constants import (
     ANIMATION_START_ROLE,
     ANIMATION_STATE_ROLE,

--- a/openpype/tools/launcher/lib.py
+++ b/openpype/tools/launcher/lib.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtGui
+from qtpy import QtGui
 import qtawesome
 from openpype import resources
 

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -6,7 +6,7 @@ import collections
 import time
 
 import appdirs
-from Qt import QtCore, QtGui
+from qtpy import QtCore, QtGui
 import qtawesome
 
 from openpype.client import (

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -1,7 +1,7 @@
 import copy
 import time
 import collections
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
 
 from openpype.tools.flickcharm import FlickCharm

--- a/openpype/tools/launcher/window.py
+++ b/openpype/tools/launcher/window.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import style
 from openpype import resources

--- a/openpype/tools/project_manager/project_manager/__init__.py
+++ b/openpype/tools/project_manager/project_manager/__init__.py
@@ -44,7 +44,7 @@ from .window import ProjectManagerWindow
 
 def main():
     import sys
-    from Qt import QtWidgets
+    from qtpy import QtWidgets
 
     app = QtWidgets.QApplication([])
 

--- a/openpype/tools/project_manager/project_manager/constants.py
+++ b/openpype/tools/project_manager/project_manager/constants.py
@@ -1,5 +1,5 @@
 import re
-from Qt import QtCore
+from qtpy import QtCore
 
 
 # Item identifier (unique ID - uuid4 is used)

--- a/openpype/tools/project_manager/project_manager/delegates.py
+++ b/openpype/tools/project_manager/project_manager/delegates.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from .widgets import (
     NameTextEdit,

--- a/openpype/tools/project_manager/project_manager/model.py
+++ b/openpype/tools/project_manager/project_manager/model.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from pymongo import UpdateOne, DeleteOne
 
-from Qt import QtCore, QtGui
+from qtpy import QtCore, QtGui
 
 from openpype.client import (
     get_projects,

--- a/openpype/tools/project_manager/project_manager/multiselection_combobox.py
+++ b/openpype/tools/project_manager/project_manager/multiselection_combobox.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 
 class ComboItemDelegate(QtWidgets.QStyledItemDelegate):

--- a/openpype/tools/project_manager/project_manager/style.py
+++ b/openpype/tools/project_manager/project_manager/style.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtGui
+from qtpy import QtGui
 
 import qtawesome
 from openpype.tools.utils import paint_image_with_color

--- a/openpype/tools/project_manager/project_manager/view.py
+++ b/openpype/tools/project_manager/project_manager/view.py
@@ -1,7 +1,7 @@
 import collections
 from queue import Queue
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype.client import get_project
 from .delegates import (

--- a/openpype/tools/project_manager/project_manager/widgets.py
+++ b/openpype/tools/project_manager/project_manager/widgets.py
@@ -16,7 +16,7 @@ from openpype.tools.utils import (
     get_warning_pixmap
 )
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 
 class NameTextEdit(QtWidgets.QLineEdit):

--- a/openpype/tools/project_manager/project_manager/window.py
+++ b/openpype/tools/project_manager/project_manager/window.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import resources
 from openpype.style import load_stylesheet

--- a/openpype/tools/standalonepublish/app.py
+++ b/openpype/tools/standalonepublish/app.py
@@ -4,7 +4,7 @@ import ctypes
 import signal
 
 from bson.objectid import ObjectId
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype.client import get_asset_by_id
 

--- a/openpype/tools/standalonepublish/widgets/__init__.py
+++ b/openpype/tools/standalonepublish/widgets/__init__.py
@@ -1,4 +1,4 @@
-from Qt import QtCore
+from qtpy import QtCore
 
 HelpRole = QtCore.Qt.UserRole + 2
 FamilyRole = QtCore.Qt.UserRole + 3

--- a/openpype/tools/standalonepublish/widgets/model_asset.py
+++ b/openpype/tools/standalonepublish/widgets/model_asset.py
@@ -1,7 +1,7 @@
 import logging
 import collections
 
-from Qt import QtCore, QtGui
+from qtpy import QtCore, QtGui
 import qtawesome
 
 from openpype.client import get_assets

--- a/openpype/tools/standalonepublish/widgets/model_filter_proxy_exact_match.py
+++ b/openpype/tools/standalonepublish/widgets/model_filter_proxy_exact_match.py
@@ -1,4 +1,4 @@
-from Qt import QtCore
+from qtpy import QtCore
 
 
 class ExactMatchesFilterProxyModel(QtCore.QSortFilterProxyModel):

--- a/openpype/tools/standalonepublish/widgets/model_filter_proxy_recursive_sort.py
+++ b/openpype/tools/standalonepublish/widgets/model_filter_proxy_recursive_sort.py
@@ -1,5 +1,5 @@
-from Qt import QtCore
 import re
+from qtpy import QtCore
 
 
 class RecursiveSortFilterProxyModel(QtCore.QSortFilterProxyModel):

--- a/openpype/tools/standalonepublish/widgets/model_tasks_template.py
+++ b/openpype/tools/standalonepublish/widgets/model_tasks_template.py
@@ -1,4 +1,4 @@
-from Qt import QtCore
+from qtpy import QtCore
 import qtawesome
 
 from openpype.style import get_default_entity_icon_color

--- a/openpype/tools/standalonepublish/widgets/model_tree.py
+++ b/openpype/tools/standalonepublish/widgets/model_tree.py
@@ -1,4 +1,4 @@
-from Qt import QtCore
+from qtpy import QtCore
 from . import Node
 
 

--- a/openpype/tools/standalonepublish/widgets/model_tree_view_deselectable.py
+++ b/openpype/tools/standalonepublish/widgets/model_tree_view_deselectable.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 
 class DeselectableTreeView(QtWidgets.QTreeView):

--- a/openpype/tools/standalonepublish/widgets/widget_asset.py
+++ b/openpype/tools/standalonepublish/widgets/widget_asset.py
@@ -1,5 +1,5 @@
 import contextlib
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 import qtawesome
 
 from openpype.client import (

--- a/openpype/tools/standalonepublish/widgets/widget_component_item.py
+++ b/openpype/tools/standalonepublish/widgets/widget_component_item.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from .resources import get_resource
 
 

--- a/openpype/tools/standalonepublish/widgets/widget_components.py
+++ b/openpype/tools/standalonepublish/widgets/widget_components.py
@@ -4,7 +4,7 @@ import tempfile
 import random
 import string
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from openpype.pipeline import legacy_io
 from openpype.lib import (

--- a/openpype/tools/standalonepublish/widgets/widget_components_list.py
+++ b/openpype/tools/standalonepublish/widgets/widget_components_list.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 
 class ComponentsList(QtWidgets.QTableWidget):

--- a/openpype/tools/standalonepublish/widgets/widget_drop_empty.py
+++ b/openpype/tools/standalonepublish/widgets/widget_drop_empty.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 
 class DropEmpty(QtWidgets.QWidget):

--- a/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/openpype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -4,7 +4,7 @@ import json
 import clique
 import subprocess
 import openpype.lib
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 from . import DropEmpty, ComponentsList, ComponentItem
 
 

--- a/openpype/tools/standalonepublish/widgets/widget_family.py
+++ b/openpype/tools/standalonepublish/widgets/widget_family.py
@@ -1,6 +1,6 @@
 import re
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from openpype.client import (
     get_asset_by_name,

--- a/openpype/tools/standalonepublish/widgets/widget_family_desc.py
+++ b/openpype/tools/standalonepublish/widgets/widget_family_desc.py
@@ -1,5 +1,5 @@
 import six
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
 from . import FamilyRole, PluginRole
 

--- a/openpype/tools/standalonepublish/widgets/widget_shadow.py
+++ b/openpype/tools/standalonepublish/widgets/widget_shadow.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 
 class ShadowWidget(QtWidgets.QWidget):

--- a/openpype/tools/stdout_broker/window.py
+++ b/openpype/tools/stdout_broker/window.py
@@ -1,7 +1,7 @@
 import re
 import collections
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype import style
 

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -2,7 +2,7 @@ import os
 import json
 import collections
 
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from openpype import style
 from openpype import resources

--- a/openpype/tools/tray/pype_tray.py
+++ b/openpype/tools/tray/pype_tray.py
@@ -6,7 +6,7 @@ import subprocess
 
 import platform
 
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import openpype.version
 from openpype import resources, style

--- a/openpype/tools/traypublisher/window.py
+++ b/openpype/tools/traypublisher/window.py
@@ -8,7 +8,7 @@ publishing plugins.
 
 import platform
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 import qtawesome
 import appdirs
 


### PR DESCRIPTION
## Brief description
Use `qtpy` modules instead of `Qt` in OpenPype host agnostic tools.

## Description
Replaced import of `Qt` by `qtpy`.

## Testing notes:
- [x] Tray works
- [x] Standalone publisher works
- [x] Tray publisher works
- [x] StdOut broker UI works
- [x] Launcher works
- [x] Context dialog works
- [x] Project manager works