### PR TITLE
Nuke: Use qtpy in Nuke

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 import clique
 
 import nuke
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from openpype.client import (
     get_project,
@@ -81,7 +81,6 @@ class Context:
 def get_main_window():
     """Acquire Nuke's main window"""
     if Context.main_window is None:
-        from Qt import QtWidgets
 
         top_widgets = QtWidgets.QApplication.topLevelWidgets()
         name = "Foundry::UI::DockMainWindow"


### PR DESCRIPTION
## Brief description
Use `qtpy` in nuke host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Nuke UIs should work as did before (even in older then 13.*).