### PR TITLE
Igniter: Use qtpy modules instead of Qt

### DIFF
--- a/igniter/__init__.py
+++ b/igniter/__init__.py
@@ -24,7 +24,7 @@ def open_dialog():
     if os.getenv("OPENPYPE_HEADLESS_MODE"):
         print("!!! Can't open dialog in headless mode. Exiting.")
         sys.exit(1)
-    from Qt import QtWidgets, QtCore
+    from qtpy import QtWidgets, QtCore
     from .install_dialog import InstallDialog
 
     scale_attr = getattr(QtCore.Qt, "AA_EnableHighDpiScaling", None)
@@ -47,7 +47,7 @@ def open_update_window(openpype_version):
     if os.getenv("OPENPYPE_HEADLESS_MODE"):
         print("!!! Can't open dialog in headless mode. Exiting.")
         sys.exit(1)
-    from Qt import QtWidgets, QtCore
+    from qtpy import QtWidgets, QtCore
     from .update_window import UpdateWindow
 
     scale_attr = getattr(QtCore.Qt, "AA_EnableHighDpiScaling", None)
@@ -71,7 +71,7 @@ def show_message_dialog(title, message):
     if os.getenv("OPENPYPE_HEADLESS_MODE"):
         print("!!! Can't open dialog in headless mode. Exiting.")
         sys.exit(1)
-    from Qt import QtWidgets, QtCore
+    from qtpy import QtWidgets, QtCore
     from .message_dialog import MessageDialog
 
     scale_attr = getattr(QtCore.Qt, "AA_EnableHighDpiScaling", None)

--- a/igniter/__main__.py
+++ b/igniter/__main__.py
@@ -2,8 +2,7 @@
 """Open install dialog."""
 
 import sys
-from Qt import QtWidgets  # noqa
-from Qt.QtCore import Signal  # noqa
+from qtpy import QtWidgets
 
 from .install_dialog import InstallDialog
 

--- a/igniter/install_dialog.py
+++ b/igniter/install_dialog.py
@@ -5,9 +5,7 @@ import sys
 import re
 import collections
 
-from Qt import QtCore, QtGui, QtWidgets  # noqa
-from Qt.QtGui import QValidator  # noqa
-from Qt.QtCore import QTimer  # noqa
+from qtpy import QtCore, QtGui, QtWidgets
 
 from .install_thread import InstallThread
 from .tools import (

--- a/igniter/install_thread.py
+++ b/igniter/install_thread.py
@@ -4,7 +4,7 @@ import os
 import sys
 from pathlib import Path
 
-from Qt.QtCore import QThread, Signal, QObject  # noqa
+from qtpy import QtCore
 
 from .bootstrap_repos import (
     BootstrapRepos,
@@ -17,7 +17,7 @@ from .bootstrap_repos import (
 from .tools import validate_mongo_connection
 
 
-class InstallThread(QThread):
+class InstallThread(QtCore.QThread):
     """Install Worker thread.
 
     This class takes care of finding OpenPype version on user entered path
@@ -28,14 +28,14 @@ class InstallThread(QThread):
     user data dir.
 
     """
-    progress = Signal(int)
-    message = Signal((str, bool))
+    progress = QtCore.Signal(int)
+    message = QtCore.Signal((str, bool))
 
     def __init__(self, parent=None,):
         self._mongo = None
         self._result = None
 
-        QThread.__init__(self, parent)
+        super().__init__(self, parent)
 
     def result(self):
         """Result of finished installation."""

--- a/igniter/install_thread.py
+++ b/igniter/install_thread.py
@@ -35,7 +35,7 @@ class InstallThread(QtCore.QThread):
         self._mongo = None
         self._result = None
 
-        super().__init__(self, parent)
+        super().__init__(parent)
 
     def result(self):
         """Result of finished installation."""

--- a/igniter/message_dialog.py
+++ b/igniter/message_dialog.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui
 
 from .tools import (
     load_stylesheet,

--- a/igniter/nice_progress_bar.py
+++ b/igniter/nice_progress_bar.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtGui, QtWidgets  # noqa
+from qtpy import QtWidgets
 
 
 class NiceProgressBar(QtWidgets.QProgressBar):

--- a/igniter/update_thread.py
+++ b/igniter/update_thread.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Working thread for update."""
-from Qt.QtCore import QThread, Signal, QObject  # noqa
+from qtpy import QtCore
 
 from .bootstrap_repos import (
     BootstrapRepos,
@@ -8,7 +8,7 @@ from .bootstrap_repos import (
 )
 
 
-class UpdateThread(QThread):
+class UpdateThread(QtCore.QThread):
     """Install Worker thread.
 
     This class takes care of finding OpenPype version on user entered path
@@ -19,13 +19,13 @@ class UpdateThread(QThread):
     user data dir.
 
     """
-    progress = Signal(int)
-    message = Signal((str, bool))
+    progress = QtCore.Signal(int)
+    message = QtCore.Signal((str, bool))
 
     def __init__(self, parent=None):
         self._result = None
         self._openpype_version = None
-        QThread.__init__(self, parent)
+        super().__init__(parent)
 
     def set_version(self, openpype_version: OpenPypeVersion):
         self._openpype_version = openpype_version

--- a/igniter/update_window.py
+++ b/igniter/update_window.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """Progress window to show when OpenPype is updating/installing locally."""
 import os
+
+from qtpy import QtCore, QtGui, QtWidgets
+
 from .update_thread import UpdateThread
-from Qt import QtCore, QtGui, QtWidgets  # noqa
 from .bootstrap_repos import OpenPypeVersion
 from .nice_progress_bar import NiceProgressBar
 from .tools import load_stylesheet

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ install_requires = [
     "jinxed",
     "blessed",
     "Qt",
+    "qtpy",
     "speedcopy",
     "googleapiclient",
     "httplib2",


### PR DESCRIPTION
## Brief description
Replaced usage of `Qt.py` module with `qtpy` in igniter.

## Testing notes:
Igniter tools should work as usually.
- [x] Login (to mongo) screen is shown
- [x] Update dialog is visible