### PR TITLE
SiteSync: anatomy local drive site roots ignored

### DIFF
--- a/openpype/modules/sync_server/providers/dropbox.py
+++ b/openpype/modules/sync_server/providers/dropbox.py
@@ -22,7 +22,7 @@ class DropboxHandler(AbstractProvider):
             )
             return
 
-        if not self.presets["enabled"]:
+        if not self.presets.get("enabled"):
             self.log.debug("Sync Server: Site {} not enabled for {}.".
                       format(site_name, project_name))
             return

--- a/openpype/modules/sync_server/providers/gdrive.py
+++ b/openpype/modules/sync_server/providers/gdrive.py
@@ -74,7 +74,7 @@ class GDriveHandler(AbstractProvider):
             )
             return
 
-        if not self.presets["enabled"]:
+        if not self.presets.get("enabled"):
             self.log.debug(
                 "Sync Server: Site {} not enabled for {}.".format(
                     site_name, project_name

--- a/openpype/modules/sync_server/providers/local_drive.py
+++ b/openpype/modules/sync_server/providers/local_drive.py
@@ -5,6 +5,7 @@ import threading
 import time
 
 from openpype.lib import Logger
+from openpype.lib.local_settings import get_local_site_id
 from openpype.pipeline import Anatomy
 from .abstract_provider import AbstractProvider
 
@@ -220,6 +221,6 @@ class LocalDriveHandler(AbstractProvider):
 
     def _normalize_site_name(self, site_name):
         """Transform user id to 'local' for Local settings"""
-        if site_name != 'studio':
+        if site_name == get_local_site_id():
             return 'local'
         return site_name

--- a/openpype/modules/sync_server/providers/sftp.py
+++ b/openpype/modules/sync_server/providers/sftp.py
@@ -72,7 +72,7 @@ class SFTPHandler(AbstractProvider):
         Returns:
             (boolean)
         """
-        return self.presets["enabled"] and self.conn is not None
+        return self.self.presets.get("enabled") and self.conn is not None
 
     @classmethod
     def get_system_settings_schema(cls):

--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -24,6 +24,7 @@ from openpype.lib.path_templates import (
     FormatObject,
 )
 from openpype.lib.log import Logger
+from openpype.lib import get_local_site_id
 
 log = Logger.get_logger(__name__)
 
@@ -59,6 +60,10 @@ class BaseAnatomy(object):
     def __init__(self, project_doc, local_settings, site_name):
         project_name = project_doc["name"]
         self.project_name = project_name
+
+        if site_name not in ["studio", get_local_site_id()]:
+            raise RuntimeError("Anatomy could be created only for default "
+                               "local sites")
 
         self._site_name = site_name
 

--- a/openpype/tools/settings/local_settings/projects_widget.py
+++ b/openpype/tools/settings/local_settings/projects_widget.py
@@ -248,6 +248,9 @@ class SitesWidget(QtWidgets.QWidget):
         main_layout.addWidget(comboboxes_widget, 0)
         main_layout.addWidget(content_widget, 1)
 
+        active_site_widget.value_changed.connect(self.refresh)
+        remote_site_widget.value_changed.connect(self.refresh)
+
         self.active_site_widget = active_site_widget
         self.remote_site_widget = remote_site_widget
 
@@ -268,25 +271,29 @@ class SitesWidget(QtWidgets.QWidget):
             self.modules_manager.modules_by_name["sync_server"]
         )
 
-        # This is temporary modification
-        # - whole logic here should be in sync module's providers
-        site_names = sync_server_module.get_active_sites_from_settings(
-            self.project_settings["project_settings"].value
-        )
+        site_configs = sync_server_module.get_all_site_configs(
+            self._project_name)
 
         roots_entity = (
             self.project_settings[PROJECT_ANATOMY_KEY][LOCAL_ROOTS_KEY]
         )
-
+        site_names = [self.active_site_widget.current_text(),
+                      self.remote_site_widget.current_text()]
         output = []
         for site_name in site_names:
+            if not site_name:
+                continue
+
             site_inputs = []
-            for root_name, path_entity in roots_entity.items():
-                platform_entity = path_entity[platform.system().lower()]
+            site_config = site_configs[site_name]
+            for root_name, path_entity in site_config.get("root", {}).items():
+                if not path_entity:
+                    continue
+                platform_value = path_entity[platform.system().lower()]
                 site_inputs.append({
                     "label": root_name,
                     "key": root_name,
-                    "value": platform_entity.value
+                    "value": platform_value
                 })
 
             output.append(
@@ -436,6 +443,7 @@ class SitesWidget(QtWidgets.QWidget):
 
 class _SiteCombobox(QtWidgets.QWidget):
     input_label = None
+    value_changed = QtCore.Signal()
 
     def __init__(self, modules_manager, project_settings, parent):
         super(_SiteCombobox, self).__init__(parent)
@@ -661,6 +669,7 @@ class _SiteCombobox(QtWidgets.QWidget):
 
         self._set_local_settings_value(self.current_text())
         self._update_style()
+        self.value_changed.emit()
 
     def _set_local_settings_value(self, value):
         raise NotImplementedError(


### PR DESCRIPTION
## Brief description
After discussion Anatomy object shouldn't be created for other sites than 'studio' and `get_local_site_id`

## Description
Anatomy object is used for standard path resolving, it shouldn't be aware of other Site Sync sites. Resolving of path should be handled on site/handler of Site Sync sites.
(eg `Anatomy('my_project', 'my_gdrive_site').roots()` will raise an Exception.)

## Additional info
Each site (eg. handler) should implement `get_roots_config` and `resolve_path` to provide and resolve paths with `{root[work]}` placeholder into path that particular handler understands.

`site_name` argument in Anatomy is only because possible overrides from Local Settings and it is not the cleanest approach, tha t should be potentially refactored in the future.

Small fixes for Local settings, labels for roots are matching to selected site in dropdowns. 


## Testing notes:
1. experiment with Local Settings and change sites in Active and remote