### PR TITLE
Hiero: Use qtpy in Hiero

### DIFF
--- a/openpype/hosts/hiero/api/launchforhiero.py
+++ b/openpype/hosts/hiero/api/launchforhiero.py
@@ -1,7 +1,7 @@
 import logging
 
 from scriptsmenu import scriptsmenu
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 
 log = logging.getLogger(__name__)

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -15,7 +15,7 @@ import secrets
 import shutil
 import hiero
 
-from Qt import QtWidgets, QtCore, QtXml
+from qtpy import QtWidgets, QtCore, QtXml
 
 from openpype.client import get_project
 from openpype.settings import get_project_settings

--- a/openpype/hosts/hiero/api/lib.py
+++ b/openpype/hosts/hiero/api/lib.py
@@ -15,7 +15,11 @@ import secrets
 import shutil
 import hiero
 
-from qtpy import QtWidgets, QtCore, QtXml
+from qtpy import QtWidgets, QtCore
+try:
+    from PySide import QtXml
+except ImportError:
+    from PySide2 import QtXml
 
 from openpype.client import get_project
 from openpype.settings import get_project_settings

--- a/openpype/hosts/hiero/api/menu.py
+++ b/openpype/hosts/hiero/api/menu.py
@@ -43,7 +43,7 @@ def menu_install():
 
     """
 
-    from Qt import QtGui
+    from qtpy import QtGui
     from . import (
         publish, launch_workfiles_app, reload_config,
         apply_colorspace_project, apply_colorspace_clips

--- a/openpype/hosts/hiero/api/plugin.py
+++ b/openpype/hosts/hiero/api/plugin.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import hiero
 
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 import qargparse
 
 from openpype.settings import get_current_project_settings

--- a/openpype/hosts/hiero/plugins/publish/precollect_workfile.py
+++ b/openpype/hosts/hiero/plugins/publish/precollect_workfile.py
@@ -3,7 +3,7 @@ import tempfile
 from pprint import pformat
 
 import pyblish.api
-from Qt.QtGui import QPixmap
+from qtpy.QtGui import QPixmap
 
 import hiero.ui
 


### PR DESCRIPTION
## Brief description
Use `qtpy` in hiero host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Hiero UIs should work as did before (even in older then 13.*).