### PR TITLE
Publisher: Fix 'CreatorType' not equal for Python 2 DCCs

### DIFF
--- a/openpype/tools/publisher/control.py
+++ b/openpype/tools/publisher/control.py
@@ -788,6 +788,10 @@ class CreatorType:
     def __eq__(self, other):
         return self.name == str(other)
 
+    def __ne__(self, other):
+        # This is implemented only because of Python 2
+        return not self == other
+
 
 class CreatorTypes:
     base = CreatorType("base")


### PR DESCRIPTION
## Brief description
Implement `__ne__` method in `CreatorType` for `!=` comparison in Python 2 DCCs.

## Description
It seems that the method must be explicitly implemented for Python 2 otherwise default implementation is used instead of negation of `__eq__`.

## Testing notes:
Create plugins should be visible in Publisher in any Python 2 DCC.