### PR TITLE
Houdini: Use qtpy in Houdini

### DIFF
--- a/openpype/hosts/houdini/api/usd.py
+++ b/openpype/hosts/houdini/api/usd.py
@@ -3,7 +3,7 @@
 import contextlib
 import logging
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from openpype import style
 from openpype.client import get_asset_by_name


### PR DESCRIPTION
## Brief description
Use `qtpy` in houdini host implementation instead of `Qt.py`.

## Additional information
This PR does not change usage in host tools just imports used inside host implementation.

## Testing notes:
Houdini UIs should work as did before.