### PR TITLE
Blender: Workfile Loader

### DIFF
--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import bpy
+
+from openpype.hosts.blender.api import plugin
+
+
+class ImportBlendLoader(plugin.AssetLoader):
+    """Import action for Blender (unmanaged)
+
+    Warning:
+        The loaded content will be unmanaged and is *not* visible in the
+        scene inventory. It's purely intended to merge content into your scene
+        so you could also use it as a new base.
+
+    """
+
+    representations = ["blend"]
+    families = ["*"]
+
+    label = "Import"
+    order = 10
+    icon = "arrow-circle-down"
+    color = "#775555"
+
+    def load(self, context, name=None, namespace=None, data=None):
+        scene = bpy.context.scene
+
+        with bpy.data.libraries.load(self.fname) as (data_from, data_to):
+            for attr in dir(data_to):
+                setattr(data_to, attr, getattr(data_from, attr))
+
+        # Add objects to current scene
+        # for obj in data_to.objects:
+        #     scene.collection.objects.link(obj)
+
+        # We do not containerize imported content, it remains unmanaged
+        return

--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -16,7 +16,7 @@ class AppendBlendLoader(plugin.AssetLoader):
     families = ["*"]
 
     label = "Append Workfile"
-    order = 10
+    order = 9
     icon = "arrow-circle-down"
     color = "#775555"
 
@@ -25,10 +25,37 @@ class AppendBlendLoader(plugin.AssetLoader):
             for attr in dir(data_to):
                 setattr(data_to, attr, getattr(data_from, attr))
 
+        # We do not containerize imported content, it remains unmanaged
+        return
+
+class ImportBlendLoader(plugin.AssetLoader):
+    """Import workfile in the current Blender scene (unmanaged)
+
+    Warning:
+        The loaded content will be unmanaged and is *not* visible in the
+        scene inventory. It's purely intended to merge content into your scene
+        so you could also use it as a new base.
+    """
+
+    representations = ["blend"]
+    families = ["*"]
+
+    label = "Import Workfile"
+    order = 9
+    icon = "arrow-circle-down"
+    color = "#775555"
+
+    def load(self, context, name=None, namespace=None, data=None):
+        with bpy.data.libraries.load(self.fname) as (data_from, data_to):
+            for attr in dir(data_to):
+                if attr == "scenes":
+                    continue
+                setattr(data_to, attr, getattr(data_from, attr))
+
         # Add objects to current scene
-        # scene = bpy.context.scene
-        # for obj in data_to.objects:
-        #     scene.collection.objects.link(obj)
+        scene = bpy.context.scene
+        for obj in data_to.objects:
+            scene.collection.objects.link(obj)
 
         # We do not containerize imported content, it remains unmanaged
         return

--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import bpy
 
 from openpype.hosts.blender.api import plugin
@@ -24,13 +22,12 @@ class ImportBlendLoader(plugin.AssetLoader):
     color = "#775555"
 
     def load(self, context, name=None, namespace=None, data=None):
-        scene = bpy.context.scene
-
         with bpy.data.libraries.load(self.fname) as (data_from, data_to):
             for attr in dir(data_to):
                 setattr(data_to, attr, getattr(data_from, attr))
 
         # Add objects to current scene
+        # scene = bpy.context.scene
         # for obj in data_to.objects:
         #     scene.collection.objects.link(obj)
 

--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -1,6 +1,18 @@
+from pathlib import Path
+
 import bpy
 
 from openpype.hosts.blender.api import plugin
+
+
+def get_unique_number(asset, subset):
+    count = 1
+    name = f"{asset}_{count:0>2}_{subset}"
+    collection_names = [coll.name for coll in bpy.data.collections]
+    while name in collection_names:
+        count += 1
+        name = f"{asset}_{count:0>2}_{subset}"
+    return f"{count:0>2}"
 
 
 class AppendBlendLoader(plugin.AssetLoader):
@@ -28,6 +40,7 @@ class AppendBlendLoader(plugin.AssetLoader):
         # We do not containerize imported content, it remains unmanaged
         return
 
+
 class ImportBlendLoader(plugin.AssetLoader):
     """Import workfile in the current Blender scene (unmanaged)
 
@@ -46,16 +59,26 @@ class ImportBlendLoader(plugin.AssetLoader):
     color = "#775555"
 
     def load(self, context, name=None, namespace=None, data=None):
+        asset = context['asset']['name']
+        subset = context['subset']['name']
+
+        unique_number = get_unique_number(asset, subset)
+        group_name = plugin.asset_name(asset, subset, unique_number)
+
         with bpy.data.libraries.load(self.fname) as (data_from, data_to):
             for attr in dir(data_to):
-                if attr == "scenes":
-                    continue
                 setattr(data_to, attr, getattr(data_from, attr))
 
-        # Add objects to current scene
-        scene = bpy.context.scene
-        for obj in data_to.objects:
-            scene.collection.objects.link(obj)
+        current_scene = bpy.context.scene
+
+        for scene in data_to.scenes:
+            # scene.name = group_name
+            collection = bpy.data.collections.new(name=group_name)
+            for obj in scene.objects:
+                collection.objects.link(obj)
+            current_scene.collection.children.link(collection)
+            for coll in scene.collection.children:
+                collection.children.link(coll)
 
         # We do not containerize imported content, it remains unmanaged
         return

--- a/openpype/hosts/blender/plugins/load/import_workfile.py
+++ b/openpype/hosts/blender/plugins/load/import_workfile.py
@@ -3,20 +3,19 @@ import bpy
 from openpype.hosts.blender.api import plugin
 
 
-class ImportBlendLoader(plugin.AssetLoader):
-    """Import action for Blender (unmanaged)
+class AppendBlendLoader(plugin.AssetLoader):
+    """Append workfile in Blender (unmanaged)
 
     Warning:
         The loaded content will be unmanaged and is *not* visible in the
         scene inventory. It's purely intended to merge content into your scene
         so you could also use it as a new base.
-
     """
 
     representations = ["blend"]
     families = ["*"]
 
-    label = "Import"
+    label = "Append Workfile"
     order = 10
     icon = "arrow-circle-down"
     color = "#775555"


### PR DESCRIPTION
## Brief description
Implemented the importer for other blend workfiles.

## Description
The workfile importer will import everything from another blend file, but it will not create any container for it. It will just merge the content in the current blend file.