### PR TITLE
General: Use qtpy in modules and hosts UIs which are running in OpenPype process

### DIFF
--- a/openpype/hosts/aftereffects/api/launch_logic.py
+++ b/openpype/hosts/aftereffects/api/launch_logic.py
@@ -10,7 +10,7 @@ from wsrpc_aiohttp import (
     WebSocketAsync
 )
 
-from Qt import QtCore
+from qtpy import QtCore
 
 from openpype.lib import Logger
 from openpype.pipeline import legacy_io

--- a/openpype/hosts/aftereffects/api/lib.py
+++ b/openpype/hosts/aftereffects/api/lib.py
@@ -7,7 +7,7 @@ import traceback
 import logging
 from functools import partial
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype.pipeline import install_host
 from openpype.modules import ModulesManager

--- a/openpype/hosts/aftereffects/api/pipeline.py
+++ b/openpype/hosts/aftereffects/api/pipeline.py
@@ -1,6 +1,6 @@
 import os
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 import pyblish.api
 

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Dict, List, Optional, Union
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 import bpy
 import bpy.utils.previews

--- a/openpype/hosts/fusion/api/menu.py
+++ b/openpype/hosts/fusion/api/menu.py
@@ -1,6 +1,6 @@
 import sys
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype.tools.utils import host_tools
 from openpype.style import load_stylesheet

--- a/openpype/hosts/fusion/api/pipeline.py
+++ b/openpype/hosts/fusion/api/pipeline.py
@@ -6,7 +6,7 @@ import sys
 import logging
 
 import pyblish.api
-from Qt import QtCore
+from qtpy import QtCore
 
 from openpype.lib import (
     Logger,

--- a/openpype/hosts/fusion/api/pulse.py
+++ b/openpype/hosts/fusion/api/pulse.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from Qt import QtCore
+from qtpy import QtCore
 
 
 class PulseThread(QtCore.QThread):

--- a/openpype/hosts/fusion/deploy/MenuScripts/install_pyside2.py
+++ b/openpype/hosts/fusion/deploy/MenuScripts/install_pyside2.py
@@ -6,10 +6,10 @@ import importlib
 
 
 try:
-    from Qt import QtWidgets  # noqa: F401
-    from Qt import __binding__
-    print(f"Qt binding: {__binding__}")
-    mod = importlib.import_module(__binding__)
+    from qtpy import API_NAME
+
+    print(f"Qt binding: {API_NAME}")
+    mod = importlib.import_module(API_NAME)
     print(f"Qt path: {mod.__file__}")
     print("Qt library found, nothing to do..")
 

--- a/openpype/hosts/fusion/deploy/Scripts/Comp/OpenPype/switch_ui.py
+++ b/openpype/hosts/fusion/deploy/Scripts/Comp/OpenPype/switch_ui.py
@@ -3,7 +3,7 @@ import sys
 import glob
 import logging
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 import qtawesome as qta
 

--- a/openpype/hosts/fusion/plugins/inventory/set_tool_color.py
+++ b/openpype/hosts/fusion/plugins/inventory/set_tool_color.py
@@ -1,4 +1,4 @@
-from Qt import QtGui, QtWidgets
+from qtpy import QtGui, QtWidgets
 
 from openpype.pipeline import InventoryAction
 from openpype import style

--- a/openpype/hosts/fusion/scripts/set_rendermode.py
+++ b/openpype/hosts/fusion/scripts/set_rendermode.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets
+from qtpy import QtWidgets
 import qtawesome
 from openpype.hosts.fusion.api import get_current_comp
 

--- a/openpype/hosts/harmony/api/lib.py
+++ b/openpype/hosts/harmony/api/lib.py
@@ -14,7 +14,7 @@ import json
 import signal
 import time
 from uuid import uuid4
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 import collections
 
 from .server import Server

--- a/openpype/hosts/photoshop/api/launch_logic.py
+++ b/openpype/hosts/photoshop/api/launch_logic.py
@@ -8,7 +8,7 @@ from wsrpc_aiohttp import (
     WebSocketAsync
 )
 
-from Qt import QtCore
+from qtpy import QtCore
 
 from openpype.lib import Logger
 from openpype.pipeline import legacy_io

--- a/openpype/hosts/photoshop/api/lib.py
+++ b/openpype/hosts/photoshop/api/lib.py
@@ -3,7 +3,7 @@ import sys
 import contextlib
 import traceback
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype.lib import env_value_to_bool, Logger
 from openpype.modules import ModulesManager

--- a/openpype/hosts/photoshop/api/pipeline.py
+++ b/openpype/hosts/photoshop/api/pipeline.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 import pyblish.api
 

--- a/openpype/hosts/photoshop/plugins/create/create_legacy_image.py
+++ b/openpype/hosts/photoshop/plugins/create/create_legacy_image.py
@@ -1,6 +1,6 @@
 import re
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 from openpype.pipeline import create
 from openpype.hosts.photoshop import api as photoshop
 

--- a/openpype/hosts/tvpaint/api/launch_script.py
+++ b/openpype/hosts/tvpaint/api/launch_script.py
@@ -6,7 +6,7 @@ import ctypes
 import platform
 import logging
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import style
 from openpype.pipeline import install_host

--- a/openpype/hosts/tvpaint/plugins/create/create_render_layer.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render_layer.py
@@ -207,8 +207,8 @@ class CreateRenderlayer(plugin.Creator):
         )
 
     def _ask_user_subset_override(self, instance):
-        from Qt import QtCore
-        from Qt.QtWidgets import QMessageBox
+        from qtpy import QtCore
+        from qtpy.QtWidgets import QMessageBox
 
         title = "Subset \"{}\" already exist".format(instance["subset"])
         text = (

--- a/openpype/hosts/unreal/api/tools_ui.py
+++ b/openpype/hosts/unreal/api/tools_ui.py
@@ -1,5 +1,5 @@
 import sys
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import (
     resources,

--- a/openpype/modules/avalon_apps/avalon_app.py
+++ b/openpype/modules/avalon_apps/avalon_app.py
@@ -57,7 +57,7 @@ class AvalonModule(OpenPypeModule, ITrayModule):
         if not self._library_loader_imported:
             return
 
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
         # Actions
         action_library_loader = QtWidgets.QAction(
             "Loader", tray_menu
@@ -75,7 +75,7 @@ class AvalonModule(OpenPypeModule, ITrayModule):
 
     def show_library_loader(self):
         if self._library_loader_window is None:
-            from Qt import QtCore
+            from qtpy import QtCore
             from openpype.tools.libraryloader import LibraryLoaderWindow
             from openpype.pipeline import install_openpype_plugins
 

--- a/openpype/modules/clockify/clockify_module.py
+++ b/openpype/modules/clockify/clockify_module.py
@@ -183,7 +183,7 @@ class ClockifyModule(
     # Definition of Tray menu
     def tray_menu(self, parent_menu):
         # Menu for Tray App
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
         menu = QtWidgets.QMenu("Clockify", parent_menu)
         menu.setProperty("submenu", "on")
 

--- a/openpype/modules/clockify/widgets.py
+++ b/openpype/modules/clockify/widgets.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from openpype import resources, style
 
 

--- a/openpype/modules/example_addons/example_addon/widgets.py
+++ b/openpype/modules/example_addons/example_addon/widgets.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype.style import load_stylesheet
 

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -3,9 +3,9 @@ import time
 import datetime
 import threading
 
-from Qt import QtCore, QtWidgets, QtGui
-
 import ftrack_api
+from qtpy import QtCore, QtWidgets, QtGui
+
 from openpype import resources
 from openpype.lib import Logger
 from openpype_modules.ftrack import resolve_ftrack_url, FTRACK_MODULE_DIR

--- a/openpype/modules/ftrack/tray/login_dialog.py
+++ b/openpype/modules/ftrack/tray/login_dialog.py
@@ -1,10 +1,13 @@
 import os
+
 import requests
+from qtpy import QtCore, QtGui, QtWidgets
+
 from openpype import style
 from openpype_modules.ftrack.lib import credentials
-from . import login_tools
 from openpype import resources
-from Qt import QtCore, QtGui, QtWidgets
+
+from . import login_tools
 
 
 class CredentialsDialog(QtWidgets.QDialog):

--- a/openpype/modules/interfaces.py
+++ b/openpype/modules/interfaces.py
@@ -222,7 +222,7 @@ class ITrayAction(ITrayModule):
         pass
 
     def tray_menu(self, tray_menu):
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
 
         if self.admin_action:
             menu = self.admin_submenu(tray_menu)
@@ -247,7 +247,7 @@ class ITrayAction(ITrayModule):
     @staticmethod
     def admin_submenu(tray_menu):
         if ITrayAction._admin_submenu is None:
-            from Qt import QtWidgets
+            from qtpy import QtWidgets
 
             admin_submenu = QtWidgets.QMenu("Admin", tray_menu)
             admin_submenu.menuAction().setVisible(False)
@@ -279,7 +279,7 @@ class ITrayService(ITrayModule):
     @staticmethod
     def services_submenu(tray_menu):
         if ITrayService._services_submenu is None:
-            from Qt import QtWidgets
+            from qtpy import QtWidgets
 
             services_submenu = QtWidgets.QMenu("Services", tray_menu)
             services_submenu.menuAction().setVisible(False)
@@ -294,7 +294,7 @@ class ITrayService(ITrayModule):
 
     @staticmethod
     def _load_service_icons():
-        from Qt import QtGui
+        from qtpy import QtGui
 
         ITrayService._failed_icon = QtGui.QIcon(
             resources.get_resource("icons", "circle_red.png")
@@ -325,7 +325,7 @@ class ITrayService(ITrayModule):
         return ITrayService._failed_icon
 
     def tray_menu(self, tray_menu):
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
 
         action = QtWidgets.QAction(
             self.label,

--- a/openpype/modules/kitsu/kitsu_widgets.py
+++ b/openpype/modules/kitsu/kitsu_widgets.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import style
 from openpype.modules.kitsu.utils.credentials import (

--- a/openpype/modules/log_viewer/log_view_module.py
+++ b/openpype/modules/log_viewer/log_view_module.py
@@ -22,7 +22,7 @@ class LogViewModule(OpenPypeModule, ITrayModule):
 
     # Definition of Tray menu
     def tray_menu(self, tray_menu):
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
         # Menu for Tray App
         menu = QtWidgets.QMenu('Logging', tray_menu)
 

--- a/openpype/modules/log_viewer/tray/app.py
+++ b/openpype/modules/log_viewer/tray/app.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 from .widgets import LogsWidget, OutputWidget
 from openpype import style
 

--- a/openpype/modules/log_viewer/tray/models.py
+++ b/openpype/modules/log_viewer/tray/models.py
@@ -1,5 +1,5 @@
 import collections
-from Qt import QtCore, QtGui
+from qtpy import QtCore, QtGui
 from openpype.lib import Logger
 
 

--- a/openpype/modules/log_viewer/tray/widgets.py
+++ b/openpype/modules/log_viewer/tray/widgets.py
@@ -1,5 +1,5 @@
 import html
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 import qtawesome
 from .models import LogModel, LogsFilterProxy
 

--- a/openpype/modules/muster/muster.py
+++ b/openpype/modules/muster/muster.py
@@ -53,7 +53,7 @@ class MusterModule(OpenPypeModule, ITrayModule):
     # Definition of Tray menu
     def tray_menu(self, parent):
         """Add **change credentials** option to tray menu."""
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
 
         # Menu for Tray App
         menu = QtWidgets.QMenu('Muster', parent)

--- a/openpype/modules/muster/widget_login.py
+++ b/openpype/modules/muster/widget_login.py
@@ -1,5 +1,4 @@
-import os
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from openpype import resources, style
 
 

--- a/openpype/modules/python_console_interpreter/window/widgets.py
+++ b/openpype/modules/python_console_interpreter/window/widgets.py
@@ -5,7 +5,7 @@ import collections
 from code import InteractiveInterpreter
 
 import appdirs
-from Qt import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtWidgets, QtGui
 
 from openpype import resources
 from openpype.style import load_stylesheet

--- a/openpype/modules/shotgrid/tray/credential_dialog.py
+++ b/openpype/modules/shotgrid/tray/credential_dialog.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtWidgets, QtGui
 
 from openpype import style
 from openpype import resources

--- a/openpype/modules/shotgrid/tray/shotgrid_tray.py
+++ b/openpype/modules/shotgrid/tray/shotgrid_tray.py
@@ -1,7 +1,7 @@
 import os
 import webbrowser
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype.modules.shotgrid.lib import credentials
 from openpype.modules.shotgrid.tray.credential_dialog import (

--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1244,7 +1244,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
         if not self.enabled:
             return
 
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
         """Add menu or action to Tray(or parent)'s menu"""
         action = QtWidgets.QAction(self.label, parent_menu)
         action.triggered.connect(self.show_widget)

--- a/openpype/modules/sync_server/tray/app.py
+++ b/openpype/modules/sync_server/tray/app.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype.tools.settings import style
 

--- a/openpype/modules/sync_server/tray/delegates.py
+++ b/openpype/modules/sync_server/tray/delegates.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtWidgets, QtGui
 
 from openpype.lib import Logger
 

--- a/openpype/modules/sync_server/tray/models.py
+++ b/openpype/modules/sync_server/tray/models.py
@@ -3,8 +3,7 @@ import attr
 from bson.objectid import ObjectId
 import datetime
 
-from Qt import QtCore
-from Qt.QtCore import Qt
+from qtpy import QtCore
 import qtawesome
 
 from openpype.tools.utils.delegates import pretty_timestamp
@@ -79,16 +78,16 @@ class _SyncRepresentationModel(QtCore.QAbstractTableModel):
     def columnCount(self, _index=None):
         return len(self._header)
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole):
+    def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
         if section >= len(self.COLUMN_LABELS):
             return
 
-        if role == Qt.DisplayRole:
-            if orientation == Qt.Horizontal:
+        if role == QtCore.Qt.DisplayRole:
+            if orientation == QtCore.Qt.Horizontal:
                 return self.COLUMN_LABELS[section][1]
 
         if role == HEADER_NAME_ROLE:
-            if orientation == Qt.Horizontal:
+            if orientation == QtCore.Qt.Horizontal:
                 return self.COLUMN_LABELS[section][0]  # return name
 
     def data(self, index, role):
@@ -123,7 +122,7 @@ class _SyncRepresentationModel(QtCore.QAbstractTableModel):
             return item.status == lib.STATUS[2] and \
                 item.remote_progress < 1
 
-        if role in (Qt.DisplayRole, Qt.EditRole):
+        if role in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole):
             # because of ImageDelegate
             if header_value in ['remote_site', 'local_site']:
                 return ""
@@ -146,7 +145,7 @@ class _SyncRepresentationModel(QtCore.QAbstractTableModel):
         if role == STATUS_ROLE:
             return item.status
 
-        if role == Qt.UserRole:
+        if role == QtCore.Qt.UserRole:
             return item._id
 
     @property
@@ -409,7 +408,7 @@ class _SyncRepresentationModel(QtCore.QAbstractTableModel):
         """
         for i in range(self.rowCount(None)):
             index = self.index(i, 0)
-            value = self.data(index, Qt.UserRole)
+            value = self.data(index, QtCore.Qt.UserRole)
             if value == id:
                 return index
         return None
@@ -917,7 +916,7 @@ class SyncRepresentationSummaryModel(_SyncRepresentationModel):
         if not self.can_edit:
             return
 
-        repre_id = self.data(index, Qt.UserRole)
+        repre_id = self.data(index, QtCore.Qt.UserRole)
 
         representation = get_representation_by_id(self.project, repre_id)
         if representation:
@@ -1353,7 +1352,7 @@ class SyncRepresentationDetailModel(_SyncRepresentationModel):
         if not self.can_edit:
             return
 
-        file_id = self.data(index, Qt.UserRole)
+        file_id = self.data(index, QtCore.Qt.UserRole)
 
         updated_file = None
         representation = get_representation_by_id(self.project, self._id)

--- a/openpype/modules/sync_server/tray/widgets.py
+++ b/openpype/modules/sync_server/tray/widgets.py
@@ -3,8 +3,7 @@ import subprocess
 import sys
 from functools import partial
 
-from Qt import QtWidgets, QtCore, QtGui
-from Qt.QtCore import Qt
+from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
 
 from openpype.tools.settings import style
@@ -260,7 +259,7 @@ class _SyncRepresentationWidget(QtWidgets.QWidget):
         self._selected_ids = set()
 
         for index in idxs:
-            self._selected_ids.add(self.model.data(index, Qt.UserRole))
+            self._selected_ids.add(self.model.data(index, QtCore.Qt.UserRole))
 
     def _set_selection(self):
         """
@@ -291,7 +290,7 @@ class _SyncRepresentationWidget(QtWidgets.QWidget):
                 self.table_view.openPersistentEditor(index)
                 return
 
-        _id = self.model.data(index, Qt.UserRole)
+        _id = self.model.data(index, QtCore.Qt.UserRole)
         detail_window = SyncServerDetailWindow(
             self.sync_server, _id, self.model.project, parent=self)
         detail_window.exec()
@@ -615,7 +614,7 @@ class SyncRepresentationSummaryWidget(_SyncRepresentationWidget):
         table_view.setSelectionBehavior(
             QtWidgets.QAbstractItemView.SelectRows)
         table_view.horizontalHeader().setSortIndicator(
-            -1, Qt.AscendingOrder)
+            -1, QtCore.Qt.AscendingOrder)
         table_view.setAlternatingRowColors(True)
         table_view.verticalHeader().hide()
         table_view.viewport().setAttribute(QtCore.Qt.WA_Hover, True)
@@ -773,7 +772,8 @@ class SyncRepresentationDetailWidget(_SyncRepresentationWidget):
             QtWidgets.QAbstractItemView.ExtendedSelection)
         table_view.setSelectionBehavior(
             QtWidgets.QTableView.SelectRows)
-        table_view.horizontalHeader().setSortIndicator(-1, Qt.AscendingOrder)
+        table_view.horizontalHeader().setSortIndicator(
+            -1, QtCore.Qt.AscendingOrder)
         table_view.horizontalHeader().setSortIndicatorShown(True)
         table_view.setAlternatingRowColors(True)
         table_view.verticalHeader().hide()

--- a/openpype/modules/timers_manager/idle_threads.py
+++ b/openpype/modules/timers_manager/idle_threads.py
@@ -1,5 +1,5 @@
 import time
-from Qt import QtCore
+from qtpy import QtCore
 from pynput import mouse, keyboard
 
 from openpype.lib import Logger

--- a/openpype/modules/timers_manager/widget_user_idle.py
+++ b/openpype/modules/timers_manager/widget_user_idle.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from openpype import resources, style
 
 

--- a/openpype/modules/webserver/host_console_listener.py
+++ b/openpype/modules/webserver/host_console_listener.py
@@ -3,7 +3,7 @@ from aiohttp import web
 import json
 import logging
 from concurrent.futures import CancelledError
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype.modules import ITrayService
 


### PR DESCRIPTION
## Brief description
Use `qtpy` module instead of `Qt` in UIs which are running in OpenPype processes or in processes which install known binding.

## Testing notes:
Test if modules have working UI tools and if tools are working in modified hosts.
Modules:
- [x] Ftrack (login)
- [ ] Clockify (login)
- [ ] Kitsu (login)
- [ ] Shotgrid (login)
- [x] Sync server
- [x] Log viewer
- [x] Admin > Console
- [x] Timers manager (on windows)
Hosts:
- [ ] Muster
- [x] Aftereffects
- [x] Blender
- [ ] Fusion
- [ ] Harmony
- [x] Photoshop
- [x] TVPaint
- [x] Unreal