### PR TITLE
Maya: Use qtpy in Maya

### DIFF
--- a/openpype/hosts/maya/api/commands.py
+++ b/openpype/hosts/maya/api/commands.py
@@ -39,7 +39,7 @@ class ToolWindows:
 
 
 def edit_shader_definitions():
-    from Qt import QtWidgets
+    from qtpy import QtWidgets
     from openpype.hosts.maya.api.shader_definition_editor import (
         ShaderDefinitionsEditor
     )

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -116,7 +116,7 @@ RENDERLIKE_INSTANCE_FAMILIES = ["rendering", "vrayscene"]
 
 def get_main_window():
     """Acquire Maya's main window"""
-    from Qt import QtWidgets
+    from qtpy import QtWidgets
 
     if self._parent is None:
         self._parent = {
@@ -3018,7 +3018,7 @@ def update_content_on_context_change():
 
 
 def show_message(title, msg):
-    from Qt import QtWidgets
+    from qtpy import QtWidgets
     from openpype.widgets import message_window
 
     # Find maya main window

--- a/openpype/hosts/maya/api/menu.py
+++ b/openpype/hosts/maya/api/menu.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from Qt import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui
 
 import maya.utils
 import maya.cmds as cmds

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -563,7 +563,7 @@ def on_save():
 def on_open():
     """On scene open let's assume the containers have changed."""
 
-    from Qt import QtWidgets
+    from qtpy import QtWidgets
     from openpype.widgets import popup
 
     cmds.evalDeferred(

--- a/openpype/hosts/maya/api/shader_definition_editor.py
+++ b/openpype/hosts/maya/api/shader_definition_editor.py
@@ -5,7 +5,7 @@ Shader names are stored as simple text file over GridFS in mongodb.
 
 """
 import os
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 from openpype.client.mongo import OpenPypeMongoConnection
 from openpype import resources
 import gridfs

--- a/openpype/hosts/maya/plugins/load/actions.py
+++ b/openpype/hosts/maya/plugins/load/actions.py
@@ -153,7 +153,7 @@ class ImportMayaLoader(load.LoaderPlugin):
 
         """
 
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
 
         accept = QtWidgets.QMessageBox.Ok
         buttons = accept | QtWidgets.QMessageBox.Cancel

--- a/openpype/hosts/maya/plugins/load/load_image_plane.py
+++ b/openpype/hosts/maya/plugins/load/load_image_plane.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from openpype.client import (
     get_asset_by_id,

--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -3,7 +3,7 @@
 import json
 from collections import defaultdict
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from openpype.client import get_representation_by_name
 from openpype.pipeline import (

--- a/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
+++ b/openpype/hosts/maya/plugins/publish/validate_assembly_transforms.py
@@ -89,7 +89,7 @@ class ValidateAssemblyModelTransforms(pyblish.api.InstancePlugin):
 
         """
 
-        from Qt import QtWidgets
+        from qtpy import QtWidgets
         from openpype.hosts.maya.api import lib
 
         # Store namespace in variable, cosmetics thingy


### PR DESCRIPTION
## Brief description
Use `qtpy` in maya host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Maya UIs should work as did before (even in Maya 2020).