### PR TITLE
Max: Use qtpy in Max

### DIFF
--- a/openpype/hosts/max/api/menu.py
+++ b/openpype/hosts/max/api/menu.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """3dsmax menu definition of OpenPype."""
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 from pymxs import runtime as rt
 
 from openpype.tools.utils import host_tools


### PR DESCRIPTION
## Brief description
Use `qtpy` in max host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Max UIs should work as did before.