### PR TITLE
Slack: Added dynamic message

### DIFF
--- a/openpype/modules/slack/plugins/publish/collect_slack_family.py
+++ b/openpype/modules/slack/plugins/publish/collect_slack_family.py
@@ -1,10 +1,12 @@
 import pyblish.api
 
 from openpype.lib.profiles_filtering import filter_profiles
-from openpype.pipeline import legacy_io
+from openpype.lib import attribute_definitions
+from openpype.pipeline import OpenPypePyblishPluginMixin
 
 
-class CollectSlackFamilies(pyblish.api.InstancePlugin):
+class CollectSlackFamilies(pyblish.api.InstancePlugin,
+                           OpenPypePyblishPluginMixin):
     """Collect family for Slack notification
 
         Expects configured profile in
@@ -16,6 +18,18 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin):
     label = 'Collect Slack family'
 
     profiles = None
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            attribute_definitions.TextDef(
+                # Key under which it will be stored
+                "additional_message",
+                # Use plugin label as label for attribute
+                label="Additional Slack message",
+                placeholder="<Only if Slack is configured>"
+            )
+        ]
 
     def process(self, instance):
         task_data = instance.data["anatomyData"].get("task", {})
@@ -54,6 +68,11 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin):
                                             ["slack"]
                                             ["token"])
         instance.data["slack_token"] = slack_token
+
+        attribute_values = self.get_attr_values_from_data(instance.data)
+        additional_message = attribute_values.get("additional_message")
+        if additional_message:
+            instance.data["slack_additional_message"] = additional_message
 
     def main_family_from_instance(self, instance):  # TODO yank from integrate
         """Returns main family of entered instance."""

--- a/openpype/modules/slack/plugins/publish/integrate_slack_api.py
+++ b/openpype/modules/slack/plugins/publish/integrate_slack_api.py
@@ -31,11 +31,14 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         review_path = self._get_review_path(instance)
 
         publish_files = set()
+        message = ''
+        additional_message = instance.data.get("slack_additional_message")
+        if additional_message:
+            message = "{} \n".format(additional_message)
         for message_profile in instance.data["slack_channel_message_profiles"]:
-            message = self._get_filled_message(message_profile["message"],
-                                               instance,
-                                               review_path)
-            self.log.debug("message:: {}".format(message))
+            message += self._get_filled_message(message_profile["message"],
+                                                instance,
+                                                review_path)
             if not message:
                 return
 

--- a/website/docs/module_slack.md
+++ b/website/docs/module_slack.md
@@ -94,6 +94,12 @@ Few keys also have Capitalized and UPPERCASE format. Values will be modified acc
 Here you can find review {review_filepath}
 ```
 
+##### Dynamic message for artists
+If artists uses host with implemented Publisher (new UI for publishing, implemented in Tray Publisher, Adobe products etc), it is possible for
+them to add additional message (notification for specific users for example, artists must provide proper user id with '@').
+Additional message will be sent only if at least one profile, eg. one target channel is configured.
+All available template keys (see higher) could be used here as a placeholder too.
+
 #### Message retention
 Currently no purging of old messages is implemented in Openpype. Admins of Slack should set their own retention of messages and files per channel.
 (see https://slack.com/help/articles/203457187-Customize-message-and-file-retention-policies)


### PR DESCRIPTION
## Brief description
Artist can now add additional message, specific per instance and publish, if they are using Publisher.

## Description
It will send message only if profile (token + channel) is configured in `project_settings/slack/publish/CollectSlackFamilies`


## Testing notes:
1. use Tray Publisher, fill value in
![slack_additional_message](https://user-images.githubusercontent.com/4457962/209343379-4ea61d95-7b11-4370-bd70-2c36367bde1b.png)
