### PR TITLE
Flame: Use qtpy in flame

### DIFF
--- a/openpype/hosts/flame/api/menu.py
+++ b/openpype/hosts/flame/api/menu.py
@@ -1,5 +1,5 @@
 import os
-from Qt import QtWidgets
+from qtpy import QtWidgets
 from copy import deepcopy
 from pprint import pformat
 from openpype.tools.utils.host_tools import HostToolsHelper

--- a/openpype/hosts/flame/api/plugin.py
+++ b/openpype/hosts/flame/api/plugin.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from xml.etree import ElementTree as ET
 
 import qargparse
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from openpype import style
 from openpype.lib import Logger

--- a/openpype/hosts/flame/startup/openpype_babypublisher/modules/panel_app.py
+++ b/openpype/hosts/flame/startup/openpype_babypublisher/modules/panel_app.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 import uiwidgets
 import app_utils

--- a/openpype/hosts/flame/startup/openpype_babypublisher/modules/uiwidgets.py
+++ b/openpype/hosts/flame/startup/openpype_babypublisher/modules/uiwidgets.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 
 class FlameLabel(QtWidgets.QLabel):

--- a/openpype/hosts/flame/startup/openpype_in_flame.py
+++ b/openpype/hosts/flame/startup/openpype_in_flame.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from Qt import QtWidgets
+from qtpy import QtWidgets
 from pprint import pformat
 import atexit
 


### PR DESCRIPTION
## Brief description
Use `qtpy` in flame host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Flame UIs should work as did before.