### PR TITLE
hiero: creator gui with min max 

### DIFF
--- a/openpype/hosts/hiero/api/plugin.py
+++ b/openpype/hosts/hiero/api/plugin.py
@@ -276,8 +276,8 @@ class CreatorWidget(QtWidgets.QDialog):
             elif v["type"] == "QSpinBox":
                 data[k]["value"] = self.create_row(
                     content_layout, "QSpinBox", v["label"],
-                    setRange=(1, 9999999), setValue=v["value"],
-                    setToolTip=tool_tip)
+                    setValue=v["value"], setMinimum=0,
+                    setMaximum=100000, setToolTip=tool_tip)
         return data
 
 


### PR DESCRIPTION
## Brief description
Hiero creator gui is number input with improved min and max.

## Description
The number input for handles start/end is now allowing `0` input and workfile start is able to define `1001`. 

## Testing notes:
1. open Heiro
2. select a clip
3. go to OpenPype Create
4. go to bottom and notice the workfile is set to `1001`, before it only allowed to set it to `99`
5. also set Handle Start to `0` and it will stay at `0`
6. if all that works this PR is success!
2. follow this step